### PR TITLE
feat: improve recent projects list filtering and directory dialog

### DIFF
--- a/Aether-wechat-bridge/aether_wechat_agent.py
+++ b/Aether-wechat-bridge/aether_wechat_agent.py
@@ -298,7 +298,11 @@ class AetherAgent(Agent):
             return cached
         try:
             item = next(
-                (item for item in await self._get_projects() if self._project_dir(item) == directory),
+                (
+                    item
+                    for item in await self._get_projects()
+                    if self._project_dir(item) == directory
+                ),
                 None,
             )
             if item:
@@ -575,11 +579,7 @@ class AetherAgent(Agent):
             changed = False
             for directory, hide_time in list(self._hidden_dirs.items()):
                 item = next(
-                    (
-                        p
-                        for p in all_projects
-                        if self._project_dir(p) == directory
-                    ),
+                    (p for p in all_projects if self._project_dir(p) == directory),
                     None,
                 )
                 activity = (((item or {}).get("time") or {}).get("activity")) or 0
@@ -591,9 +591,7 @@ class AetherAgent(Agent):
                 self._save_hidden_dirs()
 
         projects = [
-            p
-            for p in all_projects
-            if self._project_dir(p) not in self._hidden_dirs
+            p for p in all_projects if self._project_dir(p) not in self._hidden_dirs
         ]
         current_dir = self._conv_dirs.get(conv_id) or self.directory
 
@@ -667,7 +665,9 @@ class AetherAgent(Agent):
             lines.append(f"{idx}. {self._project_name(item)}{tag}")
             lines.append(f"   {directory}")
         lines.append("")
-        lines.append("💡 /project n 切换 | /project list 查看全部 | /project hide n 隐藏")
+        lines.append(
+            "💡 /project n 切换 | /project list 查看全部 | /project hide n 隐藏"
+        )
         if self._hidden_dirs:
             lines.append(
                 f"ℹ️ 已隐藏 {len(self._hidden_dirs)} 个项目（重新使用后自动恢复）"
@@ -707,6 +707,7 @@ class AetherAgent(Agent):
             return
         if self._wechat_client:
             from wechat_agent_sdk.messaging.send import send_response as wechat_send
+
             ctx = self._wechat_ctx.get(conv_id, "")
             await wechat_send(
                 self._wechat_client, conv_id, ChatResponse(text=text), ctx
@@ -936,7 +937,9 @@ class AetherAgent(Agent):
                     try:
                         await self._send_to_conv(
                             conv_id,
-                            await self._wrap_message(text_so_far, session_id, directory),
+                            await self._wrap_message(
+                                text_so_far, session_id, directory
+                            ),
                         )
                     except Exception as e:
                         logger.warning(f"推送中间文本失败: {e}")
@@ -961,7 +964,9 @@ class AetherAgent(Agent):
                     try:
                         await self._send_to_conv(
                             conv_id,
-                            await self._wrap_message(text_so_far, session_id, directory),
+                            await self._wrap_message(
+                                text_so_far, session_id, directory
+                            ),
                         )
                     except Exception as e:
                         logger.warning(f"推送中间文本失败: {e}")
@@ -1173,7 +1178,9 @@ class AetherAgent(Agent):
                     suffix = "：" + desc if desc else ""
                     parts.append(f"  {j}. {label}{suffix}")
         parts.append("")
-        parts.append("请直接回复答案（可输入数字编号；若题目允许自定义，也可直接输入文本）。")
+        parts.append(
+            "请直接回复答案（可输入数字编号；若题目允许自定义，也可直接输入文本）。"
+        )
         parts.append("如需立即开始新问题，请先 /new 或切换 /session n。")
         return chr(10).join(parts)
 
@@ -1529,9 +1536,10 @@ class CustomWeChatBot(WeChatBot):
     """自定义 Bot，覆盖登录方法"""
 
     async def login(self, log=print) -> str:
-        stored_token = await self._storage.load_token(self._account_id)
+        transport = self._transport
+        stored_token = await transport._storage.load_token(transport.account_id)
         if stored_token:
-            self._client.token = stored_token
+            transport._client.token = stored_token
             log(f"[weixin] 使用已保存的 token")
             # 通知 Aether 已连接
             print(f"[登录成功] user: unknown (已保存的账号)")
@@ -1552,8 +1560,8 @@ class CustomWeChatBot(WeChatBot):
                     logger.warning(f"保存会话失败: {e}")
             return stored_token
 
-        token = await custom_login(self._client, log=log)
-        await self._storage.save_token(self._account_id, token)
+        token = await custom_login(transport._client, log=log)
+        await transport._storage.save_token(transport.account_id, token)
         return token
 
 
@@ -1589,7 +1597,7 @@ async def main():
         ),
     )
     # 把微信客户端传给 agent，让后台任务能直接投递消息
-    agent._wechat_client = bot._client
+    agent._wechat_client = bot._transport._client
 
     try:
         await bot.run(log=print)

--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -12,6 +12,7 @@ import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { picked } from "./pick-folder"
+import { useLayout } from "@/context/layout"
 
 interface DialogSelectDirectoryProps {
   title?: string
@@ -165,7 +166,11 @@ function useDirectorySearch(args: {
     if (!base) return
 
     const raw = normalizeDriveRoot(value)
-    if (!raw) return { directory: trimTrailing(base), path: "" }
+    if (!raw) {
+      const h = args.home()
+      if (/^[A-Za-z]:\//.test(h)) return { directory: "/", path: "" }
+      return { directory: trimTrailing(h), path: "" }
+    }
 
     const h = args.home()
     if (raw === "~") return { directory: trimTrailing(h || base), path: "" }
@@ -223,8 +228,7 @@ function useDirectorySearch(args: {
         .catch(() => [])
 
     if (!isPath) {
-      // When start is a root path (e.g. "/" on Windows), use directory listing instead of fuzzy search
-      if (rootOf(trimTrailing(scopedInput.directory)) === trimTrailing(scopedInput.directory)) {
+      if (!raw || rootOf(trimTrailing(scopedInput.directory)) === trimTrailing(scopedInput.directory)) {
         const items = await match(scopedInput.directory, "", 50)
         if (!active()) return []
         return items
@@ -281,6 +285,7 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
   const sdk = useGlobalSDK()
   const dialog = useDialog()
   const language = useLanguage()
+  const layout = useLayout()
 
   const [filter, setFilter] = createSignal("")
   const [selectedPath, setSelectedPath] = createSignal<string | null>(null)
@@ -322,11 +327,15 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
   })
   const recentProjects = createMemo(() => {
     const isExpanded = expanded()
-    const all = sync.project.recent().map((item) => {
-      const row = toRow(item.directory, home(), "recent")
-      const name = item.name || getFilename(item.directory)
-      return { ...row, search: `${row.search}\n${name}` }
-    })
+    const open = new Set(layout.projects.list().map((p) => normalizeDriveRoot(p.worktree).toLowerCase()))
+    const all = sync.project
+      .recent()
+      .filter((item) => !open.has(normalizeDriveRoot(item.directory).toLowerCase()))
+      .map((item) => {
+        const row = toRow(item.directory, home(), "recent")
+        const name = item.name || getFilename(item.directory)
+        return { ...row, search: `${row.search}\n${name}` }
+      })
 
     if (!isExpanded && all.length > RECENT_LIMIT) {
       return [

--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -8,12 +8,10 @@ import { showToast } from "@opencode-ai/ui/toast"
 import { getDirectory, getFilename } from "@opencode-ai/util/path"
 import fuzzysort from "fuzzysort"
 import { createMemo, createResource, createSignal, onMount, Show } from "solid-js"
-import { createStore } from "solid-js/store"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { picked } from "./pick-folder"
-import { Persist, persisted } from "@/utils/persist"
 
 interface DialogSelectDirectoryProps {
   title?: string
@@ -289,7 +287,6 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
   const [browsing, setBrowsing] = createSignal(false)
   const [expanded, setExpanded] = createSignal(false)
   const [creating, setCreating] = createSignal(false)
-  const [hidden, setHidden] = persisted(Persist.global("recent-projects-hidden"), createStore({ dirs: [] as string[] }))
   let list: ListRef | undefined
 
   const missingBase = createMemo(() => !(sync.data.path.home || sync.data.path.directory))
@@ -325,15 +322,11 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
   })
   const recentProjects = createMemo(() => {
     const isExpanded = expanded()
-    const known = sync.project.recent()
-    const hiddenSet = new Set(hidden.dirs)
-    const all = known
-      .map((item) => {
-        const row = toRow(item.directory, home(), "recent")
-        const name = item.name || getFilename(item.directory)
-        return { ...row, search: `${row.search}\n${name}` }
-      })
-      .filter((r) => !hiddenSet.has(r.absolute))
+    const all = sync.project.recent().map((item) => {
+      const row = toRow(item.directory, home(), "recent")
+      const name = item.name || getFilename(item.directory)
+      return { ...row, search: `${row.search}\n${name}` }
+    })
 
     if (!isExpanded && all.length > RECENT_LIMIT) {
       return [
@@ -519,51 +512,28 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
           }
 
           const path = displayPath(item.absolute, filter(), home())
-          const isRecent = item.group === "recent"
-
-          const removeBtn = (
-            <Show when={isRecent}>
-              <button
-                type="button"
-                class="opacity-0 group-hover:opacity-100 shrink-0 p-0.5 text-text-weak hover:text-text-strong transition-opacity"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  setHidden("dirs", (prev) => [...prev, item.absolute])
-                }}
-                title="从最近项目中移除"
-              >
-                ×
-              </button>
-            </Show>
-          )
 
           if (path === "~") {
             return (
-              <div class="w-full flex items-center justify-between rounded-md group">
-                <div class="flex items-center gap-x-3 grow min-w-0">
-                  <FileIcon node={{ path: item.absolute, type: "directory" }} class="shrink-0 size-4" />
-                  <div class="flex items-center text-14-regular min-w-0">
-                    <span class="text-text-strong whitespace-nowrap">~</span>
-                    <span class="text-text-weak whitespace-nowrap">/</span>
-                  </div>
+              <div class="w-full flex items-center gap-x-3 rounded-md">
+                <FileIcon node={{ path: item.absolute, type: "directory" }} class="shrink-0 size-4" />
+                <div class="flex items-center text-14-regular min-w-0">
+                  <span class="text-text-strong whitespace-nowrap">~</span>
+                  <span class="text-text-weak whitespace-nowrap">/</span>
                 </div>
-                {removeBtn}
               </div>
             )
           }
           return (
-            <div class="w-full flex items-center justify-between rounded-md group">
-              <div class="flex items-center gap-x-3 grow min-w-0">
-                <FileIcon node={{ path: item.absolute, type: "directory" }} class="shrink-0 size-4" />
-                <div class="flex items-center text-14-regular min-w-0">
-                  <span class="text-text-weak whitespace-nowrap overflow-hidden overflow-ellipsis truncate min-w-0">
-                    {getDirectory(path)}
-                  </span>
-                  <span class="text-text-strong whitespace-nowrap">{getFilename(path)}</span>
-                  <span class="text-text-weak whitespace-nowrap">/</span>
-                </div>
+            <div class="w-full flex items-center gap-x-3 rounded-md">
+              <FileIcon node={{ path: item.absolute, type: "directory" }} class="shrink-0 size-4" />
+              <div class="flex items-center text-14-regular min-w-0">
+                <span class="text-text-weak whitespace-nowrap overflow-hidden overflow-ellipsis truncate min-w-0">
+                  {getDirectory(path)}
+                </span>
+                <span class="text-text-strong whitespace-nowrap">{getFilename(path)}</span>
+                <span class="text-text-weak whitespace-nowrap">/</span>
               </div>
-              {removeBtn}
             </div>
           )
         }}

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -90,6 +90,7 @@ export namespace Project {
     time_created: number | null
     time_updated: number | null
     commands: string | null
+    session_count: number | null
   }
 
   type RecentEntry = {
@@ -135,10 +136,7 @@ export namespace Project {
     return ["/bin", "/dist", "\\bin", "\\dist"].some((item) => next.endsWith(item))
   }
 
-  function rowIcon(row: {
-    icon_url?: string | null
-    icon_color?: string | null
-  }) {
+  function rowIcon(row: { icon_url?: string | null; icon_color?: string | null }) {
     if (!row.icon_url && !row.icon_color) return
     return {
       url: row.icon_url ?? undefined,
@@ -163,8 +161,9 @@ export namespace Project {
       .prepare(`select 1 as ok from sqlite_master where type = 'table' and name = 'project_recent'`)
       .get() as { ok?: number } | undefined
     if (hasRecent?.ok) {
-      return client.prepare(
-        `select
+      return client
+        .prepare(
+          `select
           r.kind as kind,
           r.project_id as project_id,
           r.directory as directory,
@@ -176,14 +175,17 @@ export namespace Project {
           p.icon_color as icon_color,
           p.time_created as time_created,
           p.time_updated as time_updated,
-          p.commands as commands
+          p.commands as commands,
+          (select count(*) from session s where s.directory = r.directory) as session_count
         from project_recent r
         left join project p on p.id = r.project_id`,
-      ).all() as RecentRow[]
+        )
+        .all() as RecentRow[]
     }
 
-    const ps = client.prepare(
-      `select
+    const ps = client
+      .prepare(
+        `select
         'project' as kind,
         p.id as project_id,
         p.worktree as directory,
@@ -195,7 +197,8 @@ export namespace Project {
         p.icon_color as icon_color,
         p.time_created as time_created,
         p.time_updated as time_updated,
-        p.commands as commands
+        p.commands as commands,
+        (select count(*) from session s2 where s2.directory = p.worktree) as session_count
       from project p
       left join (
         select directory, max(time_updated) as time_updated
@@ -204,9 +207,11 @@ export namespace Project {
         group by directory
       ) s on s.directory = p.worktree
       where p.worktree is not null and p.worktree != '/'`,
-    ).all() as RecentRow[]
-    const ss = client.prepare(
-      `select
+      )
+      .all() as RecentRow[]
+    const ss = client
+      .prepare(
+        `select
         'directory' as kind,
         null as project_id,
         directory as directory,
@@ -218,11 +223,13 @@ export namespace Project {
         null as icon_color,
         null as time_created,
         null as time_updated,
-        null as commands
+        null as commands,
+        count(*) as session_count
       from session
       where directory is not null and directory != '/'
       group by directory`,
-    ).all() as RecentRow[]
+      )
+      .all() as RecentRow[]
     return [...ps, ...ss]
   }
 
@@ -265,7 +272,7 @@ export namespace Project {
     const read = (client: { prepare: (sql: string) => { all: () => unknown[]; get: () => unknown } }) => {
       for (const row of rawRecent(client)) {
         const dir = row.directory ?? row.worktree ?? undefined
-        if (!dir || skipDir(dir)) continue
+        if (!dir || skipDir(dir) || !row.session_count) continue
         const known = (row.project_id && byId.get(ProjectID.make(row.project_id))) ?? byDir.get(norm(dir))
         if (known && known.id !== ProjectID.global) {
           addRecent(map, {
@@ -319,13 +326,7 @@ export namespace Project {
       }
     }
 
-    Database.withSources((source) => {
-      try {
-        read(source.client)
-      } catch (error) {
-        log.warn("recent scan failed", { path: source.path, current: source.current, error })
-      }
-    })
+    read(Database.Client().$client)
 
     return [...map.values()]
       .sort((a, b) => b.time.activity - a.time.activity || a.directory.localeCompare(b.directory))

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -167,7 +167,7 @@ export namespace Project {
           r.kind as kind,
           r.project_id as project_id,
           r.directory as directory,
-          r.activity_at as activity_at,
+          coalesce(sx.activity, 0) as activity_at,
           p.worktree as worktree,
           p.vcs as vcs,
           p.name as name,
@@ -176,9 +176,15 @@ export namespace Project {
           p.time_created as time_created,
           p.time_updated as time_updated,
           p.commands as commands,
-          (select count(*) from session s where s.directory = r.directory) as session_count
+          coalesce(sx.cnt, 0) as session_count
         from project_recent r
-        left join project p on p.id = r.project_id`,
+        left join project p on p.id = r.project_id
+        left join (
+          select directory, max(time_updated) as activity, count(*) as cnt
+          from session
+          where directory is not null and directory != '/'
+          group by directory
+        ) sx on sx.directory = r.directory`,
         )
         .all() as RecentRow[]
     }

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { Project } from "../../src/project/project"
+import { Session } from "../../src/session"
+import { Instance } from "../../src/project/instance"
 import { Log } from "../../src/util/log"
 import { $ } from "bun"
 import path from "path"
@@ -417,8 +419,10 @@ describe("Project.recentList", () => {
     await using b = await tmpdir({ git: true })
 
     await Project.fromDirectory(a.path)
+    await Instance.provide({ directory: a.path, fn: async () => Session.create({}) })
     await Bun.sleep(10)
     await Project.fromDirectory(b.path)
+    await Instance.provide({ directory: b.path, fn: async () => Session.create({}) })
 
     const before = Project.recentList()
       .filter((item) => item.kind === "project")
@@ -438,14 +442,22 @@ describe("Project.recentList", () => {
     expect(after.slice(0, 2)).toEqual([b.path, a.path])
   })
 
-  test("keeps non-git directories as directory items", async () => {
+  test("filters out directories with no sessions", async () => {
     await using tmp = await tmpdir()
 
     await Project.fromDirectory(tmp.path)
 
     const item = Project.recentList().find((entry) => entry.directory === tmp.path)
-    expect(item).toBeDefined()
-    expect(item?.kind).toBe("directory")
+    expect(item).toBeUndefined()
+  })
+
+  test("filters out git projects with no sessions", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Project.fromDirectory(tmp.path)
+
+    const item = Project.recentList().find((entry) => entry.directory === tmp.path)
+    expect(item).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary

Closes #181

- Filter out projects/directories with zero sessions from the recent projects list
- Exclude already-open projects from the recent list in directory dialog
- Remove the hidden projects persistence mechanism (`Persist`/`createStore`) and "×" remove button
- Optimize recent projects query to use LEFT JOIN for session stats
- Fix empty search to show root directories on Windows

## Changes

| Commit | Description |
|--------|-------------|
| `64b34adfa` | Add `session_count` to queries and filter out entries with no sessions |
| `879e0ccd8` | Refactor session stats query to use LEFT JOIN with `coalesce` |
| `d2aeac7af` | Remove hidden projects persistence from directory dialog |
| `e593afcc2` | Show root dirs on empty search, exclude open projects from recent list |

## Test Plan

- [x] Existing tests updated to create sessions before verifying recent list entries
- [x] New test: directories with no sessions are filtered out
- [x] New test: git projects with no sessions are filtered out