### PR TITLE
fix: force refresh bypasses inflight cache to fetch latest file tree data

### DIFF
--- a/packages/app/src/context/file/tree-store.test.ts
+++ b/packages/app/src/context/file/tree-store.test.ts
@@ -26,6 +26,53 @@ const file = (path: string): Node => ({
 })
 
 describe("file tree store refresh", () => {
+  test("force refresh bypasses inflight cache when previous request is pending", async () => {
+    let callCount = 0
+    let resolveFirst: () => void
+    const firstPending = new Promise<void>((r) => { resolveFirst = r })
+
+    const data = new Map<string, Node[]>([
+      ["", [file("README.md")]],
+    ])
+
+    const tree = createFileTreeStore({
+      scope: () => "/repo",
+      normalizeDir: (input) => input.replace(/\/+$/, ""),
+      list: async (input) => {
+        callCount++
+        if (callCount === 1) {
+          await firstPending
+        }
+        return data.get(input) ?? []
+      },
+      onError: () => {},
+    })
+
+    // Start a listDir that hangs (never resolves until we want it to)
+    const firstCall = tree.listDir("")
+    // callCount should be 1 now
+    expect(callCount).toBe(1)
+
+    // Update underlying data while first request is still in-flight
+    data.set("", [file("README.md"), file("notes.md")])
+
+    // Call refreshDir which passes force=true — should start a NEW request
+    // despite the first one still being in-flight
+    const refreshPromise = tree.refreshDir("")
+
+    // Allow the first request to resolve
+    resolveFirst!()
+    await firstCall
+    await refreshPromise
+
+    // callCount should be 2: the original + the force refresh
+    expect(callCount).toBe(2)
+
+    // The tree should reflect the NEW data
+    expect(tree.children("").map((n) => n.path)).toEqual(["README.md", "notes.md"])
+  })
+
+
   test("refreshes loaded descendants when refreshing root", async () => {
     const data = new Map<string, Node[]>([
       ["", [dir("docs"), file("README.md")]],

--- a/packages/app/src/context/file/tree-store.ts
+++ b/packages/app/src/context/file/tree-store.ts
@@ -47,7 +47,7 @@ export function createFileTreeStore(options: TreeStoreOptions) {
     if (!opts?.force && current?.loaded) return Promise.resolve()
 
     const pending = inflight.get(dir)
-    if (pending) return pending
+    if (pending && !opts?.force) return pending
 
     setTree(
       "dir",


### PR DESCRIPTION
Closes #65

## Summary
 2 files changed, 48 insertions(+), 1 deletion(-)

## Changes
packages/app/src/context/file/tree-store.test.ts
packages/app/src/context/file/tree-store.ts

## Test plan
- [ ] Verify the fix works as expected
- [ ] No regressions in existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)