### PR TITLE
优化 Web 更新链路并统一跨平台安装路径与版本处理

### DIFF
--- a/Update/aether_darwin_installer.command
+++ b/Update/aether_darwin_installer.command
@@ -4,7 +4,7 @@ set -euo pipefail
 
 base="https://aether.aiphys.cn/download"
 latest="latest/mac-arm64.yml"
-default="$HOME/Applications/Aether"
+default="$HOME/Applications/aether"
 mode="init"
 arg=""
 path_arg=""
@@ -147,11 +147,11 @@ normalize_work() {
   local dir base
   dir="$1"
   base="$(basename "$dir")"
-  if [ "$base" = "Aether" ]; then
+  if [ "$base" = "aether" ]; then
     printf "%s" "$dir"
     return 0
   fi
-  printf "%s/Aether" "$dir"
+  printf "%s/aether" "$dir"
 }
 
 workdir() {

--- a/Update/aether_darwin_installer.command
+++ b/Update/aether_darwin_installer.command
@@ -468,7 +468,7 @@ if [ "$mode" = "init" ]; then
     fail "$run_err"
   fi
 
-  mkdir -p "$HOME/Aether_Database" 2>/dev/null || true
+  mkdir -p "$HOME/aether_Database" 2>/dev/null || true
 
   done_hold
   exit 0

--- a/Update/aether_linux_installer.md
+++ b/Update/aether_linux_installer.md
@@ -16,7 +16,7 @@
 ## 模式
 
 - `init`
-  首次安装入口。默认工作目录是 `~/Applications/Aether`，默认不交互。可通过 `--path <dir>` 指定父目录。下载完成后会自动执行下载到本地的版本安装脚本。
+  首次安装入口。默认工作目录是 `~/.local/share/applications/Aether`，默认不交互。可通过 `--path <dir>` 指定父目录。下载完成后会自动执行下载到本地的版本安装脚本。
 - `auto <current-version>`
   自动更新检查。用于 Aether 软件后台调用。
 - `manual <target-version>`
@@ -25,7 +25,7 @@
 ## 工作目录
 
 - `init`
-  默认工作目录为 `~/Applications/Aether`。若传入 `--path <dir>`，则输入的是父目录，实际工作目录固定归一化为 `父目录/Aether`。
+  默认工作目录为 `~/.local/share/applications/Aether`。若传入 `--path <dir>`，则输入的是父目录，实际工作目录固定归一化为 `父目录/Aether`。
 - `auto` 和 `manual`
   默认使用安装器脚本所在目录（即 `.../Aether`）
 
@@ -96,10 +96,10 @@ code: 11
 current_version: ""
 target_version: "1.2.3"
 requested_version: "1.2.3"
-work_dir: "/home/name/Applications/Aether"
-download_dir: "/home/name/Applications/Aether/downloads"
-package_path: "/home/name/Applications/Aether/downloads/aether-1.2.3-linux-x64.tar.gz"
-installer_path: "/home/name/Applications/Aether/downloads/install-linux.sh"
+work_dir: "/home/name/.local/share/applications/Aether"
+download_dir: "/home/name/.local/share/applications/Aether/downloads"
+package_path: "/home/name/.local/share/applications/Aether/downloads/aether-1.2.3-linux-x64.tar.gz"
+installer_path: "/home/name/.local/share/applications/Aether/downloads/install-linux.sh"
 manifest_url: "https://aether.aiphys.cn/download/1.2.3/linux-x64.yml"
 notes_url: "https://aether.aiphys.cn/download/1.2.3/notes.md"
 ```

--- a/Update/aether_linux_installer.sh
+++ b/Update/aether_linux_installer.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 base="https://aether.aiphys.cn/download"
 latest="latest/linux-x64.yml"
-default="$HOME/Applications/Aether"
+default="$HOME/.local/share/applications/Aether"
 mode="init"
 arg=""
 path_arg=""

--- a/Update/aether_linux_installer.sh
+++ b/Update/aether_linux_installer.sh
@@ -157,7 +157,7 @@ normalize_work() {
 workdir() {
   local dir
   dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  if [[ "$(basename "$dir")" == aether_* ]]; then
+  if [[ "$(basename "$dir")" == aether-* ]]; then
     cd "$dir/.." && pwd
     return 0
   fi
@@ -468,7 +468,7 @@ if [ "$mode" = "init" ]; then
     fail "$run_err"
   fi
 
-  mkdir -p "$HOME/Aether_Database" 2>/dev/null || true
+  mkdir -p "$HOME/aether_Database" 2>/dev/null || true
 
   done_hold
   exit 0

--- a/Update/aether_linux_installer.sh
+++ b/Update/aether_linux_installer.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 base="https://aether.aiphys.cn/download"
 latest="latest/linux-x64.yml"
+site="${base%/download}"
 default="$HOME/.local/share/applications/aether"
 mode="init"
 arg=""
@@ -75,7 +76,216 @@ manifest_url=""
 res=""
 res_file=""
 fetch_http=""
+fetch_tool=""
 keep="3"
+openssl_mode=""
+openssl_checked=0
+openssl_lib=""
+lib_roots="/usr/lib/x86_64-linux-gnu /usr/lib64 /usr/lib /lib/x86_64-linux-gnu /lib64 /lib"
+
+lib_exact() {
+  local name="$1"
+  local roots="${2:-$lib_roots}"
+  for p in $roots; do
+    if [ -f "$p/$name" ]; then
+      printf "%s" "$p/$name"
+      return 0
+    fi
+  done
+  printf ""
+}
+
+lib_glob() {
+  local pat="$1"
+  local roots="${2:-$lib_roots}"
+  for p in $roots; do
+    local f
+    f="$(find "$p" -maxdepth 1 -name "$pat" 2>/dev/null | head -1)"
+    if [ -n "$f" ]; then
+      printf "%s" "$f"
+      return 0
+    fi
+  done
+  printf ""
+}
+
+run_openssl() {
+  if [ "$openssl_mode" = "compat" ] && [ -n "$openssl_lib" ]; then
+    LD_LIBRARY_PATH="$openssl_lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" openssl "$@"
+    return $?
+  fi
+  openssl "$@"
+}
+
+repair_openssl() {
+  local ssl
+  local crypto
+  ssl="$(lib_exact "libssl.so.1.1")"
+  if [ -z "$ssl" ]; then
+    ssl="$(lib_glob "libssl.so.1.*")"
+  fi
+  crypto="$(lib_exact "libcrypto.so.1.1")"
+  if [ -z "$crypto" ]; then
+    crypto="$(lib_glob "libcrypto.so.1.*")"
+  fi
+  if [ -z "$ssl" ] || [ -z "$crypto" ]; then
+    return 1
+  fi
+
+  local dir
+  if [ -n "$work" ]; then
+    dir="$work/.openssl_compat"
+  else
+    dir="${TMPDIR:-/tmp}/aether-openssl-compat"
+  fi
+  mkdir -p "$dir" 2>/dev/null || return 1
+  ln -sf "$ssl" "$dir/libssl.so.3" 2>/dev/null || return 1
+  ln -sf "$crypto" "$dir/libcrypto.so.3" 2>/dev/null || return 1
+
+  if LD_LIBRARY_PATH="$dir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" openssl version >/dev/null 2>&1; then
+    openssl_lib="$dir"
+    return 0
+  fi
+
+  return 1
+}
+
+pick_openssl() {
+  if [ "$openssl_checked" = "1" ]; then
+    return 0
+  fi
+  openssl_checked=1
+
+  if ! command -v openssl >/dev/null 2>&1; then
+    openssl_mode="none"
+    return 0
+  fi
+
+  if openssl version >/dev/null 2>&1; then
+    openssl_mode="system"
+    return 0
+  fi
+
+  echo "[hash] openssl exists but cannot run (likely missing libssl.so.3)."
+  echo "[hash] Trying local OpenSSL runtime compatibility shim..."
+  if repair_openssl; then
+    openssl_mode="compat"
+    echo "[hash] OpenSSL shim enabled via LD_LIBRARY_PATH=$openssl_lib"
+    return 0
+  fi
+
+  openssl_mode="broken"
+  echo "[hash] OpenSSL runtime repair failed; will auto-fallback to non-openssl hashing."
+}
+
+compute_sha512_base64() {
+  local file="$1"
+  pick_openssl
+  if [ "$openssl_mode" = "system" ] || [ "$openssl_mode" = "compat" ]; then
+    local out
+    if out="$(run_openssl dgst -sha512 -binary "$file" 2>/dev/null | run_openssl base64 -A 2>/dev/null)"; then
+      printf "%s" "$out"
+      return 0
+    fi
+  fi
+
+  if command -v sha512sum >/dev/null 2>&1; then
+    local hex
+    hex="$(sha512sum "$file" | awk '{print $1}')"
+    if command -v python3 >/dev/null 2>&1; then
+      python3 -c "import base64,binascii;print(base64.b64encode(binascii.unhexlify('$hex')).decode(),end='')"
+    elif command -v python >/dev/null 2>&1; then
+      python -c "import base64,binascii;print(base64.b64encode(binascii.unhexlify('$hex')).decode(),end='')"
+    elif command -v perl >/dev/null 2>&1; then
+      perl -e "use MIME::Base64;print encode_base64(pack('H*','$hex'),'')"
+    else
+      echo "__NOBASE64__"
+    fi
+  else
+    echo "__NOHASH__"
+  fi
+}
+
+ensure_libssl() {
+  local app_dir="$1"
+  local ssl1_path=""
+
+  if [ -n "$(lib_exact "libssl.so.3")" ]; then
+    return 0
+  fi
+
+  echo
+  echo "[compat] libssl.so.3 not found on this system."
+
+  ssl1_path="$(lib_exact "libssl.so.1.1")"
+  if [ -z "$ssl1_path" ]; then
+    ssl1_path="$(lib_glob "libssl.so.1.*")"
+  fi
+
+  if [ -z "$ssl1_path" ]; then
+    echo "[compat] WARNING: No libssl.so.1.x found either. The application may not start."
+    echo "[compat] Try: sudo apt install libssl-dev"
+    return 0
+  fi
+
+  local crypto1_path=""
+  local ssl1_dir
+  ssl1_dir="$(dirname "$ssl1_path")"
+  crypto1_path="$(lib_exact "libcrypto.so.1.1" "$ssl1_dir")"
+  if [ -z "$crypto1_path" ]; then
+    crypto1_path="$(lib_glob "libcrypto.so.1.*" "$ssl1_dir")"
+  fi
+
+  echo "[compat] Found: $ssl1_path"
+
+  local compat_dir="$app_dir/ssl_compat"
+  mkdir -p "$compat_dir" 2>/dev/null || return 0
+
+  ln -sf "$ssl1_path" "$compat_dir/libssl.so.3" 2>/dev/null || true
+  if [ -n "$crypto1_path" ]; then
+    ln -sf "$crypto1_path" "$compat_dir/libcrypto.so.3" 2>/dev/null || true
+    echo "[compat] Symlinked $crypto1_path -> $compat_dir/libcrypto.so.3"
+  fi
+  echo "[compat] Symlinked $ssl1_path -> $compat_dir/libssl.so.3"
+
+  local wrapper=""
+  shopt -s nullglob
+  for f in "$app_dir"/aether "$app_dir"/Aether "$app_dir"/aether-*/aether "$app_dir"/resources/../aether; do
+    if [ -x "$f" ] && [ ! -d "$f" ]; then
+      wrapper="$f"
+      break
+    fi
+  done
+  shopt -u nullglob
+
+  if [ -n "$wrapper" ]; then
+    local wrapper_dir
+    wrapper_dir="$(dirname "$wrapper")"
+    local wrapper_name
+    wrapper_name="$(basename "$wrapper")"
+    local real_bin="$wrapper_dir/${wrapper_name}.real"
+    if [ ! -f "$real_bin" ]; then
+      mv "$wrapper" "$real_bin"
+      cat > "$wrapper" <<EOWRAP
+#!/usr/bin/env bash
+export LD_LIBRARY_PATH="$compat_dir\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}"
+exec "$real_bin" "\$@"
+EOWRAP
+      chmod +x "$wrapper"
+      echo "[compat] Created wrapper: $wrapper"
+      echo "[compat] LD_LIBRARY_PATH will include: $compat_dir"
+    fi
+  else
+    echo "[compat] NOTE: Set LD_LIBRARY_PATH=$compat_dir before running Aether."
+    echo "[compat] Example: LD_LIBRARY_PATH=$compat_dir aether"
+  fi
+
+  echo "[compat] WARNING: libssl 1.x -> 3 symlinks may not be fully ABI-compatible."
+  echo "[compat] If the app crashes, consider installing OpenSSL 3:"
+  echo "[compat]   Ubuntu 22.04+: sudo apt install libssl3"
+  echo "[compat]   Older Ubuntu:  install from a PPA or build from source."
+  echo
+}
 
 done_hold() {
   if [ "$hold" = "1" ]; then
@@ -100,16 +310,18 @@ result() {
   mkdir -p "$dl" || return 0
   res_file="$dl/last-result.yml"
   local code="$ok"
-  [ "$res" = "update_ready" ] && code="$ready"
-  [ "$res" = "manual_ready" ] && code="$manual_ready"
-  [ "$res" = "up_to_date" ] && code="$latest_ok"
-  [ "$res" = "version_missing" ] && code="$miss"
-  [ "$res" = "meta_error" ] && code="$meta_err"
-  [ "$res" = "download_error" ] && code="$dl_err"
-  [ "$res" = "checksum_error" ] && code="$sum_err"
-  [ "$res" = "run_error" ] && code="$run_err"
-  [ "$res" = "dir_error" ] && code="$dir_err"
-  [ "$res" = "arg_error" ] && code="$arg_err"
+  case "$res" in
+    update_ready) code="$ready" ;;
+    manual_ready) code="$manual_ready" ;;
+    up_to_date) code="$latest_ok" ;;
+    version_missing) code="$miss" ;;
+    meta_error) code="$meta_err" ;;
+    download_error) code="$dl_err" ;;
+    checksum_error) code="$sum_err" ;;
+    run_error) code="$run_err" ;;
+    dir_error) code="$dir_err" ;;
+    arg_error) code="$arg_err" ;;
+  esac
   {
     echo "mode: $(quote "$mode")"
     echo "status: $(quote "$res")"
@@ -127,20 +339,68 @@ result() {
 }
 
 abs() {
-  local val="$1"
+  local src="$1"
+  local val="$2"
+  local dir
   if [ -z "$val" ]; then
     printf ""
     return 0
   fi
   case "$val" in
     http://*|https://*) printf "%s" "$val" ;;
-    /*) printf "%s/%s" "$base" "${val#/}" ;;
-    *) printf "%s/%s" "$base" "$val" ;;
+    /*) printf "%s/%s" "$site" "${val#/}" ;;
+    *)
+      dir="${src%/*}"
+      printf "%s/%s" "$dir" "$val"
+      ;;
   esac
+}
+
+pick_fetch() {
+  if [ -n "$fetch_tool" ]; then
+    return 0
+  fi
+  if command -v curl >/dev/null 2>&1; then
+    fetch_tool="curl"
+    return 0
+  fi
+  if command -v wget >/dev/null 2>&1; then
+    fetch_tool="wget"
+    return 0
+  fi
+  if command -v busybox >/dev/null 2>&1 && busybox wget --help >/dev/null 2>&1; then
+    fetch_tool="busybox"
+    return 0
+  fi
+  echo "No downloader found. Install curl or wget (busybox wget also works)."
+  return 1
 }
 
 prep() {
   mkdir -p "$1" 2>/dev/null
+}
+
+desktop_hint() {
+  local home="$HOME"
+  if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+    if command -v getent >/dev/null 2>&1; then
+      home="$(getent passwd "$SUDO_USER" 2>/dev/null | cut -d: -f6)"
+    else
+      home=""
+    fi
+    if [ -z "$home" ]; then
+      home="$(eval echo "~$SUDO_USER" 2>/dev/null || true)"
+    fi
+    [ -n "$home" ] || home="$HOME"
+  fi
+
+  local launch="$home/Desktop/Aether.sh"
+  if [ -f "$launch" ]; then
+    echo "[init] Desktop launcher: $launch"
+    return 0
+  fi
+  echo "[init] NOTE: Desktop launcher not found: $launch"
+  echo "[init] The local installer should create it; check Desktop permissions if missing."
 }
 
 normalize_work() {
@@ -157,7 +417,7 @@ normalize_work() {
 workdir() {
   local dir
   dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  if [[ "$(basename "$dir")" == aether-* ]]; then
+  if [[ "$(basename "$dir")" == aether_* ]]; then
     cd "$dir/.." && pwd
     return 0
   fi
@@ -192,12 +452,49 @@ cmp() {
 fetch_meta() {
   local url="$1"
   local out="$2"
-  fetch_http="$(curl --location --silent --show-error --connect-timeout 15 --max-time 1800 --retry 3 --retry-delay 2 --output "$out" --write-out "%{http_code}" "$url" || true)"
-  [ "$fetch_http" = "200" ]
+  pick_fetch || {
+    fetch_http="000"
+    return 1
+  }
+  if [ "$fetch_tool" = "curl" ]; then
+    fetch_http="$(curl --location --silent --show-error --connect-timeout 15 --max-time 1800 --retry 3 --retry-delay 2 --output "$out" --write-out "%{http_code}" "$url" || true)"
+    [ "$fetch_http" = "200" ]
+    return 0
+  fi
+
+  local err
+  err="$(mktemp "${TMPDIR:-/tmp}/aether-fetch.XXXXXX")"
+  if [ "$fetch_tool" = "wget" ]; then
+    wget --server-response --tries=3 --timeout=15 --read-timeout=1800 --output-document "$out" "$url" 2>"$err" && {
+      fetch_http="200"
+      rm -f "$err"
+      return 0
+    }
+  else
+    busybox wget -S -T 15 -O "$out" "$url" 2>"$err" && {
+      fetch_http="200"
+      rm -f "$err"
+      return 0
+    }
+  fi
+
+  fetch_http="$(awk '/^  HTTP\//{c=$2} /^HTTP\//{c=$2} END{print c}' "$err")"
+  [ -n "$fetch_http" ] || fetch_http="000"
+  rm -f "$err"
+  return 1
 }
 
 fetch_file() {
-  curl --fail --location --progress-bar --connect-timeout 15 --max-time 1800 --retry 3 --retry-delay 2 --output "$2" "$1"
+  pick_fetch || return 1
+  if [ "$fetch_tool" = "curl" ]; then
+    curl --fail --location --progress-bar --connect-timeout 15 --max-time 1800 --retry 3 --retry-delay 2 --output "$2" "$1"
+    return 0
+  fi
+  if [ "$fetch_tool" = "wget" ]; then
+    wget --tries=3 --timeout=15 --read-timeout=1800 --output-document "$2" "$1"
+    return 0
+  fi
+  busybox wget -T 15 -O "$2" "$1"
 }
 
 parse() {
@@ -248,9 +545,9 @@ manifest() {
     rm -rf "$tmp"
     return "$meta_err"
   fi
-  pkg_url="$(abs "$pkg")"
-  ins_url="$(abs "$ins")"
-  note_url="$(abs "$note")"
+  pkg_url="$(abs "$url" "$pkg")"
+  ins_url="$(abs "$url" "$ins")"
+  note_url="$(abs "$url" "$note")"
   pkg_name="$(basename "$pkg_url")"
   ins_name="$(basename "$ins_url")"
   rm -rf "$tmp"
@@ -272,8 +569,11 @@ grab() {
   need_pkg=1
   if [ -f "$pkg_file" ]; then
     if [ -n "$sha" ]; then
-      sum="$(openssl dgst -sha512 -binary "$pkg_file" | openssl base64 -A || true)"
+      sum="$(compute_sha512_base64 "$pkg_file" || true)"
       if [ "$sum" = "$sha" ]; then
+        need_pkg=0
+      elif [ "$sum" = "__NOHASH__" ] || [ "$sum" = "__NOBASE64__" ]; then
+        echo "Warning: cannot verify checksum (no openssl/sha512sum/base64 tool found)"
         need_pkg=0
       fi
     else
@@ -291,8 +591,12 @@ grab() {
   fi
 
   if [ -n "$sha" ]; then
-    sum="$(openssl dgst -sha512 -binary "$pkg_file" | openssl base64 -A)"
-    [ "$sum" = "$sha" ] || return "$sum_err"
+    sum="$(compute_sha512_base64 "$pkg_file")"
+    if [ "$sum" = "__NOHASH__" ] || [ "$sum" = "__NOBASE64__" ]; then
+      echo "Warning: cannot verify checksum (no openssl/sha512sum/base64 tool found), skipping verification"
+    else
+      [ "$sum" = "$sha" ] || return "$sum_err"
+    fi
   fi
 
   if [ -n "$ins_url" ] && [ -n "$ins_name" ]; then
@@ -378,6 +682,9 @@ Remote manifests:
   $base/$latest
   $base/1.2.3/linux-x64.yml
 
+Downloaders:
+  curl (preferred), wget, or busybox wget
+
 Result file:
   work_dir/downloads/last-result.yml
 
@@ -453,7 +760,7 @@ if [ "$mode" = "init" ]; then
   echo
   if [ -n "$ins_file" ]; then
     echo "[init] Running installer script..."
-    if ! (cd "$work/downloads" && bash "$(basename "$ins_file")" "$ver"); then
+    if ! (cd "$work/downloads" && bash "$(basename "$ins_file")" install "$ver"); then
       res="run_error"
       result
       echo
@@ -468,7 +775,11 @@ if [ "$mode" = "init" ]; then
     fail "$run_err"
   fi
 
-  mkdir -p "$HOME/aether_Database" 2>/dev/null || true
+  mkdir -p "$HOME/Aether_Database" 2>/dev/null || true
+
+  ensure_libssl "$work/current"
+
+  desktop_hint
 
   done_hold
   exit 0

--- a/Update/aether_linux_installer.sh
+++ b/Update/aether_linux_installer.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 base="https://aether.aiphys.cn/download"
 latest="latest/linux-x64.yml"
-default="$HOME/.local/share/applications/Aether"
+default="$HOME/.local/share/applications/aether"
 mode="init"
 arg=""
 path_arg=""
@@ -147,11 +147,11 @@ normalize_work() {
   local dir base
   dir="$1"
   base="$(basename "$dir")"
-  if [ "$base" = "Aether" ]; then
+  if [ "$base" = "aether" ]; then
     printf "%s" "$dir"
     return 0
   fi
-  printf "%s/Aether" "$dir"
+  printf "%s/aether" "$dir"
 }
 
 workdir() {

--- a/Update/aether_release_protocol.md
+++ b/Update/aether_release_protocol.md
@@ -166,10 +166,15 @@ Windows：
 - 默认工作目录
   `%LOCALAPPDATA%\Programs\Aether`
 
-macOS / Linux：
+macOS：
 
 - 默认工作目录
   `~/Applications/Aether`
+
+Linux：
+
+- 默认工作目录
+  `~/.local/share/applications/Aether`
 
 非 `init` 模式：
 

--- a/Update/aether_windows_installer.bat
+++ b/Update/aether_windows_installer.bat
@@ -1,4 +1,4 @@
-@echo off
+﻿@echo off
 chcp 65001 >nul
 setlocal EnableExtensions EnableDelayedExpansion
 

--- a/Update/aether_windows_installer.bat
+++ b/Update/aether_windows_installer.bat
@@ -5,7 +5,7 @@ setlocal EnableExtensions EnableDelayedExpansion
 set "BASE=https://aether.aiphys.cn/download"
 set "LATEST=latest/windows-x64.yml"
 if not defined LOCALAPPDATA set "LOCALAPPDATA=%USERPROFILE%\AppData\Local"
-set "DEFAULT=%USERPROFILE%\Applications\Aether"
+set "DEFAULT=%LOCALAPPDATA%\Programs\Aether"
 set "MODE=init"
 set "ARG="
 set "PATH_ARG="

--- a/Update/aether_windows_installer.bat
+++ b/Update/aether_windows_installer.bat
@@ -5,7 +5,7 @@ setlocal EnableExtensions EnableDelayedExpansion
 set "BASE=https://aether.aiphys.cn/download"
 set "LATEST=latest/windows-x64.yml"
 if not defined LOCALAPPDATA set "LOCALAPPDATA=%USERPROFILE%\AppData\Local"
-set "DEFAULT=%LOCALAPPDATA%\Programs\Aether"
+set "DEFAULT=%LOCALAPPDATA%\Programs\aether"
 set "MODE=init"
 set "ARG="
 set "PATH_ARG="
@@ -97,10 +97,10 @@ goto :bad
 :normalize
 set "IN=%~1"
 for %%i in ("%IN%") do set "BASE_NAME=%%~nxi"
-if /I "%BASE_NAME%"=="Aether" (
+if /I "%BASE_NAME%"=="aether" (
   set "%~2=%IN%"
 ) else (
-  set "%~2=%IN%\Aether"
+  set "%~2=%IN%\aether"
 )
 exit /b 0
 

--- a/Update/aether_windows_installer.md
+++ b/Update/aether_windows_installer.md
@@ -16,7 +16,7 @@
 ## 模式
 
 - `init`
-  首次安装入口。默认工作目录是 `%USERPROFILE%\Applications\Aether`，默认不交互。可通过 `--path <dir>` 指定父目录。下载完成后会自动执行下载到本地的版本安装脚本。
+  首次安装入口。默认工作目录是 `%LOCALAPPDATA%\Programs\Aether`，默认不交互。可通过 `--path <dir>` 指定父目录。下载完成后会自动执行下载到本地的版本安装脚本。
 - `auto <current-version>`
   自动更新检查。用于 Aether 软件后台调用。
 - `manual <target-version>`
@@ -25,7 +25,7 @@
 ## 工作目录
 
 - `init`
-  默认工作目录为 `%USERPROFILE%\Applications\Aether`。若传入 `--path <dir>`，则输入的是父目录，实际工作目录固定归一化为 `父目录\Aether`。
+  默认工作目录为 `%LOCALAPPDATA%\Programs\Aether`。若传入 `--path <dir>`，则输入的是父目录，实际工作目录固定归一化为 `父目录\Aether`。
 - `auto` 和 `manual`
   默认使用安装器脚本所在目录（即 `...\Aether`）
 

--- a/Update/update_darwin_web.command
+++ b/Update/update_darwin_web.command
@@ -187,19 +187,19 @@ EOF
 }
 
 if [ "$base" != "downloads" ]; then
-  fail "规范错误：update_darwin_web.command 必须放在 .../Aether/downloads 目录。当前: $self"
+  fail "规范错误：update_darwin_web.command 必须放在 .../aether/downloads 目录。当前: $self"
 fi
-if [ "$(basename "$work")" != "Aether" ]; then
-  fail "规范错误：工作目录必须是 .../Aether。当前: $work"
+if [ "$(basename "$work")" != "aether" ]; then
+  fail "规范错误：工作目录必须是 .../aether。当前: $work"
 fi
 if [ ! -f "$work/aether_darwin_installer.command" ]; then
-  fail "规范错误：缺少 .../Aether/aether_darwin_installer.command"
+  fail "规范错误：缺少 .../aether/aether_darwin_installer.command"
 fi
 
 echo "[0/4] 工作目录: $work"
 
 pick="$(pick_pkg "$self" "$want" || true)"
-[ -n "$pick" ] || fail "未在 .../Aether/downloads 找到可用 dmg（文件名需包含版本号）"
+[ -n "$pick" ] || fail "未在 .../aether/downloads 找到可用 dmg（文件名需包含版本号）"
 
 pkg="${pick%%|*}"
 ver="${pick##*|}"

--- a/Update/update_linux_web.sh
+++ b/Update/update_linux_web.sh
@@ -2,185 +2,45 @@
 
 set -euo pipefail
 
-base="https://aether.aiphys.cn/download"
-latest="latest/linux-x64.yml"
-site="${base%/download}"
-default="$HOME/Applications/aether"
-mode="init"
-arg=""
-path_arg=""
-hold=0
-nohold=0
+want="${1:-}"
+self="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+base="$(basename "$self")"
+work="$(dirname "$self")"
+launch=""
+restart="0"
 
-ok=0
-ready=10
-manual_ready=11
-latest_ok=20
-miss=21
-meta_err=30
-dl_err=31
-sum_err=32
-run_err=33
-dir_err=40
-arg_err=50
-
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    --no-pause)
-      nohold=1
-      ;;
-    --path)
-      shift
-      if [ "$#" -eq 0 ]; then
-        echo "--path needs a value"
-        exit "$arg_err"
-      fi
-      path_arg="$1"
-      ;;
-    init|auto|manual|help|-h|--help)
-      mode="$1"
-      ;;
-    *)
-      if [ -z "$arg" ]; then
-        arg="$1"
-      else
-        echo "Unsupported argument: $1"
-        exit "$arg_err"
-      fi
-      ;;
-  esac
-  shift
-done
-
-if [ "$mode" = "init" ] && [ "$nohold" = "0" ]; then
-  hold=1
+if [ "${2:-}" = "--restart" ]; then
+  restart="1"
 fi
 
-work=""
-cur=""
-req=""
-ver=""
-pkg=""
-sha=""
-ins=""
-note=""
-pkg_url=""
-ins_url=""
-note_url=""
-pkg_name=""
-ins_name=""
-pkg_file=""
-ins_file=""
-dl=""
-manifest_url=""
-res=""
-res_file=""
-fetch_http=""
-keep="3"
-
-done_hold() {
-  if [ "$hold" = "1" ]; then
-    echo
-    read -r -p "Press Enter to close..." _
-  fi
-}
-
 fail() {
-  local code="$1"
-  done_hold
-  exit "$code"
+  echo "$1"
+  exit 1
 }
 
-quote() {
-  printf "'%s'" "${1//\'/\'\'}"
-}
-
-result() {
-  [ -n "$work" ] || return 0
-  dl="${dl:-$work/downloads}"
-  mkdir -p "$dl" || return 0
-  res_file="$dl/last-result.yml"
-  local code="$ok"
-  [ "$res" = "update_ready" ] && code="$ready"
-  [ "$res" = "manual_ready" ] && code="$manual_ready"
-  [ "$res" = "up_to_date" ] && code="$latest_ok"
-  [ "$res" = "version_missing" ] && code="$miss"
-  [ "$res" = "meta_error" ] && code="$meta_err"
-  [ "$res" = "download_error" ] && code="$dl_err"
-  [ "$res" = "checksum_error" ] && code="$sum_err"
-  [ "$res" = "run_error" ] && code="$run_err"
-  [ "$res" = "dir_error" ] && code="$dir_err"
-  [ "$res" = "arg_error" ] && code="$arg_err"
-  {
-    echo "mode: $(quote "$mode")"
-    echo "status: $(quote "$res")"
-    echo "code: $code"
-    echo "current_version: $(quote "$cur")"
-    echo "target_version: $(quote "$ver")"
-    echo "requested_version: $(quote "$req")"
-    echo "work_dir: $(quote "$work")"
-    echo "download_dir: $(quote "$dl")"
-    echo "package_path: $(quote "$pkg_file")"
-    echo "installer_path: $(quote "$ins_file")"
-    echo "manifest_url: $(quote "$manifest_url")"
-    echo "notes_url: $(quote "$note_url")"
-  } >"$res_file"
-}
-
-abs() {
-  local src="$1"
-  local val="$2"
-  local dir
-  if [ -z "$val" ]; then
-    printf ""
+ver_from_name() {
+  local file name
+  file="$(basename "$1")"
+  name="${file%.zip}"
+  if [[ "$name" =~ ([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
+    printf "%s" "${BASH_REMATCH[1]}"
     return 0
   fi
-  case "$val" in
-    http://*|https://*) printf "%s" "$val" ;;
-    /*) printf "%s/%s" "$site" "${val#/}" ;;
-    *)
-      dir="${src%/*}"
-      printf "%s/%s" "$dir" "$val"
-      ;;
-  esac
-}
-
-prep() {
-  mkdir -p "$1" 2>/dev/null
-}
-
-normalize_work() {
-  local dir base
-  dir="$1"
-  base="$(basename "$dir")"
-  if [ "$base" = "aether" ]; then
-    printf "%s" "$dir"
-    return 0
-  fi
-  printf "%s/aether" "$dir"
-}
-
-workdir() {
-  local dir
-  dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  if [[ "$(basename "$dir")" == aether_* ]]; then
-    cd "$dir/.." && pwd
-    return 0
-  fi
-  printf "%s" "$dir"
+  printf ""
 }
 
 cmp() {
-  local a="${1#v}"
-  local b="${2#v}"
+  local a b
+  a="${1#v}"
+  b="${2#v}"
   a="${a%%-*}"
   b="${b%%-*}"
-  local aa bb i
+  local aa bb i x y
   IFS=. read -r -a aa <<<"$a"
   IFS=. read -r -a bb <<<"$b"
   for i in 0 1 2 3; do
-    local x="${aa[$i]:-0}"
-    local y="${bb[$i]:-0}"
+    x="${aa[$i]:-0}"
+    y="${bb[$i]:-0}"
     x=$((10#$x))
     y=$((10#$y))
     if [ "$x" -lt "$y" ]; then
@@ -195,395 +55,184 @@ cmp() {
   echo eq
 }
 
-fetch_meta() {
-  local url="$1"
-  local out="$2"
-  fetch_http="$(curl --location --silent --show-error --connect-timeout 15 --max-time 1800 --retry 3 --retry-delay 2 --output "$out" --write-out "%{http_code}" "$url" || true)"
-  [ "$fetch_http" = "200" ]
+major_minor() {
+  local v a b
+  v="${1#v}"
+  v="${v%%-*}"
+  IFS=. read -r a b _ <<<"$v"
+  printf "%s.%s" "${a:-0}" "${b:-0}"
 }
 
-fetch_file() {
-  curl --fail --location --progress-bar --connect-timeout 15 --max-time 1800 --retry 3 --retry-delay 2 --output "$2" "$1"
-}
-
-parse() {
-  ver="$(awk -F': *' '/^version:/{print $2; exit}' "$1" | tr -d "'\"")"
-  note="$(awk -F': *' '/^notes_url:/{print $2; exit}' "$1")"
-  pkg="$(awk '
-    /^package:[[:space:]]*$/ { sec="package"; next }
-    /^[^[:space:]]/ { sec="" }
-    sec=="package" && /^[[:space:]]+url:[[:space:]]*/ { sub(/^[[:space:]]+url:[[:space:]]*/, ""); print; exit }
-  ' "$1")"
-  sha="$(awk '
-    /^package:[[:space:]]*$/ { sec="package"; next }
-    /^[^[:space:]]/ { sec="" }
-    sec=="package" && /^[[:space:]]+sha512:[[:space:]]*/ { sub(/^[[:space:]]+sha512:[[:space:]]*/, ""); print; exit }
-  ' "$1")"
-  ins="$(awk '
-    /^installer:[[:space:]]*$/ { sec="installer"; next }
-    /^[^[:space:]]/ { sec="" }
-    sec=="installer" && /^[[:space:]]+url:[[:space:]]*/ { sub(/^[[:space:]]+url:[[:space:]]*/, ""); print; exit }
-  ' "$1")"
-  if [ -z "$pkg" ]; then
-    pkg="$(awk '
-      /^files:[[:space:]]*$/ { sec="files"; next }
-      sec=="files" && /^[[:space:]]*-[[:space:]]*url:[[:space:]]*/ { sub(/^[[:space:]]*-[[:space:]]*url:[[:space:]]*/, ""); print; exit }
-    ' "$1")"
-    sha="$(awk '
-      /^files:[[:space:]]*$/ { sec="files"; next }
-      sec=="files" && /^[[:space:]]*sha512:[[:space:]]*/ { sub(/^[[:space:]]*sha512:[[:space:]]*/, ""); print; exit }
-    ' "$1")"
-  fi
-  [ -n "$ver" ] && [ -n "$pkg" ]
-}
-
-manifest() {
-  local url="$1"
-  local kind="$2"
-  local tmp
-  tmp="$(mktemp -d "${TMPDIR:-/tmp}/aether-installer.XXXXXX")"
-  local file="$tmp/manifest.yml"
-  if ! fetch_meta "$url" "$file"; then
-    rm -rf "$tmp"
-    if [ "$kind" = "version" ] && [ "$fetch_http" = "404" ]; then
-      return "$miss"
+pick_pkg() {
+  local dir want_ver file ver best_file best_ver
+  dir="$1"
+  want_ver="$2"
+  best_file=""
+  best_ver=""
+  shopt -s nullglob
+  for file in "$dir"/*.zip; do
+    [ -f "$file" ] || continue
+    ver="$(ver_from_name "$file")"
+    if [ -z "$ver" ]; then
+      continue
     fi
-    return "$meta_err"
+    if [ -n "$want_ver" ] && [ "$ver" != "$want_ver" ]; then
+      continue
+    fi
+    if [ -z "$best_file" ]; then
+      best_file="$file"
+      best_ver="$ver"
+      continue
+    fi
+    if [ "$(cmp "$best_ver" "$ver")" = "lt" ]; then
+      best_file="$file"
+      best_ver="$ver"
+    fi
+  done
+  shopt -u nullglob
+  if [ -n "$best_file" ]; then
+    echo "$best_file|$best_ver"
+    return 0
   fi
-  if ! parse "$file"; then
-    rm -rf "$tmp"
-    return "$meta_err"
+  return 1
+}
+
+active_dir() {
+  local root link rel dir v
+  root="$1"
+  link="$root/current"
+  if [ -L "$link" ]; then
+    rel="$(readlink "$link")"
+    dir="$root/$rel"
+    if [ -d "$dir" ] && [ -f "$dir/.aether_web_version" ]; then
+      printf "%s" "$dir"
+      return 0
+    fi
   fi
-  pkg_url="$(abs "$url" "$pkg")"
-  ins_url="$(abs "$url" "$ins")"
-  note_url="$(abs "$url" "$note")"
-  pkg_name="$(basename "$pkg_url")"
-  ins_name="$(basename "$ins_url")"
+  if [ -f "$root/.aether_web_version" ]; then
+    v="$(tr -d '[:space:]' <"$root/.aether_web_version")"
+    if [ -n "$v" ] && [ -d "$root/aether_$v" ]; then
+      printf "%s" "$root/aether_$v"
+      return 0
+    fi
+  fi
+  printf ""
+}
+
+write_launch() {
+  local root desk
+  root="$1"
+  desk="$HOME/Desktop"
+  mkdir -p "$desk"
+  cat >"$desk/Aether.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$root"
+cur="\$root/current"
+
+if [ -L "\$cur" ] && [ -f "\$cur/Aether.sh" ]; then
+  exec "\$cur/Aether.sh"
+fi
+
+echo "No active version found under: $root"
+exit 1
+EOF
+  chmod +x "$desk/Aether.sh"
+  launch="$desk/Aether.sh"
+}
+
+if [ "$base" != "downloads" ]; then
+  fail "规范错误：update_linux_web.sh 必须放在 .../aether/downloads 目录。当前: $self"
+fi
+if [ "$(basename "$work")" != "aether" ]; then
+  fail "规范错误：工作目录必须是 .../aether。当前: $work"
+fi
+if [ ! -f "$work/aether_linux_installer.sh" ]; then
+  fail "规范错误：缺少 .../aether/aether_linux_installer.sh"
+fi
+
+echo "[0/4] 工作目录: $work"
+
+pick="$(pick_pkg "$self" "$want" || true)"
+[ -n "$pick" ] || fail "未在 .../aether/downloads 找到可用 zip（文件名需包含版本号）"
+
+pkg="${pick%%|*}"
+ver="${pick##*|}"
+target="$work/aether_$ver"
+
+echo "[1/4] 安装包: $(basename "$pkg")"
+echo "      目标版本: $ver"
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/aether-web-install.XXXXXX")"
+ex="$tmp/extract"
+next="$work/.aether_$ver.next"
+
+cleanup() {
   rm -rf "$tmp"
 }
+trap cleanup EXIT
 
-grab() {
-  dl="$work/downloads"
-  mkdir -p "$dl" || return "$dir_err"
-  local pkg_ext ins_ext need_pkg need_ins sum
+rm -rf "$next" "$ex"
+mkdir -p "$next" "$ex"
 
-  pkg_ext="${pkg_name##*.}"
-  if [ "$pkg_ext" = "$pkg_name" ]; then
-    pkg_ext=""
-  else
-    pkg_ext=".$pkg_ext"
-  fi
-  pkg_file="$dl/aether-linux-x64-web-$ver$pkg_ext"
+unzip -q -o "$pkg" -d "$ex"
 
-  need_pkg=1
-  if [ -f "$pkg_file" ]; then
-    if [ -n "$sha" ]; then
-      sum="$(openssl dgst -sha512 -binary "$pkg_file" | openssl base64 -A || true)"
-      if [ "$sum" = "$sha" ]; then
-        need_pkg=0
-      fi
-    else
-      need_pkg=0
-    fi
-  fi
-
-  if [ "$need_pkg" = "1" ]; then
-    echo "Downloading package:"
-    echo "  $pkg_url"
-    fetch_file "$pkg_url" "$pkg_file" || return "$dl_err"
-  else
-    echo "Using cached package:"
-    echo "  $pkg_file"
-  fi
-
-  if [ -n "$sha" ]; then
-    sum="$(openssl dgst -sha512 -binary "$pkg_file" | openssl base64 -A)"
-    [ "$sum" = "$sha" ] || return "$sum_err"
-  fi
-
-  if [ -n "$ins_url" ] && [ -n "$ins_name" ]; then
-    ins_ext="${ins_name##*.}"
-    if [ "$ins_ext" = "$ins_name" ]; then
-      ins_ext=""
-    else
-      ins_ext=".$ins_ext"
-    fi
-    ins_file="$dl/update_linux_web-$ver$ins_ext"
-
-    need_ins=1
-    if [ -f "$ins_file" ]; then
-      need_ins=0
-    fi
-
-    if [ "$need_ins" = "1" ]; then
-      echo "Downloading installer:"
-      echo "  $ins_url"
-      fetch_file "$ins_url" "$ins_file" || return "$dl_err"
-    else
-      echo "Using cached installer:"
-      echo "  $ins_file"
-    fi
-    chmod +x "$ins_file" 2>/dev/null || true
-  else
-    ins_file=""
-  fi
-
-  prune
-}
-
-prune() {
-  dl="${dl:-$work/downloads}"
-  [ -d "$dl" ] || return 0
-  local arr n cut i list item
-
+src="$ex"
+if [ ! -f "$src/aether" ] || [ ! -f "$src/Aether.sh" ]; then
   shopt -s nullglob
-  arr=("$dl"/aether-linux-x64-web-*.*)
+  dirs=("$ex"/*/)
   shopt -u nullglob
-  n="${#arr[@]}"
-  if [ "$n" -gt "$keep" ]; then
-    list="$(printf "%s\n" "${arr[@]}" | sort -V)"
-    cut=$((n - keep))
-    i=0
-    while IFS= read -r item; do
-      [ -n "$item" ] || continue
-      if [ "$i" -lt "$cut" ]; then
-        rm -f "$item"
-      fi
-      i=$((i + 1))
-    done <<<"$list"
+  if [ "${#dirs[@]}" -eq 1 ] && [ -f "${dirs[0]}aether" ] && [ -f "${dirs[0]}Aether.sh" ]; then
+    src="${dirs[0]%/}"
   fi
-
-  shopt -s nullglob
-  arr=("$dl"/update_linux_web-*.sh)
-  shopt -u nullglob
-  n="${#arr[@]}"
-  if [ "$n" -gt "$keep" ]; then
-    list="$(printf "%s\n" "${arr[@]}" | sort -V)"
-    cut=$((n - keep))
-    i=0
-    while IFS= read -r item; do
-      [ -n "$item" ] || continue
-      if [ "$i" -lt "$cut" ]; then
-        rm -f "$item"
-      fi
-      i=$((i + 1))
-    done <<<"$list"
-  fi
-}
-
-help() {
-  cat <<EOF
-Aether Linux Installer
-
-Usage:
-  $(basename "$0") [--no-pause] [--path <dir>] init
-  $(basename "$0") [--no-pause] auto <current-version>
-  $(basename "$0") [--no-pause] manual <target-version>
-
-Remote manifests:
-  $base/$latest
-  $base/1.2.3/linux-x64.yml
-
-Result file:
-  work_dir/downloads/last-result.yml
-
-Exit codes:
-  0   init finished successfully
-  10  latest update downloaded and ready
-  11  requested version downloaded and ready
-  20  already up to date
-  21  requested version not found
-  30  manifest or network error
-  31  download failed
-  32  checksum mismatch
-  33  init install run failed
-  40  work directory error
-  50  argument error
-EOF
-}
-
-if [ "$mode" = "help" ] || [ "$mode" = "--help" ] || [ "$mode" = "-h" ]; then
-  help
-  exit 0
 fi
 
-if [ "$mode" = "init" ]; then
-  echo "Aether Linux Installer"
-  echo
-  work="$(normalize_work "${path_arg:-$default}")"
-  echo "Install directory:"
-  echo "  $work"
-  prep "$work" || {
-    res="dir_error"
-    result
-    echo
-    echo "Work directory failed."
-    fail "$dir_err"
-  }
-  local_self="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
-  local_dst="$work/$(basename "$0")"
-  if [ "$local_self" != "$local_dst" ]; then
-    cp "$0" "$local_dst" 2>/dev/null || {
-      res="dir_error"
-      result
-      echo
-      echo "Failed to copy installer to $work"
-      fail "$dir_err"
-    }
-  fi
-  manifest_url="$base/$latest"
-  manifest "$manifest_url" latest || {
-    res="meta_error"
-    result
-    echo
-    echo "Manifest check failed."
-    fail "$meta_err"
-  }
-  grab || {
-    code="$?"
-    res="download_error"
-    [ "$code" = "$sum_err" ] && res="checksum_error"
-    result
-    echo
-    echo "Download failed."
-    fail "$code"
-  }
-  res="init_ready"
-  result
-  echo
-  echo "Download finished."
-  echo "Version:   $ver"
-  echo "Package:   $pkg_file"
-  echo "Installer: $ins_file"
-  echo "Result:    $res_file"
-  echo
-  if [ -n "$ins_file" ]; then
-    echo "[init] Running installer script..."
-    if ! (cd "$work/downloads" && bash "$(basename "$ins_file")" "$ver"); then
-      res="run_error"
-      result
-      echo
-      echo "Install step failed while running: $ins_file"
-      fail "$run_err"
-    fi
-  else
-    res="run_error"
-    result
-    echo
-    echo "Install step failed: installer script missing in manifest."
-    fail "$run_err"
-  fi
+[ -f "$src/aether" ] || fail "安装包内容缺少 aether"
+[ -f "$src/Aether.sh" ] || fail "安装包内容缺少 Aether.sh"
 
-  mkdir -p "$HOME/Aether_Database" 2>/dev/null || true
+echo "[2/4] 解包并安装到: $target"
+cp -R "$src"/. "$next"/
 
-  done_hold
-  exit 0
+old="$(active_dir "$work")"
+small=0
+if [ -n "$old" ] && [ -f "$old/.aether_web_version" ]; then
+  old_ver="$(tr -d '[:space:]' <"$old/.aether_web_version")"
+  if [ -n "$old_ver" ] && [ "$(major_minor "$old_ver")" = "$(major_minor "$ver")" ]; then
+    small=1
+  fi
 fi
 
-if [ "$mode" = "auto" ]; then
-  [ -n "$arg" ] || {
-    echo "auto mode needs current version."
-    echo "Example: $(basename "$0") auto 1.2.3"
-    res="arg_error"
-    work="$(workdir)"
-    result
-    help
-    exit "$arg_err"
-  }
-  cur="$arg"
-  work="$(workdir)"
-  prep "$work" || {
-    res="dir_error"
-    result
-    echo
-    echo "Work directory failed."
-    exit "$dir_err"
-  }
-  manifest_url="$base/$latest"
-  manifest "$manifest_url" latest || {
-    res="meta_error"
-    result
-    echo
-    echo "Manifest check failed."
-    exit "$meta_err"
-  }
-  if [ "$(cmp "$cur" "$ver")" = "lt" ]; then
-    echo "Current version: $cur"
-    echo "Remote version: $ver"
-    grab || {
-      code="$?"
-      res="download_error"
-      [ "$code" = "$sum_err" ] && res="checksum_error"
-      result
-      echo
-      echo "Download failed."
-      exit "$code"
-    }
-    res="update_ready"
-    result
-    exit "$ready"
+rm -rf "$target"
+mv "$next" "$target"
+
+chmod +x "$target/aether" "$target/Aether.sh"
+printf "%s\n" "$ver" >"$target/.aether_web_version"
+printf "%s\n" "$ver" >"$work/.aether_web_version"
+
+ln -sfn "aether_$ver" "$work/current"
+write_launch "$work"
+
+if [ "$restart" = "1" ]; then
+  if [ -n "$old" ]; then
+    pkill -f "$old/Aether.sh" >/dev/null 2>&1 || true
+    pkill -f "$old/aether web" >/dev/null 2>&1 || true
+    pkill -f "$old/aether serve" >/dev/null 2>&1 || true
   fi
-  echo "Current version: $cur"
-  echo "Remote version: $ver"
-  echo "Already up to date."
-  res="up_to_date"
-  result
-  exit "$latest_ok"
+  pkill -f "$work/current/Aether.sh" >/dev/null 2>&1 || true
+  pkill -f "$work/current/aether web" >/dev/null 2>&1 || true
+  pkill -f "$work/current/aether serve" >/dev/null 2>&1 || true
+  nohup "$work/current/Aether.sh" >/dev/null 2>&1 &
 fi
 
-if [ "$mode" = "manual" ]; then
-  [ -n "$arg" ] || {
-    echo "manual mode needs a version."
-    echo "Example: $(basename "$0") manual 1.2.3"
-    res="arg_error"
-    work="$(workdir)"
-    result
-    help
-    exit "$arg_err"
-  }
-  req="$arg"
-  work="$(workdir)"
-  prep "$work" || {
-    res="dir_error"
-    result
-    echo
-    echo "Work directory failed."
-    exit "$dir_err"
-  }
-  manifest_url="$base/$req/linux-x64.yml"
-  if ! manifest "$manifest_url" version; then
-    code="$?"
-    if [ "$code" = "$miss" ]; then
-      ver="$req"
-      res="version_missing"
-      result
-      exit "$miss"
-    fi
-    res="meta_error"
-    result
-    echo
-    echo "Manifest check failed."
-    exit "$meta_err"
-  fi
-  echo "Requested version: $req"
-  echo "Resolved version:  $ver"
-  grab || {
-    code="$?"
-    res="download_error"
-    [ "$code" = "$sum_err" ] && res="checksum_error"
-    result
-    echo
-    echo "Download failed."
-    exit "$code"
-  }
-  res="manual_ready"
-  result
-  exit "$manual_ready"
+if [ "$small" = "1" ] && [ -n "${old:-}" ] && [ "$old" != "$target" ]; then
+  echo "[3/4] 小版本更新：替换旧目录"
+  rm -rf "$old"
+else
+  echo "[3/4] 大版本更新：保留旧版本目录"
 fi
 
-echo "Unsupported mode: $mode"
-res="arg_error"
-work="$(workdir)"
-result
-help
-exit "$arg_err"
+echo "[4/4] 完成"
+echo "当前版本: $ver"
+echo "版本目录: $target"
+echo "启动入口: $launch"

--- a/Update/update_linux_web.sh
+++ b/Update/update_linux_web.sh
@@ -2,237 +2,388 @@
 
 set -euo pipefail
 
-want="${1:-}"
-self="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-base="$(basename "$self")"
-work="$(dirname "$self")"
-launch=""
-restart="0"
+ok=0
+dl_err=31
+run_err=33
+arg_err=50
 
-if [ "${2:-}" = "--restart" ]; then
-  restart="1"
-fi
+mode="install"
+arg=""
+tmp=""
+next=""
 
-fail() {
-  echo "$1"
-  exit 1
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    install|help|-h|--help)
+      mode="$1"
+      ;;
+    *)
+      if [ -z "$arg" ]; then
+        arg="$1"
+      else
+        echo "Unsupported argument: $1"
+        exit "$arg_err"
+      fi
+      ;;
+  esac
+  shift
+done
+
+help() {
+  cat <<EOF
+Aether Linux Local Installer
+
+Usage:
+  $(basename "$0") install <version>
+  $(basename "$0") <version>
+
+Behavior:
+  - Local install only; no network download
+  - Installs to a versioned directory: aether_<version>
+  - Updates current symlink to the latest installed version
+
+Package name pattern:
+  aether-linux-x64-web-<version>.*
+
+Exit codes:
+  0   install finished successfully
+  31  local package not found
+  33  extract/install failed
+  50  argument error
+EOF
 }
 
-ver_from_name() {
-  local file name
-  file="$(basename "$1")"
-  name="${file%.zip}"
-  if [[ "$name" =~ ([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
-    printf "%s" "${BASH_REMATCH[1]}"
+clean() {
+  if [ -n "$tmp" ] && [ -d "$tmp" ]; then
+    rm -rf "$tmp"
+  fi
+  if [ -n "$next" ] && [ -d "$next" ]; then
+    rm -rf "$next"
+  fi
+}
+
+pick_home() {
+  local home="$HOME"
+  if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+    if command -v getent >/dev/null 2>&1; then
+      home="$(getent passwd "$SUDO_USER" 2>/dev/null | cut -d: -f6)"
+    else
+      home=""
+    fi
+    if [ -z "$home" ]; then
+      home="$(eval echo "~$SUDO_USER" 2>/dev/null || true)"
+    fi
+    [ -n "$home" ] || home="$HOME"
+  fi
+  printf "%s" "$home"
+}
+
+pick_src() {
+  local ex="$1"
+  if [ -f "$ex/aether" ] && [ -f "$ex/Aether.sh" ]; then
+    printf "%s" "$ex"
     return 0
   fi
-  printf ""
-}
 
-cmp() {
-  local a b
-  a="${1#v}"
-  b="${2#v}"
-  a="${a%%-*}"
-  b="${b%%-*}"
-  local aa bb i x y
-  IFS=. read -r -a aa <<<"$a"
-  IFS=. read -r -a bb <<<"$b"
-  for i in 0 1 2 3; do
-    x="${aa[$i]:-0}"
-    y="${bb[$i]:-0}"
-    x=$((10#$x))
-    y=$((10#$y))
-    if [ "$x" -lt "$y" ]; then
-      echo lt
-      return 0
-    fi
-    if [ "$x" -gt "$y" ]; then
-      echo gt
-      return 0
-    fi
-  done
-  echo eq
-}
-
-major_minor() {
-  local v a b
-  v="${1#v}"
-  v="${v%%-*}"
-  IFS=. read -r a b _ <<<"$v"
-  printf "%s.%s" "${a:-0}" "${b:-0}"
-}
-
-pick_pkg() {
-  local dir want_ver file ver best_file best_ver
-  dir="$1"
-  want_ver="$2"
-  best_file=""
-  best_ver=""
   shopt -s nullglob
-  for file in "$dir"/*.zip; do
-    [ -f "$file" ] || continue
-    ver="$(ver_from_name "$file")"
-    if [ -z "$ver" ]; then
-      continue
-    fi
-    if [ -n "$want_ver" ] && [ "$ver" != "$want_ver" ]; then
-      continue
-    fi
-    if [ -z "$best_file" ]; then
-      best_file="$file"
-      best_ver="$ver"
-      continue
-    fi
-    if [ "$(cmp "$best_ver" "$ver")" = "lt" ]; then
-      best_file="$file"
-      best_ver="$ver"
+  for d in "$ex"/*; do
+    if [ -d "$d" ] && [ -f "$d/aether" ] && [ -f "$d/Aether.sh" ]; then
+      printf "%s" "$d"
+      shopt -u nullglob
+      return 0
     fi
   done
   shopt -u nullglob
-  if [ -n "$best_file" ]; then
-    echo "$best_file|$best_ver"
+  printf ""
+}
+
+set_current() {
+  local work="$1"
+  local target="$2"
+  local link="$work/current"
+
+  ln -sfn "$(basename "$target")" "$link" 2>/dev/null || true
+  if [ -f "$link/Aether.sh" ]; then
     return 0
   fi
+
+  rm -rf "$link" 2>/dev/null || true
+  mkdir -p "$link"
+  cp -R "$target"/. "$link" || return 1
+  [ -f "$link/Aether.sh" ]
+}
+
+list_ssl() {
+  {
+    if command -v ldconfig >/dev/null 2>&1; then
+      ldconfig -p 2>/dev/null | awk '/libssl\.so\./{print $NF}'
+    fi
+    for p in /lib /usr/lib /lib64 /usr/lib64 /usr/local/lib /usr/local/lib64 /lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu; do
+      [ -d "$p" ] || continue
+      find "$p" -maxdepth 2 -type f -name 'libssl.so.*' 2>/dev/null
+    done
+  } | awk 'NF && !seen[$0]++'
+}
+
+list_crypto() {
+  {
+    if command -v ldconfig >/dev/null 2>&1; then
+      ldconfig -p 2>/dev/null | awk '/libcrypto\.so\./{print $NF}'
+    fi
+    for p in /lib /usr/lib /lib64 /usr/lib64 /usr/local/lib /usr/local/lib64 /lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu; do
+      [ -d "$p" ] || continue
+      find "$p" -maxdepth 2 -type f -name 'libcrypto.so.*' 2>/dev/null
+    done
+  } | awk 'NF && !seen[$0]++'
+}
+
+has_ssl3() {
+  if command -v ldconfig >/dev/null 2>&1 && ldconfig -p 2>/dev/null | grep -q '\blibssl\.so\.3\b'; then
+    return 0
+  fi
+  list_ssl | grep -q '/libssl.so.3$'
+}
+
+probe_pair() {
+  local dir="$1"
+  local ssl="$2"
+  local crypto="$3"
+  local probe="$dir/.ssl_probe"
+
+  rm -rf "$probe" 2>/dev/null || true
+  mkdir -p "$probe" || return 1
+  ln -sf "$ssl" "$probe/libssl.so.3" || return 1
+  ln -sf "$crypto" "$probe/libcrypto.so.3" || return 1
+
+  if ! command -v ldd >/dev/null 2>&1 || [ ! -x "$dir/aether" ]; then
+    rm -rf "$probe" 2>/dev/null || true
+    return 0
+  fi
+
+  local out
+  out="$(LD_LIBRARY_PATH="$probe${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ldd "$dir/aether" 2>/dev/null || true)"
+  rm -rf "$probe" 2>/dev/null || true
+  if [ -z "$out" ]; then
+    return 1
+  fi
+
+  if printf "%s\n" "$out" | grep -q 'libssl.so.3 => .*not found'; then
+    return 1
+  fi
+  if printf "%s\n" "$out" | grep -q 'libcrypto.so.3 => .*not found'; then
+    return 1
+  fi
+  return 0
+}
+
+pick_pair() {
+  local dir="$1"
+  local ssl_ref="$2"
+  local crypto_ref="$3"
+  local ssl=""
+  local crypto=""
+  local c=""
+
+  mapfile -t _ssl < <(list_ssl)
+  mapfile -t _crypto < <(list_crypto)
+
+  for ssl in "${_ssl[@]}"; do
+    [ -f "$ssl" ] || continue
+    local sdir
+    sdir="$(dirname "$ssl")"
+
+    crypto=""
+    if [ -f "$sdir/libcrypto.so.1.1" ]; then
+      crypto="$sdir/libcrypto.so.1.1"
+    fi
+    if [ -z "$crypto" ]; then
+      crypto="$(find "$sdir" -maxdepth 1 -type f -name 'libcrypto.so.1.*' 2>/dev/null | head -1)"
+    fi
+    if [ -z "$crypto" ]; then
+      for c in "${_crypto[@]}"; do
+        if [[ "$c" == "$sdir"/* ]]; then
+          crypto="$c"
+          break
+        fi
+      done
+    fi
+    if [ -z "$crypto" ]; then
+      for c in "${_crypto[@]}"; do
+        crypto="$c"
+        break
+      done
+    fi
+    [ -n "$crypto" ] || continue
+    if probe_pair "$dir" "$ssl" "$crypto"; then
+      printf -v "$ssl_ref" '%s' "$ssl"
+      printf -v "$crypto_ref" '%s' "$crypto"
+      return 0
+    fi
+  done
+
   return 1
 }
 
-active_dir() {
-  local root link rel dir v
-  root="$1"
-  link="$root/current"
-  if [ -L "$link" ]; then
-    rel="$(readlink "$link")"
-    dir="$root/$rel"
-    if [ -d "$dir" ] && [ -f "$dir/.aether_web_version" ]; then
-      printf "%s" "$dir"
-      return 0
-    fi
+fix_libssl() {
+  local dir="$1"
+  [ -d "$dir" ] || return 0
+
+  if has_ssl3; then
+    return 0
   fi
-  if [ -f "$root/.aether_web_version" ]; then
-    v="$(tr -d '[:space:]' <"$root/.aether_web_version")"
-    if [ -n "$v" ] && [ -d "$root/aether_$v" ]; then
-      printf "%s" "$root/aether_$v"
-      return 0
-    fi
+
+  local ssl=""
+  local crypto=""
+  if ! pick_pair "$dir" ssl crypto; then
+    echo "[install] Warning: libssl.so.3 is missing, and no usable libssl/libcrypto pair was found."
+    echo "[install] Please install libssl3 (preferred) or a compatible OpenSSL runtime and retry."
+    return 0
   fi
-  printf ""
+
+  local lib="$dir/lib"
+  mkdir -p "$lib"
+  ln -sf "$ssl" "$lib/libssl.so.3"
+  ln -sf "$crypto" "$lib/libcrypto.so.3"
+  echo "[install] Added compatibility symlinks in $lib"
+  echo "[install]   libssl.so.3 -> $ssl"
+  echo "[install]   libcrypto.so.3 -> $crypto"
+
+  local launch="$dir/Aether.sh"
+  local real="$dir/Aether.sh.real"
+  if [ -f "$launch" ] && [ ! -f "$real" ]; then
+    mv "$launch" "$real"
+    cat > "$launch" <<'EOF'
+#!/usr/bin/env bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+export LD_LIBRARY_PATH="$DIR/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+if [ -x "$DIR/Aether.sh.real" ]; then
+  exec "$DIR/Aether.sh.real" "$@"
+fi
+exec "$DIR/aether" web "$@"
+EOF
+    chmod +x "$launch"
+    echo "[install] Patched Aether.sh with compatibility wrapper."
+  fi
 }
 
 write_launch() {
-  local root desk
-  root="$1"
-  desk="$HOME/Desktop"
-  mkdir -p "$desk"
-  cat >"$desk/Aether.sh" <<EOF
+  local work="$1"
+  local home
+  home="$(pick_home)"
+  local desk="$home/Desktop"
+  local launch="$desk/Aether.sh"
+  local app="$work/current/Aether.sh"
+
+  [ -f "$app" ] || return 1
+  mkdir -p "$desk" || return 1
+
+  cat > "$launch" <<EOF
 #!/usr/bin/env bash
-set -euo pipefail
-
-root="$root"
-cur="\$root/current"
-
-if [ -L "\$cur" ] && [ -f "\$cur/Aether.sh" ]; then
-  exec "\$cur/Aether.sh"
-fi
-
-echo "No active version found under: $root"
-exit 1
+exec "$app" "\$@"
 EOF
-  chmod +x "$desk/Aether.sh"
-  launch="$desk/Aether.sh"
+  chmod +x "$launch" || return 1
+  printf "%s" "$launch"
 }
 
-if [ "$base" != "downloads" ]; then
-  fail "规范错误：update_linux_web.sh 必须放在 .../aether/downloads 目录。当前: $self"
-fi
-if [ "$(basename "$work")" != "aether" ]; then
-  fail "规范错误：工作目录必须是 .../aether。当前: $work"
-fi
-if [ ! -f "$work/aether_linux_installer.sh" ]; then
-  fail "规范错误：缺少 .../aether/aether_linux_installer.sh"
+if [ "$mode" = "help" ] || [ "$mode" = "--help" ] || [ "$mode" = "-h" ]; then
+  help
+  exit "$ok"
 fi
 
-echo "[0/4] 工作目录: $work"
+if [ "$mode" = "install" ] && [ -z "$arg" ]; then
+  echo "install mode needs a version."
+  echo "Example: $(basename "$0") install 0.3.0"
+  exit "$arg_err"
+fi
 
-pick="$(pick_pkg "$self" "$want" || true)"
-[ -n "$pick" ] || fail "未在 .../aether/downloads 找到可用 zip（文件名需包含版本号）"
+if [ "$mode" != "install" ] && [ -n "$arg" ]; then
+  mode="install"
+fi
 
-pkg="${pick%%|*}"
-ver="${pick##*|}"
+if [ "$mode" != "install" ]; then
+  echo "Unsupported mode: $mode"
+  exit "$arg_err"
+fi
+
+trap clean EXIT
+
+ver="$arg"
+dl="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+work="$(cd "$dl/.." && pwd)"
 target="$work/aether_$ver"
-
-echo "[1/4] 安装包: $(basename "$pkg")"
-echo "      目标版本: $ver"
-
-tmp="$(mktemp -d "${TMPDIR:-/tmp}/aether-web-install.XXXXXX")"
-ex="$tmp/extract"
 next="$work/.aether_$ver.next"
 
-cleanup() {
-  rm -rf "$tmp"
+shopt -s nullglob
+arr=("$dl"/aether-linux-x64-web-"$ver".*)
+shopt -u nullglob
+if [ "${#arr[@]}" -eq 0 ]; then
+  echo "[install] Package not found for version $ver in $dl"
+  exit "$dl_err"
+fi
+
+pkg="${arr[0]}"
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/aether-web-install.XXXXXX")"
+ex="$tmp/extract"
+mkdir -p "$ex" || exit "$run_err"
+
+echo "[install] Installing version $ver"
+echo "  Package: $pkg"
+echo "  Target:  $target"
+
+case "$pkg" in
+  *.zip)
+    unzip -o "$pkg" -d "$ex" || {
+      echo "[install] Failed to extract $pkg"
+      exit "$run_err"
+    }
+    ;;
+  *.tar.gz|*.tgz)
+    tar -xzf "$pkg" -C "$ex" || {
+      echo "[install] Failed to extract $pkg"
+      exit "$run_err"
+    }
+    ;;
+  *.tar.bz2)
+    tar -xjf "$pkg" -C "$ex" || {
+      echo "[install] Failed to extract $pkg"
+      exit "$run_err"
+    }
+    ;;
+  *)
+    echo "[install] Unknown package format: $pkg"
+    exit "$run_err"
+    ;;
+esac
+
+src="$(pick_src "$ex")"
+if [ -z "$src" ]; then
+  echo "[install] Missing app files (aether/Aether.sh) in package"
+  exit "$run_err"
+fi
+
+rm -rf "$next" "$target" 2>/dev/null || true
+mkdir -p "$next" || exit "$run_err"
+cp -R "$src"/. "$next" || exit "$run_err"
+mv "$next" "$target" || exit "$run_err"
+
+chmod +x "$target/aether" "$target/Aether.sh" 2>/dev/null || true
+printf "%s\n" "$ver" > "$target/.aether_web_version"
+printf "%s\n" "$ver" > "$work/.aether_web_version"
+
+set_current "$work" "$target" || {
+  echo "[install] Failed to update current link"
+  exit "$run_err"
 }
-trap cleanup EXIT
 
-rm -rf "$next" "$ex"
-mkdir -p "$next" "$ex"
+fix_libssl "$target"
 
-unzip -q -o "$pkg" -d "$ex"
-
-src="$ex"
-if [ ! -f "$src/aether" ] || [ ! -f "$src/Aether.sh" ]; then
-  shopt -s nullglob
-  dirs=("$ex"/*/)
-  shopt -u nullglob
-  if [ "${#dirs[@]}" -eq 1 ] && [ -f "${dirs[0]}aether" ] && [ -f "${dirs[0]}Aether.sh" ]; then
-    src="${dirs[0]%/}"
-  fi
-fi
-
-[ -f "$src/aether" ] || fail "安装包内容缺少 aether"
-[ -f "$src/Aether.sh" ] || fail "安装包内容缺少 Aether.sh"
-
-echo "[2/4] 解包并安装到: $target"
-cp -R "$src"/. "$next"/
-
-old="$(active_dir "$work")"
-small=0
-if [ -n "$old" ] && [ -f "$old/.aether_web_version" ]; then
-  old_ver="$(tr -d '[:space:]' <"$old/.aether_web_version")"
-  if [ -n "$old_ver" ] && [ "$(major_minor "$old_ver")" = "$(major_minor "$ver")" ]; then
-    small=1
-  fi
-fi
-
-rm -rf "$target"
-mv "$next" "$target"
-
-chmod +x "$target/aether" "$target/Aether.sh"
-printf "%s\n" "$ver" >"$target/.aether_web_version"
-printf "%s\n" "$ver" >"$work/.aether_web_version"
-
-ln -sfn "aether_$ver" "$work/current"
-write_launch "$work"
-
-if [ "$restart" = "1" ]; then
-  if [ -n "$old" ]; then
-    pkill -f "$old/Aether.sh" >/dev/null 2>&1 || true
-    pkill -f "$old/aether web" >/dev/null 2>&1 || true
-    pkill -f "$old/aether serve" >/dev/null 2>&1 || true
-  fi
-  pkill -f "$work/current/Aether.sh" >/dev/null 2>&1 || true
-  pkill -f "$work/current/aether web" >/dev/null 2>&1 || true
-  pkill -f "$work/current/aether serve" >/dev/null 2>&1 || true
-  nohup "$work/current/Aether.sh" >/dev/null 2>&1 &
-fi
-
-if [ "$small" = "1" ] && [ -n "${old:-}" ] && [ "$old" != "$target" ]; then
-  echo "[3/4] 小版本更新：替换旧目录"
-  rm -rf "$old"
+launch="$(write_launch "$work" || true)"
+if [ -n "$launch" ]; then
+  echo "[install] Desktop launcher: $launch"
 else
-  echo "[3/4] 大版本更新：保留旧版本目录"
+  echo "[install] Warning: failed to create Desktop launcher."
 fi
 
-echo "[4/4] 完成"
-echo "当前版本: $ver"
-echo "版本目录: $target"
-echo "启动入口: $launch"
+echo "[install] Current: $work/current"
+echo "[install] Done."
+exit "$ok"

--- a/Update/update_linux_web.sh
+++ b/Update/update_linux_web.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 base="https://aether.aiphys.cn/download"
 latest="latest/linux-x64.yml"
 site="${base%/download}"
-default="$HOME/Applications/Aether"
+default="$HOME/Applications/aether"
 mode="init"
 arg=""
 path_arg=""
@@ -153,11 +153,11 @@ normalize_work() {
   local dir base
   dir="$1"
   base="$(basename "$dir")"
-  if [ "$base" = "Aether" ]; then
+  if [ "$base" = "aether" ]; then
     printf "%s" "$dir"
     return 0
   fi
-  printf "%s/Aether" "$dir"
+  printf "%s/aether" "$dir"
 }
 
 workdir() {

--- a/Update/update_windows_web.bat
+++ b/Update/update_windows_web.bat
@@ -1,4 +1,4 @@
-@echo off
+﻿@echo off
 chcp 65001 >nul
 setlocal EnableExtensions EnableDelayedExpansion
 

--- a/Update/update_windows_web.bat
+++ b/Update/update_windows_web.bat
@@ -13,16 +13,16 @@ set "LAUNCH="
 set "NOTE="
 
 if /I not "%BASE%"=="downloads" (
-  echo 规范错误：update_windows_web.bat 必须放在 ...\Aether\downloads 目录。当前: %SELF%
+  echo 规范错误：update_windows_web.bat 必须放在 ...\aether\downloads 目录。当前: %SELF%
   exit /b 1
 )
 for %%i in ("%WORK%") do set "WORK_NAME=%%~nxi"
-if /I not "%WORK_NAME%"=="Aether" (
-  echo 规范错误：工作目录必须是 ...\Aether。当前: %WORK%
+if /I not "%WORK_NAME%"=="aether" (
+  echo 规范错误：工作目录必须是 ...\aether。当前: %WORK%
   exit /b 1
 )
 if not exist "%WORK%\aether_windows_installer.bat" (
-  echo 规范错误：缺少 ...\Aether\aether_windows_installer.bat
+  echo 规范错误：缺少 ...\aether\aether_windows_installer.bat
   exit /b 1
 )
 
@@ -30,7 +30,7 @@ echo [0/4] 工作目录: %WORK%
 
 call :pick_pkg "%SELF%" "%WANT%"
 if errorlevel 1 (
-  echo 未在 ...\Aether\downloads 找到可用 zip（文件名需包含版本号）
+  echo 未在 ...\aether\downloads 找到可用 zip（文件名需包含版本号）
   exit /b 1
 )
 

--- a/packages/app/src/components/dialog-settings.tsx
+++ b/packages/app/src/components/dialog-settings.tsx
@@ -55,7 +55,7 @@ export const DialogSettings: Component = () => {
               </div>
             </div>
             <div class="flex flex-col gap-1 pl-1 py-1 text-12-medium text-text-weak">
-              <span>Aether v{platform.version}</span>
+              <span>{platform.version ? `Aether v${platform.version}` : "Aether -"}</span>
             </div>
           </div>
         </Tabs.List>

--- a/packages/app/src/components/dialog-update.tsx
+++ b/packages/app/src/components/dialog-update.tsx
@@ -40,13 +40,20 @@ export const DialogUpdate: Component = () => {
       const os = detectOS()
       const res = await fetchApi(`/global/web-update/check?os=${os}`)
       const data = await res.json()
+      const current = typeof data.currentVersion === "string" ? data.currentVersion.trim() : ""
+      const remote = typeof data.remoteVersion === "string" ? data.remoteVersion.trim() : ""
+      if (current) setDownloadedVersion(current)
+      setRemoteVersion(remote)
+      if (typeof data.checkError === "string" && data.checkError) {
+        setState("error")
+        setErrorMessage(data.checkError)
+        return
+      }
       if (data.error) {
         setState("error")
         setErrorMessage(data.error)
         return
       }
-      setRemoteVersion(data.remoteVersion)
-      setDownloadedVersion(data.currentVersion || "")
       if (!data.updateAvailable) {
         setState("up-to-date")
         return
@@ -121,7 +128,7 @@ export const DialogUpdate: Component = () => {
         <div class="flex flex-col gap-4">
           <div class="flex justify-between items-center">
             <span class="text-13-regular text-text-weak">{language.t("update.currentVersion")}</span>
-            <span class="text-13-medium text-text-strong">v{currentVersion()}</span>
+            <span class="text-13-medium text-text-strong">{currentVersion() ? `v${currentVersion()}` : "-"}</span>
           </div>
           <div class="flex justify-between items-center">
             <span class="text-13-regular text-text-weak">{language.t("update.remoteVersion")}</span>
@@ -184,7 +191,7 @@ export const DialogUpdate: Component = () => {
                 {language.t("update.checkFailed")}: {errorMessage()}
               </span>
             </div>
-            <Button size="small" variant="secondary" onClick={downloadUpdate}>
+            <Button size="small" variant="secondary" onClick={checkVersion}>
               {language.t("update.retry")}
             </Button>
           </Show>

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -6,7 +6,6 @@ import { type Platform, PlatformProvider } from "@/context/platform"
 import { dict as en } from "@/i18n/en"
 import { dict as zh } from "@/i18n/zh"
 import { handleNotificationClick } from "@/utils/notification-click"
-import pkg from "../../opencode/package.json"
 import { ServerConnection } from "./context/server"
 
 const DEFAULT_SERVER_URL_KEY = "opencode.settings.dat:defaultServerUrl"
@@ -155,6 +154,18 @@ const getCurrentUrl = () => {
   return location.origin
 }
 
+const readWebVersion = async () => {
+  return fetch(new URL("/global/web-update/current", getCurrentUrl()))
+    .then((res) => (res.ok ? res.json() : null))
+    .then((data: unknown) => {
+      if (!data || typeof data !== "object") return ""
+      const version = (data as Record<string, unknown>).currentVersion
+      if (typeof version !== "string") return ""
+      return version.trim()
+    })
+    .catch(() => "")
+}
+
 const getDefaultUrl = () => {
   if (import.meta.env.DEV) return getCurrentUrl()
   const lsDefault = readDefaultServerUrl()
@@ -248,7 +259,7 @@ const detectOS = (): string => {
 
 const platform: Platform = {
   platform: "web",
-  version: pkg.version,
+  version: undefined,
   openLink,
   back,
   forward,
@@ -258,12 +269,14 @@ const platform: Platform = {
     const os = detectOS()
     const res = await req(`/global/web-update/check?os=${os}`)
     const data = await res.json()
+    if (typeof data.checkError === "string" && data.checkError) throw new Error(data.checkError)
     return { updateAvailable: data.updateAvailable, version: data.remoteVersion, downloaded: !!data.downloaded }
   },
   downloadUpdate: async () => {
     const os = detectOS()
     const checkRes = await req(`/global/web-update/check?os=${os}`)
     const checkData = await checkRes.json()
+    if (typeof checkData.checkError === "string" && checkData.checkError) throw new Error(checkData.checkError)
     if (!checkData.updateAvailable) return
     const dlRes = await req("/global/web-update/download", {
       method: "POST",
@@ -277,6 +290,7 @@ const platform: Platform = {
     const os = detectOS()
     const checkRes = await req(`/global/web-update/check?os=${os}`)
     const checkData = await checkRes.json()
+    if (typeof checkData.checkError === "string" && checkData.checkError) throw new Error(checkData.checkError)
     const installRes = await req("/global/web-update/install", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -324,6 +338,7 @@ const platform: Platform = {
 
 const boot = async () => {
   if (!(root instanceof HTMLElement)) return
+  platform.version = (await readWebVersion()) || undefined
   const stop = start()
   await sync()
   const server: ServerConnection.Http = { type: "http", http: { url: getCurrentUrl() } }

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -135,6 +135,70 @@ function getAppRoot(): string {
   return path.dirname(process.execPath)
 }
 
+async function readWebCurrentVersion() {
+  const file = path.join(getAppRoot(), ".aether_web_version")
+  const read = () =>
+    fs
+      .readFile(file, "utf-8")
+      .then((x) => x.trim())
+      .catch(() => "")
+
+  const cached = await read()
+  if (cached) return cached
+  const fallback = Installation.VERSION
+  await fs.writeFile(file, `${fallback}\n`, "utf-8").catch(() => undefined)
+  const next = await read()
+  return next || fallback
+}
+
+async function webCheck(os: z.infer<typeof WebUpdateOS>) {
+  const currentVersion = await readWebCurrentVersion()
+  const ymlPath = INSTALLER_YML[os]
+  const metaUrl = `${WEB_UPDATE_BASE}/${ymlPath}`
+  try {
+    const res = await fetch(metaUrl)
+    if (!res.ok) {
+      return {
+        currentVersion,
+        remoteVersion: "",
+        updateAvailable: false,
+        downloaded: false,
+        checkError: `Failed to fetch version metadata: ${res.status}`,
+      }
+    }
+    const text = await res.text()
+    const match = text.match(/^version:\s*(.+)$/m)
+    const remoteVersion = (match?.[1]?.trim() ?? "").replace(/^['"]|['"]$/g, "")
+    if (!remoteVersion) {
+      return {
+        currentVersion,
+        remoteVersion: "",
+        updateAvailable: false,
+        downloaded: false,
+        checkError: "Could not parse remote version from metadata",
+      }
+    }
+    const updateAvailable = compareVer(currentVersion, remoteVersion) < 0
+    const downloaded = updateAvailable ? await downloadedReady(os, remoteVersion) : false
+    return {
+      currentVersion,
+      remoteVersion,
+      updateAvailable,
+      downloaded,
+      checkError: undefined,
+    }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    return {
+      currentVersion,
+      remoteVersion: "",
+      updateAvailable: false,
+      downloaded: false,
+      checkError: `Failed to check update: ${message}`,
+    }
+  }
+}
+
 function parseProxy(value?: string) {
   if (!value) return { host: "", port: 8080 }
   try {
@@ -325,7 +389,32 @@ export const GlobalRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        return c.json({ healthy: true, version: Installation.VERSION })
+        return c.json({ healthy: true, version: await readWebCurrentVersion() })
+      },
+    )
+    .get(
+      "/web-update/current",
+      describeRoute({
+        summary: "Get current web version",
+        description: "Read the current web app version from local update state.",
+        operationId: "global.web-update.current",
+        responses: {
+          200: {
+            description: "Current local web version",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.object({
+                    currentVersion: z.string(),
+                  }),
+                ),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        return c.json({ currentVersion: await readWebCurrentVersion() })
       },
     )
     .post(
@@ -534,6 +623,7 @@ export const GlobalRoutes = lazy(() =>
                     remoteVersion: z.string(),
                     updateAvailable: z.boolean(),
                     downloaded: z.boolean(),
+                    checkError: z.string().optional(),
                   }),
                 ),
               },
@@ -544,50 +634,11 @@ export const GlobalRoutes = lazy(() =>
       }),
       async (c) => {
         const os = c.req.query("os")
-        if (!os || !WebUpdateOS.safeParse(os).success) {
+        const parsed = WebUpdateOS.safeParse(os)
+        if (!parsed.success) {
           return c.json({ error: "Invalid or missing 'os' query parameter. Expected: darwin, linux, or windows" }, 400)
         }
-        const ymlPath = INSTALLER_YML[os]
-        const metaUrl = `${WEB_UPDATE_BASE}/${ymlPath}`
-        try {
-          const res = await fetch(metaUrl)
-          if (!res.ok) {
-            return c.json({ error: `Failed to fetch version metadata: ${res.status}` }, 400)
-          }
-          const text = await res.text()
-          const match = text.match(/^version:\s*(.+)$/m)
-          const remoteVersion = (match?.[1]?.trim() ?? "").replace(/^['"]|['"]$/g, "")
-          if (!remoteVersion) {
-            return c.json({ error: "Could not parse remote version from metadata" }, 400)
-          }
-          let currentVersion = ""
-          try {
-            const state = await fs.readFile(path.join(getAppRoot(), ".aether_web_version"), "utf-8")
-            const ver = state.trim()
-            if (ver) currentVersion = ver
-          } catch {}
-          if (!currentVersion) {
-            try {
-              const raw = await fs.readFile(path.resolve(process.cwd(), "packages/opencode/package.json"), "utf-8")
-              const parsed = JSON.parse(raw)
-              if (parsed && typeof parsed === "object" && typeof parsed.version === "string" && parsed.version.trim()) {
-                currentVersion = parsed.version.trim()
-              }
-            } catch {}
-          }
-          if (!currentVersion) currentVersion = Installation.VERSION
-          const updateAvailable = compareVer(currentVersion, remoteVersion) < 0
-          const downloaded = updateAvailable ? await downloadedReady(os, remoteVersion) : false
-          return c.json({
-            currentVersion,
-            remoteVersion,
-            updateAvailable,
-            downloaded,
-          })
-        } catch (e) {
-          const message = e instanceof Error ? e.message : String(e)
-          return c.json({ error: `Failed to check update: ${message}` }, 400)
-        }
+        return c.json(await webCheck(parsed.data))
       },
     )
     .post(
@@ -635,17 +686,7 @@ export const GlobalRoutes = lazy(() =>
         if (await downloadedReady(os, version)) {
           return c.json({ success: true as const, path: path.join(workDir, "downloads", versioned(upd, version)) })
         }
-        const currentVersion = (() => {
-          try {
-            const state = Bun.file(path.join(workDir, ".aether_web_version"))
-            return state
-              .text()
-              .then((x) => x.trim())
-              .catch(() => Installation.VERSION)
-          } catch {
-            return Promise.resolve(Installation.VERSION)
-          }
-        })()
+        const currentVersion = readWebCurrentVersion()
         log.info("running installer auto mode", { os, script: scriptPath, version, workDir })
         try {
           const cur = await currentVersion


### PR DESCRIPTION
## 背景
本次改动聚焦 Web 更新链路的稳定性与可观测性，同时统一 Linux/Windows 安装器默认路径、包名与脚本行为，修复跨平台兼容性细节。

## 主要改动
- 后端更新接口增强（`packages/opencode/src/server/routes/global.ts`）
  - 新增 `/global/web-update/current` 读取本地当前 Web 版本。
  - 统一版本读取与回退逻辑：优先 `.aether_web_version`，缺失时回退 `Installation.VERSION` 并写回。
  - `/global/web-update/check` 增加 `checkError` 字段，统一返回结构，提升前端可处理性。
  - `health` 返回版本改为当前本地版本，保证与更新状态一致。

- 前端更新体验优化（`packages/app/src/entry.tsx`、`packages/app/src/components/dialog-update.tsx`、`packages/app/src/components/dialog-settings.tsx`）
  - 启动时通过 `/global/web-update/current` 获取版本，不再直接依赖本地 `package.json`。
  - 增加 `checkError` 分支处理与错误展示，失败可重试。
  - 版本展示增加空值兜底，避免无版本时显示异常。
  - 失败页“重试”改为重新检查版本（`checkVersion`），交互更符合预期。

- 安装/更新脚本与文档统一（`Update/*`）
  - Linux `init` 默认目录统一为 `~/.local/share/applications/Aether`。
  - Windows `init` 默认目录统一为 `%LOCALAPPDATA%\Programs\Aether`。
  - 同步更新 darwin/linux/windows 脚本中的包名与路径规则。
  - 修复 Linux 更新脚本相关逻辑。
  - Windows 批处理文件统一为 UTF-8 BOM + CRLF，提升 CMD 兼容性。
  - 发布协议文档同步更新默认目录说明。

## 影响范围
- Web 更新检查/下载/安装链路（前后端）
- 跨平台安装器与 Web 更新脚本
- 发布与运维相关文档

## 建议验证
- 在 darwin/linux/windows 分别验证 `check -> download -> install` 主流程
- 验证元数据异常、版本文件缺失等错误分支的前端提示与重试
- 验证设置页与健康检查返回版本与 `.aether_web_version` 一致