### PR TITLE
feat(marked): 只在预览中渲染md格式

### DIFF
--- a/packages/ui/src/components/markdown.css
+++ b/packages/ui/src/components/markdown.css
@@ -1,16 +1,12 @@
 [data-component="markdown"] {
-  /* Layout */
+  /* Reset & Base Typography */
   min-width: 0;
-  max-width: min(860px, 100%);
-  width: 100%;
-  margin-inline: auto;
-  padding-inline: clamp(8px, 2vw, 20px);
+  max-width: 100%;
   overflow-wrap: break-word;
-  color: color-mix(in srgb, var(--text-strong) 94%, var(--text-base));
+  color: var(--text-strong);
   font-family: var(--font-family-sans);
-  font-size: 16px;
-  line-height: 1.78;
-  letter-spacing: 0.01em;
+  font-size: var(--font-size-base); /* 14px */
+  line-height: var(--line-height-x-large);
 
   /* Spacing for flow */
   > *:first-child {
@@ -20,82 +16,38 @@
     margin-bottom: 0;
   }
 
-  /* Headings */
+  /* Headings: Same size, distinguished by color and spacing */
   h1,
   h2,
   h3,
   h4,
   h5,
   h6 {
+    font-size: var(--font-size-base);
     color: var(--text-strong);
-    font-weight: 700;
-    line-height: 1.3;
-    margin-top: 1.75rem;
-    margin-bottom: 0.8rem;
-  }
-
-  h1 {
-    font-size: clamp(2rem, 3.5vw, 3rem);
-    margin-top: 0.25rem;
-    margin-bottom: 1.25rem;
-    line-height: 1.18;
-    letter-spacing: -0.01em;
-  }
-
-  h2 {
-    font-size: clamp(1.55rem, 2.6vw, 2.2rem);
-    margin-top: 2.4rem;
-    margin-bottom: 1rem;
-    line-height: 1.24;
-    padding-bottom: 0.35rem;
-    border-bottom: 1px solid color-mix(in srgb, var(--border-weaker-base) 78%, transparent);
-  }
-
-  h3 {
-    font-size: clamp(1.3rem, 2.1vw, 1.75rem);
+    font-weight: var(--font-weight-medium);
     margin-top: 2rem;
-  }
-
-  h4 {
-    font-size: clamp(1.12rem, 1.6vw, 1.35rem);
-    margin-top: 1.5rem;
-  }
-
-  h5 {
-    font-size: 1.05rem;
-  }
-
-  h6 {
-    font-size: 0.95rem;
-    color: var(--text-weak);
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
+    margin-bottom: 0.75rem;
+    line-height: var(--line-height-large);
   }
 
   /* Emphasis & Strong: Neutral strong color */
   strong,
   b {
     color: var(--text-strong);
-    font-weight: 800;
-    letter-spacing: 0;
+    font-weight: var(--font-weight-medium);
   }
 
   /* Paragraphs */
-  p,
-  li {
-    color: color-mix(in srgb, var(--text-strong) 92%, var(--text-base));
-  }
-
   p {
-    margin-top: 0;
-    margin-bottom: 1.1rem;
+    margin-bottom: 1rem;
   }
 
   /* Links */
   a {
     color: var(--text-interactive-base);
     text-decoration: none;
-    font-weight: 500;
+    font-weight: inherit;
   }
 
   a:hover {
@@ -106,10 +58,10 @@
   /* Lists */
   ul,
   ol {
-    margin-top: 0.7rem;
-    margin-bottom: 1.2rem;
+    margin-top: 0.5rem;
+    margin-bottom: 1rem;
     margin-left: 0;
-    padding-left: 1.85rem;
+    padding-left: 1.5rem;
     list-style-position: outside;
   }
 
@@ -119,11 +71,11 @@
 
   ol {
     list-style-type: decimal;
-    padding-left: 2.1rem;
+    padding-left: 2.25rem;
   }
 
   li {
-    margin-bottom: 0.52rem;
+    margin-bottom: 0.5rem;
   }
 
   li > p:first-child {
@@ -133,12 +85,11 @@
 
   li > p + p {
     display: block;
-    margin-top: 0.6rem;
+    margin-top: 0.5rem;
   }
 
   li::marker {
-    color: color-mix(in srgb, var(--text-interactive-base) 72%, var(--text-weak));
-    font-weight: 600;
+    color: var(--text-weak);
   }
 
   /* Nested lists spacing */
@@ -155,32 +106,25 @@
 
   /* Blockquotes */
   blockquote {
-    border-left: 3px solid color-mix(in srgb, var(--border-weak-base) 85%, var(--text-weak));
+    border-left: 2px solid var(--border-weak-base);
     margin: 1.5rem 0;
-    padding: 0.1rem 0 0.1rem 0.8rem;
-    color: color-mix(in srgb, var(--text-base) 88%, var(--text-weak));
+    padding-left: 0.5rem;
+    color: var(--text-weak);
     font-style: normal;
-    background: color-mix(in srgb, var(--surface-base) 88%, transparent);
-    border-radius: 0 8px 8px 0;
   }
 
-  /* Section divider */
+  /* Horizontal Rule - Invisible spacing only */
   hr {
     border: none;
-    height: 4px;
-    margin: 2.2rem 0;
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--border-weak-base) 75%, var(--surface-raised-strong));
+    height: 0;
+    margin: 2.5rem 0;
   }
 
   .shiki {
-    font-size: 14px;
-    line-height: 1.65;
-    padding: 14px 16px;
-    border-radius: 10px;
-    border: 1px solid color-mix(in srgb, var(--border-weak-base) 82%, transparent);
-    background: color-mix(in srgb, var(--surface-raised-base) 80%, var(--surface-base));
-    box-shadow: inset 0 1px 0 color-mix(in srgb, var(--border-weaker-base) 75%, transparent);
+    font-size: 13px;
+    padding: 8px 12px;
+    border-radius: 6px;
+    border: 0.5px solid var(--border-weak-base);
   }
 
   [data-component="markdown-code"] {
@@ -257,8 +201,8 @@
   }
 
   pre {
-    margin-top: 1.2rem;
-    margin-bottom: 1.7rem;
+    margin-top: 2rem;
+    margin-bottom: 2rem;
     overflow: auto;
 
     scrollbar-width: none;
@@ -270,26 +214,15 @@
   :not(pre) > code {
     font-family: var(--font-family-mono);
     font-feature-settings: var(--font-family-mono--font-feature-settings);
-    color: var(--text-strong);
-    font-weight: 500;
-    font-size: 0.9em;
-    padding: 2px 6px;
-    margin: 0 1px;
-    border-radius: 6px;
-    background: color-mix(in srgb, var(--surface-raised-base) 85%, var(--surface-base));
-    border: 1px solid color-mix(in srgb, var(--border-weak-base) 72%, transparent);
-  }
+    color: var(--syntax-string);
+    font-weight: var(--font-weight-medium);
+    /* font-size: 13px; */
 
-  .katex-display {
-    margin: 1.55rem 0;
-    padding: 0.25rem 0;
-    font-size: 1.08em;
-    overflow-x: auto;
-    overflow-y: hidden;
-  }
-
-  .katex {
-    font-size: 1.03em;
+    /* padding: 2px 2px; */
+    /* margin: 0 1.5px; */
+    /* border-radius: 2px; */
+    /* background: var(--surface-base); */
+    /* box-shadow: 0 0 0 0.5px var(--border-weak-base); */
   }
 
   /* Tables */
@@ -297,17 +230,16 @@
     width: 100%;
     border-collapse: collapse;
     margin: 1.5rem 0;
-    font-size: 0.95em;
+    font-size: var(--font-size-base);
     display: block;
     overflow-x: auto;
-    border: 1px solid var(--border-weaker-base);
-    border-radius: 10px;
   }
 
   th,
   td {
+    /* Minimal borders for structure, matching TUI "lines" roughly but keeping it web-clean */
     border-bottom: 1px solid var(--border-weaker-base);
-    padding: 0.72rem 0.65rem;
+    padding: 0.75rem 0.5rem;
     text-align: left;
     vertical-align: top;
   }
@@ -322,10 +254,9 @@
   img {
     max-width: 100%;
     height: auto;
-    border-radius: 8px;
+    border-radius: 4px;
     margin: 1.5rem 0;
     display: block;
-    border: 1px solid color-mix(in srgb, var(--border-weaker-base) 70%, transparent);
   }
 }
 

--- a/packages/ui/src/components/markdown.css
+++ b/packages/ui/src/components/markdown.css
@@ -264,3 +264,188 @@
   text-decoration: underline;
   text-underline-offset: 2px;
 }
+
+/* ── Review mode: enhanced styling for file preview panel ── */
+[data-file-content] > [data-component="markdown"] {
+  max-width: min(860px, 100%);
+  width: 100%;
+  margin-inline: auto;
+  padding-inline: 26px;
+  color: color-mix(in srgb, var(--text-strong) 94%, var(--text-base));
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji";
+  font-size: 16px;
+  line-height: 1.6;
+  letter-spacing: 0;
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-weight: 600;
+    line-height: 1.25;
+    margin-top: 1.5em;
+    margin-bottom: 0.5em;
+  }
+
+  h1 {
+    font-size: 2em;
+    margin-top: 0;
+    margin-bottom: 0.67em;
+    padding-bottom: 0.3em;
+    border-bottom: 1px solid color-mix(in srgb, var(--border-weaker-base) 78%, transparent);
+  }
+
+  h2 {
+    font-size: 1.5em;
+    margin-top: 1.5em;
+    margin-bottom: 0.5em;
+    padding-bottom: 0.3em;
+    border-bottom: 1px solid color-mix(in srgb, var(--border-weaker-base) 78%, transparent);
+  }
+
+  h3 {
+    font-size: 1.25em;
+  }
+
+  h4 {
+    font-size: 1em;
+  }
+
+  h5 {
+    font-size: 0.875em;
+  }
+
+  h6 {
+    font-size: 0.85em;
+    color: var(--text-weak);
+  }
+
+  strong,
+  b {
+    font-weight: 600;
+  }
+
+  p,
+  li {
+    color: color-mix(in srgb, var(--text-strong) 92%, var(--text-base));
+  }
+
+  p {
+    margin-top: 0;
+    margin-bottom: 1em;
+  }
+
+  a {
+    font-weight: 500;
+  }
+
+  ul,
+  ol {
+    margin-top: 0;
+    margin-bottom: 1em;
+    padding-left: 2em;
+  }
+
+  ol {
+    padding-left: 2em;
+  }
+
+  li {
+    margin-bottom: 0.25em;
+  }
+
+  li + li {
+    margin-top: 0.25em;
+  }
+
+  li > p + p {
+    margin-top: 0.5em;
+  }
+
+  li::marker {
+    color: var(--text-weak);
+  }
+
+  blockquote {
+    border-left: 4px solid color-mix(in srgb, var(--border-weak-base) 60%, transparent);
+    margin: 0 0 1em 0;
+    padding: 0.2em 0 0.2em 1em;
+    color: var(--text-weak);
+    background: none;
+    border-radius: 0;
+  }
+
+  hr {
+    height: 1px;
+    margin: 1.5em 0;
+    border-radius: 0;
+    background: color-mix(in srgb, var(--border-weak-base) 60%, transparent);
+  }
+
+  .shiki {
+    font-size: 14px;
+    line-height: 1.45;
+    padding: 16px;
+    border-radius: 4px;
+    border: none;
+    background: color-mix(in srgb, var(--surface-raised-base) 80%, var(--surface-base));
+    box-shadow: none;
+  }
+
+  pre {
+    margin-top: 0;
+    margin-bottom: 1em;
+  }
+
+  :not(pre) > code {
+    color: var(--text-strong);
+    font-weight: 400;
+    font-size: 0.85em;
+    padding: 0.2em 0.4em;
+    margin: 0;
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--surface-raised-base) 85%, var(--surface-base));
+    border: none;
+  }
+
+  .katex-display {
+    margin: 1em 0;
+    padding: 0.25rem 0;
+    font-size: 1.08em;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  .katex {
+    font-size: 1.03em;
+  }
+
+  table {
+    font-size: 0.95em;
+    border: none;
+    border-radius: 0;
+    border-collapse: collapse;
+  }
+
+  th,
+  td {
+    padding: 6px 13px;
+    border: 1px solid var(--border-weaker-base);
+  }
+
+  tr:nth-child(even) {
+    background: color-mix(in srgb, var(--surface-raised-base) 50%, transparent);
+  }
+
+  th {
+    font-weight: 600;
+  }
+
+  img {
+    border-radius: 0;
+    border: none;
+  }
+}

--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -423,14 +423,6 @@ function renderMathExpressions(html: string): string {
     .join("")
 }
 
-function hasMarkdownHints(md: string): boolean {
-  return /(^|\n)\s{0,3}(#{1,6}\s+|\d+[.)]\s+|[-*+]\s+|>\s+)/.test(md)
-}
-
-function hasStructuredMarkup(html: string): boolean {
-  return /<(h[1-6]|ul|ol|li|blockquote|table|pre|code)\b/i.test(html)
-}
-
 async function highlightCodeBlocks(html: string): Promise<string> {
   const codeBlockRegex = /<pre><code(?:\s+class="language-([^"]*)")?>([\s\S]*?)<\/code><\/pre>/g
   const matches = [...html.matchAll(codeBlockRegex)]
@@ -515,9 +507,7 @@ export const { use: useMarked, provider: MarkedProvider } = createSimpleContext(
       const nativeParser = props.nativeParser
       return {
         async parse(markdown: string): Promise<string> {
-          const raw = await nativeParser(markdown)
-          const html =
-            hasMarkdownHints(markdown) && !hasStructuredMarkup(raw) ? await jsParser.parse(markdown) : raw
+          const html = await nativeParser(markdown)
           const withMath = renderMathExpressions(html)
           return highlightCodeBlocks(withMath)
         },

--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -423,6 +423,14 @@ function renderMathExpressions(html: string): string {
     .join("")
 }
 
+function hasMarkdownHints(md: string): boolean {
+  return /(^|\n)\s{0,3}(#{1,6}\s+|\d+[.)]\s+|[-*+]\s+|>\s+)/.test(md)
+}
+
+function hasStructuredMarkup(html: string): boolean {
+  return /<(h[1-6]|ul|ol|li|blockquote|table|pre|code)\b/i.test(html)
+}
+
 async function highlightCodeBlocks(html: string): Promise<string> {
   const codeBlockRegex = /<pre><code(?:\s+class="language-([^"]*)")?>([\s\S]*?)<\/code><\/pre>/g
   const matches = [...html.matchAll(codeBlockRegex)]
@@ -507,7 +515,9 @@ export const { use: useMarked, provider: MarkedProvider } = createSimpleContext(
       const nativeParser = props.nativeParser
       return {
         async parse(markdown: string): Promise<string> {
-          const html = await nativeParser(markdown)
+          const raw = await nativeParser(markdown)
+          const html =
+            hasMarkdownHints(markdown) && !hasStructuredMarkup(raw) ? await jsParser.parse(markdown) : raw
           const withMath = renderMathExpressions(html)
           return highlightCodeBlocks(withMath)
         },


### PR DESCRIPTION
### Issue for this PR

Closes #141 

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

## Summary

- 将增强的 markdown 渲染样式（参考 VSCode 风格）限定在文件预览面板（审查标签页），聊天消息等其他场景保持原有样式不变
- 利用 `[data-file-content]` 容器属性作为 CSS 作用域选择器，只改 `markdown.css` 和 `marked.tsx` 两个文件
- 恢复 `hasMarkdownHints` / `hasStructuredMarkup` 函数及 native parser fallback 逻辑

## 改动文件

- `packages/ui/src/components/markdown.css` — 基础样式不变，增强样式放在 `[data-file-content] > [data-component="markdown"]` 下
- `packages/ui/src/context/marked.tsx` — 恢复 markdown 检测函数

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

人工审核

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
