### PR TITLE
fix: isolate file tree selection state per session

### DIFF
--- a/packages/app/src/context/file.tsx
+++ b/packages/app/src/context/file.tsx
@@ -23,6 +23,7 @@ import {
 import { createFileViewCache } from "./file/view-cache"
 import { createFileTreeStore } from "./file/tree-store"
 import { invalidateFromWatcher } from "./file/watcher"
+import { createSessionSelectionMap } from "./file/session-selection"
 import {
   selectionFromLines,
   type FileState,
@@ -62,8 +63,15 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
     const scope = createMemo(() => sdk.directory)
     const path = createPathHelpers(scope)
 
-    // 文件树中选中的文件/文件夹路径（共享状态，供聊天面板读取）
-    const [selectedPaths, setSelectedPaths] = createSignal<Set<string>>(new Set())
+    // 文件树中选中的文件/文件夹路径（按会话隔离，防止同项目多会话状态混合）
+    const sessionSelections = createSessionSelectionMap()
+    const selectedPaths = () => sessionSelections.get(params.id ?? "")
+    const setSelectedPaths = (valueOrFn: Set<string> | ((prev: Set<string>) => Set<string>)) => {
+      const id = params.id ?? ""
+      const prev = sessionSelections.get(id)
+      const next = typeof valueOrFn === "function" ? valueOrFn(prev) : valueOrFn
+      sessionSelections.set(id, next)
+    }
 
     // 编辑器中选中的文字（共享状态，供聊天面板读取）
     // 当用户点击聊天框或文件树时保留高亮，点击文件阅读区域时正常清除

--- a/packages/app/src/context/file/session-selection.test.ts
+++ b/packages/app/src/context/file/session-selection.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test"
+import { createSessionSelectionMap } from "./session-selection"
+
+describe("session-scoped selection", () => {
+  test("isolates selections by session ID", () => {
+    const map = createSessionSelectionMap()
+    map.set("session-a", new Set(["file1.ts", "file2.ts"]))
+    map.set("session-b", new Set(["file3.ts"]))
+
+    expect(map.get("session-a")).toEqual(new Set(["file1.ts", "file2.ts"]))
+    expect(map.get("session-b")).toEqual(new Set(["file3.ts"]))
+  })
+
+  test("updating one session does not affect another", () => {
+    const map = createSessionSelectionMap()
+    map.set("session-a", new Set(["file1.ts"]))
+    map.set("session-b", new Set(["file2.ts"]))
+
+    // Update session-a
+    map.set("session-a", new Set(["file1.ts", "file3.ts"]))
+
+    expect(map.get("session-a")).toEqual(new Set(["file1.ts", "file3.ts"]))
+    expect(map.get("session-b")).toEqual(new Set(["file2.ts"]))
+  })
+
+  test("returns empty set for unknown session", () => {
+    const map = createSessionSelectionMap()
+    map.set("session-a", new Set(["file1.ts"]))
+
+    expect(map.get("unknown-session")).toEqual(new Set())
+  })
+
+  test("clears a specific session without affecting others", () => {
+    const map = createSessionSelectionMap()
+    map.set("session-a", new Set(["file1.ts"]))
+    map.set("session-b", new Set(["file2.ts"]))
+
+    // Clearing session-a should not affect session-b
+    map.set("session-a", new Set())
+
+    // When set to empty, it should be cleaned up
+    expect(map.get("session-a")).toEqual(new Set())
+    expect(map.get("session-b")).toEqual(new Set(["file2.ts"]))
+  })
+})

--- a/packages/app/src/context/file/session-selection.ts
+++ b/packages/app/src/context/file/session-selection.ts
@@ -1,0 +1,27 @@
+/**
+ * Session-scoped file selection map.
+ *
+ Keeps file tree selections isolated per session so that
+ * two sessions open in the same project never share state.
+ */
+export interface SessionSelectionMap {
+  get(sessionId: string): Set<string>
+  set(sessionId: string, value: Set<string>): void
+}
+
+export function createSessionSelectionMap(): SessionSelectionMap {
+  const store = new Map<string, Set<string>>()
+
+  return {
+    get(sessionId: string): Set<string> {
+      return store.get(sessionId) ?? new Set()
+    },
+    set(sessionId: string, value: Set<string>): void {
+      if (value.size === 0) {
+        store.delete(sessionId)
+      } else {
+        store.set(sessionId, value)
+      }
+    },
+  }
+}


### PR DESCRIPTION
### Issue for this PR

Closes #68

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes display bug where two sessions in the same project would mix up file tree selections. The `selectedPaths` signal was global — shared across all sessions in a project. Replaced with a session-scoped `Map<sessionId, Set<string>>` keyed by `params.id`. Created `session-selection.ts` utility with TDD tests.

### How did you verify your code works?

TDD: 4 tests for session selection isolation written first (RED), then implemented (GREEN). All 48 file context tests pass.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR