### PR TITLE
fix: prevent stale inflight requests from overwriting force-refreshed data

### DIFF
--- a/packages/app/src/context/file/tree-store.test.ts
+++ b/packages/app/src/context/file/tree-store.test.ts
@@ -50,4 +50,49 @@ describe("file tree store refresh", () => {
     expect(tree.children("").map((item) => item.path)).toEqual(["docs", "README.md", "notes.md"])
     expect(tree.children("docs").map((item) => item.path)).toEqual(["docs/intro.md", "docs/new.md"])
   })
+
+  test("force refresh returns fresh data when an inflight request already exists", async () => {
+    let resolveInitial: () => void
+    const initialPromise = new Promise<void>((r) => { resolveInitial = r })
+
+    const data = new Map<string, Node[]>([
+      ["", [dir("src"), file("a.ts")]],
+    ])
+
+    let listCount = 0
+    const tree = createFileTreeStore({
+      scope: () => "/repo",
+      normalizeDir: (input) => input.replace(/\/+$/, ""),
+      list: async (input) => {
+        listCount++
+        if (listCount === 1) {
+          // First request reads stale data and hangs
+          await initialPromise
+          return [{ name: "src", path: "src", absolute: "/repo/src", type: "directory" as const, ignored: false }]
+        }
+        // Subsequent requests read current data
+        return data.get(input) ?? []
+      },
+      onError: () => {},
+    })
+
+    // Start the first list request (returns stale data, hangs)
+    const first = tree.listDir("")
+
+    // Change the underlying data before the first request completes
+    data.set("", [dir("src"), file("a.ts"), file("b.ts")])
+
+    // Force refresh while the first request is still inflight.
+    // This should fetch fresh data, not return the stale inflight promise.
+    const refresh = tree.refreshDir("")
+
+    // Let the initial request complete with stale data
+    resolveInitial!()
+
+    // Wait for both to complete
+    await Promise.all([first, refresh])
+
+    // The tree should reflect the fresh data (b.ts included)
+    expect(tree.children("").map((n) => n.path)).toEqual(["src", "a.ts", "b.ts"])
+  })
 })

--- a/packages/app/src/context/file/tree-store.ts
+++ b/packages/app/src/context/file/tree-store.ts
@@ -26,9 +26,11 @@ export function createFileTreeStore(options: TreeStoreOptions) {
   })
 
   const inflight = new Map<string, Promise<void>>()
+  const version = new Map<string, number>()
 
   const reset = () => {
     inflight.clear()
+    version.clear()
     setTree("node", reconcile({}))
     setTree("dir", reconcile({}))
     setTree("dir", "", { expanded: true })
@@ -46,8 +48,15 @@ export function createFileTreeStore(options: TreeStoreOptions) {
     const current = tree.dir[dir]
     if (!opts?.force && current?.loaded) return Promise.resolve()
 
-    const pending = inflight.get(dir)
-    if (pending) return pending
+    if (!opts?.force) {
+      const pending = inflight.get(dir)
+      if (pending) return pending
+    }
+
+    if (opts?.force) {
+      version.set(dir, (version.get(dir) ?? 0) + 1)
+    }
+    const ver = version.get(dir) ?? 0
 
     setTree(
       "dir",
@@ -64,6 +73,7 @@ export function createFileTreeStore(options: TreeStoreOptions) {
       .list(dir)
       .then((nodes) => {
         if (options.scope() !== directory) return
+        if ((version.get(dir) ?? 0) !== ver) return
         const prevChildren = tree.dir[dir]?.children ?? []
         const nextChildren = nodes.map((node) => node.path)
         const nextSet = new Set(nextChildren)
@@ -109,6 +119,7 @@ export function createFileTreeStore(options: TreeStoreOptions) {
       })
       .catch((e) => {
         if (options.scope() !== directory) return
+        if ((version.get(dir) ?? 0) !== ver) return
         setTree(
           "dir",
           dir,

--- a/packages/app/src/context/file/watcher.test.ts
+++ b/packages/app/src/context/file/watcher.test.ts
@@ -146,4 +146,78 @@ describe("file watcher invalidation", () => {
 
     expect(refresh).toEqual([])
   })
+
+  test("refreshes root when file added at root level", () => {
+    const refresh: string[] = []
+
+    invalidateFromWatcher(
+      {
+        type: "file.watcher.updated",
+        properties: {
+          file: "new-file.ts",
+          event: "add",
+        },
+      },
+      {
+        normalize: (input) => input,
+        hasFile: () => false,
+        loadFile: () => {},
+        node: () => undefined,
+        isDirLoaded: (path) => path === "",
+        refreshDir: (path) => refresh.push(path),
+      },
+    )
+
+    expect(refresh).toEqual([""])
+  })
+
+  test("walks up to nearest loaded ancestor for deeply nested new file", () => {
+    const refresh: string[] = []
+
+    invalidateFromWatcher(
+      {
+        type: "file.watcher.updated",
+        properties: {
+          file: "src/components/ui/button.tsx",
+          event: "add",
+        },
+      },
+      {
+        normalize: (input) => input,
+        hasFile: () => false,
+        loadFile: () => {},
+        node: () => undefined,
+        isDirLoaded: (path) => path === "src",
+        refreshDir: (path) => refresh.push(path),
+      },
+    )
+
+    expect(refresh).toEqual(["src"])
+  })
+
+  test("closes tab on unlink event", () => {
+    const closed: string[] = []
+
+    invalidateFromWatcher(
+      {
+        type: "file.watcher.updated",
+        properties: {
+          file: "src/deleted.ts",
+          event: "unlink",
+        },
+      },
+      {
+        normalize: (input) => input,
+        hasFile: () => false,
+        isOpen: (path) => path === "src/deleted.ts",
+        loadFile: () => {},
+        closeFile: (path) => closed.push(path),
+        node: () => undefined,
+        isDirLoaded: (path) => path === "src",
+        refreshDir: () => {},
+      },
+    )
+
+    expect(closed).toEqual(["src/deleted.ts"])
+  })
 })


### PR DESCRIPTION
### Issue for this PR
Closes #65

### Type of change
- [x] Bug fix

### What does this PR do?
Fixes stale inflight request overwriting force-refreshed file tree data. When `refreshDir()` is called with `force: true`, if a directory already has a pending request, the force refresh now bypasses the inflight cache and creates a new request. A per-directory version counter ensures stale responses are silently discarded.

### How did you verify your code works?
- TDD: test written first for inflight force refresh (RED), then implemented (GREEN)
- All 46 file context tests pass
- TypeScript typecheck passes

### Checklist
- [x] I have read the [contributing guidelines](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have verified my changes work as expected