### PR TITLE
fix: normalize finish reason from different providers and improve pro…

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -289,7 +289,7 @@ graph LR
     GlobalBus --> SSE_EP
     InMemory --> Internal
     SSE_EP -->|Server-Sent Events| SDK
-    SDK -->|事件合并 (16ms)| Store
+    SDK -->|"事件合并 (16ms)"| Store
 ```
 
 **事件类型定义方式：**
@@ -691,7 +691,7 @@ erDiagram
     }
 
     Permission {
-        text project_id PK_FK
+        text project_id PK
         json data
         integer time_created
         integer time_updated
@@ -715,7 +715,7 @@ erDiagram
     }
 
     SessionShare {
-        text session_id PK_FK
+        text session_id PK
         text id
         text secret
         text url

--- a/packages/app/src/components/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog-connect-provider.tsx
@@ -321,7 +321,7 @@ export function DialogConnectProvider(props: { provider: string }) {
   })
 
   async function complete() {
-    await globalSDK.client.global.dispose()
+    await globalSync.bootstrap()
     dialog.close()
     showToast({
       variant: "success",
@@ -383,17 +383,21 @@ export function DialogConnectProvider(props: { provider: string }) {
     const MASKED = "••••••••"
     const cfg = globalSync.data.config.provider?.[props.provider]
     const initURL = (cfg?.options?.["baseURL"] as string) ?? ""
+    const apiURL = provider().api ?? ""
     const hasKey = !!(provider() as unknown as { key?: string })?.key
+    let ref: HTMLFormElement | undefined
 
     const [form, setForm] = createStore({
       apiKey: hasKey ? MASKED : "",
       baseURL: initURL,
       err: undefined as string | undefined,
       urlErr: undefined as string | undefined,
+      busy: false,
     })
 
     async function handleSubmit(e: SubmitEvent) {
       e.preventDefault()
+      if (form.busy) return
 
       const key = form.apiKey.trim()
       const url = form.baseURL.trim()
@@ -409,21 +413,32 @@ export function DialogConnectProvider(props: { provider: string }) {
 
       setForm("err", undefined)
       setForm("urlErr", undefined)
+      setForm("busy", true)
 
-      if (key && key !== MASKED) {
-        await globalSDK.client.auth.set({
-          providerID: props.provider,
-          auth: { type: "api", key },
+      await (async () => {
+        if (key && key !== MASKED) {
+          await globalSDK.client.auth.set({
+            providerID: props.provider,
+            auth: { type: "api", key },
+          })
+        }
+
+        if (url !== initURL) {
+          await globalSync.updateConfig({
+            provider: { [props.provider]: { options: { baseURL: url } } },
+          })
+        }
+
+        await complete()
+      })()
+        .catch((err: unknown) => {
+          const message = formatError(err, language.t("common.requestFailed"))
+          setForm("err", message)
+          showToast({ title: language.t("common.requestFailed"), description: message })
         })
-      }
-
-      if (url !== initURL) {
-        await globalSync.updateConfig({
-          provider: { [props.provider]: { options: { baseURL: url } } },
+        .finally(() => {
+          setForm("busy", false)
         })
-      }
-
-      await complete()
     }
 
     return (
@@ -448,10 +463,10 @@ export function DialogConnectProvider(props: { provider: string }) {
             </div>
           </Match>
         </Switch>
-        <form onSubmit={handleSubmit} class="flex flex-col items-start gap-4">
+        <form ref={(el) => ref = el} onSubmit={handleSubmit} class="flex flex-col items-start gap-4">
           <TextField
             autofocus
-            type="text"
+            type="password"
             label={language.t("provider.connect.apiKey.label", { provider: provider().name })}
             placeholder={language.t("provider.connect.apiKey.placeholder")}
             description={hasKey ? language.t("provider.custom.field.apiKey.savedDescription") : undefined}
@@ -460,17 +475,31 @@ export function DialogConnectProvider(props: { provider: string }) {
             validationState={form.err ? "invalid" : undefined}
             error={form.err}
           />
-          <TextField
-            label={language.t("provider.connect.baseURL.label")}
-            placeholder={language.t("provider.connect.baseURL.placeholder")}
-            description={language.t("provider.connect.baseURL.description")}
-            value={form.baseURL}
-            onChange={(v) => { setForm("baseURL", v); setForm("urlErr", undefined) }}
-            validationState={form.urlErr ? "invalid" : undefined}
-            error={form.urlErr}
-          />
-          <Button class="w-auto" type="submit" size="large" variant="primary">
-            {language.t("common.continue")}
+          <details class="w-full rounded-lg border border-border-weak-base px-3 py-2" open={!!initURL}>
+            <summary class="cursor-pointer text-12-medium text-text-weak outline-none select-none">
+              {language.t("provider.connect.baseURL.label")}
+            </summary>
+            <div class="pt-3">
+              <TextField
+                label={language.t("provider.connect.baseURL.label")}
+                placeholder={apiURL || language.t("provider.connect.baseURL.placeholder")}
+                description={language.t("provider.connect.baseURL.description")}
+                value={form.baseURL}
+                onChange={(v) => { setForm("baseURL", v); setForm("urlErr", undefined) }}
+                validationState={form.urlErr ? "invalid" : undefined}
+                error={form.urlErr}
+              />
+            </div>
+          </details>
+          <Button
+            class="w-auto"
+            type="submit"
+            size="large"
+            variant="primary"
+            disabled={form.busy}
+            onClick={() => ref?.requestSubmit()}
+          >
+            {form.busy ? language.t("provider.connect.status.inProgress") : language.t("common.connect")}
           </Button>
         </form>
       </div>

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -21,6 +21,20 @@ export namespace SessionProcessor {
   const DOOM_LOOP_THRESHOLD = 3
   const log = Log.create({ service: "session.processor" })
 
+  export function finish(input: unknown, hasTools: boolean) {
+    if (typeof input === "string" && input.trim()) return input
+    if (input && typeof input === "object") {
+      const item = input as Record<string, unknown>
+      if (typeof item.reason === "string" && item.reason.trim()) return item.reason
+      if (typeof item.type === "string" && item.type.trim()) return item.type
+      if (typeof item.finishReason === "string" && item.finishReason.trim()) return item.finishReason
+    }
+    if (input !== undefined && input !== null) {
+      log.warn("unexpected finish reason", { input })
+    }
+    return hasTools ? "tool-calls" : "stop"
+  }
+
   export type Info = Awaited<ReturnType<typeof create>>
   export type Result = Awaited<ReturnType<Info["process"]>>
 
@@ -243,17 +257,18 @@ export namespace SessionProcessor {
                   break
 
                 case "finish-step":
+                  const finish = SessionProcessor.finish(value.finishReason, Object.keys(toolcalls).length > 0)
                   const usage = Session.getUsage({
                     model: input.model,
                     usage: value.usage,
                     metadata: value.providerMetadata,
                   })
-                  input.assistantMessage.finish = value.finishReason
+                  input.assistantMessage.finish = finish
                   input.assistantMessage.cost += usage.cost
                   input.assistantMessage.tokens = usage.tokens
                   await Session.updatePart({
                     id: PartID.ascending(),
-                    reason: value.finishReason,
+                    reason: finish,
                     snapshot: await Snapshot.track(),
                     messageID: input.assistantMessage.id,
                     sessionID: input.assistantMessage.sessionID,

--- a/packages/opencode/test/session/processor.test.ts
+++ b/packages/opencode/test/session/processor.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test"
+import { SessionProcessor } from "../../src/session/processor"
+
+describe("session.processor.finish", () => {
+  test("keeps string finish reasons", () => {
+    expect(SessionProcessor.finish("stop", false)).toBe("stop")
+    expect(SessionProcessor.finish("tool-calls", true)).toBe("tool-calls")
+  })
+
+  test("extracts finish reasons from objects", () => {
+    expect(SessionProcessor.finish({ reason: "stop" }, false)).toBe("stop")
+    expect(SessionProcessor.finish({ type: "length" }, false)).toBe("length")
+    expect(SessionProcessor.finish({ finishReason: "tool-calls" }, true)).toBe("tool-calls")
+  })
+
+  test("falls back based on tool presence for invalid values", () => {
+    expect(SessionProcessor.finish(undefined, false)).toBe("stop")
+    expect(SessionProcessor.finish(null, false)).toBe("stop")
+    expect(SessionProcessor.finish({ reason: 1 }, false)).toBe("stop")
+    expect(SessionProcessor.finish(undefined, true)).toBe("tool-calls")
+  })
+})


### PR DESCRIPTION
…vider connect dialog

- Extract SessionProcessor.finish() to handle finish reasons that arrive as strings, objects ({reason, type, finishReason}), or missing values
- Improve provider connection dialog: mask API key input, add busy state to prevent double submission, wrap baseURL in collapsible details, handle errors with toast notifications
- Replace globalSDK.client.global.dispose() with globalSync.bootstrap() in connection completion flow
- Fix Mermaid syntax and ER diagram PK annotations in architecture docs

### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
