### PR TITLE
feat: configurable config directory name via OPENCODE_CONFIG_DIR_NAME

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -1,4 +1,5 @@
 import { Config } from "../config/config"
+import { getConfigDirName } from "../config/dirname"
 import z from "zod"
 import { Provider } from "../provider/provider"
 import { ModelID, ProviderID } from "../provider/schema"
@@ -132,7 +133,7 @@ export namespace Agent {
                   },
                   edit: {
                     "*": "deny",
-                    [path.join(".opencode", "plans", "*.md")]: "allow",
+                    [path.join(getConfigDirName(), "plans", "*.md")]: "allow",
                     [path.relative(Instance.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]:
                       "allow",
                   },

--- a/packages/opencode/src/cli/cmd/agent.ts
+++ b/packages/opencode/src/cli/cmd/agent.ts
@@ -9,6 +9,7 @@ import fs from "fs/promises"
 import { Filesystem } from "../../util/filesystem"
 import matter from "gray-matter"
 import { Instance } from "../../project/instance"
+import { getConfigDirName } from "../../config/dirname"
 import { EOL } from "os"
 import type { Argv } from "yargs"
 
@@ -87,7 +88,7 @@ const AgentCreateCommand = cmd({
             scope = scopeResult
           }
           targetPath = path.join(
-            scope === "global" ? Global.Path.config : path.join(Instance.worktree, ".opencode"),
+            scope === "global" ? Global.Path.config : path.join(Instance.worktree, getConfigDirName()),
             "agent",
           )
         }

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -15,6 +15,7 @@ import { Global } from "../../global"
 import { modify, applyEdits } from "jsonc-parser"
 import { Filesystem } from "../../util/filesystem"
 import { Bus } from "../../bus"
+import { getConfigDirName } from "../../config/dirname"
 
 function getAuthStatusIcon(status: MCP.AuthStatus): string {
   switch (status) {
@@ -381,11 +382,12 @@ export const McpLogoutCommand = cmd({
 })
 
 async function resolveConfigPath(baseDir: string, global = false) {
-  // Check for existing config files (prefer .jsonc over .json, check .opencode/ subdirectory too)
+  // Check for existing config files (prefer .jsonc over .json, check config dir subdirectory too)
   const candidates = [path.join(baseDir, "opencode.json"), path.join(baseDir, "opencode.jsonc")]
 
   if (!global) {
-    candidates.push(path.join(baseDir, ".opencode", "opencode.json"), path.join(baseDir, ".opencode", "opencode.jsonc"))
+    const configDirName = getConfigDirName()
+    candidates.push(path.join(baseDir, configDirName, "opencode.json"), path.join(baseDir, configDirName, "opencode.jsonc"))
   }
 
   for (const candidate of candidates) {

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -3,6 +3,7 @@ import path from "path"
 import { createEffect, createMemo, onCleanup, onMount } from "solid-js"
 import { createSimpleContext } from "./helper"
 import { Glob } from "../../../../util/glob"
+import { getConfigDirName } from "@/config/dirname"
 import aura from "./theme/aura.json" with { type: "json" }
 import ayu from "./theme/ayu.json" with { type: "json" }
 import catppuccin from "./theme/catppuccin.json" with { type: "json" }
@@ -438,7 +439,7 @@ async function getCustomThemes() {
     Global.Path.config,
     ...(await Array.fromAsync(
       Filesystem.up({
-        targets: [".opencode"],
+        targets: [getConfigDirName()],
         start: process.cwd(),
       }),
     )),

--- a/packages/opencode/src/cli/cmd/uninstall.ts
+++ b/packages/opencode/src/cli/cmd/uninstall.ts
@@ -8,6 +8,7 @@ import path from "path"
 import os from "os"
 import { Filesystem } from "../../util/filesystem"
 import { Process } from "../../util/process"
+import { getConfigDirName } from "@/config/dirname"
 
 interface UninstallArgs {
   keepConfig: boolean
@@ -215,7 +216,7 @@ async function executeUninstall(method: Installation.Method, targets: RemovalTar
     prompts.log.info(`  rm "${targets.binary}"`)
 
     const binDir = path.dirname(targets.binary)
-    if (binDir.includes(".opencode")) {
+    if (binDir.includes(getConfigDirName())) {
       prompts.log.info(`  rmdir "${binDir}" 2>/dev/null`)
     }
   }
@@ -266,7 +267,8 @@ async function getShellConfigFile(): Promise<string | null> {
     if (!exists) continue
 
     const content = await Filesystem.readText(file).catch(() => "")
-    if (content.includes("# opencode") || content.includes(".opencode/bin")) {
+    const configDirName = getConfigDirName()
+    if (content.includes("# opencode") || content.includes(`${configDirName}/bin`)) {
       return file
     }
   }
@@ -277,6 +279,7 @@ async function getShellConfigFile(): Promise<string | null> {
 async function cleanShellConfig(file: string) {
   const content = await Filesystem.readText(file)
   const lines = content.split("\n")
+  const configDirName = getConfigDirName()
 
   const filtered: string[] = []
   let skip = false
@@ -291,14 +294,14 @@ async function cleanShellConfig(file: string) {
 
     if (skip) {
       skip = false
-      if (trimmed.includes(".opencode/bin") || trimmed.includes("fish_add_path")) {
+      if (trimmed.includes(`${configDirName}/bin`) || trimmed.includes("fish_add_path")) {
         continue
       }
     }
 
     if (
-      (trimmed.startsWith("export PATH=") && trimmed.includes(".opencode/bin")) ||
-      (trimmed.startsWith("fish_add_path") && trimmed.includes(".opencode"))
+      (trimmed.startsWith("export PATH=") && trimmed.includes(`${configDirName}/bin`)) ||
+      (trimmed.startsWith("fish_add_path") && trimmed.includes(configDirName))
     ) {
       continue
     }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -35,6 +35,7 @@ import { proxied } from "@/util/proxied"
 import { iife } from "@/util/iife"
 import { Account } from "@/account"
 import { ConfigPaths } from "./paths"
+import { getConfigDirName } from "./dirname"
 import { Filesystem } from "@/util/filesystem"
 import matter from "gray-matter"
 import { Process } from "@/util/process"
@@ -142,7 +143,7 @@ export namespace Config {
     const deps = []
 
     for (const dir of unique(directories)) {
-      if (dir.endsWith(".opencode") || dir === Flag.OPENCODE_CONFIG_DIR) {
+      if (dir.endsWith(getConfigDirName()) || dir === Flag.OPENCODE_CONFIG_DIR) {
         for (const file of ["opencode.jsonc", "opencode.json"]) {
           log.debug(`loading config from ${path.join(dir, file)}`)
           result = mergeConfigConcatArrays(result, await loadFile(path.join(dir, file)))
@@ -401,7 +402,7 @@ export namespace Config {
       })
       if (!md) continue
 
-      const patterns = ["/.opencode/command/", "/.opencode/commands/", "/command/", "/commands/"]
+      const patterns = [`/${getConfigDirName()}/command/`, `/${getConfigDirName()}/commands/`, "/command/", "/commands/"]
       const file = rel(item, patterns) ?? path.basename(item)
       const name = trim(file)
 
@@ -440,7 +441,7 @@ export namespace Config {
       })
       if (!md) continue
 
-      const patterns = ["/.opencode/agent/", "/.opencode/agents/", "/agent/", "/agents/"]
+      const patterns = [`/${getConfigDirName()}/agent/`, `/${getConfigDirName()}/agents/`, "/agent/", "/agents/"]
       const file = rel(item, patterns) ?? path.basename(item)
       const agentName = trim(file)
 
@@ -1362,13 +1363,13 @@ export namespace Config {
   })
   export type DefaultSkill = z.infer<typeof DefaultSkill>
 
-  // Search upward from process.cwd() for .opencode/skills, calculated once at startup.
+  // Search upward from process.cwd() for <configDir>/skills, calculated once at startup.
   // This ensures the source skills dir is always the server's own project regardless of
   // which project the user is currently viewing.
   function findServerSkillsDirSync(): string | undefined {
     let dir = process.cwd()
     while (true) {
-      const candidate = path.join(dir, ".opencode", "skills")
+      const candidate = path.join(dir, getConfigDirName(), "skills")
       try {
         if (statSync(candidate).isDirectory()) return candidate
       } catch {}
@@ -1420,7 +1421,7 @@ export namespace Config {
 
   export async function saveDefaultSkill(name: string, description: string, content: string): Promise<void> {
     const skillsDir = getDefaultSkillsDir()
-    if (!skillsDir) throw new Error("No .opencode directory found")
+    if (!skillsDir) throw new Error(`No ${getConfigDirName()} directory found`)
     const skillDir = path.join(skillsDir, name)
     await fs.mkdir(skillDir, { recursive: true })
     const skillFile = path.join(skillDir, "SKILL.md")
@@ -1430,7 +1431,7 @@ export namespace Config {
 
   export async function deleteDefaultSkill(name: string): Promise<void> {
     const skillsDir = getDefaultSkillsDir()
-    if (!skillsDir) throw new Error("No .opencode directory found")
+    if (!skillsDir) throw new Error(`No ${getConfigDirName()} directory found`)
     const skillDir = path.join(skillsDir, name)
     await fs.rm(skillDir, { recursive: true, force: true })
   }
@@ -1440,8 +1441,8 @@ export namespace Config {
     const sourceSkillsDir = getDefaultSkillsDir()
     if (!sourceSkillsDir) return []
 
-    // Target: the currently viewed project (.opencode/skills/ under Instance.directory)
-    const targetSkillsDir = path.join(Instance.directory, ".opencode", "skills")
+    // Target: the currently viewed project (<configDir>/skills/ under Instance.directory)
+    const targetSkillsDir = path.join(Instance.directory, getConfigDirName(), "skills")
     await fs.mkdir(targetSkillsDir, { recursive: true })
 
     // Copy each skill directory from source to target

--- a/packages/opencode/src/config/dirname.test.ts
+++ b/packages/opencode/src/config/dirname.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test"
+import { getConfigDirName } from "./dirname"
+
+describe("getConfigDirName", () => {
+  test("defaults to .opencode when env variable is not set", () => {
+    delete process.env.OPENCODE_CONFIG_DIR_NAME
+    const dir = getConfigDirName()
+    expect(dir).toBe(".opencode")
+  })
+
+  test("uses custom name from OPENCODE_CONFIG_DIR_NAME env variable", () => {
+    process.env.OPENCODE_CONFIG_DIR_NAME = ".aether"
+    const dir = getConfigDirName()
+    expect(dir).toBe(".aether")
+    delete process.env.OPENCODE_CONFIG_DIR_NAME
+  })
+
+  test("returns .opencode when OPENCODE_CONFIG_DIR_NAME is empty string", () => {
+    process.env.OPENCODE_CONFIG_DIR_NAME = ""
+    const dir = getConfigDirName()
+    expect(dir).toBe(".opencode")
+    delete process.env.OPENCODE_CONFIG_DIR_NAME
+  })
+
+  test("trims whitespace from env value", () => {
+    process.env.OPENCODE_CONFIG_DIR_NAME = "  .myconfig  "
+    const dir = getConfigDirName()
+    expect(dir).toBe(".myconfig")
+    delete process.env.OPENCODE_CONFIG_DIR_NAME
+  })
+})

--- a/packages/opencode/src/config/dirname.ts
+++ b/packages/opencode/src/config/dirname.ts
@@ -1,0 +1,13 @@
+/**
+ * Centralized resolution of the config directory name.
+ *
+ * The default is `.opencode` for backward compatibility.  Users can override
+ * the name by setting `OPENCODE_CONFIG_DIR_NAME` (e.g. `.aether`,
+ * `.config/opencode`).  The value must be a relative directory name / path,
+ * **not** an absolute path – use `OPENCODE_CONFIG_DIR` for that.
+ */
+const DEFAULT_CONFIG_DIR_NAME = ".opencode"
+
+export function getConfigDirName(): string {
+  return process.env.OPENCODE_CONFIG_DIR_NAME?.trim() || DEFAULT_CONFIG_DIR_NAME
+}

--- a/packages/opencode/src/config/paths.ts
+++ b/packages/opencode/src/config/paths.ts
@@ -6,6 +6,7 @@ import { NamedError } from "@opencode-ai/util/error"
 import { Filesystem } from "@/util/filesystem"
 import { Flag } from "@/flag/flag"
 import { Global } from "@/global"
+import { getConfigDirName } from "./dirname"
 
 export namespace ConfigPaths {
   export async function projectFiles(name: string, directory: string, worktree: string) {
@@ -23,13 +24,14 @@ export namespace ConfigPaths {
     // Include the directory next to the binary so bundled default skills are found
     // when running a compiled single binary (e.g. dist/.../bin/aether + dist/.../bin/.opencode/skills/)
     const binaryDir = path.dirname(process.execPath)
+    const configDirName = getConfigDirName()
 
     return [
       Global.Path.config,
       ...(!Flag.OPENCODE_DISABLE_PROJECT_CONFIG
         ? await Array.fromAsync(
             Filesystem.up({
-              targets: [".opencode"],
+              targets: [configDirName],
               start: directory,
               stop: worktree,
             }),
@@ -37,14 +39,14 @@ export namespace ConfigPaths {
         : []),
       ...(await Array.fromAsync(
         Filesystem.up({
-          targets: [".opencode"],
+          targets: [configDirName],
           start: Global.Path.home,
           stop: Global.Path.home,
         }),
       )),
       ...(await Array.fromAsync(
         Filesystem.up({
-          targets: [".opencode"],
+          targets: [configDirName],
           start: binaryDir,
           stop: binaryDir,
         }),

--- a/packages/opencode/src/config/tui.ts
+++ b/packages/opencode/src/config/tui.ts
@@ -8,6 +8,7 @@ import { TuiInfo } from "./tui-schema"
 import { Instance } from "@/project/instance"
 import { Flag } from "@/flag/flag"
 import { Log } from "@/util/log"
+import { getConfigDirName } from "./dirname"
 import { Global } from "@/global"
 
 export namespace TuiConfig {
@@ -54,7 +55,7 @@ export namespace TuiConfig {
     }
 
     for (const dir of unique(directories)) {
-      if (!dir.endsWith(".opencode") && dir !== Flag.OPENCODE_CONFIG_DIR) continue
+      if (!dir.endsWith(getConfigDirName()) && dir !== Flag.OPENCODE_CONFIG_DIR) continue
       for (const file of ConfigPaths.fileInDirectory(dir, "tui")) {
         result = mergeInfo(result, await loadFile(file))
       }

--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -13,6 +13,7 @@ import { text } from "node:stream/consumers"
 
 import { ZipReader, BlobReader, BlobWriter } from "@zip.js/zip.js"
 import { Log } from "@/util/log"
+import { getConfigDirName } from "@/config/dirname"
 
 export namespace Ripgrep {
   const log = Log.create({ service: "ripgrep" })
@@ -292,7 +293,7 @@ export namespace Ripgrep {
 
     const root: Node = { name: "", children: new Map() }
     for (const file of files) {
-      if (file.includes(".opencode")) continue
+      if (file.includes(getConfigDirName())) continue
       const parts = file.split(path.sep)
       if (parts.length < 2) continue
       let node = root

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -8,6 +8,7 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import path from "path"
 import z from "zod"
 import { BusEvent } from "@/bus/bus-event"
+import { getConfigDirName } from "@/config/dirname"
 import { Flag } from "../flag/flag"
 import { Log } from "../util/log"
 
@@ -172,7 +173,7 @@ export namespace Installation {
         )
 
         const methodImpl = Effect.fn("Installation.method")(function* () {
-          if (process.execPath.includes(path.join(".opencode", "bin"))) return "curl" as Method
+          if (process.execPath.includes(path.join(getConfigDirName(), "bin"))) return "curl" as Method
           if (process.execPath.includes(path.join(".local", "bin"))) return "curl" as Method
           const exec = process.execPath.toLowerCase()
 

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -6,6 +6,7 @@ import { Decimal } from "decimal.js"
 import z from "zod"
 import { type ProviderMetadata } from "ai"
 import { Config } from "../config/config"
+import { getConfigDirName } from "../config/dirname"
 import { Flag } from "../flag/flag"
 import { Installation } from "../installation"
 
@@ -355,7 +356,7 @@ export namespace Session {
 
   export function plan(input: { slug: string; time: { created: number } }) {
     const base = Instance.project.vcs
-      ? path.join(Instance.worktree, ".opencode", "plans")
+      ? path.join(Instance.worktree, getConfigDirName(), "plans")
       : path.join(Global.Path.data, "plans")
     return path.join(base, [input.time.created, input.slug].join("-") + ".md")
   }


### PR DESCRIPTION
### Issue for this PR
Closes #58

### Type of change
- [x] New feature

### What does this PR do?
Makes the `.opencode` configuration directory name configurable via the `OPENCODE_CONFIG_DIR_NAME` environment variable. Defaults to `.opencode` for full backward compatibility. Users can set `OPENCODE_CONFIG_DIR_NAME=.aether` to use a custom directory name.

Changes:
- Creates `packages/opencode/src/config/dirname.ts` with `getConfigDirName()` that reads from `OPENCODE_CONFIG_DIR_NAME` env var (with whitespace trimming)
- Creates `packages/opencode/src/config/dirname.test.ts` with 4 tests (default, custom, empty string, whitespace trim)
- Replaces all hardcoded `".opencode"` string literals across 11 files with `getConfigDirName()`
- Files updated: agent.ts, cli/cmd/agent.ts, cli/cmd/mcp.ts, cli/cmd/tui/context/theme.tsx, cli/cmd/uninstall.ts, config/config.ts, config/paths.ts, config/tui.ts, file/ripgrep.ts, installation/index.ts, session/index.ts

### How did you verify your code works?
- TDD: wrote tests for default, custom, empty string, and whitespace-trimmed env values
- All 4 new tests pass
- Full typecheck passes across all 19 packages
- Backward compatible (defaults to .opencode)

### Checklist
- [x] I have read the [contributing guidelines](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have verified my changes work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)