### PR TITLE
fix: avoid bash dependency for Python on Windows, add venv support

### DIFF
--- a/packages/opencode/src/pdf-converter/image-cropper.ts
+++ b/packages/opencode/src/pdf-converter/image-cropper.ts
@@ -16,9 +16,12 @@ export async function cropImage(
   bbox: [number, number, number, number],
   outputPath: string,
 ): Promise<CropResult> {
-  const pythonPath = await findPython()
+  // Derive project directory from the image file's parent for venv detection
+  const projectDir = path.dirname(imagePath)
+  const pythonPath = await findPython(projectDir)
   if (!pythonPath) {
-    throw new Error("Python 环境不可用")
+    const pythonName = process.platform === "win32" ? "Python" : "Python3"
+    throw new Error(`${pythonName} 环境不可用`)
   }
 
   const input = JSON.stringify({

--- a/packages/opencode/src/pdf-converter/pdf-renderer.ts
+++ b/packages/opencode/src/pdf-converter/pdf-renderer.ts
@@ -5,6 +5,7 @@
 import path from "path"
 import type { PageRenderResult } from "./types"
 import { Log } from "../util/log"
+import { getAllPythonCandidates } from "../util/python-resolver"
 
 const log = Log.create({ service: "pdf-renderer" })
 
@@ -14,11 +15,11 @@ const RENDER_SCRIPT = path.join(import.meta.dir, "python", "render_page.py")
 /** 检测可用的 Python 命令 */
 let cachedPythonPath: string | null | undefined = undefined
 
-export async function findPython(): Promise<string | null> {
+export async function findPython(projectDir?: string): Promise<string | null> {
   if (cachedPythonPath !== undefined) return cachedPythonPath
 
-  // 也尝试常见的绝对路径
-  const candidates = ["python3", "python", "/usr/bin/python3", "/usr/local/bin/python3"]
+  // Use cross-platform candidates with venv detection
+  const candidates = getAllPythonCandidates(projectDir)
   for (const cmd of candidates) {
     try {
       const proc = Bun.spawn([cmd, "-c", "import fitz; from PIL import Image; print('ok')"], {
@@ -41,12 +42,13 @@ export async function findPython(): Promise<string | null> {
 }
 
 /** 检查 Python 环境是否可用 */
-export async function checkPythonAvailable(): Promise<{
+export async function checkPythonAvailable(projectDir?: string): Promise<{
   available: boolean
   pythonPath: string | null
   missingDeps: string[]
 }> {
-  for (const cmd of ["python3", "python", "/usr/bin/python3", "/usr/local/bin/python3"]) {
+  const candidates = getAllPythonCandidates(projectDir)
+  for (const cmd of candidates) {
     try {
       const proc = Bun.spawn(
         [cmd, "-c", "import sys; print(sys.version); import fitz; from PIL import Image; print('deps_ok')"],
@@ -78,7 +80,10 @@ export async function checkPythonAvailable(): Promise<{
       // 继续
     }
   }
-  return { available: false, pythonPath: null, missingDeps: ["Python3", "PyMuPDF", "Pillow"] }
+  const defaultMissing = process.platform === "win32"
+    ? ["Python", "PyMuPDF", "Pillow"]
+    : ["Python3", "PyMuPDF", "Pillow"]
+  return { available: false, pythonPath: null, missingDeps: defaultMissing }
 }
 
 /** 调用 Python 脚本渲染 PDF 页面 */
@@ -88,9 +93,12 @@ export async function renderPage(
   outputDir: string,
   dpi: number = 400,
 ): Promise<PageRenderResult> {
-  const pythonPath = await findPython()
+  // Derive project directory from the PDF file's parent directory for venv detection
+  const projectDir = path.dirname(pdfPath)
+  const pythonPath = await findPython(projectDir)
   if (!pythonPath) {
-    throw new Error("Python 环境不可用，请安装 Python3、PyMuPDF 和 Pillow")
+    const pythonName = process.platform === "win32" ? "Python" : "Python3"
+    throw new Error(`${pythonName} 环境不可用，请安装 ${pythonName}、PyMuPDF 和 Pillow`)
   }
 
   const input = JSON.stringify({

--- a/packages/opencode/src/util/python-resolver.ts
+++ b/packages/opencode/src/util/python-resolver.ts
@@ -1,0 +1,115 @@
+/**
+ * Python resolver: cross-platform Python detection with virtual environment support.
+ *
+ * On Windows, uses `python` (or `python.exe`) directly instead of relying on bash.
+ * On Unix, prefers `python3` with fallback to `python`.
+ * Detects and uses virtual environments (.venv, venv, VIRTUAL_ENV) when available.
+ */
+
+import path from "path"
+import { existsSync } from "fs"
+
+/**
+ * Returns the preferred Python command name for the current platform.
+ * - Windows: "python"
+ * - Unix: "python3"
+ */
+export function resolvePythonCommand(): string {
+  return process.platform === "win32" ? "python" : "python3"
+}
+
+/**
+ * Returns an ordered list of Python command candidates to probe.
+ * On Windows, skips Unix-only absolute paths.
+ * On Unix, includes common absolute paths as fallbacks.
+ */
+export function getPythonCandidates(): string[] {
+  const primary = resolvePythonCommand()
+  const candidates: string[] = []
+
+  if (process.platform === "win32") {
+    // On Windows: try "python", then "py" launcher
+    candidates.push("python", "py")
+  } else {
+    // On Unix: try python3 first, then python, then common absolute paths
+    candidates.push("python3", "python", "/usr/bin/python3", "/usr/local/bin/python3")
+  }
+
+  // Deduplicate in case primary is already in the list
+  return [...new Set(candidates)]
+}
+
+/**
+ * Returns the platform-specific Python binary path inside a virtual environment.
+ * - Windows: `.venv/Scripts/python.exe`
+ * - Unix: `.venv/bin/python`
+ */
+export function getVenvPythonPaths(projectDir: string): string[] {
+  const isWindows = process.platform === "win32"
+  const pythonRelPath = isWindows
+    ? path.join("Scripts", "python.exe")
+    : path.join("bin", "python")
+
+  return [
+    path.join(projectDir, ".venv", pythonRelPath),
+    path.join(projectDir, "venv", pythonRelPath),
+  ]
+}
+
+/**
+ * Searches for a Python interpreter inside a virtual environment.
+ *
+ * Checks in order:
+ * 1. VIRTUAL_ENV environment variable
+ * 2. .venv/ in the project directory
+ * 3. venv/ in the project directory
+ *
+ * Returns the absolute path to the Python binary if found, null otherwise.
+ */
+export function findVenvPython(projectDir: string): string | null {
+  const isWindows = process.platform === "win32"
+  const pythonRelPath = isWindows
+    ? path.join("Scripts", "python.exe")
+    : path.join("bin", "python")
+
+  // Check VIRTUAL_ENV environment variable first
+  const virtualEnv = process.env.VIRTUAL_ENV
+  if (virtualEnv) {
+    const venvPython = path.join(virtualEnv, pythonRelPath)
+    if (existsSync(venvPython)) {
+      return venvPython
+    }
+  }
+
+  // Check .venv/ and venv/ in the project directory
+  const venvPaths = getVenvPythonPaths(projectDir)
+  for (const venvPython of venvPaths) {
+    if (existsSync(venvPython)) {
+      return venvPython
+    }
+  }
+
+  return null
+}
+
+/**
+ * Returns all Python candidate paths in priority order:
+ * 1. Virtual environment Python (if detected)
+ * 2. Platform-appropriate command names and absolute paths
+ */
+export function getAllPythonCandidates(projectDir?: string): string[] {
+  const candidates: string[] = []
+
+  // Check for venv Python first (highest priority)
+  if (projectDir) {
+    const venvPython = findVenvPython(projectDir)
+    if (venvPython) {
+      candidates.push(venvPython)
+    }
+  }
+
+  // Add platform-specific candidates
+  candidates.push(...getPythonCandidates())
+
+  return candidates
+}

--- a/packages/opencode/test/util/python-resolver.test.ts
+++ b/packages/opencode/test/util/python-resolver.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test"
+import fs from "fs"
+import path from "path"
+import os from "os"
+
+// We import the module under test after setting up mocks
+describe("util.python-resolver", () => {
+  // Store original platform
+  const originalPlatform = process.platform
+  const originalEnv = process.env
+
+  function mockPlatform(platform: string) {
+    Object.defineProperty(process, "platform", { value: platform, configurable: true })
+  }
+
+  function restorePlatform() {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true })
+  }
+
+  describe("resolvePythonCommand", () => {
+    test("returns 'python' on Windows", async () => {
+      mockPlatform("win32")
+      // Dynamic import to pick up the platform change
+      const { resolvePythonCommand } = await import("../../src/util/python-resolver")
+      const result = resolvePythonCommand()
+      expect(result).toBe("python")
+      restorePlatform()
+    })
+
+    test("returns 'python3' on macOS", async () => {
+      mockPlatform("darwin")
+      const { resolvePythonCommand } = await import("../../src/util/python-resolver")
+      const result = resolvePythonCommand()
+      expect(result).toBe("python3")
+      restorePlatform()
+    })
+
+    test("returns 'python3' on Linux", async () => {
+      mockPlatform("linux")
+      const { resolvePythonCommand } = await import("../../src/util/python-resolver")
+      const result = resolvePythonCommand()
+      expect(result).toBe("python3")
+      restorePlatform()
+    })
+  })
+
+  describe("getPythonCandidates", () => {
+    test("includes Windows-specific paths on win32", async () => {
+      mockPlatform("win32")
+      const { getPythonCandidates } = await import("../../src/util/python-resolver")
+      const candidates = getPythonCandidates()
+      expect(candidates[0]).toBe("python")
+      // Should NOT include Unix-only paths
+      expect(candidates).not.toContain("/usr/bin/python3")
+      expect(candidates).not.toContain("/usr/local/bin/python3")
+      restorePlatform()
+    })
+
+    test("includes Unix paths on darwin", async () => {
+      mockPlatform("darwin")
+      const { getPythonCandidates } = await import("../../src/util/python-resolver")
+      const candidates = getPythonCandidates()
+      expect(candidates[0]).toBe("python3")
+      expect(candidates).toContain("python")
+      expect(candidates).toContain("/usr/bin/python3")
+      expect(candidates).toContain("/usr/local/bin/python3")
+      restorePlatform()
+    })
+  })
+
+  describe("findVenvPython", () => {
+    test("returns venv python path when .venv exists (Unix)", async () => {
+      const { findVenvPython } = await import("../../src/util/python-resolver")
+      // Create a temporary directory structure
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "python-resolver-test-"))
+      const venvBin = path.join(tmpDir, ".venv", "bin")
+      fs.mkdirSync(venvBin, { recursive: true })
+      const pythonPath = path.join(venvBin, "python")
+      fs.writeFileSync(pythonPath, "", { mode: 0o755 })
+
+      mockPlatform("darwin")
+      const result = findVenvPython(tmpDir)
+      expect(result).toBe(pythonPath)
+
+      // Cleanup
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+      restorePlatform()
+    })
+
+    test("returns venv python path when .venv exists (Windows)", async () => {
+      const { findVenvPython } = await import("../../src/util/python-resolver")
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "python-resolver-test-"))
+      const venvScripts = path.join(tmpDir, ".venv", "Scripts")
+      fs.mkdirSync(venvScripts, { recursive: true })
+      const pythonExe = path.join(venvScripts, "python.exe")
+      fs.writeFileSync(pythonExe, "")
+
+      mockPlatform("win32")
+      const result = findVenvPython(tmpDir)
+      expect(result).toBe(pythonExe)
+
+      // Cleanup
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+      restorePlatform()
+    })
+
+    test("returns venv python path when venv/ exists (Unix)", async () => {
+      const { findVenvPython } = await import("../../src/util/python-resolver")
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "python-resolver-test-"))
+      const venvBin = path.join(tmpDir, "venv", "bin")
+      fs.mkdirSync(venvBin, { recursive: true })
+      const pythonPath = path.join(venvBin, "python")
+      fs.writeFileSync(pythonPath, "", { mode: 0o755 })
+
+      mockPlatform("darwin")
+      const result = findVenvPython(tmpDir)
+      expect(result).toBe(pythonPath)
+
+      // Cleanup
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+      restorePlatform()
+    })
+
+    test("returns null when no venv found", async () => {
+      const { findVenvPython } = await import("../../src/util/python-resolver")
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "python-resolver-test-"))
+
+      mockPlatform("darwin")
+      const result = findVenvPython(tmpDir)
+      expect(result).toBeNull()
+
+      // Cleanup
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+      restorePlatform()
+    })
+
+    test("respects VIRTUAL_ENV environment variable", async () => {
+      const { findVenvPython } = await import("../../src/util/python-resolver")
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "python-resolver-test-"))
+      const venvBin = path.join(tmpDir, "bin")
+      fs.mkdirSync(venvBin, { recursive: true })
+      const pythonPath = path.join(venvBin, "python")
+      fs.writeFileSync(pythonPath, "", { mode: 0o755 })
+
+      // Set VIRTUAL_ENV
+      const origVenv = process.env.VIRTUAL_ENV
+      process.env.VIRTUAL_ENV = tmpDir
+
+      mockPlatform("darwin")
+      const result = findVenvPython("/some/other/project")
+      expect(result).toBe(pythonPath)
+
+      // Cleanup
+      if (origVenv !== undefined) {
+        process.env.VIRTUAL_ENV = origVenv
+      } else {
+        delete process.env.VIRTUAL_ENV
+      }
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+      restorePlatform()
+    })
+  })
+
+  describe("getVenvPythonPaths", () => {
+    test("returns Windows paths on win32", async () => {
+      mockPlatform("win32")
+      const { getVenvPythonPaths } = await import("../../src/util/python-resolver")
+      const paths = getVenvPythonPaths("/project")
+      expect(paths).toEqual([
+        path.join("/project", ".venv", "Scripts", "python.exe"),
+        path.join("/project", "venv", "Scripts", "python.exe"),
+      ])
+      restorePlatform()
+    })
+
+    test("returns Unix paths on darwin", async () => {
+      mockPlatform("darwin")
+      const { getVenvPythonPaths } = await import("../../src/util/python-resolver")
+      const paths = getVenvPythonPaths("/project")
+      expect(paths).toEqual([
+        path.join("/project", ".venv", "bin", "python"),
+        path.join("/project", "venv", "bin", "python"),
+      ])
+      restorePlatform()
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR
Closes #57

### Type of change
- [x] Bug fix

### What does this PR do?
Replaces hardcoded Unix-only Python candidate paths (`python3`, `/usr/bin/python3`, `/usr/local/bin/python3`) with a cross-platform `python-resolver` utility. On Windows, uses `python`/`py` directly without depending on bash. Adds virtual environment detection (`.venv`, `venv`, `VIRTUAL_ENV` env var) so projects with virtual environments automatically use the correct Python interpreter.

### How did you verify your code works?
- TDD: wrote 12 tests for platform detection, venv discovery, and candidate generation
- All 12 new tests pass, all 133 existing util tests pass, no regressions in full test suite (1530 pass, 18 pre-existing failures unrelated to this change)
- TypeScript type checking passes across all 12 packages

### Checklist
- [x] I have read the [contributing guidelines](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have verified my changes work as expected