### PR TITLE
feat: improve markdown rendering with better syntax highlighting

### DIFF
--- a/packages/app/src/components/code-editor.tsx
+++ b/packages/app/src/components/code-editor.tsx
@@ -43,9 +43,16 @@ const customHighlightStyle = HighlightStyle.define([
   { tag: t.escape, color: "var(--syntax-constant)" },
   { tag: t.link, color: "var(--text-interactive-base)", textDecoration: "underline" },
   { tag: t.strikethrough, textDecoration: "line-through" },
+  // Markdown-specific highlighting
+  { tag: t.heading, color: "var(--text-strong)", fontWeight: "bold" },
+  { tag: t.emphasis, fontStyle: "italic" },
+  { tag: t.strong, fontWeight: "bold", color: "var(--text-strong)" },
+  { tag: t.monospace, color: "var(--syntax-string)", fontFamily: "var(--font-family-mono)" },
+  { tag: t.url, color: "var(--text-interactive-base)", textDecoration: "underline" },
+  { tag: t.special(t.string), color: "var(--syntax-string)" },
 ])
 
-function getLanguageExtension(filename: string) {
+export function getLanguageExtension(filename: string) {
   const ext = filename.split(".").pop()?.toLowerCase() ?? ""
   switch (ext) {
     case "py":

--- a/packages/app/src/components/markdown-renderer.test.ts
+++ b/packages/app/src/components/markdown-renderer.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test"
+
+describe("markdown language extension", () => {
+  test("getLanguageExtension is exported and returns markdown extension for .md files", async () => {
+    const { getLanguageExtension } = await import("./code-editor")
+    const ext = getLanguageExtension("test.md")
+    expect(ext).not.toBeNull()
+    expect(ext).not.toBeUndefined()
+  })
+
+  test("getLanguageExtension returns extension for .mdx files", async () => {
+    const { getLanguageExtension } = await import("./code-editor")
+    const ext = getLanguageExtension("doc.mdx")
+    expect(ext).not.toBeNull()
+  })
+
+  test("getLanguageExtension returns extension for .markdown files", async () => {
+    const { getLanguageExtension } = await import("./code-editor")
+    const ext = getLanguageExtension("README.markdown")
+    expect(ext).not.toBeNull()
+  })
+
+  test("getLanguageExtension returns null for unknown extensions", async () => {
+    const { getLanguageExtension } = await import("./code-editor")
+    const ext = getLanguageExtension("file.xyz")
+    expect(ext).toBeNull()
+  })
+
+  test("getLanguageExtension returns extension for .py files", async () => {
+    const { getLanguageExtension } = await import("./code-editor")
+    const ext = getLanguageExtension("script.py")
+    expect(ext).not.toBeNull()
+  })
+
+  test("getLanguageExtension returns extension for .ts files", async () => {
+    const { getLanguageExtension } = await import("./code-editor")
+    const ext = getLanguageExtension("index.ts")
+    expect(ext).not.toBeNull()
+  })
+
+  test("getLanguageExtension returns extension for .json files", async () => {
+    const { getLanguageExtension } = await import("./code-editor")
+    const ext = getLanguageExtension("package.json")
+    expect(ext).not.toBeNull()
+  })
+})

--- a/packages/ui/src/components/markdown.css
+++ b/packages/ui/src/components/markdown.css
@@ -233,21 +233,78 @@
     font-size: var(--font-size-base);
     display: block;
     overflow-x: auto;
+    scrollbar-width: thin;
   }
 
   th,
   td {
-    /* Minimal borders for structure, matching TUI "lines" roughly but keeping it web-clean */
     border-bottom: 1px solid var(--border-weaker-base);
-    padding: 0.75rem 0.5rem;
+    padding: 0.5rem 0.75rem;
     text-align: left;
     vertical-align: top;
+    min-width: 3rem;
   }
 
   th {
     color: var(--text-strong);
     font-weight: var(--font-weight-medium);
-    border-bottom: 1px solid var(--border-weak-base);
+    border-bottom: 2px solid var(--border-weak-base);
+    background: var(--surface-base);
+  }
+
+  tr:hover td {
+    background: var(--surface-base-hover);
+  }
+
+  /* Task list checkboxes */
+  input[type="checkbox"] {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 1rem;
+    height: 1rem;
+    border: 1px solid var(--border-base);
+    border-radius: 3px;
+    vertical-align: middle;
+    margin-right: 0.375rem;
+    position: relative;
+    cursor: default;
+  }
+
+  input[type="checkbox"]:checked {
+    background: var(--text-interactive-base);
+    border-color: var(--text-interactive-base);
+  }
+
+  input[type="checkbox"]:checked::after {
+    content: "";
+    position: absolute;
+    left: 3px;
+    top: 0.5px;
+    width: 4px;
+    height: 8px;
+    border: solid var(--background-stronger);
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+  }
+
+  /* Task list items */
+  li:has(> input[type="checkbox"]) {
+    list-style-type: none;
+    margin-left: -1.25rem;
+  }
+
+  /* Code block language badge */
+  [data-component="markdown-code"] > [data-component="icon"]:first-child {
+    position: absolute;
+    top: 4px;
+    left: 8px;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    pointer-events: none;
+  }
+
+  [data-component="markdown-code"]:hover > [data-component="icon"]:first-child {
+    opacity: 1;
   }
 
   /* Images */


### PR DESCRIPTION
Closes #48

## Summary
 3 files changed, 114 insertions(+), 4 deletions(-)

## Changes
packages/app/src/components/code-editor.tsx
packages/app/src/components/markdown-renderer.test.ts
packages/ui/src/components/markdown.css

## Test plan
- [ ] Verify the fix works as expected
- [ ] No regressions in existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)