### PR TITLE
docs: 飞书配置指南补充 im:message.p2p_msg:readonly 权限

### DIFF
--- a/docs/feishu-setup-guide.md
+++ b/docs/feishu-setup-guide.md
@@ -53,6 +53,7 @@ Aether 支持通过飞书进行对话，体验与微信连接一致：
 |------|------|
 | `im:message` | 获取与发送消息 |
 | `im:message:send_as_bot` | 以机器人身份发送消息 |
+| `im:message.p2p_msg:readonly` | 读取私聊消息 |
 
 ### 第五步：发布应用
 


### PR DESCRIPTION
### Issue for this PR

Closes #156
Depends on #155

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

飞书配置指南的权限表中缺少 `im:message.p2p_msg:readonly`，该权限是机器人接收私聊消息所必需的。补充到权限配置表中。

### How did you verify your code works?

文档修改，无需代码验证。

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR