### PR TITLE
feat: add auto-refresh for long-running file tree sessions

### DIFF
--- a/packages/app/src/context/file.tsx
+++ b/packages/app/src/context/file.tsx
@@ -23,6 +23,7 @@ import {
 import { createFileViewCache } from "./file/view-cache"
 import { createFileTreeStore } from "./file/tree-store"
 import { invalidateFromWatcher } from "./file/watcher"
+import { createAutoRefresh } from "./file/auto-refresh"
 import {
   selectionFromLines,
   type FileState,
@@ -186,6 +187,15 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
       },
     })
 
+    // Auto-refresh keeps the tree in sync during long-running sessions where
+    // WebSocket events may be dropped or the connection can silently break.
+    const AUTO_REFRESH_INTERVAL_MS = 30_000
+    const autoRefresh = createAutoRefresh({
+      intervalMs: AUTO_REFRESH_INTERVAL_MS,
+      refreshDir: () => void tree.refreshDir(""),
+    })
+    autoRefresh.start()
+
     const evictContent = (keep?: Set<string>) => {
       evictContentLru(keep, (target) => {
         if (!store.file[target]) return
@@ -348,6 +358,7 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
       withPath(input, (file) => view().setSelectedLines(file, range))
 
     onCleanup(() => {
+      autoRefresh.stop()
       stop()
       viewCache.clear()
     })

--- a/packages/app/src/context/file/auto-refresh.test.ts
+++ b/packages/app/src/context/file/auto-refresh.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test"
+import { createAutoRefresh } from "./auto-refresh"
+
+describe("file tree auto-refresh", () => {
+  test("calls refreshDir at the specified interval", async () => {
+    const refreshCalls: string[] = []
+    let now = 0
+    const settled = Promise.withResolvers<void>()
+
+    const { start, stop } = createAutoRefresh({
+      intervalMs: 100,
+      refreshDir: (dir: string) => {
+        refreshCalls.push(dir)
+        if (refreshCalls.length >= 3) settled.resolve()
+      },
+      getNow: () => now,
+    })
+
+    start()
+
+    // Simulate time advancing: advance past interval boundaries
+    // The auto-refresh uses setInterval, so we need real time to pass
+    await settled.promise
+    stop()
+
+    expect(refreshCalls.length).toBeGreaterThanOrEqual(3)
+    // Every call should refresh root
+    for (const call of refreshCalls) {
+      expect(call).toBe("")
+    }
+  })
+
+  test("does not refresh before start is called", async () => {
+    const refreshCalls: string[] = []
+
+    const { start, stop } = createAutoRefresh({
+      intervalMs: 50,
+      refreshDir: (dir: string) => {
+        refreshCalls.push(dir)
+      },
+    })
+
+    // Wait some time without calling start
+    await new Promise((resolve) => setTimeout(resolve, 150))
+
+    expect(refreshCalls.length).toBe(0)
+    stop()
+  })
+
+  test("stops refreshing after stop is called", async () => {
+    const refreshCalls: string[] = []
+    const firstRefresh = Promise.withResolvers<void>()
+
+    const { start, stop } = createAutoRefresh({
+      intervalMs: 30,
+      refreshDir: (dir: string) => {
+        refreshCalls.push(dir)
+        if (refreshCalls.length === 1) firstRefresh.resolve()
+      },
+    })
+
+    start()
+    await firstRefresh.promise
+
+    const countAfterFirst = refreshCalls.length
+    stop()
+
+    await new Promise((resolve) => setTimeout(resolve, 150))
+
+    // Should not have grown significantly after stop
+    expect(refreshCalls.length).toBeLessThanOrEqual(countAfterFirst + 1)
+  })
+
+  test("handles refreshDir errors gracefully", async () => {
+    const refreshCalls: string[] = []
+    const secondRefresh = Promise.withResolvers<void>()
+
+    const { start, stop } = createAutoRefresh({
+      intervalMs: 30,
+      refreshDir: (dir: string) => {
+        refreshCalls.push(dir)
+        if (refreshCalls.length === 1) throw new Error("network error")
+        if (refreshCalls.length === 2) secondRefresh.resolve()
+      },
+    })
+
+    start()
+    await secondRefresh.promise
+    stop()
+
+    // Should have continued refreshing despite errors
+    expect(refreshCalls.length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/packages/app/src/context/file/auto-refresh.ts
+++ b/packages/app/src/context/file/auto-refresh.ts
@@ -1,0 +1,42 @@
+/**
+ * Periodic auto-refresh for the file tree.
+ *
+ * In long-running sessions WebSocket events can be missed or the connection
+ * may drop silently. This utility periodically calls `refreshDir("")` (root)
+ * to keep the tree in sync with the actual filesystem.
+ */
+
+export type AutoRefreshOptions = {
+  /** Interval between refreshes in milliseconds. */
+  intervalMs: number
+  /** Called on every tick – typically `tree.refreshDir("")`. */
+  refreshDir: (dir: string) => void
+  /** Injectable clock for testing. Defaults to `Date.now`. */
+  getNow?: () => number
+}
+
+export function createAutoRefresh(options: AutoRefreshOptions) {
+  const { intervalMs, refreshDir } = options
+  let timer: ReturnType<typeof setInterval> | undefined
+
+  const tick = () => {
+    try {
+      refreshDir("")
+    } catch {
+      // Swallow errors so the interval keeps running.
+    }
+  }
+
+  const start = () => {
+    if (timer !== undefined) return
+    timer = setInterval(tick, intervalMs)
+  }
+
+  const stop = () => {
+    if (timer === undefined) return
+    clearInterval(timer)
+    timer = undefined
+  }
+
+  return { start, stop }
+}


### PR DESCRIPTION
Closes #42

## Summary
 4 files changed, 151 insertions(+)

## Changes
packages/app/e2e/files/file-tree.spec.ts
packages/app/src/context/file.tsx
packages/app/src/context/file/auto-refresh.test.ts
packages/app/src/context/file/auto-refresh.ts

## Test plan
- [ ] Verify the fix works as expected
- [ ] No regressions in existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)