### PR TITLE
feat: 右键目录上传文件与批量拖拽上传增强

### DIFF
--- a/packages/app/src/components/file-tree.tsx
+++ b/packages/app/src/components/file-tree.tsx
@@ -239,6 +239,8 @@ export default function FileTree(props: {
   onFileDrop?: (paths: string[], targetDir: string) => void
   /** External file/folder uploads into folders */
   onUploadDrop?: (event: DragEvent, targetDir: string) => void
+  /** Upload files to a specific directory via picker */
+  onUploadToDir?: (dir: string, type: "file" | "directory") => void
   /** PDF 转 Markdown（单文件或批量） */
   onPdfConvert?: (paths: string[]) => void
   /** Markdown 翻译为中文（单文件或批量） */
@@ -558,6 +560,13 @@ export default function FileTree(props: {
                         <ContextMenu.ItemLabel>新建文件夹</ContextMenu.ItemLabel>
                       </ContextMenu.Item>
                       <ContextMenu.Separator />
+                      <ContextMenu.Item onSelect={() => props.onUploadToDir?.(node.path, "file")}>
+                        <ContextMenu.ItemLabel>上传文件到此处</ContextMenu.ItemLabel>
+                      </ContextMenu.Item>
+                      <ContextMenu.Item onSelect={() => props.onUploadToDir?.(node.path, "directory")}>
+                        <ContextMenu.ItemLabel>上传文件夹到此处</ContextMenu.ItemLabel>
+                      </ContextMenu.Item>
+                      <ContextMenu.Separator />
                     </>
                   )}
                   <ContextMenu.Item
@@ -841,6 +850,7 @@ export default function FileTree(props: {
                           onMultiCut={props.onMultiCut}
                           onFileDrop={props.onFileDrop}
                           onUploadDrop={props.onUploadDrop}
+                          onUploadToDir={props.onUploadToDir}
                           onPdfConvert={props.onPdfConvert}
                           onTranslateMarkdown={props.onTranslateMarkdown}
                           _filter={filter()}

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -39,7 +39,7 @@ import { createOpenSessionFileTab, createSessionTabs, getTabReorderIndex, type S
 import { setSessionHandoff } from "@/pages/session/handoff"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { save } from "./download"
-import { fromDir, fromDrop, fromList, isExternal, send } from "./upload"
+import { fromDir, fromDrop, fromList, isExternal, send, withTarget } from "./upload"
 import type { FileNode } from "@opencode-ai/sdk/v2"
 
 export function SessionSidePanel(props: {
@@ -618,7 +618,9 @@ export function SessionSidePanel(props: {
   const [dragging, setDragging] = createSignal(false)
   let fileInput: HTMLInputElement | undefined
   let dirInput: HTMLInputElement | undefined
+  let dirUploadInput: HTMLInputElement | undefined
   let drag = 0
+  let uploadTarget = ""
 
   const refreshUpload = (dir: string) => {
     file.tree.refresh(dir)
@@ -704,14 +706,45 @@ export function SessionSidePanel(props: {
     dirInput?.click()
   }
 
+  const uploadToDir = async (dir: string, type: "file" | "directory") => {
+    uploadTarget = dir
+    if (type === "directory") {
+      if (typeof window !== "undefined" && "showDirectoryPicker" in window) {
+        try {
+          const pick = window.showDirectoryPicker as () => Promise<FileSystemDirectoryHandle>
+          const handle = await pick()
+          await upload(withTarget(await fromDir(handle), dir), dir)
+          uploadTarget = ""
+          return
+        } catch (err) {
+          uploadTarget = ""
+          if (err instanceof DOMException && err.name === "AbortError") return
+          showToast({
+            variant: "error",
+            title: "选择文件夹失败",
+            description: err instanceof Error ? err.message : String(err),
+          })
+          return
+        }
+      }
+      dirUploadInput?.click()
+      return
+    }
+    fileInput?.click()
+  }
+
   const uploadFiles = async (list: FileList | null) => {
     if (!list || list.length === 0) return
-    await upload(fromList(list), "")
+    const target = uploadTarget
+    uploadTarget = ""
+    await upload(withTarget(fromList(list), target), target)
   }
 
   const uploadDirs = async (list: FileList | null) => {
     if (!list || list.length === 0) return
-    await upload(fromList(list), "")
+    const target = uploadTarget
+    uploadTarget = ""
+    await upload(withTarget(fromList(list), target), target)
   }
 
   const handleUploadDrop = async (event: globalThis.DragEvent, dir: string) => {
@@ -1108,6 +1141,7 @@ export function SessionSidePanel(props: {
                           onMultiCut={handleMultiCut}
                           onFileDrop={handleFileDrop}
                           onUploadDrop={(event, dir) => void handleUploadDrop(event, dir)}
+                          onUploadToDir={(dir, type) => void uploadToDir(dir, type)}
                           onPdfConvert={handlePdfConvert}
                           onTranslateMarkdown={handleTranslateMarkdown}
                         />
@@ -1127,6 +1161,20 @@ export function SessionSidePanel(props: {
                   <input
                     ref={(el) => {
                       dirInput = el
+                      el.setAttribute("webkitdirectory", "")
+                      el.setAttribute("directory", "")
+                    }}
+                    type="file"
+                    multiple
+                    class="hidden"
+                    onChange={(event) => {
+                      void uploadDirs(event.currentTarget.files)
+                      event.currentTarget.value = ""
+                    }}
+                  />
+                  <input
+                    ref={(el) => {
+                      dirUploadInput = el
                       el.setAttribute("webkitdirectory", "")
                       el.setAttribute("directory", "")
                     }}

--- a/packages/app/src/pages/session/upload.test.ts
+++ b/packages/app/src/pages/session/upload.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { fromList, isExternal } from "./upload"
+import { fromList, isExternal, merge, withTarget, type Batch } from "./upload"
 
 const withPath = (file: File, path: string) => {
   Object.defineProperty(file, "webkitRelativePath", {
@@ -31,5 +31,48 @@ describe("session upload helpers", () => {
     expect(isExternal({ types: ["Files"] } as unknown as DataTransfer)).toBe(true)
     expect(isExternal({ types: ["text/plain"] } as unknown as DataTransfer)).toBe(false)
     expect(isExternal(null)).toBe(false)
+  })
+
+  test("merge deduplicates files by path", () => {
+    const a: Batch = { dirs: ["src"], files: [{ path: "a.txt", file: new File(["a"], "a.txt") }] }
+    const b: Batch = { dirs: ["lib"], files: [{ path: "a.txt", file: new File(["a2"], "a.txt") }] }
+    const out = merge(a, b)
+    expect(out.files.length).toBe(1)
+    expect(out.dirs).toEqual(["src", "lib"])
+  })
+
+  test("withTarget rewrites batch paths under a directory", () => {
+    const batch: Batch = {
+      dirs: ["docs"],
+      files: [
+        { path: "docs/a.txt", file: new File(["a"], "a.txt") },
+        { path: "readme.md", file: new File(["r"], "readme.md") },
+      ],
+    }
+    const out = withTarget(batch, "subdir")
+    expect(out.files.map((f) => f.path)).toEqual(["subdir/docs/a.txt", "subdir/readme.md"])
+    expect(out.dirs).toEqual(["subdir/docs"])
+  })
+
+  test("withTarget with empty target returns batch unchanged", () => {
+    const batch: Batch = {
+      dirs: ["docs"],
+      files: [{ path: "docs/a.txt", file: new File(["a"], "a.txt") }],
+    }
+    const out = withTarget(batch, "")
+    expect(out.files.map((f) => f.path)).toEqual(["docs/a.txt"])
+    expect(out.dirs).toEqual(["docs"])
+  })
+
+  test("batch size tracks total files and dirs", () => {
+    const batch: Batch = {
+      dirs: ["src", "lib"],
+      files: [
+        { path: "a.txt", file: new File(["a"], "a.txt") },
+        { path: "b.txt", file: new File(["b"], "b.txt") },
+      ],
+    }
+    expect(batch.files.length).toBe(2)
+    expect(batch.dirs.length).toBe(2)
   })
 })

--- a/packages/app/src/pages/session/upload.ts
+++ b/packages/app/src/pages/session/upload.ts
@@ -48,7 +48,7 @@ const clean = (input: string) => {
   return list.join("/")
 }
 
-const merge = (out: Batch, next: Batch) => {
+export const merge = (out: Batch, next: Batch) => {
   const dirs = new Set([...out.dirs, ...next.dirs])
   const files = [...out.files]
   const seen = new Set(files.map((item) => item.path))
@@ -136,6 +136,14 @@ const fromEntry = async (item: WebEntry, root = ""): Promise<Batch> => {
     for (const child of list) {
       out = merge(out, await fromEntry(child, path))
     }
+  }
+}
+
+export const withTarget = (batch: Batch, target: string): Batch => {
+  if (!target) return batch
+  return {
+    dirs: batch.dirs.map((d) => `${target}/${d}`),
+    files: batch.files.map((f) => ({ ...f, path: `${target}/${f.path}` })),
   }
 }
 


### PR DESCRIPTION
Closes #54

## Summary
 4 files changed, 114 insertions(+), 5 deletions(-)

## Changes
packages/app/src/components/file-tree.tsx
packages/app/src/pages/session/session-side-panel.tsx
packages/app/src/pages/session/upload.test.ts
packages/app/src/pages/session/upload.ts

## Test plan
- [ ] Verify the fix works as expected
- [ ] No regressions in existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)