### PR TITLE
feat: shorten tab names with smart disambiguation

### DIFF
--- a/packages/app/src/components/session/session-sortable-tab.tsx
+++ b/packages/app/src/components/session/session-sortable-tab.tsx
@@ -5,12 +5,21 @@ import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { TooltipKeybind } from "@opencode-ai/ui/tooltip"
 import { Tabs } from "@opencode-ai/ui/tabs"
-import { getFilename } from "@opencode-ai/util/path"
 import { useFile } from "@/context/file"
 import { useLanguage } from "@/context/language"
 import { useCommand } from "@/context/command"
+import { computeTabLabel } from "@/utils/tab-name"
 
-export function FileVisual(props: { path: string; active?: boolean }): JSX.Element {
+export function FileVisual(props: { path: string; active?: boolean; otherPaths?: string[] }): JSX.Element {
+  const label = createMemo(() => {
+    if (props.otherPaths && props.otherPaths.length > 0) {
+      return computeTabLabel(props.path, props.otherPaths)
+    }
+    // Fallback: just use the filename
+    const parts = props.path.replace(/[\/\\]+$/, "").split(/[\/\\]/)
+    return parts[parts.length - 1] ?? ""
+  })
+
   return (
     <div class="flex items-center gap-x-1.5 min-w-0">
       <Show
@@ -22,21 +31,29 @@ export function FileVisual(props: { path: string; active?: boolean }): JSX.Eleme
           <FileIcon node={{ path: props.path, type: "file" }} mono class="absolute inset-0 size-4 tab-fileicon-mono" />
         </span>
       </Show>
-      <span class="text-14-medium truncate">{getFilename(props.path)}</span>
+      <span class="text-14-medium truncate">{label()}</span>
     </div>
   )
 }
 
-export function SortableTab(props: { tab: string; onTabClose: (tab: string) => void }): JSX.Element {
+export function SortableTab(props: { tab: string; onTabClose: (tab: string) => void; allTabs?: string[] }): JSX.Element {
   const file = useFile()
   const language = useLanguage()
   const command = useCommand()
   const sortable = createSortable(props.tab)
   const path = createMemo(() => file.pathFromTab(props.tab))
+  const otherPaths = createMemo(() => {
+    const myPath = path()
+    if (!myPath || !props.allTabs) return []
+    return props.allTabs
+      .filter((t) => t !== props.tab)
+      .map((t) => file.pathFromTab(t))
+      .filter((p): p is string => !!p && p !== myPath)
+  })
   const content = createMemo(() => {
     const value = path()
     if (!value) return
-    return <FileVisual path={value} />
+    return <FileVisual path={value} otherPaths={otherPaths()} />
   })
 
   let wrapperRef: HTMLDivElement | undefined

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -870,7 +870,7 @@ export function SessionSidePanel(props: {
                         </Tabs.Trigger>
                       </Show>
                       <SortableProvider ids={openedTabs()}>
-                        <For each={openedTabs()}>{(tab) => <SortableTab tab={tab} onTabClose={tabs().close} />}</For>
+                        <For each={openedTabs()}>{(tab) => <SortableTab tab={tab} onTabClose={tabs().close} allTabs={openedTabs()} />}</For>
                       </SortableProvider>
                       <div class="bg-background-stronger h-full shrink-0 sticky right-0 z-10 flex items-center justify-center pr-3">
                         <TooltipKeybind

--- a/packages/app/src/utils/tab-name.test.ts
+++ b/packages/app/src/utils/tab-name.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test"
+import { computeTabLabel } from "./tab-name"
+
+describe("computeTabLabel", () => {
+  test("returns filename when unique among tabs", () => {
+    const result = computeTabLabel("src/components/Button.tsx", ["src/utils/helper.ts", "README.md"])
+    expect(result).toBe("Button.tsx")
+  })
+
+  test("returns filename when it is the only tab", () => {
+    const result = computeTabLabel("src/main.ts", [])
+    expect(result).toBe("main.ts")
+  })
+
+  test("adds parent dir when filename collides", () => {
+    const result = computeTabLabel("src/utils/helper.ts", ["src/hooks/helper.ts"])
+    expect(result).toBe("utils/helper.ts")
+  })
+
+  test("adds more parent dirs if still ambiguous", () => {
+    const result = computeTabLabel("a/src/utils/helper.ts", ["b/src/utils/helper.ts"])
+    expect(result).toBe("a/src/utils/helper.ts")
+  })
+
+  test("handles root-level files without collision", () => {
+    const result = computeTabLabel("README.md", ["package.json"])
+    expect(result).toBe("README.md")
+  })
+
+  test("handles root-level files with collision", () => {
+    const result = computeTabLabel("README.md", ["subdir/README.md"])
+    expect(result).toBe("README.md")
+  })
+
+  test("handles subdir file colliding with root-level file", () => {
+    const result = computeTabLabel("subdir/README.md", ["README.md"])
+    expect(result).toBe("subdir/README.md")
+  })
+
+  test("handles three-way collision with different parents", () => {
+    const result = computeTabLabel("src/utils/helper.ts", ["src/hooks/helper.ts", "lib/helper.ts"])
+    expect(result).toBe("utils/helper.ts")
+  })
+
+  test("handles three-way collision where parent dirs also collide", () => {
+    const result = computeTabLabel("a/src/helper.ts", ["b/src/helper.ts", "c/src/helper.ts"])
+    expect(result).toBe("a/src/helper.ts")
+  })
+
+  test("handles Windows-style backslash paths", () => {
+    const result = computeTabLabel("src\\utils\\helper.ts", ["src\\hooks\\helper.ts"])
+    expect(result).toBe("utils/helper.ts")
+  })
+
+  test("handles trailing slashes", () => {
+    const result = computeTabLabel("src/utils/helper.ts/", ["src/hooks/helper.ts"])
+    expect(result).toBe("utils/helper.ts")
+  })
+})

--- a/packages/app/src/utils/tab-name.ts
+++ b/packages/app/src/utils/tab-name.ts
@@ -1,0 +1,51 @@
+/**
+ * Compute a shortened, unique tab label for a file path given the other open
+ * file paths. The algorithm progressively adds parent directories until the
+ * suffix is unique among all tabs.
+ *
+ * Examples:
+ *   "src/utils/helper.ts" with ["src/hooks/helper.ts"] => "utils/helper.ts"
+ *   "src/Button.tsx" with ["README.md"] => "Button.tsx"
+ *   "a/src/helper.ts" with ["b/src/helper.ts"] => "a/src/helper.ts"
+ */
+
+const SEP_RE = /[\/\\]/
+
+function splitPath(path: string): string[] {
+  const trimmed = path.replace(/[\/\\]+$/, "")
+  return trimmed.split(SEP_RE)
+}
+
+function getFilename(path: string): string {
+  const parts = splitPath(path)
+  return parts[parts.length - 1] ?? ""
+}
+
+export function computeTabLabel(path: string, otherPaths: string[]): string {
+  const parts = splitPath(path)
+  if (parts.length === 0) return path
+
+  // Build suffixes for every other path (one segment from the right, then two, etc.)
+  const otherSuffixes: string[][] = otherPaths.map((op) => splitPath(op))
+
+  // Starting from the rightmost segment (filename), progressively add parent
+  // segments until the suffix is unique.
+  for (let len = 1; len <= parts.length; len++) {
+    const suffix = parts.slice(-len)
+    const suffixStr = suffix.join("/")
+
+    // Check if any other path ends with the same suffix
+    const collides = otherSuffixes.some((other) => {
+      if (other.length < len) return false
+      const otherSuffix = other.slice(-len)
+      return otherSuffix.join("/") === suffixStr
+    })
+
+    if (!collides) {
+      return suffixStr
+    }
+  }
+
+  // Fallback: return the full normalized path
+  return parts.join("/")
+}


### PR DESCRIPTION
### Issue for this PR
Closes #45

### Type of change
- [x] New feature

### What does this PR do?
Displays shortened tab names when multiple documents are open. Shows just the filename when unique, and progressively adds parent directories when names collide (e.g., `utils/helper.ts` vs `hooks/helper.ts`).

The algorithm works from right to left, starting with just the filename and adding parent directory segments until the suffix is unique among all open tabs.

### How did you verify your code works?
- TDD: wrote 11 tests for the `computeTabLabel` algorithm covering unique names, collisions, multi-level disambiguation, Windows paths, and trailing slashes
- All 11 new tests pass; all 314 pre-existing passing tests remain passing
- Typecheck passes (tsgo)

### Checklist
- [x] I have read the [contributing guidelines](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have verified my changes work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)