### PR TITLE
fix: use bootstrap() on provider disconnect and add provider SDK over…

### DIFF
--- a/packages/app/src/components/settings-providers.tsx
+++ b/packages/app/src/components/settings-providers.tsx
@@ -144,7 +144,7 @@ export const SettingsProviders: Component = () => {
     await globalSDK.client.auth
       .remove({ providerID })
       .then(async () => {
-        await globalSDK.client.global.dispose()
+        await globalSync.bootstrap()
         showToast({
           variant: "success",
           icon: "circle-check",

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -179,6 +179,12 @@ export namespace Provider {
     "@ai-sdk/github-copilot": createGitHubCopilotOpenAICompatible,
   }
 
+  // Providers whose upstream npm package is incompatible with bundled AI SDK versions.
+  // Override to use a bundled, compatible SDK instead.
+  const PROVIDER_OVERRIDES: Record<string, { npm?: string; api?: string }> = {
+    aihubmix: { npm: "@ai-sdk/openai-compatible", api: "https://aihubmix.com/v1" },
+  }
+
   type CustomModelLoader = (sdk: any, modelID: string, options?: Record<string, any>) => Promise<any>
   type CustomVarsLoader = (options: Record<string, any>) => Record<string, string>
   type CustomDiscoverModels = () => Promise<Record<string, Model>>
@@ -889,8 +895,8 @@ export namespace Provider {
       family: model.family,
       api: {
         id: model.id,
-        url: model.provider?.api ?? provider.api!,
-        npm: model.provider?.npm ?? provider.npm ?? "@ai-sdk/openai-compatible",
+        url: model.provider?.api ?? PROVIDER_OVERRIDES[provider.id]?.api ?? provider.api!,
+        npm: model.provider?.npm ?? PROVIDER_OVERRIDES[provider.id]?.npm ?? provider.npm ?? "@ai-sdk/openai-compatible",
       },
       status: model.status ?? "active",
       headers: model.headers ?? {},


### PR DESCRIPTION
…rides

- Replace globalSDK.client.global.dispose() with globalSync.bootstrap() when disconnecting a provider, matching the pattern used on connect
- Add PROVIDER_OVERRIDES mechanism for providers whose upstream npm packages are incompatible with bundled AI SDK versions (aihubmix)

### Issue for this PR

Closes #139 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

<img width="792" height="1486" alt="image" src="https://github.com/user-attachments/assets/c4ba751d-0cb2-4902-976b-144e190ab67d" />
