### PR TITLE
fix: resolve windows paths in wsl tools

### DIFF
--- a/packages/opencode/src/tool/glob.ts
+++ b/packages/opencode/src/tool/glob.ts
@@ -6,6 +6,7 @@ import DESCRIPTION from "./glob.txt"
 import { Ripgrep } from "../file/ripgrep"
 import { Instance } from "../project/instance"
 import { assertExternalDirectory } from "./external-directory"
+import { resolveInput } from "./path"
 
 export const GlobTool = Tool.define("glob", {
   description: DESCRIPTION,
@@ -29,8 +30,7 @@ export const GlobTool = Tool.define("glob", {
       },
     })
 
-    let search = params.path ?? Instance.directory
-    search = path.isAbsolute(search) ? search : path.resolve(Instance.directory, search)
+    const search = resolveInput(Instance.directory, params.path ?? Instance.directory)
     await assertExternalDirectory(ctx, search, { kind: "directory" })
 
     const limit = 100

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -9,6 +9,7 @@ import DESCRIPTION from "./grep.txt"
 import { Instance } from "../project/instance"
 import path from "path"
 import { assertExternalDirectory } from "./external-directory"
+import { resolveInput } from "./path"
 
 const MAX_LINE_LENGTH = 2000
 
@@ -35,8 +36,7 @@ export const GrepTool = Tool.define("grep", {
       },
     })
 
-    let searchPath = params.path ?? Instance.directory
-    searchPath = path.isAbsolute(searchPath) ? searchPath : path.resolve(Instance.directory, searchPath)
+    const searchPath = resolveInput(Instance.directory, params.path ?? Instance.directory)
     await assertExternalDirectory(ctx, searchPath, { kind: "directory" })
 
     const rgPath = await Ripgrep.filepath()

--- a/packages/opencode/src/tool/ls.ts
+++ b/packages/opencode/src/tool/ls.ts
@@ -5,6 +5,7 @@ import DESCRIPTION from "./ls.txt"
 import { Instance } from "../project/instance"
 import { Ripgrep } from "../file/ripgrep"
 import { assertExternalDirectory } from "./external-directory"
+import { resolveInput } from "./path"
 
 export const IGNORE_PATTERNS = [
   "node_modules/",
@@ -42,7 +43,7 @@ export const ListTool = Tool.define("list", {
     ignore: z.array(z.string()).describe("List of glob patterns to ignore").optional(),
   }),
   async execute(params, ctx) {
-    const searchPath = path.resolve(Instance.directory, params.path || ".")
+    const searchPath = resolveInput(Instance.directory, params.path || ".")
     await assertExternalDirectory(ctx, searchPath, { kind: "directory" })
 
     await ctx.ask({

--- a/packages/opencode/src/tool/path.test.ts
+++ b/packages/opencode/src/tool/path.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test"
+import { resolveInput, wsl } from "./path"
+
+describe("wsl", () => {
+  test("converts a windows path in wsl", () => {
+    expect(wsl("C:\\Songtan\\paper.pdf", "5.15.167.4-microsoft-standard-WSL2")).toBe("/mnt/c/Songtan/paper.pdf")
+  })
+
+  test("converts a windows path with slash separators in wsl", () => {
+    expect(wsl("C:/Songtan/paper.pdf", "5.15.167.4-microsoft-standard-WSL2")).toBe("/mnt/c/Songtan/paper.pdf")
+  })
+
+  test("converts a drive root in wsl", () => {
+    expect(wsl("C:\\", "5.15.167.4-microsoft-standard-WSL2")).toBe("/mnt/c")
+  })
+
+  test("leaves a windows path unchanged outside wsl", () => {
+    expect(wsl("C:\\Songtan\\paper.pdf", "6.8.0-generic")).toBe("C:\\Songtan\\paper.pdf")
+  })
+
+  test("leaves a unix path unchanged in wsl", () => {
+    expect(wsl("/mnt/c/Songtan/paper.pdf", "5.15.167.4-microsoft-standard-WSL2")).toBe("/mnt/c/Songtan/paper.pdf")
+  })
+})
+
+describe("resolveInput", () => {
+  test("treats a wsl windows path as absolute", () => {
+    expect(resolveInput("/home/st_97142/Aether", "C:\\Songtan\\paper.pdf", "5.15.167.4-microsoft-standard-WSL2")).toBe(
+      "/mnt/c/Songtan/paper.pdf",
+    )
+  })
+
+  test("resolves a relative path from the root", () => {
+    expect(resolveInput("/home/st_97142/Aether", "docs/paper.pdf", "5.15.167.4-microsoft-standard-WSL2")).toBe(
+      "/home/st_97142/Aether/docs/paper.pdf",
+    )
+  })
+})

--- a/packages/opencode/src/tool/path.ts
+++ b/packages/opencode/src/tool/path.ts
@@ -1,0 +1,19 @@
+import { release } from "os"
+import path from "path"
+
+export function wsl(input: string, rel = release()) {
+  if (!rel.toUpperCase().includes("WSL")) return input
+
+  const next = input.replaceAll("\\", "/")
+  const match = next.match(/^([a-zA-Z]):(?:\/(.*))?$/)
+  if (!match) return input
+
+  const rest = match[2] ? `/${match[2]}` : ""
+  return `/mnt/${match[1].toLowerCase()}${rest}`
+}
+
+export function resolveInput(root: string, input: string, rel = release()) {
+  const next = wsl(input, rel)
+  if (path.isAbsolute(next)) return next
+  return path.resolve(root, next)
+}

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -11,6 +11,7 @@ import { Instance } from "../project/instance"
 import { assertExternalDirectory } from "./external-directory"
 import { InstructionPrompt } from "../session/instruction"
 import { Filesystem } from "../util/filesystem"
+import { resolveInput } from "./path"
 
 const DEFAULT_READ_LIMIT = 2000
 const MAX_LINE_LENGTH = 2000
@@ -29,10 +30,7 @@ export const ReadTool = Tool.define("read", {
     if (params.offset !== undefined && params.offset < 1) {
       throw new Error("offset must be greater than or equal to 1")
     }
-    let filepath = params.filePath
-    if (!path.isAbsolute(filepath)) {
-      filepath = path.resolve(Instance.directory, filepath)
-    }
+    const filepath = resolveInput(Instance.directory, params.filePath)
     const title = path.relative(Instance.worktree, filepath)
 
     const stat = Filesystem.stat(filepath)


### PR DESCRIPTION
### Issue for this PR

Closes #106

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes WSL handling for Windows absolute paths in the file tools.

Before this change, inputs like `C:\Songtan\papers\a.pdf` were treated as relative paths on Linux/WSL because Node's `path.isAbsolute()` returns `false` for Windows drive-letter paths there. That caused tools such as `read`, `glob`, `ls`, and `grep` to resolve the path under the current repo directory and fail to find the file.

This PR adds a shared WSL path normalizer that converts Windows drive-letter paths to `/mnt/...` before normal resolution, and wires that helper into the four affected tools.

The fix works because those tools now normalize the path at the boundary instead of relying on Linux path semantics for Windows-style input.

### How did you verify your code works?

- `bun test src/tool/path.test.ts` in `packages/opencode`
- `bun typecheck` in `packages/opencode`

### Screenshots / recordings

Not applicable. This is a backend/tooling path resolution fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
