### PR TITLE
fix: open new project starting from recent project folder

### DIFF
--- a/packages/app/src/components/dialog-new-project.tsx
+++ b/packages/app/src/components/dialog-new-project.tsx
@@ -9,7 +9,10 @@ import fuzzysort from "fuzzysort"
 import { createMemo, createResource, createSignal } from "solid-js"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
+import { useLayout } from "@/context/layout"
+import { useServer } from "@/context/server"
 import { useLanguage } from "@/context/language"
+import { recentProjectStart } from "@/pages/layout/helpers"
 
 interface DialogNewProjectProps {
   onSelect: (result: string | null) => void
@@ -250,6 +253,8 @@ function resolveNewPath(value: string, home: string, start: string): { parent: s
 export function DialogNewProject(props: DialogNewProjectProps) {
   const sync = useGlobalSync()
   const sdk = useGlobalSDK()
+  const layout = useLayout()
+  const server = useServer()
   const dialog = useDialog()
   const language = useLanguage()
 
@@ -270,9 +275,20 @@ export function DialogNewProject(props: DialogNewProjectProps) {
   )
 
   const home = createMemo(() => sync.data.path.home || fallbackPath()?.home || "")
-  const start = createMemo(
-    () => sync.data.path.home || sync.data.path.directory || fallbackPath()?.home || fallbackPath()?.directory || "",
-  )
+  const start = createMemo(() => {
+    const lastProject = server.projects.last()
+    const lastProjectList = layout.projects.list()
+    const recent = lastProjectList.find((p) => p.worktree === lastProject)
+    const recentDir = recentProjectStart(recent, home())
+    return (
+      recentDir ||
+      sync.data.path.home ||
+      sync.data.path.directory ||
+      fallbackPath()?.home ||
+      fallbackPath()?.directory ||
+      ""
+    )
+  })
 
   const directories = useDirectorySearch({ sdk, home, start })
 

--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -10,7 +10,9 @@ import { createMemo, createResource, createSignal, Show } from "solid-js"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLayout } from "@/context/layout"
+import { useServer } from "@/context/server"
 import { useLanguage } from "@/context/language"
+import { recentProjectStart } from "@/pages/layout/helpers"
 
 interface DialogSelectDirectoryProps {
   title?: string
@@ -250,6 +252,7 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
   const sync = useGlobalSync()
   const sdk = useGlobalSDK()
   const layout = useLayout()
+  const server = useServer()
   const dialog = useDialog()
   const language = useLanguage()
 
@@ -271,9 +274,19 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
   )
 
   const home = createMemo(() => sync.data.path.home || fallbackPath()?.home || "")
-  const start = createMemo(
-    () => sync.data.path.home || sync.data.path.directory || fallbackPath()?.home || fallbackPath()?.directory,
-  )
+  const start = createMemo(() => {
+    const lastProject = server.projects.last()
+    const lastProjectList = layout.projects.list()
+    const recent = lastProjectList.find((p) => p.worktree === lastProject)
+    const recentDir = recentProjectStart(recent, home())
+    return (
+      recentDir ||
+      sync.data.path.home ||
+      sync.data.path.directory ||
+      fallbackPath()?.home ||
+      fallbackPath()?.directory
+    )
+  })
 
   const directories = useDirectorySearch({
     sdk,

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -13,6 +13,7 @@ import {
   errorMessage,
   hasProjectPermissions,
   latestRootSession,
+  recentProjectStart,
   workspaceKey,
 } from "./helpers"
 
@@ -207,5 +208,53 @@ describe("layout workspace helpers", () => {
     expect(errorMessage({ data: { message: "boom" } }, "fallback")).toBe("boom")
     expect(errorMessage(new Error("broken"), "fallback")).toBe("broken")
     expect(errorMessage("unknown", "fallback")).toBe("fallback")
+  })
+
+  describe("recentProjectStart", () => {
+    test("returns the parent directory of the most recent project", () => {
+      const result = recentProjectStart(
+        { worktree: "/home/user/projects/myapp" },
+        "/home/user",
+      )
+      expect(result).toBe("/home/user/projects")
+    })
+
+    test("returns the parent directory for Windows-style paths", () => {
+      const result = recentProjectStart(
+        { worktree: "C:\\Users\\dev\\code\\myproject" },
+        "C:\\Users\\dev",
+      )
+      // workspaceKey lowercases drive letters
+      expect(result).toBe("c:/users/dev/code")
+    })
+
+    test("returns home when the project is directly inside home", () => {
+      const result = recentProjectStart(
+        { worktree: "/home/user/myapp" },
+        "/home/user",
+      )
+      expect(result).toBe("/home/user")
+    })
+
+    test("returns home when the project equals home", () => {
+      const result = recentProjectStart(
+        { worktree: "/home/user" },
+        "/home/user",
+      )
+      expect(result).toBe("/home/user")
+    })
+
+    test("returns undefined when no recent project is provided", () => {
+      const result = recentProjectStart(undefined, "/home/user")
+      expect(result).toBeUndefined()
+    })
+
+    test("returns root when project is at root level", () => {
+      const result = recentProjectStart(
+        { worktree: "/myapp" },
+        "/",
+      )
+      expect(result).toBe("/")
+    })
   })
 })

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -73,6 +73,43 @@ export const errorMessage = (err: unknown, fallback: string) => {
   return fallback
 }
 
+/**
+ * Derive a starting directory for the "open project" dialog from the most
+ * recently used project.  Returns the *parent* of the last project's worktree
+ * so the user lands in the folder that contains sibling projects.
+ *
+ * Returns `undefined` when no recent project is available.
+ */
+export const recentProjectStart = (
+  recent: { worktree: string } | undefined,
+  home: string,
+): string | undefined => {
+  if (!recent) return undefined
+
+  const normalized = recent.worktree.replace(/\\/g, "/")
+  const key = workspaceKey(normalized)
+  const homeKey = workspaceKey(home)
+
+  // If the project is the home directory itself, or directly inside home,
+  // just return home.
+  if (key === homeKey) return home
+
+  // Find the parent directory.
+  const lastSlash = key.lastIndexOf("/")
+  if (lastSlash <= 0) return "/" // POSIX root
+
+  const parent = key.slice(0, lastSlash)
+
+  // If parent is the root of a Windows drive (e.g. "C:"), normalize.
+  if (/^[A-Za-z]:$/.test(parent)) return parent + "/"
+
+  // If parent is the same as (or above) home, just use home.
+  if (parent.length < homeKey.length) return home
+  if (parent === homeKey) return home
+
+  return parent
+}
+
 export const effectiveWorkspaceOrder = (local: string, dirs: string[], persisted?: string[]) => {
   const root = workspaceKey(local)
   const live = new Map<string, string>()


### PR DESCRIPTION
Closes #40

## Summary
 4 files changed, 121 insertions(+), 6 deletions(-)

## Changes
packages/app/src/components/dialog-new-project.tsx
packages/app/src/components/dialog-select-directory.tsx
packages/app/src/pages/layout/helpers.test.ts
packages/app/src/pages/layout/helpers.ts

## Test plan
- [ ] Verify the fix works as expected
- [ ] No regressions in existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)