### PR TITLE
fix: preserve open tab content during file eviction

### DIFF
--- a/packages/app/src/context/file.tsx
+++ b/packages/app/src/context/file.tsx
@@ -11,6 +11,7 @@ import { useLayout } from "@/context/layout"
 import { createPathHelpers } from "./file/path"
 import {
   approxBytes,
+  buildEvictionKeepSet,
   evictContentLru,
   getFileContentBytesTotal,
   getFileContentEntryCount,
@@ -34,6 +35,7 @@ import {
 export type { FileSelection, SelectedLineRange, FileViewState, FileState }
 export { selectionFromLines }
 export {
+  buildEvictionKeepSet,
   evictContentLru,
   getFileContentBytesTotal,
   getFileContentEntryCount,
@@ -283,7 +285,8 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
 
           if (!content) return
           touchFileContent(file, approxBytes(content))
-          evictContent(new Set([file]))
+          const openTabs = tabs.all().map((tab) => ({ tab, path: path.pathFromTab(tab) }))
+          evictContent(buildEvictionKeepSet(file, openTabs))
         })
         .catch((e) => {
           if (scope() !== directory) return

--- a/packages/app/src/context/file/content-cache.test.ts
+++ b/packages/app/src/context/file/content-cache.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import {
+  buildEvictionKeepSet,
+  evictContentLru,
+  getFileContentBytesTotal,
+  getFileContentEntryCount,
+  hasFileContent,
+  removeFileContentBytes,
+  resetFileContentLru,
+  setFileContentBytes,
+} from "./content-cache"
+
+describe("content-cache eviction with open files", () => {
+  afterEach(() => {
+    resetFileContentLru()
+  })
+
+  test("preserves all files in keep set when evicting", () => {
+    // Fill the LRU beyond capacity (MAX_FILE_CONTENT_ENTRIES = 40)
+    for (const i of Array.from({ length: 50 }, (_, n) => n)) {
+      setFileContentBytes(`f-${i}`, 1)
+    }
+    expect(getFileContentEntryCount()).toBe(50)
+
+    // Simulate: user has 3 files open in tabs
+    const openFiles = new Set(["f-47", "f-48", "f-49"])
+
+    // Track which files got evicted
+    const evicted: string[] = []
+    evictContentLru(openFiles, (path) => evicted.push(path))
+
+    // All open files should still be tracked in the LRU
+    for (const f of openFiles) {
+      expect(hasFileContent(f)).toBe(true)
+    }
+
+    // The evicted files should NOT include any open file
+    for (const evictedPath of evicted) {
+      expect(openFiles.has(evictedPath)).toBe(false)
+    }
+
+    // Entry count should be at or below max
+    expect(getFileContentEntryCount()).toBeLessThanOrEqual(40)
+  })
+
+  test("does not evict a file that is currently being edited", () => {
+    // Fill to capacity
+    for (const i of Array.from({ length: 40 }, (_, n) => n)) {
+      setFileContentBytes(`f-${i}`, 1)
+    }
+
+    // Add one more file (the one being edited) - now we're at 41, over capacity
+    setFileContentBytes("editing-file", 1)
+    expect(getFileContentEntryCount()).toBe(41)
+
+    // Evict while protecting the editing file
+    const evicted: string[] = []
+    evictContentLru(new Set(["editing-file"]), (path) => evicted.push(path))
+
+    // The editing file must NOT be evicted
+    expect(hasFileContent("editing-file")).toBe(true)
+    expect(evicted).not.toContain("editing-file")
+
+    // Something should have been evicted to get back to capacity
+    expect(evicted.length).toBeGreaterThan(0)
+    expect(getFileContentEntryCount()).toBeLessThanOrEqual(40)
+  })
+
+  test("evicts oldest files first, skipping keep set entries", () => {
+    // Add files in order: a, b, c, d (well under capacity, but force eviction via bytes)
+    const chunk = 6 * 1024 * 1024 // 6MB each, 4 = 24MB > 20MB limit
+    setFileContentBytes("a", chunk)
+    setFileContentBytes("b", chunk)
+    setFileContentBytes("c", chunk)
+    setFileContentBytes("d", chunk)
+
+    // Protect "a" (oldest) and "b" (second oldest) -- simulating open tabs
+    const keep = new Set(["a", "b"])
+    const evicted: string[] = []
+    evictContentLru(keep, (path) => evicted.push(path))
+
+    // "a" and "b" must survive because they're in the keep set
+    expect(hasFileContent("a")).toBe(true)
+    expect(hasFileContent("b")).toBe(true)
+    // "c" should be evicted (oldest unprotected)
+    expect(evicted).toContain("c")
+  })
+})
+
+describe("buildEvictionKeepSet", () => {
+  test("includes loaded file path", () => {
+    const result = buildEvictionKeepSet("src/main.ts", [])
+    expect(result.has("src/main.ts")).toBe(true)
+  })
+
+  test("includes all open tab file paths", () => {
+    const openTabs = [
+      { tab: "file://src/a.ts", path: "src/a.ts" },
+      { tab: "file://src/b.ts", path: "src/b.ts" },
+      { tab: "file://src/c.ts", path: "src/c.ts" },
+    ]
+    const result = buildEvictionKeepSet("src/new.ts", openTabs)
+    expect(result.has("src/new.ts")).toBe(true)
+    expect(result.has("src/a.ts")).toBe(true)
+    expect(result.has("src/b.ts")).toBe(true)
+    expect(result.has("src/c.ts")).toBe(true)
+  })
+
+  test("deduplicates loaded file with open tab", () => {
+    const openTabs = [{ tab: "file://src/main.ts", path: "src/main.ts" }]
+    const result = buildEvictionKeepSet("src/main.ts", openTabs)
+    expect(result.size).toBe(1)
+    expect(result.has("src/main.ts")).toBe(true)
+  })
+
+  test("handles empty open tabs list", () => {
+    const result = buildEvictionKeepSet("src/only.ts", [])
+    expect(result.size).toBe(1)
+    expect(result.has("src/only.ts")).toBe(true)
+  })
+
+  test("skips tabs with undefined path", () => {
+    const openTabs = [
+      { tab: "file://src/a.ts", path: "src/a.ts" },
+      { tab: "context", path: undefined },
+      { tab: "file://src/b.ts", path: "src/b.ts" },
+    ]
+    const result = buildEvictionKeepSet("src/new.ts", openTabs)
+    expect(result.size).toBe(3) // new + a + b (no undefined entry)
+    expect(result.has("src/new.ts")).toBe(true)
+    expect(result.has("src/a.ts")).toBe(true)
+    expect(result.has("src/b.ts")).toBe(true)
+  })
+})

--- a/packages/app/src/context/file/content-cache.ts
+++ b/packages/app/src/context/file/content-cache.ts
@@ -86,3 +86,12 @@ export function getFileContentEntryCount() {
 export function hasFileContent(path: string) {
   return lru.has(path)
 }
+
+export function buildEvictionKeepSet(loaded: string, openTabs: Array<{ tab: string; path: string | undefined }>) {
+  const keep = new Set<string>()
+  keep.add(loaded)
+  for (const entry of openTabs) {
+    if (entry.path) keep.add(entry.path)
+  }
+  return keep
+}


### PR DESCRIPTION
### Issue for this PR
Closes #69

### Type of change
- [x] Bug fix

### What does this PR do?
Prevents the LRU content cache from evicting files that are currently open in editor tabs. Previously, editing a new file could cause actively-edited files to be evicted from cache, losing unsaved content. Now `buildEvictionKeepSet()` includes all open tab paths, ensuring files being edited are never evicted.

### How did you verify your code works?
- Added 8 TDD tests covering: eviction with keep set, currently-edited file protection, oldest-first eviction with skipping, keep set construction with open tabs, deduplication, empty tabs, and undefined path handling
- All tests pass with `bun test`

### Checklist
- [x] I have read the [contributing guidelines](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have verified my changes work as expected