### PR TITLE
refactor: rename database filenames to aether

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -601,7 +601,7 @@ graph TB
 
 ### 5.1 本地数据库（SQLite）
 
-数据库文件遵循 XDG Base Directory 规范，位于 `$XDG_DATA_HOME/opencode/opencode.db`（Linux 默认为 `~/.local/share/opencode/opencode.db`）。频道为 `latest` 或 `beta` 时使用 `opencode.db`，其他频道使用 `opencode-<channel>.db`。使用 Drizzle ORM 管理 Schema，启动时自动迁移。
+数据库文件遵循 XDG Base Directory 规范，位于 `$XDG_DATA_HOME/opencode/aether.db`（Linux 默认为 `~/.local/share/opencode/aether.db`）。频道为 `latest` 或 `beta` 时使用 `aether.db`，其他频道使用 `aether-<channel>.db`。使用 Drizzle ORM 管理 Schema，启动时自动迁移。
 
 #### ER 图
 

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -373,7 +373,7 @@ async function getSidecarPort() {
 function sqliteFileExists() {
   const xdg = process.env.XDG_DATA_HOME
   const base = xdg && xdg.length > 0 ? xdg : join(homedir(), ".local", "share")
-  return existsSync(join(base, "opencode", "opencode.db"))
+  return existsSync(join(base, "opencode", "aether.db"))
 }
 
 function setupAutoUpdater() {

--- a/packages/opencode/drizzle.config.ts
+++ b/packages/opencode/drizzle.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   schema: "./src/**/*.sql.ts",
   out: "./migration",
   dbCredentials: {
-    url: "/home/thdxr/.local/share/opencode/opencode.db",
+    url: "/home/thdxr/.local/share/opencode/aether.db",
   },
 })

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -40,9 +40,9 @@ export namespace Database {
   export function getChannelPath() {
     const channel = Installation.CHANNEL
     if (["latest", "beta"].includes(channel) || Flag.OPENCODE_DISABLE_CHANNEL_DB)
-      return path.join(Global.Path.data, "opencode.db")
+      return path.join(Global.Path.data, "aether.db")
     const safe = channel.replace(/[^a-zA-Z0-9._-]/g, "-")
-    return path.join(Global.Path.data, `opencode-${safe}.db`)
+    return path.join(Global.Path.data, `aether-${safe}.db`)
   }
 
   export const Path = iife(() => {
@@ -63,7 +63,7 @@ export namespace Database {
     try {
       const seen = new Set<string>()
       return readdirSync(Global.Path.data, { withFileTypes: true })
-        .filter((entry) => entry.isFile() && /^opencode.*\.db$/i.test(entry.name))
+        .filter((entry) => entry.isFile() && /^aether.*\.db$/i.test(entry.name))
         .map((entry) => path.join(Global.Path.data, entry.name))
         .sort()
         .filter((file) => {

--- a/packages/opencode/test/storage/db.test.ts
+++ b/packages/opencode/test/storage/db.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { rm } from "fs/promises"
 import path from "path"
 import { Global } from "../../src/global"
 import { Installation } from "../../src/installation"
@@ -7,8 +8,8 @@ import { Database } from "../../src/storage/db"
 describe("Database.Path", () => {
   test("returns database path for the current channel", () => {
     const expected = ["latest", "beta"].includes(Installation.CHANNEL)
-      ? path.join(Global.Path.data, "opencode.db")
-      : path.join(Global.Path.data, `opencode-${Installation.CHANNEL.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`)
+      ? path.join(Global.Path.data, "aether.db")
+      : path.join(Global.Path.data, `aether-${Installation.CHANNEL.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`)
     expect(Database.getChannelPath()).toBe(expected)
   })
 
@@ -26,5 +27,17 @@ describe("Database.Path", () => {
       path: Database.currentPath(),
       current: true,
     })
+  })
+
+  test("knownPaths only returns aether databases", async () => {
+    const one = path.join(Global.Path.data, "aether.db")
+    const two = path.join(Global.Path.data, "aether-local.db")
+    const old = path.join(Global.Path.data, "opencode.db")
+    await Promise.all([Bun.write(one, ""), Bun.write(two, ""), Bun.write(old, "")])
+    try {
+      expect(Database.knownPaths().sort()).toEqual([one, two].sort())
+    } finally {
+      await Promise.all([rm(one, { force: true }), rm(two, { force: true }), rm(old, { force: true })])
+    }
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #183

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Rename the local SQLite database filenames from `opencode-*` to `aether-*` to match the Aether fork branding.

This update changes the runtime database path logic, the DB file discovery pattern, the test coverage for path generation, the local Drizzle config, the desktop Electron startup check, and the architecture doc that describes the database layout.

I intentionally kept the scope limited to database file naming only. It does not rename directories, environment variables, package names, or other unrelated branding strings.

### How did you verify your code works?

- `cd packages/opencode && bun test test/storage/db.test.ts`
- `cd packages/opencode && bun typecheck`
- `cd packages/opencode && bun test --timeout 30000`
- `cd packages/desktop-electron && bun typecheck`
- `bun typecheck`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR