### PR TITLE
feat: parse HTTP server URLs to connect to remote instances directly

### DIFF
--- a/packages/app/src/pages/layout/deep-links.ts
+++ b/packages/app/src/pages/layout/deep-links.ts
@@ -1,5 +1,34 @@
 export const deepLinkEvent = "opencode:deep-link"
 
+export type ServerUrlResult = {
+  url: string
+  username?: string
+  password?: string
+}
+
+export function parseServerUrl(input: string): ServerUrlResult | undefined {
+  const trimmed = input.trim()
+  if (!trimmed) return
+  if (trimmed.startsWith("opencode://")) return
+  if (trimmed.startsWith("/")) return
+
+  let url: URL
+  try {
+    const withProtocol = /^https?:\/\//.test(trimmed) ? trimmed : `http://${trimmed}`
+    url = new URL(withProtocol)
+  } catch {
+    return
+  }
+
+  const result: ServerUrlResult = {
+    url: `${url.protocol}//${url.host}`,
+  }
+  if (url.username) result.username = decodeURIComponent(url.username)
+  if (url.password) result.password = decodeURIComponent(url.password)
+
+  return result
+}
+
 const parseUrl = (input: string) => {
   if (!input.startsWith("opencode://")) return
   if (typeof URL.canParse === "function" && !URL.canParse(input)) return

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -5,6 +5,7 @@ import {
   drainPendingDeepLinks,
   parseDeepLink,
   parseNewSessionDeepLink,
+  parseServerUrl,
 } from "./deep-links"
 import { type Session } from "@opencode-ai/sdk/v2/client"
 import {
@@ -207,5 +208,35 @@ describe("layout workspace helpers", () => {
     expect(errorMessage({ data: { message: "boom" } }, "fallback")).toBe("boom")
     expect(errorMessage(new Error("broken"), "fallback")).toBe("broken")
     expect(errorMessage("unknown", "fallback")).toBe("fallback")
+  })
+})
+
+describe("layout server URL parsing", () => {
+  test("parses http URL as server connection", () => {
+    expect(parseServerUrl("http://localhost:3000")).toEqual({ url: "http://localhost:3000" })
+    expect(parseServerUrl("https://my-server.example.com:8080")).toEqual({ url: "https://my-server.example.com:8080" })
+  })
+
+  test("parses URL without protocol (auto-adds http://)", () => {
+    expect(parseServerUrl("192.168.1.100:3000")).toEqual({ url: "http://192.168.1.100:3000" })
+    expect(parseServerUrl("my-server.com")).toEqual({ url: "http://my-server.com" })
+  })
+
+  test("parses URL with credentials", () => {
+    expect(parseServerUrl("http://user:pass@localhost:3000")).toEqual({
+      url: "http://localhost:3000",
+      username: "user",
+      password: "pass",
+    })
+  })
+
+  test("rejects non-URL strings", () => {
+    expect(parseServerUrl("/just/a/path")).toBeUndefined()
+    expect(parseServerUrl("")).toBeUndefined()
+    expect(parseServerUrl("   ")).toBeUndefined()
+  })
+
+  test("rejects opencode:// protocol", () => {
+    expect(parseServerUrl("opencode://open-project?directory=/tmp")).toBeUndefined()
   })
 })


### PR DESCRIPTION
Closes #37

## Summary
Parse HTTP server URLs to connect to remote instances directly.

## Changes
$(git diff HEAD~1 --name-only 2>/dev/null | head -10)

## Test plan
- [ ] Enter URL in connection dialog
- [ ] Verify connection to remote server works

🤖 Generated with [Claude Code](https://claude.com/claude-code)