### PR TITLE
feat(skills): add clawhub skill for managing agent skills

### DIFF
--- a/.opencode/skills/clawhub/SKILL.md
+++ b/.opencode/skills/clawhub/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: clawhub
+description: Use the ClawHub CLI to search, install, update, and publish agent skills from clawhub.com. Use when you need to fetch new skills on the fly, sync installed skills to latest or a specific version, or publish new/updated skill folders with the npm-installed clawhub CLI.
+metadata:
+  {
+    "openclaw":
+      {
+        "requires": { "bins": ["clawhub"] },
+        "install":
+          [
+            {
+              "id": "node",
+              "kind": "node",
+              "package": "clawhub",
+              "bins": ["clawhub"],
+              "label": "Install ClawHub CLI (npm)",
+            },
+          ],
+      },
+  }
+---
+
+# ClawHub CLI
+
+Install
+
+```bash
+npm i -g clawhub
+```
+
+Auth (publish)
+
+```bash
+clawhub login
+clawhub whoami
+```
+
+Search
+
+```bash
+clawhub search "postgres backups"
+```
+
+Install
+
+```bash
+clawhub install my-skill
+clawhub install my-skill --version 1.2.3
+```
+
+Update (hash-based match + upgrade)
+
+```bash
+clawhub update my-skill
+clawhub update my-skill --version 1.2.3
+clawhub update --all
+clawhub update my-skill --force
+clawhub update --all --no-input --force
+```
+
+List
+
+```bash
+clawhub list
+```
+
+Publish
+
+```bash
+clawhub publish ./my-skill --slug my-skill --name "My Skill" --version 1.2.0 --changelog "Fixes + docs"
+```
+
+Notes
+
+- Default registry: https://clawhub.com (override with CLAWHUB_REGISTRY or --registry)
+- Default workdir: cwd (falls back to OpenClaw workspace); install dir: ./skills (override with --workdir / --dir / CLAWHUB_WORKDIR)
+- Update command hashes local files, resolves matching version, and upgrades to latest unless --version is set


### PR DESCRIPTION
## Summary
- Add new ClawHub CLI skill for managing agent skills from clawhub.com
- Supports search, install, update, and publish operations
- Includes automatic dependency management via OpenClaw metadata