### PR TITLE
fix: prevent PDF viewer focus stealing and improve translation quality

### DIFF
--- a/packages/opencode/src/markdown-translator/chunker.test.ts
+++ b/packages/opencode/src/markdown-translator/chunker.test.ts
@@ -1,0 +1,373 @@
+import { describe, expect, test } from "bun:test"
+import { chunkByContent } from "./chunker"
+
+describe("chunkByContent", () => {
+  test("splits by ## headings", () => {
+    const md = `# Title
+
+Intro paragraph.
+
+## Section 1
+
+Content of section 1.
+
+## Section 2
+
+Content of section 2.`
+    const chunks = chunkByContent(md)
+    expect(chunks.length).toBe(3)
+    expect(chunks[0]).toContain("Intro paragraph")
+    expect(chunks[1]).toContain("Section 1")
+    expect(chunks[2]).toContain("Section 2")
+  })
+
+  test("splits by blank lines when no ## headings", () => {
+    const md = `First paragraph.
+
+
+Second paragraph.
+
+
+Third paragraph.`
+    const chunks = chunkByContent(md)
+    expect(chunks.length).toBe(3)
+  })
+
+  test("treats single blank line as same chunk (paragraph continuation)", () => {
+    const md = `First paragraph.
+
+Second paragraph.`
+    const chunks = chunkByContent(md)
+    // Single blank line = paragraph break within same chunk
+    expect(chunks.length).toBe(1)
+    expect(chunks[0]).toContain("First paragraph")
+    expect(chunks[0]).toContain("Second paragraph")
+  })
+
+  test("preserves code blocks within a chunk", () => {
+    const md = `## Code Example
+
+Here is some code:
+
+\`\`\`python
+def hello():
+    print("hello")
+
+    for i in range(10):
+        print(i)
+\`\`\`
+
+After code.`
+    const chunks = chunkByContent(md)
+    expect(chunks.length).toBe(1)
+    expect(chunks[0]).toContain("```python")
+    expect(chunks[0]).toContain("```")
+  })
+
+  test("preserves math blocks within a chunk", () => {
+    const md = `## Equations
+
+The energy-mass relation:
+
+$$
+E = mc^2
+$$
+
+And the momentum: $p = mv$.`
+    const chunks = chunkByContent(md)
+    expect(chunks.length).toBe(1)
+    expect(chunks[0]).toContain("$$")
+    expect(chunks[0]).toContain("$p = mv$")
+  })
+
+  test("handles scientific paper with mixed sections", () => {
+    const md = `# Paper Title
+
+Abstract text here.
+
+## Introduction
+
+Some intro text with formula $E = mc^2$.
+
+## Methods
+
+We used the following approach:
+
+1. Step one
+2. Step two
+
+## Results
+
+| Experiment | Value |
+| --- | --- |
+| A | 1.0 |
+| B | 2.0 |
+
+## Conclusion
+
+Final remarks.`
+    const chunks = chunkByContent(md)
+    expect(chunks.length).toBe(5)
+  })
+
+  test("handles empty content", () => {
+    expect(chunkByContent("")).toHaveLength(0)
+    expect(chunkByContent("   \n  \n  ")).toHaveLength(0)
+  })
+
+  test("handles single paragraph without headings", () => {
+    const md = "Just a single paragraph of text."
+    const chunks = chunkByContent(md)
+    expect(chunks.length).toBe(1)
+    expect(chunks[0]).toBe("Just a single paragraph of text.")
+  })
+
+  test("does not split code blocks across chunks", () => {
+    const code = "x".repeat(2000)
+    const md = `## Section
+
+Intro text.
+
+\`\`\`python
+${code}
+\`\`\`
+
+More text after code.
+
+## Next Section
+
+Another section.`
+    const chunks = chunkByContent(md)
+    // The code block should stay in the same chunk as its section
+    const codeChunk = chunks.find(c => c.includes("```python"))
+    expect(codeChunk).toBeDefined()
+    expect(codeChunk!.includes("```")).toBe(true)
+    // Opening and closing backtick fences should be in the same chunk
+    const fences = codeChunk!.match(/```/g)
+    expect(fences).toHaveLength(2)
+  })
+
+  test("does not split display math across chunks", () => {
+    const formula = "x".repeat(500)
+    const md = `## Derivation
+
+Starting from:
+
+$$
+${formula}
+$$
+
+We conclude.`
+    const chunks = chunkByContent(md)
+    expect(chunks.length).toBe(1)
+    expect(chunks[0]).toContain("$$")
+  })
+
+  test("handles table staying in one chunk", () => {
+    const md = `## Results
+
+Our measurements:
+
+| Name | Value | Error |
+| --- | --- | --- |
+| alpha | 1.234 | 0.001 |
+| beta | 5.678 | 0.002 |
+| gamma | 9.012 | 0.003 |
+
+Discussion of results.`
+    const chunks = chunkByContent(md)
+    expect(chunks.length).toBe(1)
+    const tableChunk = chunks[0]
+    expect(tableChunk).toContain("| Name |")
+    expect(tableChunk).toContain("| gamma |")
+  })
+
+  test("handles consecutive headings without body", () => {
+    const md = `## A
+## B
+## C
+Content here.`
+    const chunks = chunkByContent(md)
+    // Each heading creates a new chunk; C has content
+    expect(chunks.length).toBeGreaterThanOrEqual(1)
+  })
+
+  test("preserves ### subheadings within a ## chunk", () => {
+    const md = `## Methods
+
+### Part A
+
+Content A.
+
+### Part B
+
+Content B.`
+    const chunks = chunkByContent(md)
+    expect(chunks.length).toBe(1)
+    expect(chunks[0]).toContain("### Part A")
+    expect(chunks[0]).toContain("### Part B")
+  })
+
+  test("does not split inside fenced code blocks even with internal blank lines", () => {
+    const md = `## Code
+
+Intro.
+
+\`\`\`python
+def foo():
+    pass
+
+def bar():
+    pass
+\`\`\`
+
+Post-code.`
+    const chunks = chunkByContent(md)
+    const codeChunk = chunks.find(c => c.includes("```python"))
+    expect(codeChunk).toBeDefined()
+    // The code block must not be split across chunks
+    expect(codeChunk!.includes("def bar")).toBe(true)
+    expect(codeChunk!.includes("Post-code")).toBe(true)
+  })
+
+  test("handles $$ math with blank lines inside", () => {
+    const md = `## Math
+
+Some text.
+
+$$
+\\begin{aligned}
+a &= b \\\\
+c &= d
+\\end{aligned}
+$$
+
+After math.`
+    const chunks = chunkByContent(md)
+    const mathChunk = chunks.find(c => c.includes("$$"))
+    expect(mathChunk).toBeDefined()
+    expect(mathChunk!.includes("\\begin{aligned}")).toBe(true)
+    expect(mathChunk!.includes("After math")).toBe(true)
+  })
+
+  test("does not split markdown table with blank rows", () => {
+    const md = `## Data
+
+Header text.
+
+| A | B |
+| --- | --- |
+| 1 | 2 |
+
+| 3 | 4 |
+| 5 | 6 |
+
+Footer text.`
+    const chunks = chunkByContent(md)
+    const tableChunk = chunks.find(c => c.includes("| A |"))
+    expect(tableChunk).toBeDefined()
+    expect(tableChunk!.includes("| 5 |")).toBe(true)
+  })
+
+  test("does not treat ## inside fenced code blocks as headings", () => {
+    const md = `## Section
+
+Before code.
+
+\`\`\`markdown
+## This is inside a code block
+
+Some text inside the block.
+\`\`\`
+
+After code.`
+    const chunks = chunkByContent(md)
+    expect(chunks.length).toBe(1)
+    // The ## inside the code block must NOT cause a split
+    expect(chunks[0]).toContain("## This is inside a code block")
+    expect(chunks[0]).toContain("After code")
+  })
+
+  test("does not split $$ display math in splitLargeChunk", () => {
+    const para = "x".repeat(4000)
+    const md = `${para}
+
+Starting text.
+
+$$
+E = mc^2
+
+F = ma
+$$
+
+Ending text.`
+    const chunks = chunkByContent(md)
+    // The $$ block must not be split
+    const mathChunk = chunks.find(c => c.includes("$$"))
+    expect(mathChunk).toBeDefined()
+    expect(mathChunk!.includes("E = mc^2")).toBe(true)
+    expect(mathChunk!.includes("F = ma")).toBe(true)
+  })
+
+  test("does not split fenced code blocks in splitLargeChunk", () => {
+    const para = "x".repeat(4000)
+    const md = `${para}
+
+Intro.
+
+\`\`\`python
+def foo():
+    pass
+
+def bar():
+    pass
+\`\`\`
+
+Post.`
+    const chunks = chunkByContent(md)
+    const codeChunk = chunks.find(c => c.includes("```python"))
+    expect(codeChunk).toBeDefined()
+    expect(codeChunk!.includes("def bar")).toBe(true)
+  })
+
+  test("handles nested code blocks with different fence lengths", () => {
+    const md = `## Example
+
+Before.
+
+\`\`\`
+Inside outer code block.
+## Fake heading
+
+More code.
+\`\`\`
+
+After.`
+    const chunks = chunkByContent(md)
+    expect(chunks.length).toBe(1)
+    expect(chunks[0]).toContain("## Fake heading")
+    expect(chunks[0]).toContain("After")
+  })
+
+  test("respects ### sub-headings as boundaries within ## sections when content is large", () => {
+    const para = "x".repeat(3000)
+    const md = `## Methods
+
+${para}
+
+### Submethod A
+
+Content about submethod A.
+
+### Submethod B
+
+Content about submethod B.`
+    const chunks = chunkByContent(md)
+    // The large initial paragraph and sub-methods should be logically grouped
+    expect(chunks.length).toBeGreaterThanOrEqual(1)
+    // Verify sub-headings are preserved
+    const allText = chunks.join(" ")
+    expect(allText).toContain("### Submethod A")
+    expect(allText).toContain("### Submethod B")
+  })
+})

--- a/packages/opencode/src/markdown-translator/chunker.ts
+++ b/packages/opencode/src/markdown-translator/chunker.ts
@@ -49,8 +49,8 @@ export function chunkByContent(content: string): string[] {
     // 按 ## 标题分块
     rawChunks = splitByHeading(content)
   } else {
-    // 按连续空行分块
-    rawChunks = content.split(/\n{3,}/).filter((c) => c.trim().length > 0)
+    // 按连续空行分块（保护代码块、公式、表格）
+    rawChunks = splitSafeParagraphs(content)
   }
 
   // 如果只有一个块且内容为空，返回空
@@ -69,14 +69,45 @@ export function chunkByContent(content: string): string[] {
   return result
 }
 
-/** 按 ## 标题分块 */
+/** Track whether a line is inside a fenced code block */
+function isInCodeBlock(lines: string[]): boolean[] {
+  const flags: boolean[] = new Array(lines.length).fill(false)
+  let inside = false
+  let fenceLen = 0
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!
+    if (!inside) {
+      const m = line.match(/^(>{0,3})\s*(`{3,}|~{3,})/)
+      if (m) {
+        inside = true
+        fenceLen = m[2]!.length
+        flags[i] = false // opening fence itself is not "inside"
+        continue
+      }
+    } else {
+      const m = line.match(/^\s*(`{3,}|~{3,})\s*$/)
+      if (m && m[1]!.length >= fenceLen) {
+        inside = false
+        flags[i] = false
+        continue
+      }
+    }
+    flags[i] = inside
+  }
+  return flags
+}
+
+/** 按 ## 标题分块（不拆分代码块内部） */
 function splitByHeading(content: string): string[] {
   const lines = content.split("\n")
+  const codeFlags = isInCodeBlock(lines)
   const chunks: string[] = []
   let current: string[] = []
 
-  for (const line of lines) {
-    if (/^## /.test(line) && current.length > 0) {
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!
+    // Only split on ## headings that are NOT inside a fenced code block
+    if (/^## /.test(line) && current.length > 0 && !codeFlags[i]) {
       const text = current.join("\n").trim()
       if (text) chunks.push(text)
       current = []
@@ -92,9 +123,76 @@ function splitByHeading(content: string): string[] {
   return chunks
 }
 
-/** 在段落边界处拆分超大块 */
+/**
+ * Split a string by triple-or-more newlines while keeping $$ math blocks,
+ * fenced code blocks, and tables intact as single units.
+ */
+function splitSafeParagraphs(chunk: string): string[] {
+  // Collect ranges that must not be split across
+  const protectedRanges: [number, number][] = []
+
+  // Protect fenced code blocks
+  for (const m of chunk.matchAll(/```[\s\S]*?```/g)) {
+    if (m.index !== undefined) protectedRanges.push([m.index, m.index + m[0].length])
+  }
+
+  // Protect $$ ... $$ (non-greedy, including newlines)
+  for (const m of chunk.matchAll(/\$\$[\s\S]*?\$\$/g)) {
+    if (m.index !== undefined) protectedRanges.push([m.index, m.index + m[0].length])
+  }
+
+  // Protect single-dollar block math ($ on its own line)
+  for (const m of chunk.matchAll(/^\$\s*\n[\s\S]*?\n\$\s*$/gm)) {
+    if (m.index !== undefined) protectedRanges.push([m.index, m.index + m[0].length])
+  }
+
+  // Protect tables: lines starting with | (header + separator + data rows)
+  // Find contiguous groups of | lines
+  const lines = chunk.split("\n")
+  let tableStart = -1
+  for (let i = 0; i < lines.length; i++) {
+    if (/^\s*\|/.test(lines[i]!)) {
+      if (tableStart === -1) tableStart = i
+    } else {
+      if (tableStart !== -1) {
+        const startIdx = chunk.indexOf(lines[tableStart]!)
+        const endLine = lines[i - 1]!
+        const endIdx = chunk.indexOf(endLine, startIdx) + endLine.length
+        protectedRanges.push([startIdx, endIdx])
+        tableStart = -1
+      }
+    }
+  }
+  if (tableStart !== -1) {
+    const startIdx = chunk.indexOf(lines[tableStart]!)
+    const endLine = lines[lines.length - 1]!
+    const endIdx = chunk.indexOf(endLine, startIdx) + endLine.length
+    protectedRanges.push([startIdx, endIdx])
+  }
+
+  // Split by 3+ newlines (two or more blank lines)
+  const result: string[] = []
+  let lastEnd = 0
+  for (const m of chunk.matchAll(/\n{3,}/g)) {
+    const splitAt = m.index!
+    // Check if this split point is inside a protected range
+    const inProtected = protectedRanges.some(
+      ([start, end]) => splitAt >= start && splitAt < end,
+    )
+    if (!inProtected) {
+      const segment = chunk.slice(lastEnd, splitAt)
+      if (segment.trim()) result.push(segment)
+      lastEnd = splitAt + m[0].length
+    }
+  }
+  const tail = chunk.slice(lastEnd)
+  if (tail.trim()) result.push(tail)
+  return result
+}
+
+/** 在安全段落边界处拆分超大块（保护代码、公式、表格） */
 function splitLargeChunk(chunk: string): string[] {
-  const paragraphs = chunk.split(/\n\n+/)
+  const paragraphs = splitSafeParagraphs(chunk)
   const result: string[] = []
   let current: string[] = []
   let currentSize = 0

--- a/packages/opencode/src/markdown-translator/formula-protector.test.ts
+++ b/packages/opencode/src/markdown-translator/formula-protector.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test"
+import { FormulaProtector } from "./formula-protector"
+
+describe("FormulaProtector", () => {
+  test("protects and restores inline formulas", () => {
+    const fp = new FormulaProtector()
+    const input = 'The energy is $E = mc^2$ and momentum is $p = mv$.'
+    const protected_ = fp.protect(input)
+    expect(protected_).not.toContain("$E = mc^2$")
+    expect(protected_).not.toContain("$p = mv$")
+    const restored = fp.restore(protected_)
+    expect(restored).toBe(input)
+  })
+
+  test("protects and restores block formulas", () => {
+    const fp = new FormulaProtector()
+    const input = "Some text\n$$\n\\int_0^1 f(x) dx\n$$\nMore text"
+    const protected_ = fp.protect(input)
+    expect(protected_).not.toContain("\\int_0^1")
+    const restored = fp.restore(protected_)
+    expect(restored).toBe(input)
+  })
+
+  test("protects block formulas before inline to avoid $$ misparse", () => {
+    const fp = new FormulaProtector()
+    const input = "$$block$$ and $inline$"
+    const protected_ = fp.protect(input)
+    expect(protected_).toContain("FORMULA_BLOCK")
+    expect(protected_).toContain("FORMULA_INLINE")
+    const restored = fp.restore(protected_)
+    expect(restored).toBe(input)
+  })
+
+  test("protects and restores image references", () => {
+    const fp = new FormulaProtector()
+    const input = "See figure ![diagram](images/fig1.png) below."
+    const protected_ = fp.protect(input)
+    expect(protected_).not.toContain("![diagram](images/fig1.png)")
+    const restored = fp.restore(protected_)
+    expect(restored).toBe(input)
+  })
+
+  test("protects and restores FIGURE placeholders", () => {
+    const fp = new FormulaProtector()
+    const input = "As shown in [FIGURE:fig_1] and [FORMULA_FIGURE:ffig_2]."
+    const protected_ = fp.protect(input)
+    expect(protected_).not.toContain("[FIGURE:fig_1]")
+    expect(protected_).not.toContain("[FORMULA_FIGURE:ffig_2]")
+    const restored = fp.restore(protected_)
+    expect(restored).toBe(input)
+  })
+
+  test("handles scientific literature with mixed formulas and images", () => {
+    const fp = new FormulaProtector()
+    const input = `# Quantum Field Theory
+
+The Lagrangian is given by:
+
+$$
+\\mathcal{L} = \\bar{\\psi}(i\\gamma^\\mu\\partial_\\mu - m)\\psi
+$$
+
+As shown in ![Feynman diagram](images/feynman.png), the coupling constant $g$ determines the interaction strength.
+
+The propagator is [FIGURE:fig_3] and the self-energy [FORMULA_FIGURE:ffig_1] is computed perturbatively.
+`
+    const protected_ = fp.protect(input)
+    // All protected elements should be replaced with placeholders
+    expect(protected_).not.toContain("$$")
+    expect(protected_).not.toContain("![Feynman diagram]")
+    expect(protected_).not.toContain("[FIGURE:fig_3]")
+    expect(protected_).not.toContain("[FORMULA_FIGURE:ffig_1]")
+    // Text content should remain
+    expect(protected_).toContain("Quantum Field Theory")
+    expect(protected_).toContain("The Lagrangian is given by")
+
+    const restored = fp.restore(protected_)
+    expect(restored).toBe(input)
+  })
+
+  test("verify detects formula count mismatch", () => {
+    const fp = new FormulaProtector()
+    const original = "Test $a$ and $b$ formulas."
+    fp.protect(original)
+    // Simulate a translation that lost one formula
+    const badTranslation = "Test ⟦FORMULA_INLINE_0⟧ formulas."
+    const restored = fp.restore(badTranslation)
+    const issues = fp.verify(original, restored)
+    expect(issues.length).toBeGreaterThan(0)
+    expect(issues[0]).toContain("行内公式数量不匹配")
+  })
+
+  test("verify passes when all formulas are preserved", () => {
+    const fp = new FormulaProtector()
+    const original = "Test $a$ and $b$ with $$c$$ block."
+    const protected_ = fp.protect(original)
+    const restored = fp.restore(protected_)
+    const issues = fp.verify(original, restored)
+    expect(issues).toHaveLength(0)
+  })
+
+  test("tolerates corrupted placeholders during restore", () => {
+    const fp = new FormulaProtector()
+    const input = "Energy $E=mc^2$ here."
+    fp.protect(input)
+    // Simulate LLM truncating closing bracket
+    const corrupted = "Energy ⟦FORMULA_INLINE_0 here."
+    const restored = fp.restore(corrupted)
+    expect(restored).toContain("$E=mc^2$")
+  })
+
+  test("handles single-dollar block formulas from PDF conversion", () => {
+    const fp = new FormulaProtector()
+    const input = "Before\n$\nE = mc^2\n$\nAfter"
+    const protected_ = fp.protect(input)
+    expect(protected_).toContain("FORMULA_BLOCK")
+    const restored = fp.restore(protected_)
+    expect(restored).toBe(input)
+  })
+
+  test("protects multi-line inline formula does not cross lines", () => {
+    const fp = new FormulaProtector()
+    const input = "Value $x$\nnot $y$ here"
+    const protected_ = fp.protect(input)
+    expect(protected_).toContain("FORMULA_INLINE_0")
+    expect(protected_).toContain("FORMULA_INLINE_1")
+    const restored = fp.restore(protected_)
+    expect(restored).toBe(input)
+  })
+})

--- a/packages/ui/src/components/file-media.tsx
+++ b/packages/ui/src/components/file-media.tsx
@@ -1,5 +1,5 @@
 import type { FileContent } from "@opencode-ai/sdk/v2"
-import { createEffect, createMemo, createResource, Match, on, Show, Switch, type JSX } from "solid-js"
+import { createEffect, createMemo, createResource, Match, on, onCleanup, Show, Switch, type JSX } from "solid-js"
 import { useI18n } from "../context/i18n"
 import {
   dataUrlFromMediaValue,
@@ -174,6 +174,42 @@ export function FileMedia(props: { media?: FileMediaOptions; fallback: () => JSX
   const kindLabel = (value: "image" | "audio") =>
     i18n.t(value === "image" ? "ui.fileMedia.kind.image" : "ui.fileMedia.kind.audio")
 
+  const handlePdfFocus = (e: FocusEvent) => {
+    // Prevent the PDF embed/iframe from stealing keyboard focus from the editor.
+    // When the browser's PDF plugin loads, it auto-focuses the embed element,
+    // which steals shortcuts like Cmd+S, Cmd+P, etc.
+    const target = e.target as HTMLElement
+    if (target.tagName === "EMBED" || target.tagName === "IFRAME") {
+      e.preventDefault()
+      target.blur()
+    }
+  }
+
+  const handlePdfKeydown = (e: KeyboardEvent) => {
+    // Block keyboard shortcuts from propagating out of the PDF viewer area.
+    // The browser PDF plugin captures Cmd+S, Cmd+P, etc. when focused.
+    if (e.metaKey || e.ctrlKey) {
+      e.stopPropagation()
+    }
+  }
+
+  let pdfContainerRef: HTMLDivElement | undefined
+
+  const setupPdfFocusGuard = () => {
+    // Use capture phase to intercept focus before the embed gets it
+    pdfContainerRef?.addEventListener("focusin", handlePdfFocus, true)
+    pdfContainerRef?.addEventListener("keydown", handlePdfKeydown, true)
+  }
+
+  const teardownPdfFocusGuard = () => {
+    pdfContainerRef?.removeEventListener("focusin", handlePdfFocus, true)
+    pdfContainerRef?.removeEventListener("keydown", handlePdfKeydown, true)
+  }
+
+  createEffect(() => {
+    return () => teardownPdfFocusGuard()
+  })
+
   return (
     <Switch>
       <Match when={kind() === "image" || kind() === "audio"}>
@@ -295,11 +331,12 @@ export function FileMedia(props: { media?: FileMediaOptions; fallback: () => JSX
                     </button>
                   </div>
                 </div>
-                <div class="flex flex-1 justify-center bg-background-stronger">
+                <div ref={(el) => { pdfContainerRef = el; setupPdfFocusGuard() }} class="flex flex-1 justify-center bg-background-stronger">
                   <embed
                     src={pdfObjectUrl || ""}
                     title={filename}
                     class="w-full max-w-full border border-border-weak-base rounded h-[80vh]"
+                    tabIndex={-1}
                     onLoad={onLoad}
                   />
                 </div>

--- a/packages/ui/src/components/pdf-viewer.tsx
+++ b/packages/ui/src/components/pdf-viewer.tsx
@@ -223,7 +223,7 @@ export const PdfViewer: Component<PdfViewerProps> = (props) => {
           </div>
         }
       >
-        <div ref={containerRef} class="flex-1 overflow-auto bg-background-stronger flex justify-center py-4">
+        <div ref={containerRef} class="flex-1 overflow-auto bg-background-stronger flex justify-center py-4" tabIndex={-1}>
           <div class="relative inline-block">
             <canvas ref={canvasRef} />
             <div


### PR DESCRIPTION
### Issue for this PR
Closes #43

### Type of change
- [x] Bug fix

### What does this PR do?
Fixes PDF viewer focus stealing by preventing keyboard focus capture. Improves scientific literature translation with better paragraph detection and formatting preservation.

### How did you verify your code works?
- All type checks pass
- Build completes successfully

### Checklist
- [x] I have read the [contributing guidelines](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] I have verified my changes work as expected