### PR TITLE
feat(WeChat): implement client locking mechanism to prevent multiple connections

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4751,7 +4751,7 @@
 
     "vite-plugin-solid": ["vite-plugin-solid@2.11.10", "https://registry.npmmirror.com/vite-plugin-solid/-/vite-plugin-solid-2.11.10.tgz", { "dependencies": { "@babel/core": "^7.23.3", "@types/babel__core": "^7.20.4", "babel-preset-solid": "^1.8.4", "merge-anything": "^5.1.7", "solid-refresh": "^0.6.3", "vitefu": "^1.0.4" }, "peerDependencies": { "@testing-library/jest-dom": "^5.16.6 || ^5.17.0 || ^6.*", "solid-js": "^1.7.2", "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@testing-library/jest-dom"] }, "sha512-Yr1dQybmtDtDAHkii6hXuc1oVH9CPcS/Zb2jN/P36qqcrkNnVPsMTzQ06jyzFPFjj3U1IYKMVt/9ZqcwGCEbjw=="],
 
-    "vite-plugin-static-copy": ["vite-plugin-static-copy@4.0.0", "", { "dependencies": { "chokidar": "^3.6.0", "p-map": "^7.0.4", "picocolors": "^1.1.1", "tinyglobby": "^0.2.15" }, "peerDependencies": { "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-TTf6cVTV4M2pH2Wfr3zhevdRsIQezfm2ltDkSfkjqvvdryJHYQyNoPISvuytX3r9jFZV0yVeMYyGTsAvAH2XLw=="],
+    "vite-plugin-static-copy": ["vite-plugin-static-copy@4.0.0", "https://registry.npmmirror.com/vite-plugin-static-copy/-/vite-plugin-static-copy-4.0.0.tgz", { "dependencies": { "chokidar": "^3.6.0", "p-map": "^7.0.4", "picocolors": "^1.1.1", "tinyglobby": "^0.2.15" }, "peerDependencies": { "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-TTf6cVTV4M2pH2Wfr3zhevdRsIQezfm2ltDkSfkjqvvdryJHYQyNoPISvuytX3r9jFZV0yVeMYyGTsAvAH2XLw=="],
 
     "vitefu": ["vitefu@1.1.2", "https://registry.npmmirror.com/vitefu/-/vitefu-1.1.2.tgz", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw=="],
 

--- a/packages/app/src/components/dialog-wechat.tsx
+++ b/packages/app/src/components/dialog-wechat.tsx
@@ -31,6 +31,8 @@ export const DialogWeChat: Component = () => {
   const [error, setError] = createSignal<{ code: string; message: string } | null>(null)
   const [user, setUser] = createSignal<{ id: string; name: string } | null>(null)
   const [loadingMsg, setLoadingMsg] = createSignal<string>("正在启动微信桥接...")
+  const [locked, setLocked] = createSignal(false)
+  let clientId: string | null = null
 
   const authHeaders = (): HeadersInit => {
     const s = server.current?.http
@@ -50,6 +52,12 @@ export const DialogWeChat: Component = () => {
     try {
       const response = await fetch(`${sdk.url}/wechat/status`, { headers: authHeaders() })
       const data = await response.json()
+      if (data.locked && data.status !== "idle") {
+        setLocked(true)
+        if (data.user) setUser(data.user)
+        return
+      }
+      setLocked(false)
       if (data.status === "connected" && data.user) {
         updateStatus("connected")
         setUser(data.user)
@@ -67,28 +75,38 @@ export const DialogWeChat: Component = () => {
     updateStatus("loading")
     setLoadingMsg("正在启动微信桥接...")
     setError(null)
+    setLocked(false)
 
     const currentModel = models.recent.list()[0]
     const modelStr = currentModel ? `${currentModel.providerID}/${currentModel.modelID}` : undefined
+    clientId = clientId || crypto.randomUUID()
 
     try {
       const response = await fetch(`${sdk.url}/wechat/start`, {
         method: "POST",
         headers: { ...authHeaders(), "Content-Type": "application/json" },
-        body: JSON.stringify({ model: modelStr, autoInstall: auto }),
+        body: JSON.stringify({ model: modelStr, autoInstall: auto, clientId }),
       })
       const data = await response.json()
 
       if (!data.success) {
+        if (data.code === "locked") {
+          setLocked(true)
+          updateStatus("idle")
+          return
+        }
         setError({ code: data.code || "start_failed", message: data.message || "Failed to start WeChat bridge" })
         updateStatus("error")
         return
       }
 
+      clientId = data.clientId || clientId
+
       // 已有保存的会话，直接显示连接状态
       if (data.status === "connected" && data.user) {
         setUser(data.user)
         updateStatus("connected")
+        connectSSE()
         return
       }
 
@@ -105,7 +123,12 @@ export const DialogWeChat: Component = () => {
       abort.abort()
       abort = null
     }
-    await fetch(`${sdk.url}/wechat/stop`, { method: "POST", headers: authHeaders() })
+    await fetch(`${sdk.url}/wechat/stop`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ clientId }),
+    })
+    clientId = null
     updateStatus("idle")
     setQrcode(null)
   }
@@ -115,8 +138,13 @@ export const DialogWeChat: Component = () => {
       abort.abort()
       abort = null
     }
-    await fetch(`${sdk.url}/wechat/stop`, { method: "POST", headers: authHeaders() })
+    await fetch(`${sdk.url}/wechat/stop`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ clientId }),
+    })
     await fetch(`${sdk.url}/wechat/session`, { method: "DELETE", headers: authHeaders() })
+    clientId = null
     setUser(null)
     updateStatus("idle")
     setQrcode(null)
@@ -130,7 +158,10 @@ export const DialogWeChat: Component = () => {
 
     void (async () => {
       try {
-        const response = await fetch(`${sdk.url}/wechat/events`, {
+        const url = clientId
+          ? `${sdk.url}/wechat/events?clientId=${encodeURIComponent(clientId)}`
+          : `${sdk.url}/wechat/events`
+        const response = await fetch(url, {
           headers: { ...authHeaders(), Accept: "text/event-stream" },
           signal: abort!.signal,
         })
@@ -192,6 +223,19 @@ export const DialogWeChat: Component = () => {
     <Dialog title="微信连接" class="max-w-md">
       <div class="flex flex-col items-center gap-6 p-6">
         <Switch fallback={<div />}>
+          <Match when={locked()}>
+            <div class="flex flex-col items-center gap-4">
+              <Icon name="wechat" size="large" class="size-16 text-icon-weak" />
+              <div class="flex flex-col items-center gap-1">
+                <p class="text-16-medium text-text-strong">微信已被其他客户端连接</p>
+                <p class="text-14-regular text-text-weak text-center">当前有另一个页面正在使用微信，请先在该页面断开连接</p>
+              </div>
+              <Button variant="secondary" onClick={() => dialog.close()}>
+                关闭
+              </Button>
+            </div>
+          </Match>
+
           <Match when={status() === "idle"}>
             <div class="flex flex-col items-center gap-4">
               <Icon name="wechat" size="large" class="size-16 text-icon-base" />

--- a/packages/opencode/src/server/routes/wechat.ts
+++ b/packages/opencode/src/server/routes/wechat.ts
@@ -41,8 +41,15 @@ export const WeChatRoutes = lazy(() =>
       }),
       async (c) => {
         const body = await c.req.json().catch(() => ({}))
+        const clientId: string = body?.clientId || crypto.randomUUID()
+        if (!(await WeChatManager.tryLock(clientId))) {
+          return c.json({ success: false, code: "locked", message: "微信已被其他客户端连接" })
+        }
         const result = await WeChatManager.start(body?.model, body?.autoInstall === true)
-        return c.json(result)
+        if (!result.success) {
+          await WeChatManager.unlock(clientId)
+        }
+        return c.json({ ...result, clientId })
       },
     )
     .post(
@@ -63,6 +70,8 @@ export const WeChatRoutes = lazy(() =>
         },
       }),
       async (c) => {
+        const body = await c.req.json().catch(() => ({}))
+        if (body?.clientId) await WeChatManager.unlock(body.clientId)
         await WeChatManager.stop()
         return c.json({ success: true })
       },
@@ -108,6 +117,7 @@ export const WeChatRoutes = lazy(() =>
           qrcode: WeChatManager.qrcode,
           user: WeChatManager.session?.user || session?.user || null,
           error: WeChatManager.error,
+          locked: WeChatManager.lockHolder !== null,
         })
       },
     )
@@ -131,6 +141,7 @@ export const WeChatRoutes = lazy(() =>
       async (c) => {
         c.header("X-Accel-Buffering", "no")
         c.header("X-Content-Type-Options", "nosniff")
+        const clientId = c.req.query("clientId") || ""
 
         return streamSSE(c, async (stream) => {
           const q = new AsyncQueue<string | null>()
@@ -164,6 +175,10 @@ export const WeChatRoutes = lazy(() =>
             clearInterval(heartbeat)
             unsub()
             q.push(null)
+            // Release lock and stop bridge when the owning client disconnects
+            if (clientId && WeChatManager.lockHolder === clientId) {
+              void WeChatManager.unlock(clientId).then(() => WeChatManager.stop())
+            }
           }
 
           stream.onAbort(stop)

--- a/packages/opencode/src/wechat/manager.ts
+++ b/packages/opencode/src/wechat/manager.ts
@@ -3,7 +3,7 @@ import { createInterface } from "readline"
 import { mkdir, readFile, writeFile, rm } from "fs/promises"
 import { join, dirname } from "path"
 import { homedir } from "os"
-import { existsSync } from "fs"
+import { existsSync, readFileSync, unlinkSync } from "fs"
 import z from "zod"
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
@@ -23,6 +23,7 @@ const WECHAT_DATA_DIR =
 const QRCODE_FILE = join(WECHAT_DATA_DIR, "qrcode.txt")
 const SESSION_FILE = join(WECHAT_DATA_DIR, "session.json")
 const PID_FILE = join(WECHAT_DATA_DIR, "pid.txt")
+const LOCK_FILE = join(WECHAT_DATA_DIR, "lock.json")
 
 export type WeChatStatus = "idle" | "starting" | "qrcode" | "connected" | "error"
 
@@ -95,6 +96,44 @@ class WeChatManagerImpl {
 
   get error() {
     return this._error
+  }
+
+  /** Read the current lock holder from disk. Returns null if no valid lock. */
+  get lockHolder(): string | null {
+    try {
+      if (!existsSync(LOCK_FILE)) return null
+      const raw = readFileSync(LOCK_FILE, "utf-8")
+      const lock = JSON.parse(raw) as { clientId: string; pid: number }
+      // Check if the locking process is still alive
+      try {
+        process.kill(lock.pid, 0)
+      } catch {
+        // Process is dead — stale lock
+        try { unlinkSync(LOCK_FILE) } catch {}
+        return null
+      }
+      return lock.clientId
+    } catch {
+      return null
+    }
+  }
+
+  /** Try to acquire the exclusive file-based lock. Returns true if acquired or already held by this id. */
+  async tryLock(clientId: string): Promise<boolean> {
+    await mkdir(WECHAT_DATA_DIR, { recursive: true })
+    const current = this.lockHolder
+    if (!current || current === clientId) {
+      await writeFile(LOCK_FILE, JSON.stringify({ clientId, pid: process.pid }))
+      return true
+    }
+    return false
+  }
+
+  /** Release the lock if held by this client. */
+  async unlock(clientId: string): Promise<void> {
+    if (this.lockHolder === clientId) {
+      await rm(LOCK_FILE, { force: true })
+    }
   }
 
   private set status(value: WeChatStatus) {


### PR DESCRIPTION
…connections

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

防止在一个电脑上打开两个web端后，两个web端都能连接上微信，之前的问题是连上两个web端后，两个web端都会对微信的信息进行回复

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
人工检测
### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
