### PR TITLE
Windows 安装/更新链路增强：多下载器回退、current 链接修复、快捷方式完善与脚本瘦身

### DIFF
--- a/Update/aether_windows_installer.bat
+++ b/Update/aether_windows_installer.bat
@@ -1,4 +1,5 @@
 @echo off
+chcp 65001 >nul
 setlocal EnableExtensions EnableDelayedExpansion
 
 set "BASE=https://aether.aiphys.cn/download"
@@ -239,7 +240,7 @@ if not "%RC%"=="0" (
   exit /b %META_ERR%
 )
 
-for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$sec=''; $ver=''; $pkg=''; $sha=''; $ins=''; $note=''; foreach($line in Get-Content -Path $env:MANIFEST){ if($line -match '^\s*version:\s*(.+?)\s*$'){ $ver=$matches[1].Trim().Trim("'\""); continue }; if($line -match '^\s*package:\s*$'){ $sec='package'; continue }; if($line -match '^\s*installer:\s*$'){ $sec='installer'; continue }; if($line -match '^\s*notes_url:\s*(.+?)\s*$'){ $note=$matches[1].Trim(); continue }; if($line -match '^\S'){ $sec='' }; if($sec -eq 'package' -and $line -match '^\s*url:\s*(.+?)\s*$'){ $pkg=$matches[1].Trim(); continue }; if($sec -eq 'package' -and $line -match '^\s*sha512:\s*(.+?)\s*$'){ $sha=$matches[1].Trim(); continue }; if($sec -eq 'installer' -and $line -match '^\s*url:\s*(.+?)\s*$'){ $ins=$matches[1].Trim(); continue } }; if([string]::IsNullOrEmpty($pkg)){ foreach($line in Get-Content -Path $env:MANIFEST){ if($line -match '^\s*files:\s*$'){ $sec='files'; continue }; if($line -match '^\S'){ $sec='' }; if($sec -eq 'files' -and $line -match '^\s*-\s*url:\s*(.+?)\s*$'){ $pkg=$matches[1].Trim(); continue }; if($sec -eq 'files' -and $line -match '^\s*sha512:\s*(.+?)\s*$'){ $sha=$matches[1].Trim(); continue } } }; 'VER=' + $ver; 'PKG=' + $pkg; 'SHA=' + $sha; 'INS=' + $ins; 'NOTE=' + $note"`) do set "%%i"
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$sec=''; $ver=''; $pkg=''; $sha=''; $ins=''; $note=''; $clean={ param($v) $v.Trim().Trim([char]39).Trim([char]34) }; foreach($line in Get-Content -Path $env:MANIFEST){ if($line -match '^\s*version:\s*(.+?)\s*$'){ $ver=& $clean $matches[1]; continue }; if($line -match '^\s*package:\s*$'){ $sec='package'; continue }; if($line -match '^\s*installer:\s*$'){ $sec='installer'; continue }; if($line -match '^\s*notes_url:\s*(.+?)\s*$'){ $note=& $clean $matches[1]; continue }; if($line -match '^\S'){ $sec='' }; if($sec -eq 'package' -and $line -match '^\s*url:\s*(.+?)\s*$'){ $pkg=& $clean $matches[1]; continue }; if($sec -eq 'package' -and $line -match '^\s*sha512:\s*(.+?)\s*$'){ $sha=& $clean $matches[1]; continue }; if($sec -eq 'installer' -and $line -match '^\s*url:\s*(.+?)\s*$'){ $ins=& $clean $matches[1]; continue } }; if([string]::IsNullOrEmpty($pkg)){ foreach($line in Get-Content -Path $env:MANIFEST){ if($line -match '^\s*files:\s*$'){ $sec='files'; continue }; if($line -match '^\S'){ $sec='' }; if($sec -eq 'files' -and $line -match '^\s*-\s*url:\s*(.+?)\s*$'){ $pkg=& $clean $matches[1]; continue }; if($sec -eq 'files' -and $line -match '^\s*sha512:\s*(.+?)\s*$'){ $sha=& $clean $matches[1]; continue } } }; 'VER=' + $ver; 'PKG=' + $pkg; 'SHA=' + $sha; 'INS=' + $ins; 'NOTE=' + $note"`) do set "%%i"
 
 if not defined VER (
   rmdir /s /q "%TMP%" >nul 2>nul
@@ -272,7 +273,7 @@ if exist "%PKG_FILE%" (
     set "NEED_PKG=0"
   ) else (
     for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$h=[Security.Cryptography.SHA512]::Create().ComputeHash([IO.File]::ReadAllBytes($env:PKG_FILE)); [Convert]::ToBase64String($h)"`) do set "SUM=%%i"
-    if /I "%SUM%"=="%SHA%" set "NEED_PKG=0"
+    if /I "!SUM!"=="!SHA!" set "NEED_PKG=0"
   )
 )
 
@@ -287,19 +288,19 @@ if "%NEED_PKG%"=="1" (
 
 if defined SHA (
   for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$h=[Security.Cryptography.SHA512]::Create().ComputeHash([IO.File]::ReadAllBytes($env:PKG_FILE)); [Convert]::ToBase64String($h)"`) do set "SUM=%%i"
-  if /I not "%SUM%"=="%SHA%" exit /b %SUM_ERR%
+  if /I not "!SUM!"=="!SHA!" exit /b %SUM_ERR%
 )
 
 if defined INS_URL if defined INS_NAME (
-  for %%i in ("%INS_NAME%") do set "INS_EXT=%%~xi"
-  set "INS_FILE=%DL%\update_windows_web-%VER%%INS_EXT%"
-  if exist "%INS_FILE%" (
+  for %%i in ("!INS_NAME!") do set "INS_EXT=%%~xi"
+  set "INS_FILE=!DL!\update_windows_web-!VER!!INS_EXT!"
+  if exist "!INS_FILE!" (
     echo Using cached installer:
-    echo   %INS_FILE%
+    echo   !INS_FILE!
   ) else (
     echo Downloading installer:
-    echo   %INS_URL%
-    call :fetch_file "%INS_URL%" "%INS_FILE%" || exit /b %DL_ERR%
+    echo   !INS_URL!
+    call :fetch_file "!INS_URL!" "!INS_FILE!" || exit /b %DL_ERR%
   )
 )
 
@@ -334,7 +335,7 @@ exit /b 0
 :cmp
 set "A=%~1"
 set "B=%~2"
-for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$a=$env:A; $b=$env:B; function norm([string]$v){ if(!$v){ return $null }; $v=$v.Trim(); $v=$v -replace '^v',''; $v=$v.Split('-')[0]; $p=$v.Split('.'); while($p.Count -lt 4){ $p += '0' }; if($p.Count -gt 4){ $p=$p[0..3] }; [string]::Join('.', $p) }; $x=norm $a; $y=norm $b; if(!$x -or !$y){ if($a -eq $b){ 'eq' } else { 'lt' }; exit 0 }; if(([version]$x) -lt ([version]$y)){ 'lt' } elseif(([version]$x) -gt ([version]$y)){ 'gt' } else { 'eq' }"`) do set "CMP=%%i"
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$a=$env:A; $b=$env:B; function norm([string]$v){ if($null -eq $v -or $v -eq ''){ return $null }; $v=$v.Trim(); $v=$v -replace '^v',''; $v=$v.Split('-')[0]; $p=$v.Split('.'); while($p.Count -lt 4){ $p += '0' }; if($p.Count -gt 4){ $p=$p[0..3] }; [string]::Join('.', $p) }; $x=norm $a; $y=norm $b; if($null -eq $x -or $null -eq $y){ if($a -eq $b){ 'eq' } else { 'lt' }; exit 0 }; if(([version]$x) -lt ([version]$y)){ 'lt' } elseif(([version]$x) -gt ([version]$y)){ 'gt' } else { 'eq' }"`) do set "CMP=%%i"
 exit /b 0
 
 :work
@@ -380,28 +381,123 @@ exit /b 0
 set "URL=%~1"
 set "OUT=%~2"
 set "FETCH_HTTP="
-where curl.exe >nul 2>nul
-if not errorlevel 1 (
-  for /f "delims=" %%i in ('curl.exe --location --silent --show-error --connect-timeout %CTO% --max-time %TMO% --retry %RETRY% --retry-delay %DELAY% --output "%OUT%" --write-out "%%{http_code}" "%URL%"') do set "FETCH_HTTP=%%i"
-  if "%FETCH_HTTP%"=="200" exit /b 0
-  if exist "%OUT%" del /f /q "%OUT%" >nul 2>nul
-  exit /b 1
-)
-for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "& { try { $r=Invoke-WebRequest -UseBasicParsing -Uri $env:URL -OutFile $env:OUT -PassThru; [Console]::Out.Write([int]$r.StatusCode) } catch { if(Test-Path $env:OUT){ Remove-Item -LiteralPath $env:OUT -Force -ErrorAction SilentlyContinue }; if($_.Exception.Response){ [Console]::Out.Write([int]$_.Exception.Response.StatusCode) } else { [Console]::Out.Write('000') }; exit 1 } }"`) do set "FETCH_HTTP=%%i"
-if "%FETCH_HTTP%"=="200" exit /b 0
+set "META_404=0"
+call :detect_git_curl
+call :meta_try git
+if "%ERRORLEVEL%"=="0" exit /b 0
+if "%FETCH_HTTP%"=="404" set "META_404=1"
+call :meta_try curl
+if "%ERRORLEVEL%"=="0" exit /b 0
+if "%FETCH_HTTP%"=="404" set "META_404=1"
+call :meta_try iwr
+if "%ERRORLEVEL%"=="0" exit /b 0
+if "%FETCH_HTTP%"=="404" set "META_404=1"
+call :meta_try bits
+if "%ERRORLEVEL%"=="0" exit /b 0
+if "%META_404%"=="1" set "FETCH_HTTP=404"
 exit /b 1
 
 :fetch_file
 set "URL=%~1"
 set "OUT=%~2"
-where curl.exe >nul 2>nul
-if not errorlevel 1 (
-  curl.exe --fail --location --progress-bar --connect-timeout %CTO% --max-time %TMO% --retry %RETRY% --retry-delay %DELAY% --retry-all-errors --output "%OUT%" "%URL%"
+call :detect_git_curl
+call :file_try git
+if "%ERRORLEVEL%"=="0" exit /b 0
+call :file_try curl
+if "%ERRORLEVEL%"=="0" exit /b 0
+call :file_try iwr
+if "%ERRORLEVEL%"=="0" exit /b 0
+call :file_try bits
+if "%ERRORLEVEL%"=="0" exit /b 0
+exit /b 1
+
+:detect_git_curl
+set "GIT_CURL="
+if exist "%ProgramFiles%\Git\mingw64\bin\curl.exe" set "GIT_CURL=%ProgramFiles%\Git\mingw64\bin\curl.exe"
+if not defined GIT_CURL if exist "%ProgramFiles%\Git\usr\bin\curl.exe" set "GIT_CURL=%ProgramFiles%\Git\usr\bin\curl.exe"
+if not defined GIT_CURL if defined ProgramFiles(x86) if exist "%ProgramFiles(x86)%\Git\mingw64\bin\curl.exe" set "GIT_CURL=%ProgramFiles(x86)%\Git\mingw64\bin\curl.exe"
+if not defined GIT_CURL if defined ProgramFiles(x86) if exist "%ProgramFiles(x86)%\Git\usr\bin\curl.exe" set "GIT_CURL=%ProgramFiles(x86)%\Git\usr\bin\curl.exe"
+exit /b 0
+
+:meta_try
+set "TOOL=%~1"
+if /I "%TOOL%"=="git" (
+  if not defined GIT_CURL exit /b 1
+  echo [meta] Downloader: git curl
+  call :curl_meta "%GIT_CURL%"
   exit /b %ERRORLEVEL%
 )
-echo curl.exe not found. Falling back to PowerShell download...
-powershell -NoProfile -Command "& { Invoke-WebRequest -UseBasicParsing -Uri $env:URL -OutFile $env:OUT }"
-exit /b %ERRORLEVEL%
+if /I "%TOOL%"=="curl" (
+  where curl.exe >nul 2>nul
+  if errorlevel 1 exit /b 1
+  echo [meta] Downloader: curl.exe
+  call :curl_meta "curl.exe"
+  exit /b %ERRORLEVEL%
+)
+if /I "%TOOL%"=="iwr" (
+  echo [meta] Downloader: Invoke-WebRequest
+  for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "& { try { $r=Invoke-WebRequest -UseBasicParsing -Uri $env:URL -OutFile $env:OUT -PassThru -ErrorAction Stop; [Console]::Out.Write([int]$r.StatusCode) } catch { if(Test-Path $env:OUT){ Remove-Item -LiteralPath $env:OUT -Force -ErrorAction SilentlyContinue }; if($_.Exception.Response){ [Console]::Out.Write([int]$_.Exception.Response.StatusCode) } else { [Console]::Out.Write('000') }; exit 1 } }"`) do set "FETCH_HTTP=%%i"
+  if "%FETCH_HTTP%"=="200" exit /b 0
+  exit /b 1
+)
+if /I "%TOOL%"=="bits" (
+  echo [meta] Downloader: Start-BitsTransfer
+  for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "& { if(-not (Get-Command Start-BitsTransfer -ErrorAction SilentlyContinue)){ [Console]::Out.Write('000'); exit 1 }; try { Start-BitsTransfer -Source $env:URL -Destination $env:OUT -ErrorAction Stop; [Console]::Out.Write('200') } catch { if(Test-Path $env:OUT){ Remove-Item -LiteralPath $env:OUT -Force -ErrorAction SilentlyContinue }; [Console]::Out.Write('000'); exit 1 } }"`) do set "FETCH_HTTP=%%i"
+  if "%FETCH_HTTP%"=="200" exit /b 0
+  exit /b 1
+)
+exit /b 1
+
+:file_try
+set "TOOL=%~1"
+if /I "%TOOL%"=="git" (
+  if not defined GIT_CURL exit /b 1
+  echo [file] Downloader: git curl
+  call :curl_file "%GIT_CURL%"
+  exit /b %ERRORLEVEL%
+)
+if /I "%TOOL%"=="curl" (
+  where curl.exe >nul 2>nul
+  if errorlevel 1 exit /b 1
+  echo [file] Downloader: curl.exe
+  call :curl_file "curl.exe"
+  exit /b %ERRORLEVEL%
+)
+if /I "%TOOL%"=="iwr" (
+  echo [file] Downloader: Invoke-WebRequest
+  powershell -NoProfile -Command "& { try { Invoke-WebRequest -UseBasicParsing -Uri $env:URL -OutFile $env:OUT -ErrorAction Stop } catch { if(Test-Path $env:OUT){ Remove-Item -LiteralPath $env:OUT -Force -ErrorAction SilentlyContinue }; exit 1 } }"
+  if errorlevel 1 exit /b 1
+  exit /b 0
+)
+if /I "%TOOL%"=="bits" (
+  echo [file] Downloader: Start-BitsTransfer
+  powershell -NoProfile -Command "& { if(-not (Get-Command Start-BitsTransfer -ErrorAction SilentlyContinue)){ exit 1 }; try { Start-BitsTransfer -Source $env:URL -Destination $env:OUT -ErrorAction Stop } catch { if(Test-Path $env:OUT){ Remove-Item -LiteralPath $env:OUT -Force -ErrorAction SilentlyContinue }; exit 1 } }"
+  if errorlevel 1 exit /b 1
+  exit /b 0
+)
+exit /b 1
+
+:curl_meta
+set "BIN=%~1"
+set "FETCH_HTTP="
+set "HTTP_FILE=%TEMP%\aether-http-%RANDOM%%RANDOM%.txt"
+"%BIN%" --location --silent --show-error --connect-timeout %CTO% --max-time %TMO% --retry %RETRY% --retry-delay %DELAY% --output "%OUT%" --write-out "%%{http_code}" "%URL%" > "%HTTP_FILE%"
+if exist "%HTTP_FILE%" (
+  set /p FETCH_HTTP=<"%HTTP_FILE%"
+  del /f /q "%HTTP_FILE%" >nul 2>nul
+)
+if "%FETCH_HTTP%"=="200" exit /b 0
+if exist "%OUT%" del /f /q "%OUT%" >nul 2>nul
+exit /b 1
+
+:curl_file
+set "BIN=%~1"
+"%BIN%" --fail --location --progress-bar --connect-timeout %CTO% --max-time %TMO% --retry %RETRY% --retry-delay %DELAY% --retry-all-errors --output "%OUT%" "%URL%"
+if errorlevel 1 (
+  if exist "%OUT%" del /f /q "%OUT%" >nul 2>nul
+  exit /b 1
+)
+exit /b 0
 
 :help
 echo Aether Windows Installer

--- a/Update/update_windows_web.bat
+++ b/Update/update_windows_web.bat
@@ -1,4 +1,5 @@
 @echo off
+chcp 65001 >nul
 setlocal EnableExtensions EnableDelayedExpansion
 
 set "WANT=%~1"
@@ -42,8 +43,7 @@ set "EX=%TMP%\extract"
 set "NEXT=%WORK%\.aether_%VER%.next"
 set "SRC_FILE=%TMP%\src.txt"
 
-if exist "%TMP%" rmdir /s /q "%TMP%" >nul 2>nul
-if exist "%NEXT%" rmdir /s /q "%NEXT%" >nul 2>nul
+call :clean_tmp
 mkdir "%EX%" || exit /b 1
 mkdir "%NEXT%" || exit /b 1
 
@@ -76,8 +76,7 @@ move "%NEXT%" "%TARGET%" >nul || goto :fail
 echo %VER%>"%TARGET%\.aether_web_version"
 echo %VER%>"%WORK%\.aether_web_version"
 
-if exist "%WORK%\current" rmdir "%WORK%\current" >nul 2>nul
-mklink /J "%WORK%\current" "%TARGET%" >nul
+call :set_current || goto :fail
 
 call :write_launch
 
@@ -96,28 +95,34 @@ echo 版本目录: %TARGET%
 echo 启动入口: %LAUNCH%
 if defined NOTE echo %NOTE%
 
-rmdir /s /q "%TMP%" >nul 2>nul
+call :clean_tmp
 exit /b 0
 
 :write_launch
 set "DESK=%USERPROFILE%\Desktop"
 if not exist "%DESK%" mkdir "%DESK%"
 set "LNK=%DESK%\Aether.lnk"
+set "MENU=%APPDATA%\Microsoft\Windows\Start Menu\Programs"
+if not exist "%MENU%" mkdir "%MENU%"
+set "MLNK=%MENU%\Aether.lnk"
 set "CMD=%WORK%\current\Aether.vbs"
-powershell -NoProfile -Command "$w=New-Object -ComObject WScript.Shell; $s=$w.CreateShortcut($env:LNK); $s.TargetPath=$env:CMD; $s.WorkingDirectory=(Split-Path -Parent $env:CMD); $s.IconLocation=$env:CMD+',0'; $s.Save()"
+if exist "%LNK%" del /f /q "%LNK%" >nul 2>nul
+if exist "%MLNK%" del /f /q "%MLNK%" >nul 2>nul
+powershell -NoProfile -Command "$w=New-Object -ComObject WScript.Shell; $mk={ param($p,$t) $s=$w.CreateShortcut($p); $s.TargetPath=$t; $s.WorkingDirectory=(Split-Path -Parent $t); $s.Save() }; & $mk $env:LNK $env:CMD; & $mk $env:MLNK $env:CMD"
 if exist "%LNK%" (
   set "LAUNCH=%LNK%"
+) else if exist "%MLNK%" (
+  set "LAUNCH=%MLNK%"
+  set "NOTE=Desktop shortcut failed, Start Menu shortcut created."
 ) else (
   set "LAUNCH=%CMD%"
-  set "NOTE=桌面快捷方式创建失败，已回退到直接启动路径。"
+  set "NOTE=Desktop and Start Menu shortcuts both failed, using direct launch path."
 )
 exit /b 0
 
 :restart
-if defined OLD (
-  powershell -NoProfile -Command "$p=$env:OLD; Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like ('*' + $p + '*') -and ($_.Name -ieq 'aether.exe' -or $_.Name -ieq 'wscript.exe' -or $_.Name -ieq 'cscript.exe') } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
-)
-powershell -NoProfile -Command "$p=$env:WORK + '\\current'; Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like ('*' + $p + '*') -and ($_.Name -ieq 'aether.exe' -or $_.Name -ieq 'wscript.exe' -or $_.Name -ieq 'cscript.exe') } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+powershell -NoProfile -Command "& { $names=@('aether.exe','wscript.exe','cscript.exe','node.exe','bun.exe'); $roots=@(); if($env:OLD){ $roots += [IO.Path]::GetFullPath($env:OLD) }; $roots += [IO.Path]::GetFullPath($env:WORK + '\current'); if($env:TARGET){ $roots += [IO.Path]::GetFullPath($env:TARGET) }; $roots += (Get-ChildItem -Path $env:WORK -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }); $roots=$roots | Where-Object { $_ } | Select-Object -Unique; Get-CimInstance Win32_Process | Where-Object { $n=$_.Name.ToLowerInvariant(); if($names -notcontains $n){ return $false }; $cmd=$_.CommandLine; $exe=$_.ExecutablePath; foreach($r in $roots){ if(($cmd -and $cmd -like ('*' + $r + '*')) -or ($exe -and $exe -like ($r + '*'))){ return $true } }; return $false } | Sort-Object ProcessId -Descending | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue } }"
+timeout /t 1 /nobreak >nul
 start "" "%WORK%\current\Aether.vbs"
 exit /b 0
 
@@ -163,5 +168,23 @@ exit /b 0
 
 :fail
 echo Update failed.
-rmdir /s /q "%TMP%" >nul 2>nul
+call :clean_tmp
 exit /b 1
+
+:clean_tmp
+if exist "%TMP%" rmdir /s /q "%TMP%" >nul 2>nul
+if exist "%NEXT%" rmdir /s /q "%NEXT%" >nul 2>nul
+exit /b 0
+
+:set_current
+if exist "%WORK%\current" rmdir "%WORK%\current" >nul 2>nul
+if exist "%WORK%\current" rmdir /s /q "%WORK%\current" >nul 2>nul
+mklink /J "%WORK%\current" "%TARGET%" >nul 2>nul
+if exist "%WORK%\current\Aether.vbs" exit /b 0
+
+mkdir "%WORK%\current" >nul 2>nul
+robocopy "%TARGET%" "%WORK%\current" /MIR /NFL /NDL /NJH /NJS /NP >nul
+set "RC=%ERRORLEVEL%"
+if %RC% GEQ 8 exit /b 1
+if not exist "%WORK%\current\Aether.vbs" exit /b 1
+exit /b 0


### PR DESCRIPTION
背景
本 PR 聚焦 Windows 安装与更新脚本的稳定性问题，修复了更新后 current 缺失导致快捷方式失效等关键故障，并对下载链路与脚本结构做了去冗余优化。

主要改动
aether_windows_installer.bat 下载能力增强
增加多下载器回退机制，顺序为：
git curl
curl.exe
Invoke-WebRequest
Start-BitsTransfer
manifest 下载与文件下载统一走回退链路，提升不同用户环境下成功率。
保留并兼容现有状态码/结果文件协议。
aether_windows_installer.bat 稳定性修复
修复批处理块内变量展开导致的误判问题（包括 checksum 判断、installer 扩展名/路径等）。
修复版本比较在 delayed expansion 下的兼容问题。
优化 manifest 字段解析与清洗，避免异常字符影响。
update_windows_web.bat 安装后可用性修复（关键）
修复更新后未正确创建 current 的问题：
新增 :set_current，先尝试 mklink /J。
若链接失败，自动回退为目录镜像（robocopy /MIR）。
强校验 current\Aether.vbs 必须存在，否则安装失败。
避免“安装成功但快捷方式指向失效路径”。
快捷方式能力增强
保持桌面快捷方式创建。
新增开始菜单快捷方式创建（Start Menu\Programs\Aether.lnk）。
创建前清理旧 .lnk，避免“旧文件存在导致误判创建成功”。
重启阶段进程清理增强
:restart 从单一路径匹配升级为多路径匹配（OLD/current/TARGET/aether_*）。
进程识别从仅 CommandLine 扩展到 CommandLine + ExecutablePath。
扩展需清理的进程名（aether/wscript/cscript/node/bun），并在拉起新版本前增加短等待。
编码与输出一致性
两个脚本统一增加 chcp 65001 >nul，降低中文输出乱码风险。
脚本瘦身（功能不变）
合并 installer 中重复下载函数，提炼通用入口，减少重复代码与维护成本。
抽取 update 脚本临时目录清理逻辑，降低重复代码。
修复的问题
更新后 current 缺失，导致快捷方式失效/启动报路径不存在。
部分环境下下载器不可用导致更新失败。
脚本在部分变量展开场景下的误判与不稳定行为。
验证
非 init 更新场景：可正确识别远端版本、下载并完成安装。
last-result.yml 状态与路径写入正确。
更新后 current\Aether.vbs 可用，快捷方式路径可解析。
下载器回退链路可按预期工作。