### PR TITLE
fix: surface unavailable folder picker errors

### DIFF
--- a/docs/superpowers/plans/2026-04-03-browse-picker-feedback.md
+++ b/docs/superpowers/plans/2026-04-03-browse-picker-feedback.md
@@ -1,0 +1,99 @@
+# Browse Picker Feedback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a clear toast when `Browse` cannot open a native folder picker and returns no path.
+
+**Architecture:** Extend the server route to distinguish "no picker backend exists" from "user canceled". Add a small shared frontend helper so the same fallback message is used in both directory-selection dialogs and can be unit-tested without rendering the full UI.
+
+**Tech Stack:** Bun, Solid, TypeScript, bun:test
+
+---
+
+### Task 1: Add Picker Availability Helpers
+
+**Files:**
+- Create: `packages/opencode/src/server/pick-folder.ts`
+- Test: `packages/opencode/src/server/pick-folder.test.ts`
+- Create: `packages/app/src/components/pick-folder.ts`
+- Test: `packages/app/src/components/pick-folder.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add tests for helpers that:
+- detect when Linux has no supported picker backend
+- returns the picked path when present
+- stays silent on a normal cancel
+- shows a toast and returns `undefined` when the backend marks the picker as unavailable
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/app/src/components/pick-folder.test.ts`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create:
+- a server helper that resolves Linux picker commands or reports unavailability
+- a frontend helper that consumes the API result and toast callback
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test packages/app/src/components/pick-folder.test.ts`
+
+- [ ] **Step 5: Commit**
+
+Commit message: `fix: show feedback when folder picker is unavailable`
+
+### Task 2: Use Helper in Browse Entrypoints and SDK
+
+**Files:**
+- Modify: `packages/opencode/src/server/routes/file.ts`
+- Modify: `packages/app/src/components/dialog-select-directory.tsx`
+- Modify: `packages/app/src/components/dialog-new-project.tsx`
+- Modify: `packages/sdk/js/src/v2/gen/sdk.gen.ts`
+- Modify: `packages/sdk/js/src/v2/gen/types.gen.ts`
+
+- [ ] **Step 1: Replace inline `pickFolder()` handling**
+
+Use the shared helper in both browse buttons and return the explicit unavailable state from the backend.
+
+- [ ] **Step 2: Keep existing success behavior unchanged**
+
+Only update the path/filter when a path exists.
+
+- [ ] **Step 3: Regenerate the JS SDK**
+
+Run: `./packages/sdk/js/script/build.ts`
+
+- [ ] **Step 4: Run targeted tests**
+
+Run:
+- `bun test src/server/pick-folder.test.ts` from `packages/opencode`
+- `bun test src/components/pick-folder.test.ts` from `packages/app`
+
+- [ ] **Step 5: Run package typecheck**
+
+Run:
+- from `packages/opencode`: `bun typecheck`
+- from `packages/app`: `bun typecheck`
+
+- [ ] **Step 6: Commit**
+
+Commit message: `fix: surface browse picker failures in project dialogs`
+
+### Task 3: Reproduce and Verify Manually
+
+**Files:**
+- No file changes required
+
+- [ ] **Step 1: Start isolated backend/frontend**
+
+Use the temporary-data setup so the old local DB does not interfere.
+
+- [ ] **Step 2: Verify the toast in a no-picker environment**
+
+Click `Browse` from the open-project dialog and confirm the new toast appears.
+
+- [ ] **Step 3: Capture evidence**
+
+Save a Playwright screenshot if needed.

--- a/docs/superpowers/specs/2026-04-03-browse-picker-feedback-design.md
+++ b/docs/superpowers/specs/2026-04-03-browse-picker-feedback-design.md
@@ -1,0 +1,11 @@
+# Browse Picker Feedback Design
+
+**Scope:** Fix the `Browse` button UX when the backend cannot open a native folder picker and returns `null`.
+
+**Problem:** In WSL/Linux environments without `zenity` or `kdialog`, `file.pickFolder` returns `{ path: null }`. Current callers treat that as a no-op, so the user clicks `Browse` and sees no visible feedback.
+
+**Approach:** Add an explicit unavailable state to `file.pickFolder` when Linux/WSL has no supported native picker backend. Update the frontend callers of `pickFolder()` to surface an error toast only for that unavailable state, while keeping a normal user cancel silent. Reuse the same message in both project-opening entry points so behavior stays consistent.
+
+**User-visible result:** Clicking `Browse` in affected environments will show a toast telling the user to enter the path manually or install a supported picker, instead of appearing broken.
+
+**Out of scope:** Database migration failures, backend picker implementation changes, adding new Linux picker backends, or changing path parsing behavior.

--- a/packages/app/src/components/dialog-new-project.tsx
+++ b/packages/app/src/components/dialog-new-project.tsx
@@ -4,12 +4,14 @@ import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { Button } from "@opencode-ai/ui/button"
 import { List } from "@opencode-ai/ui/list"
 import type { ListRef } from "@opencode-ai/ui/list"
+import { showToast } from "@opencode-ai/ui/toast"
 import { getDirectory, getFilename } from "@opencode-ai/util/path"
 import fuzzysort from "fuzzysort"
 import { createMemo, createResource, createSignal } from "solid-js"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
+import { picked } from "./pick-folder"
 
 interface DialogNewProjectProps {
   onSelect: (result: string | null) => void
@@ -338,9 +340,9 @@ export function DialogNewProject(props: DialogNewProjectProps) {
                 setBrowsing(true)
                 try {
                   const result = await sdk.client.file.pickFolder()
-                  const picked = result.data?.path
-                  if (picked) {
-                    list?.setFilter(picked)
+                  const path = picked(result.data, showToast, language.t("common.requestFailed"))
+                  if (path) {
+                    list?.setFilter(path)
                   }
                 } finally {
                   setBrowsing(false)

--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -4,6 +4,7 @@ import { Button } from "@opencode-ai/ui/button"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { List } from "@opencode-ai/ui/list"
 import type { ListRef } from "@opencode-ai/ui/list"
+import { showToast } from "@opencode-ai/ui/toast"
 import { getDirectory, getFilename } from "@opencode-ai/util/path"
 import fuzzysort from "fuzzysort"
 import { createMemo, createResource, createSignal, onMount, Show } from "solid-js"
@@ -11,6 +12,7 @@ import { createStore } from "solid-js/store"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
+import { picked } from "./pick-folder"
 import { Persist, persisted } from "@/utils/persist"
 
 interface DialogSelectDirectoryProps {
@@ -408,10 +410,10 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
                   setBrowsing(true)
                   try {
                     const result = await sdk.client.file.pickFolder()
-                    const picked = result.data?.path
-                    if (picked) {
-                      list?.setFilter(picked)
-                      setSelectedPath(picked)
+                    const path = picked(result.data, showToast, language.t("common.requestFailed"))
+                    if (path) {
+                      list?.setFilter(path)
+                      setSelectedPath(path)
                     }
                   } finally {
                     setBrowsing(false)

--- a/packages/app/src/components/pick-folder.test.ts
+++ b/packages/app/src/components/pick-folder.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test"
+import { picked } from "./pick-folder"
+
+describe("picked", () => {
+  test("returns the selected path", () => {
+    const out: unknown[] = []
+
+    expect(picked({ path: " /tmp/demo " }, (input) => out.push(input), "Request failed")).toBe("/tmp/demo")
+    expect(out).toHaveLength(0)
+  })
+
+  test("stays silent when the user cancels", () => {
+    const out: unknown[] = []
+
+    expect(picked({ path: null }, (input) => out.push(input), "Request failed")).toBeUndefined()
+    expect(out).toHaveLength(0)
+  })
+
+  test("shows a toast when no picker is available", () => {
+    const out: unknown[] = []
+
+    expect(
+      picked({ path: null, unavailable: true, reason: "missing_picker" }, (input) => out.push(input), "Request failed"),
+    ).toBeUndefined()
+    expect(out).toEqual([
+      {
+        variant: "error",
+        title: "Request failed",
+        description: "This server cannot open a folder picker here. Enter the path manually or install zenity/kdialog.",
+      },
+    ])
+  })
+})

--- a/packages/app/src/components/pick-folder.ts
+++ b/packages/app/src/components/pick-folder.ts
@@ -1,0 +1,26 @@
+type Pick = {
+  path: string | null
+  unavailable?: boolean
+  reason?: "missing_picker" | string
+}
+
+type Toast = (input: {
+  variant: "error"
+  title: string
+  description: string
+}) => unknown
+
+export function picked(input: Pick | undefined, toast: Toast, title: string) {
+  const path = input?.path?.trim()
+  if (path) return path
+  if (!input?.unavailable) return
+
+  toast({
+    variant: "error",
+    title,
+    description:
+      input.reason === "missing_picker"
+        ? "This server cannot open a folder picker here. Enter the path manually or install zenity/kdialog."
+        : "This server cannot open a folder picker here. Enter the path manually.",
+  })
+}

--- a/packages/opencode/src/server/pick-folder.test.ts
+++ b/packages/opencode/src/server/pick-folder.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { linux, missing } from "./pick-folder"
+import { linux, missing, windows, wsl, wslPath } from "./pick-folder"
 
 describe("linux", () => {
   test("prefers zenity when available", () => {
@@ -21,6 +21,50 @@ describe("linux", () => {
 
   test("returns undefined when no picker exists", () => {
     expect(linux({ HOME: "/tmp" }, () => null)).toBeUndefined()
+  })
+})
+
+describe("windows", () => {
+  test("returns the powershell picker command", () => {
+    expect(windows((cmd) => (cmd === "powershell.exe" ? "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe" : null)))
+      .toEqual([
+        "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        expect.stringContaining("FolderBrowserDialog"),
+      ])
+  })
+
+  test("returns undefined when powershell is unavailable", () => {
+    expect(windows(() => null)).toBeUndefined()
+  })
+})
+
+describe("wsl", () => {
+  test("returns the windows picker when running in wsl", () => {
+    expect(wsl("5.15.167.4-microsoft-standard-WSL2", (cmd) => (cmd === "powershell.exe" ? "/mnt/c/powershell.exe" : null)))
+      .toEqual([
+        "/mnt/c/powershell.exe",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        expect.stringContaining("FolderBrowserDialog"),
+      ])
+  })
+
+  test("returns undefined outside wsl", () => {
+    expect(wsl("6.8.0-generic", () => "/mnt/c/powershell.exe")).toBeUndefined()
+  })
+})
+
+describe("wslPath", () => {
+  test("converts a windows path to wsl format", () => {
+    expect(wslPath("C:\\Songtan\\Gewu")).toBe("/mnt/c/Songtan/Gewu")
+  })
+
+  test("keeps non-windows paths unchanged", () => {
+    expect(wslPath("/mnt/c/Songtan/Gewu")).toBe("/mnt/c/Songtan/Gewu")
   })
 })
 

--- a/packages/opencode/src/server/pick-folder.test.ts
+++ b/packages/opencode/src/server/pick-folder.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test"
+import { linux, missing } from "./pick-folder"
+
+describe("linux", () => {
+  test("prefers zenity when available", () => {
+    expect(linux({ HOME: "/tmp" }, (cmd) => (cmd === "zenity" ? "/usr/bin/zenity" : null))).toEqual([
+      "/usr/bin/zenity",
+      "--file-selection",
+      "--directory",
+      "--title=Select Folder",
+    ])
+  })
+
+  test("falls back to kdialog", () => {
+    expect(linux({ HOME: "/tmp" }, (cmd) => (cmd === "kdialog" ? "/usr/bin/kdialog" : null))).toEqual([
+      "/usr/bin/kdialog",
+      "--getexistingdirectory",
+      "/tmp",
+    ])
+  })
+
+  test("returns undefined when no picker exists", () => {
+    expect(linux({ HOME: "/tmp" }, () => null)).toBeUndefined()
+  })
+})
+
+describe("missing", () => {
+  test("marks picker as unavailable", () => {
+    expect(missing()).toEqual({
+      path: null,
+      unavailable: true,
+      reason: "missing_picker",
+    })
+  })
+})

--- a/packages/opencode/src/server/pick-folder.ts
+++ b/packages/opencode/src/server/pick-folder.ts
@@ -1,3 +1,4 @@
+import { release } from "os"
 import { which } from "../util/which"
 
 export type Pick = {
@@ -5,6 +6,9 @@ export type Pick = {
   unavailable?: boolean
   reason?: "missing_picker"
 }
+
+const script =
+  "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; Add-Type -AssemblyName System.Windows.Forms; $d = New-Object System.Windows.Forms.FolderBrowserDialog; $d.ShowNewFolderButton = $true; $owner = New-Object System.Windows.Forms.Form; $owner.TopMost = $true; $owner.WindowState = 'Minimized'; $owner.ShowInTaskbar = $false; $owner.Show(); $owner.Hide(); if ($d.ShowDialog($owner) -eq 'OK') { $d.SelectedPath }; $owner.Dispose()"
 
 export function missing(): Pick {
   return {
@@ -20,4 +24,23 @@ export function linux(env: NodeJS.ProcessEnv = process.env, find = which) {
 
   const kdialog = find("kdialog", env)
   if (kdialog) return [kdialog, "--getexistingdirectory", env.HOME || "/"]
+}
+
+export function windows(find = which, env: NodeJS.ProcessEnv = process.env) {
+  const shell = find("powershell.exe", env)
+  if (!shell) return
+  return [shell, "-NoProfile", "-NonInteractive", "-Command", script]
+}
+
+export function wsl(rel = release(), find = which, env: NodeJS.ProcessEnv = process.env) {
+  if (!rel.toUpperCase().includes("WSL")) return
+  return windows(find, env)
+}
+
+export function wslPath(input: string) {
+  const path = input.trim().replaceAll("\\", "/")
+  const match = path.match(/^([a-zA-Z]):(?:\/(.*))?$/)
+  if (!match) return path
+  const rest = match[2] ? `/${match[2]}` : ""
+  return `/mnt/${match[1].toLowerCase()}${rest}`
 }

--- a/packages/opencode/src/server/pick-folder.ts
+++ b/packages/opencode/src/server/pick-folder.ts
@@ -1,0 +1,23 @@
+import { which } from "../util/which"
+
+export type Pick = {
+  path: string | null
+  unavailable?: boolean
+  reason?: "missing_picker"
+}
+
+export function missing(): Pick {
+  return {
+    path: null,
+    unavailable: true,
+    reason: "missing_picker",
+  }
+}
+
+export function linux(env: NodeJS.ProcessEnv = process.env, find = which) {
+  const zenity = find("zenity", env)
+  if (zenity) return [zenity, "--file-selection", "--directory", "--title=Select Folder"]
+
+  const kdialog = find("kdialog", env)
+  if (kdialog) return [kdialog, "--getexistingdirectory", env.HOME || "/"]
+}

--- a/packages/opencode/src/server/routes/file.ts
+++ b/packages/opencode/src/server/routes/file.ts
@@ -33,7 +33,7 @@ import {
 } from "../../markdown-translator"
 import { detectDataJson, chunkByContent, chunksFromDataJson } from "../../markdown-translator/chunker"
 import fs from "fs/promises"
-import { linux, missing } from "../pick-folder"
+import { linux, missing, windows, wsl, wslPath } from "../pick-folder"
 
 const encode = (input: string) =>
   encodeURIComponent(input).replace(/['()*]/g, (part) => `%${part.charCodeAt(0).toString(16).toUpperCase()}`)
@@ -744,13 +744,9 @@ export const FileRoutes = lazy(() =>
         try {
           let selected: string | null = null
           if (process.platform === "win32") {
-            const ps = spawn([
-              "powershell.exe",
-              "-NoProfile",
-              "-NonInteractive",
-              "-Command",
-              "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; Add-Type -AssemblyName System.Windows.Forms; $d = New-Object System.Windows.Forms.FolderBrowserDialog; $d.ShowNewFolderButton = $true; $owner = New-Object System.Windows.Forms.Form; $owner.TopMost = $true; $owner.WindowState = 'Minimized'; $owner.ShowInTaskbar = $false; $owner.Show(); $owner.Hide(); if ($d.ShowDialog($owner) -eq 'OK') { $d.SelectedPath }; $owner.Dispose()",
-            ])
+            const cmd = windows()
+            if (!cmd) return c.json(missing())
+            const ps = spawn(cmd)
             const output = await new Response(ps.stdout).text()
             await ps.exited
             const trimmed = output.trim()
@@ -762,13 +758,13 @@ export const FileRoutes = lazy(() =>
             const trimmed = output.trim()
             if (trimmed) selected = trimmed.replace(/\/$/, "")
           } else {
-            const cmd = linux()
+            const cmd = linux() || wsl()
             if (!cmd) return c.json(missing())
             const proc = spawn(cmd)
             const output = await new Response(proc.stdout).text()
             await proc.exited
             const trimmed = output.trim()
-            if (trimmed) selected = trimmed
+            if (trimmed) selected = cmd.at(0)?.toLowerCase().endsWith("powershell.exe") ? wslPath(trimmed) : trimmed
           }
           return c.json({ path: selected })
         } catch (error) {

--- a/packages/opencode/src/server/routes/file.ts
+++ b/packages/opencode/src/server/routes/file.ts
@@ -33,6 +33,7 @@ import {
 } from "../../markdown-translator"
 import { detectDataJson, chunkByContent, chunksFromDataJson } from "../../markdown-translator/chunker"
 import fs from "fs/promises"
+import { linux, missing } from "../pick-folder"
 
 const encode = (input: string) =>
   encodeURIComponent(input).replace(/['()*]/g, (part) => `%${part.charCodeAt(0).toString(16).toUpperCase()}`)
@@ -725,7 +726,17 @@ export const FileRoutes = lazy(() =>
         responses: {
           200: {
             description: "Selected folder path or null if cancelled",
-            content: { "application/json": { schema: resolver(z.object({ path: z.string().nullable() })) } },
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.object({
+                    path: z.string().nullable(),
+                    unavailable: z.boolean().optional(),
+                    reason: z.enum(["missing_picker"]).optional(),
+                  }),
+                ),
+              },
+            },
           },
         },
       }),
@@ -751,23 +762,13 @@ export const FileRoutes = lazy(() =>
             const trimmed = output.trim()
             if (trimmed) selected = trimmed.replace(/\/$/, "")
           } else {
-            try {
-              const proc = spawn(["zenity", "--file-selection", "--directory", "--title=Select Folder"])
-              const output = await new Response(proc.stdout).text()
-              await proc.exited
-              const trimmed = output.trim()
-              if (trimmed) selected = trimmed
-            } catch {
-              try {
-                const proc = spawn(["kdialog", "--getexistingdirectory", process.env.HOME || "/"])
-                const output = await new Response(proc.stdout).text()
-                await proc.exited
-                const trimmed = output.trim()
-                if (trimmed) selected = trimmed
-              } catch {
-                // No native dialog available
-              }
-            }
+            const cmd = linux()
+            if (!cmd) return c.json(missing())
+            const proc = spawn(cmd)
+            const output = await new Response(proc.stdout).text()
+            await proc.exited
+            const trimmed = output.trim()
+            if (trimmed) selected = trimmed
           }
           return c.json({ path: selected })
         } catch (error) {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -5127,6 +5127,8 @@ export type FilePickFolderResponses = {
    */
   200: {
     path: string | null
+    unavailable?: boolean
+    reason?: "missing_picker"
   }
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #104

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Browse` in the project dialogs had two bad behaviors on Linux/WSL.

First, if `zenity` and `kdialog` were both missing, the backend returned `path: null` with no distinction between user cancel and picker unavailability. That made the button look like it did nothing.

Second, on WSL we can often still open the native Windows folder picker through `powershell.exe`, but the server was only checking Linux pickers.

This PR fixes both cases:
- the backend returns an explicit unavailable state when no picker backend exists
- the frontend shows an error toast only for that unavailable state, while keeping normal cancel silent
- on WSL, the backend falls back to the Windows folder picker via `powershell.exe` and converts the selected `C:\...` path to `/mnt/...`

The changes work because the route now distinguishes three different outcomes instead of collapsing them into one: successful selection, user cancel, and picker unavailable. WSL is also handled as its own execution environment instead of being treated like generic Linux.

### How did you verify your code works?

- `bun test src/server/pick-folder.test.ts` in `packages/opencode`
- `bun test src/components/pick-folder.test.ts` in `packages/app`
- `bun typecheck` in `packages/opencode`
- `bun typecheck` in `packages/app`
- manual Playwright check for the unavailable-picker case
- manual runtime check on WSL that `powershell.exe` is detected and `C:\Songtan\Gewu` is converted to `/mnt/c/Songtan/Gewu`

### Screenshots / recordings

No screenshot attached for the WSL fallback itself because it uses the native Windows folder dialog outside the browser surface.

For the unavailable-picker path, I verified the UI toast locally with Playwright during development.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
