### PR TITLE
feat: add per-file discard for AI-modified files

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -50,6 +50,7 @@ import {
 } from "@/pages/session/helpers"
 import { MessageTimeline } from "@/pages/session/message-timeline"
 import { type DiffStyle, SessionReviewTab, type SessionReviewTabProps } from "@/pages/session/review-tab"
+import { discardFileDiff } from "@/pages/session/review-discard"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { syncSessionModel } from "@/pages/session/session-model-helpers"
 import { SessionSidePanel } from "@/pages/session/session-side-panel"
@@ -1146,6 +1147,38 @@ export default function Page() {
     loadFile: file.load,
   })
 
+  const handleDiscardFile = async (filePath: string) => {
+    const id = params.id
+    if (!id) return
+
+    const currentDiffs = reviewDiffs()
+    const result = discardFileDiff(currentDiffs, filePath)
+
+    if (result.action === "none") return
+
+    try {
+      if (result.action === "delete") {
+        await sdk.client.file.delete({ path: filePath })
+      } else {
+        await sdk.client.file.write({ path: filePath, content: result.content ?? "" })
+      }
+
+      file.tree.refresh("")
+      sync.set("session_diff", (value) => {
+        const next = { ...value }
+        delete next[id]
+        return next
+      })
+      void sync.session.diff(id, { force: true })
+    } catch (err: any) {
+      showToast({
+        variant: "error",
+        title: language.t("common.requestFailed"),
+        description: formatServerError(err, language.t),
+      })
+    }
+  }
+
   const changesTitle = () => {
     if (!canReview()) {
       return null
@@ -1248,6 +1281,7 @@ export default function Page() {
         focusedComment={comments.focus()}
         onFocusedCommentChange={comments.setFocus}
         onViewFile={openReviewFile}
+        onDiscardFile={store.changes === "session" || store.changes === "turn" ? handleDiscardFile : undefined}
         classes={input.classes}
       />
     </Show>

--- a/packages/app/src/pages/session/review-discard.test.ts
+++ b/packages/app/src/pages/session/review-discard.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test"
+import { discardFileDiff } from "./review-discard"
+import type { FileDiff } from "@opencode-ai/sdk/v2"
+
+/**
+ * Tests for the per-file discard logic used in the review panel.
+ *
+ * The discard action restores a file to its pre-AI state using the `before`
+ * content from the FileDiff. For "added" files it deletes the file; for
+ * "deleted" or "modified" files it writes the original content back.
+ */
+
+const diffs: FileDiff[] = [
+  {
+    file: "src/foo.ts",
+    before: "original foo",
+    after: "modified foo",
+    additions: 1,
+    deletions: 1,
+    status: "modified",
+  },
+  {
+    file: "src/bar.ts",
+    before: "",
+    after: "new file content",
+    additions: 5,
+    deletions: 0,
+    status: "added",
+  },
+  {
+    file: "src/baz.ts",
+    before: "original baz content",
+    after: "",
+    additions: 0,
+    deletions: 3,
+    status: "deleted",
+  },
+]
+
+describe("discardFileDiff", () => {
+  test("discards a modified file (write action with before content)", () => {
+    const result = discardFileDiff(diffs, "src/foo.ts")
+    expect(result.action).toBe("write")
+    expect(result.content).toBe("original foo")
+    expect(result.remaining).toHaveLength(2)
+    expect(result.remaining.map((d) => d.file)).not.toContain("src/foo.ts")
+  })
+
+  test("discards an added file (delete action)", () => {
+    const result = discardFileDiff(diffs, "src/bar.ts")
+    expect(result.action).toBe("delete")
+    expect(result.content).toBeUndefined()
+    expect(result.remaining).toHaveLength(2)
+    expect(result.remaining.map((d) => d.file)).not.toContain("src/bar.ts")
+  })
+
+  test("discards a deleted file (write action with before content)", () => {
+    const result = discardFileDiff(diffs, "src/baz.ts")
+    expect(result.action).toBe("write")
+    expect(result.content).toBe("original baz content")
+    expect(result.remaining).toHaveLength(2)
+    expect(result.remaining.map((d) => d.file)).not.toContain("src/baz.ts")
+  })
+
+  test("returns none when file path does not exist in diffs", () => {
+    const result = discardFileDiff(diffs, "src/nonexistent.ts")
+    expect(result.action).toBe("none")
+    expect(result.remaining).toHaveLength(3)
+  })
+
+  test("handles empty diffs array", () => {
+    const result = discardFileDiff([], "src/foo.ts")
+    expect(result.action).toBe("none")
+    expect(result.remaining).toHaveLength(0)
+  })
+
+  test("treats file with empty before as added (delete action)", () => {
+    const noStatusDiffs: FileDiff[] = [
+      {
+        file: "new.ts",
+        before: "",
+        after: "content",
+        additions: 1,
+        deletions: 0,
+      },
+    ]
+    const result = discardFileDiff(noStatusDiffs, "new.ts")
+    expect(result.action).toBe("delete")
+  })
+})

--- a/packages/app/src/pages/session/review-discard.ts
+++ b/packages/app/src/pages/session/review-discard.ts
@@ -1,0 +1,41 @@
+import type { FileDiff } from "@opencode-ai/sdk/v2"
+
+export type DiscardAction = {
+  /** What to do to discard the file change */
+  action: "write" | "delete" | "none"
+  /** Content to write back (for "write" action) */
+  content?: string
+  /** Remaining diffs after removing the discarded file */
+  remaining: FileDiff[]
+}
+
+/**
+ * Determines what operations to perform to discard a single file change
+ * from a list of diffs. Returns the action type, content to restore,
+ * and the remaining diffs with the target file removed.
+ *
+ * - "modified" files: write back the `before` content
+ * - "added" files (empty `before`): delete the file
+ * - "deleted" files (empty `after`): write back the `before` content
+ */
+export function discardFileDiff(diffs: FileDiff[], filePath: string): DiscardAction {
+  const idx = diffs.findIndex((d) => d.file === filePath)
+  if (idx === -1) {
+    return { action: "none", remaining: diffs }
+  }
+
+  const diff = diffs[idx]
+  const remaining = [...diffs.slice(0, idx), ...diffs.slice(idx + 1)]
+
+  const isAdded = diff.status === "added" || (diff.before === "" && diff.after.length > 0)
+
+  if (isAdded) {
+    return { action: "delete", remaining }
+  }
+
+  return {
+    action: "write",
+    content: diff.before,
+    remaining,
+  }
+}

--- a/packages/app/src/pages/session/review-tab.tsx
+++ b/packages/app/src/pages/session/review-tab.tsx
@@ -24,6 +24,7 @@ export interface SessionReviewTabProps {
   diffStyle: DiffStyle
   onDiffStyleChange?: (style: DiffStyle) => void
   onViewFile?: (file: string) => void
+  onDiscardFile?: (file: string) => void
   onLineComment?: (comment: { file: string; selection: SelectedLineRange; comment: string; preview?: string }) => void
   onLineCommentUpdate?: (comment: SessionReviewCommentUpdate) => void
   onLineCommentDelete?: (comment: SessionReviewCommentDelete) => void
@@ -190,6 +191,7 @@ export function SessionReviewTab(props: SessionReviewTabProps) {
       diffStyle={props.diffStyle}
       onDiffStyleChange={props.onDiffStyleChange}
       onViewFile={props.onViewFile}
+      onDiscardFile={props.onDiscardFile}
       focusedFile={props.focusedFile}
       readFile={readFile}
       onLineComment={props.onLineComment}

--- a/packages/ui/src/components/session-review.tsx
+++ b/packages/ui/src/components/session-review.tsx
@@ -89,6 +89,8 @@ export interface SessionReviewProps {
   diffs: ReviewDiff[]
   onViewFile?: (file: string) => void
   readFile?: (path: string) => Promise<FileContent | undefined>
+  onDiscardFile?: (file: string) => void
+  discardLabel?: string
 }
 
 function ReviewCommentMenu(props: {
@@ -419,6 +421,26 @@ export const SessionReview = (props: SessionReviewProps) => {
                                         }}
                                       >
                                         <Icon name="open-file" size="small" />
+                                      </button>
+                                    </Tooltip>
+                                  </Show>
+                                  <Show when={props.onDiscardFile}>
+                                    <Tooltip
+                                      value={props.discardLabel ?? i18n.t("ui.sessionReview.discard")}
+                                      placement="top"
+                                      gutter={4}
+                                    >
+                                      <button
+                                        data-slot="session-review-discard-button"
+                                        type="button"
+                                        aria-label={props.discardLabel ?? i18n.t("ui.sessionReview.discard")}
+                                        class="text-text-weaker hover:text-icon-danger-base transition-colors"
+                                        onClick={(e) => {
+                                          e.stopPropagation()
+                                          props.onDiscardFile?.(file)
+                                        }}
+                                      >
+                                        <Icon name="reset" size="small" />
                                       </button>
                                     </Tooltip>
                                   </Show>

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -16,6 +16,7 @@ export const dict: Record<string, string> = {
   "ui.sessionReview.largeDiff.meta": "Limit: {{limit}} changed lines. Current: {{current}} changed lines.",
   "ui.sessionReview.largeDiff.renderAnyway": "Render anyway",
   "ui.sessionReview.openFile": "Open file",
+  "ui.sessionReview.discard": "Discard changes",
   "ui.sessionReview.selection.line": "line {{line}}",
   "ui.sessionReview.selection.lines": "lines {{start}}-{{end}}",
 

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -8,6 +8,7 @@ export const dict = {
   "ui.sessionReview.diffStyle.unified": "统一",
   "ui.sessionReview.diffStyle.split": "拆分",
   "ui.sessionReview.openFile": "打开文件",
+  "ui.sessionReview.discard": "丢弃更改",
   "ui.sessionReview.selection.line": "第 {{line}} 行",
   "ui.sessionReview.selection.lines": "第 {{start}}-{{end}} 行",
   "ui.sessionReview.expandAll": "全部展开",


### PR DESCRIPTION
### Issue for this PR
Closes #68

### Type of change
- [x] New feature

### What does this PR do?
Adds a "discard changes" button per file in the session/turn review panel that restores the original file content. For newly added files, the discard action deletes the file; for modified/deleted files, it writes back the original content. The button only appears in session and turn change modes (not git/branch diffs).

### How did you verify your code works?
- TDD: 6 unit tests for `discardFileDiff()` written first (RED), then implemented (GREEN)
- TypeScript type-check passes across all packages
- All existing tests continue to pass

### Checklist
- [x] I have read the [contributing guidelines](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have verified my changes work as expected