### PR TITLE
feat: imporve file-tree ui performance

### DIFF
--- a/packages/app/src/components/file-tree.tsx
+++ b/packages/app/src/components/file-tree.tsx
@@ -711,21 +711,24 @@ export default function FileTree(props: {
                     >
                       <Collapsible.Trigger>
                         <FileTreeNode
-                        node={node}
-                        level={level}
-                        active={props.active}
-                        selected={props.selectedPaths?.has(node.path)}
-                        selectedPaths={props.selectedPaths}
-                        nodeClass={props.nodeClass}
-                        draggable={draggable()}
-                        kinds={kinds()}
-                        marks={marks()}
-                      >
-                        <div class="size-4 flex items-center justify-center text-icon-weak">
-                          <Icon name={expanded() ? "chevron-down" : "chevron-right"} size="small" />
-                        </div>
-                      </FileTreeNode>
-                    </Collapsible.Trigger>
+                          node={node}
+                          level={level}
+                          active={props.active}
+                          selected={props.selectedPaths?.has(node.path)}
+                          selectedPaths={props.selectedPaths}
+                          nodeClass={props.nodeClass}
+                          draggable={draggable()}
+                          kinds={kinds()}
+                          marks={marks()}
+                        >
+                          <div class="size-4 flex items-center justify-center text-icon-weak">
+                            <Icon name={expanded() ? "chevron-down" : "chevron-right"} size="small" />
+                          </div>
+                        </FileTreeNode>
+                        <Show when={node.symlinkTarget}>
+                          <Icon name="link" size="small" class="size-3.5 text-text-weak ml-1 flex-shrink-0 align-middle" />
+                        </Show>
+                      </Collapsible.Trigger>
                     </div>
                     <Collapsible.Content class="relative pt-0.5">
                       <div
@@ -773,53 +776,58 @@ export default function FileTree(props: {
               </Match>
               <Match when={node.type === "file"}>
                 {wrapContextMenu(() => (
-                  <FileTreeNode
-                    node={node}
-                    level={level}
-                    active={props.active}
-                    selected={props.selectedPaths?.has(node.path)}
-                    selectedPaths={props.selectedPaths}
-                    nodeClass={props.nodeClass}
-                    draggable={draggable()}
-                    kinds={kinds()}
-                    marks={marks()}
-                    as="button"
-                    type="button"
-                    onClick={(e: MouseEvent) => props.onFileClick?.(node, e)}
-                  >
-                    <div class="w-4 shrink-0" />
-                    <Switch>
-                      <Match when={node.ignored}>
-                        <FileIcon
-                          node={node}
-                          class="size-4 filetree-icon filetree-icon--mono"
-                          style="color: var(--icon-weak-base)"
-                          mono
-                        />
-                      </Match>
-                      <Match when={active()}>
-                        <FileIcon
-                          node={node}
-                          class="size-4 filetree-icon filetree-icon--mono"
-                          style={kindTextColor(kind()!)}
-                          mono
-                        />
-                      </Match>
-                      <Match when={!node.ignored}>
-                        <span class="filetree-iconpair size-4">
+                  <div class="flex items-center">
+                    <FileTreeNode
+                      node={node}
+                      level={level}
+                      active={props.active}
+                      selected={props.selectedPaths?.has(node.path)}
+                      selectedPaths={props.selectedPaths}
+                      nodeClass={props.nodeClass}
+                      draggable={draggable()}
+                      kinds={kinds()}
+                      marks={marks()}
+                      as="button"
+                      type="button"
+                      onClick={(e: MouseEvent) => props.onFileClick?.(node, e)}
+                    >
+                      <div class="w-4 shrink-0" />
+                      <Switch>
+                        <Match when={node.ignored}>
                           <FileIcon
                             node={node}
-                            class="size-4 filetree-icon filetree-icon--color opacity-0 group-hover/filetree:opacity-100"
-                          />
-                          <FileIcon
-                            node={node}
-                            class="size-4 filetree-icon filetree-icon--mono group-hover/filetree:opacity-0"
+                            class="size-4 filetree-icon filetree-icon--mono"
+                            style="color: var(--icon-weak-base)"
                             mono
                           />
-                        </span>
-                      </Match>
-                    </Switch>
-                  </FileTreeNode>
+                        </Match>
+                        <Match when={active()}>
+                          <FileIcon
+                            node={node}
+                            class="size-4 filetree-icon filetree-icon--mono"
+                            style={kindTextColor(kind()!)}
+                            mono
+                          />
+                        </Match>
+                        <Match when={!node.ignored}>
+                          <span class="filetree-iconpair size-4">
+                            <FileIcon
+                              node={node}
+                              class="size-4 filetree-icon filetree-icon--color opacity-0 group-hover/filetree:opacity-100"
+                            />
+                            <FileIcon
+                              node={node}
+                              class="size-4 filetree-icon filetree-icon--mono group-hover/filetree:opacity-0"
+                              mono
+                            />
+                          </span>
+                        </Match>
+                      </Switch>
+                    </FileTreeNode>
+                    <Show when={node.symlinkTarget}>
+                      <Icon name="link" size="small" class="size-3.5 text-text-weak ml-1 flex-shrink-0 align-middle" />
+                    </Show>
+                  </div>
                 ))}
               </Match>
             </Switch>

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -755,7 +755,7 @@ export function SessionSidePanel(props: {
                     </Match>
                   </Switch>
                 </Tabs.Content>
-                <Tabs.Content value="all" class="bg-background-stronger px-3 py-0 flex flex-col">
+                <Tabs.Content value="all" class="bg-background-stronger px-3 py-0 flex flex-col @container">
                   <div class="flex items-center gap-1 py-1.5 border-b border-border-weak-base">
                     <Tooltip value="在项目根目录新建文件">
                       <button
@@ -764,7 +764,7 @@ export function SessionSidePanel(props: {
                         onClick={() => handleFileCreate("", "file")}
                       >
                         <Icon name="plus-small" size="small" />
-                        新建文件
+                        <span class="hidden @sm:block">新建文件</span>
                       </button>
                     </Tooltip>
                     <Tooltip value="在项目根目录新建文件夹">
@@ -774,7 +774,7 @@ export function SessionSidePanel(props: {
                         onClick={() => handleFileCreate("", "directory")}
                       >
                         <Icon name="folder-add-left" size="small" />
-                        新建文件夹
+                        <span class="hidden @sm:block">新建文件夹</span>
                       </button>
                     </Tooltip>
                     <Tooltip value="为项目所有文件夹生成 .summary 摘要文件">
@@ -785,7 +785,9 @@ export function SessionSidePanel(props: {
                         disabled={isSummarizing()}
                       >
                         <Icon name="bullet-list" size="small" />
-                        {isSummarizing() ? "生成中..." : "生成摘要"}
+                        <span class="hidden @sm:block">
+                          {isSummarizing() ? "生成中..." : "生成摘要"}
+                        </span>
                       </button>
                     </Tooltip>
                     <Tooltip value="刷新项目文件列表">
@@ -795,7 +797,7 @@ export function SessionSidePanel(props: {
                         onClick={handleRefresh}
                       >
                         <Icon name="arrow-down-to-line" size="small" />
-                        刷新
+                        <span class="hidden @sm:block">刷新</span>
                       </button>
                     </Tooltip>
                   </div>

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -38,6 +38,7 @@ export namespace File {
       path: z.string(),
       absolute: z.string(),
       type: z.enum(["file", "directory"]),
+      symlinkTarget: z.string().optional(),
       ignored: z.boolean(),
     })
     .meta({
@@ -721,12 +722,29 @@ export namespace File {
             if (exclude.includes(entry.name)) continue
             const absolute = path.join(resolved, entry.name)
             const file = path.relative(Instance.directory, absolute)
-            const type = entry.isDirectory() ? "directory" : "file"
+            
+            let type: "file" | "directory";
+            let symlinkTarget: string | undefined;
+            
+            if (entry.isSymbolicLink()) {
+              try {
+                const targetStat = await fs.promises.stat(absolute);
+                type = targetStat.isDirectory() ? "directory" : "file";
+                symlinkTarget = await fs.promises.readlink(absolute);
+              } catch {
+                type = "file";
+                symlinkTarget = undefined;
+              }
+            } else {
+              type = entry.isDirectory() ? "directory" : "file";
+            }
+            
             nodes.push({
               name: entry.name,
               path: file,
               absolute,
               type,
+              symlinkTarget,
               ignored: ignored(type === "directory" ? file + "/" : file),
             })
           }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1819,6 +1819,7 @@ export type FileNode = {
   path: string
   absolute: string
   type: "file" | "directory"
+  symlinkTarget?: string
   ignored: boolean
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

file-tab中的label在宽度不足时会隐藏
支持symlink在file-tree中的显示

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

在windows和linux中检验

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
