### PR TITLE
feat: add legacy db migration guard with agent merge and archive flow

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -48,6 +48,7 @@ import DirectoryLayout from "@/pages/directory-layout"
 import Layout from "@/pages/layout"
 import { ErrorPage } from "./pages/error"
 import { useCheckServerHealth } from "./utils/server-health"
+import { LegacyDBGuard } from "@/components/legacy-db-guard"
 
 const HomeRoute = lazy(() => import("@/pages/home"))
 const Session = lazy(() => import("@/pages/session"))
@@ -133,6 +134,7 @@ function SessionProviders(props: ParentProps) {
 function RouterRoot(props: ParentProps<{ appChildren?: JSX.Element }>) {
   return (
     <AppShellProviders>
+      <LegacyDBGuard />
       <Suspense fallback={<Loading />}>
         {props.appChildren}
         {props.children}

--- a/packages/app/src/components/legacy-db-guard.tsx
+++ b/packages/app/src/components/legacy-db-guard.tsx
@@ -15,10 +15,15 @@ type Status = {
 
 type Merge = {
   sessionID?: string
-  archive?: {
+}
+
+type ArchiveState = {
+  state: "idle" | "running" | "done" | "error"
+  result?: {
     history: string
     clean: boolean
   }
+  error?: string
 }
 
 const retry_delays = [200, 400, 800, 1200, 1800, 2500]
@@ -84,6 +89,49 @@ export function LegacyDBGuard() {
         navigate(`/${dir}/session/${sessionID}`)
       }
 
+      const watch = async () => {
+        for (let i = 0; i < 120; i++) {
+          const state = await fetch(`${conn.url}/database/legacy/archive/state`, {
+            headers: head,
+            signal: abort.signal,
+          })
+            .then((x) => (x.ok ? x.json() : undefined))
+            .catch(() => undefined)
+          if (!state) {
+            await new Promise((resolve) => setTimeout(resolve, 2000))
+            continue
+          }
+          const info = state as ArchiveState
+          if (info.state === "running") {
+            await new Promise((resolve) => setTimeout(resolve, 2000))
+            continue
+          }
+          if (info.state === "done" && info.result?.history) {
+            showToast({
+              title: "旧会话记录已归档",
+              description: `旧会话记录被归档至 ${info.result.history}`,
+            })
+            if (!info.result.clean) {
+              showToast({
+                variant: "error",
+                title: "旧数据库文件未完全归档",
+                description: "请查看数据库目录并手动检查剩余 .db 文件。",
+              })
+            }
+            return
+          }
+          if (info.state === "error") {
+            showToast({
+              variant: "error",
+              title: "旧数据库归档失败",
+              description: info.error || "请查看后端服务日志。",
+            })
+            return
+          }
+          return
+        }
+      }
+
       showToast({
         persistent: true,
         icon: "download",
@@ -117,19 +165,7 @@ export function LegacyDBGuard() {
               }
               sessionStorage.setItem(key(conn.url), "1")
               const info = merge as Merge
-              if (info.archive?.history) {
-                showToast({
-                  title: "旧会话记录已归档",
-                  description: `旧会话记录被归档至 ${info.archive.history}`,
-                })
-                if (!info.archive.clean) {
-                  showToast({
-                    variant: "error",
-                    title: "旧数据库文件未完全归档",
-                    description: "请查看数据库目录并手动检查剩余 .db 文件。",
-                  })
-                }
-              }
+              void watch()
               open(info.sessionID)
             },
           },

--- a/packages/app/src/components/legacy-db-guard.tsx
+++ b/packages/app/src/components/legacy-db-guard.tsx
@@ -15,6 +15,10 @@ type Status = {
 
 type Merge = {
   sessionID?: string
+  archive?: {
+    history: string
+    clean: boolean
+  }
 }
 
 const retry_delays = [200, 400, 800, 1200, 1800, 2500]
@@ -112,7 +116,21 @@ export function LegacyDBGuard() {
                 return
               }
               sessionStorage.setItem(key(conn.url), "1")
-              open((merge as Merge).sessionID)
+              const info = merge as Merge
+              if (info.archive?.history) {
+                showToast({
+                  title: "旧会话记录已归档",
+                  description: `旧会话记录被归档至 ${info.archive.history}`,
+                })
+                if (!info.archive.clean) {
+                  showToast({
+                    variant: "error",
+                    title: "旧数据库文件未完全归档",
+                    description: "请查看数据库目录并手动检查剩余 .db 文件。",
+                  })
+                }
+              }
+              open(info.sessionID)
             },
           },
           {
@@ -147,7 +165,7 @@ export function LegacyDBGuard() {
                       sessionStorage.setItem(key(conn.url), "1")
                       showToast({
                         description:
-                          "已关闭，如需将对话合并到新版本请参考https://aether.aiphys.cn中的常见问题。",
+                          "已关闭询问，如需将对话合并到新版本请参考https://aether.aiphys.cn中的常见问题。",
                       })
                     },
                   },

--- a/packages/app/src/components/legacy-db-guard.tsx
+++ b/packages/app/src/components/legacy-db-guard.tsx
@@ -3,11 +3,13 @@ import { useServer } from "@/context/server"
 import { useLayout } from "@/context/layout"
 import { useNavigate } from "@solidjs/router"
 import { base64Encode } from "@opencode-ai/util/encode"
+import { showToast } from "@opencode-ai/ui/toast"
 
 type Status = {
   directory: string
   has_legacy: boolean
   message: string
+  dismissed: boolean
   legacy_count: number
 }
 
@@ -24,8 +26,8 @@ function auth(input: { url: string; username?: string; password?: string }) {
   return head
 }
 
-function key(url: string, count: number) {
-  return `aether.legacy.prompt.${url}.${count}`
+function key(url: string) {
+  return `aether.legacy.prompt.once.${url}`
 }
 
 export function LegacyDBGuard() {
@@ -64,36 +66,97 @@ export function LegacyDBGuard() {
       if (!status) return
       const info = status as Status
       if (!info.has_legacy) return
-      if (localStorage.getItem(key(conn.url, info.legacy_count)) === "1") return
+      if (info.dismissed) return
+      if (sessionStorage.getItem(key(conn.url)) === "1") return
 
-      const yes = confirm("侦测到旧版本的数据文件，是否合并到新版本")
-      localStorage.setItem(key(conn.url, info.legacy_count), "1")
-      if (!yes) return
-
-      const merge = await fetch(`${conn.url}/database/legacy/merge`, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          ...head,
-        },
-        body: JSON.stringify({
-          mode: "auto",
-          session: true,
-        }),
-        signal: abort.signal,
-      })
-        .then((x) => x.json())
-        .catch(() => undefined)
-      if (!merge) return
-      const sessionID = (merge as Merge).sessionID
-      layout.projects.open(info.directory)
-      server.projects.touch(info.directory)
-      const dir = base64Encode(info.directory)
-      if (!sessionID) {
-        navigate(`/${dir}`)
-        return
+      const open = (sessionID?: string) => {
+        layout.projects.open(info.directory)
+        server.projects.touch(info.directory)
+        const dir = base64Encode(info.directory)
+        if (!sessionID) {
+          navigate(`/${dir}`)
+          return
+        }
+        navigate(`/${dir}/session/${sessionID}`)
       }
-      navigate(`/${dir}/session/${sessionID}`)
+
+      showToast({
+        persistent: true,
+        icon: "download",
+        title: "侦测到旧版本的对话记录",
+        description: "是否全部合并到新版本的对话中?",
+        actions: [
+          {
+            label: "立即合并",
+            onClick: async () => {
+              const merge = await fetch(`${conn.url}/database/legacy/merge`, {
+                method: "POST",
+                headers: {
+                  "content-type": "application/json",
+                  ...head,
+                },
+                body: JSON.stringify({
+                  mode: "auto",
+                  session: true,
+                }),
+                signal: abort.signal,
+              })
+                .then((x) => (x.ok ? x.json() : undefined))
+                .catch(() => undefined)
+              if (!merge) {
+                showToast({
+                  variant: "error",
+                  title: "数据库合并启动失败",
+                  description: "请稍后重试或检查后端服务日志。",
+                })
+                return
+              }
+              sessionStorage.setItem(key(conn.url), "1")
+              open((merge as Merge).sessionID)
+            },
+          },
+          {
+            label: "取消",
+            onClick: () => {
+              showToast({
+                persistent: true,
+                icon: "download",
+                title: "侦测到旧版本的对话记录",
+                description: "已取消，是否下次开启Aether时执行对话记录合并。",
+                actions: [
+                  {
+                    label: "下一次提醒我",
+                    onClick: () => {
+                      sessionStorage.setItem(key(conn.url), "1")
+                    },
+                  },
+                  {
+                    label: "不再询问",
+                    onClick: async () => {
+                      await fetch(`${conn.url}/database/legacy/preference`, {
+                        method: "PATCH",
+                        headers: {
+                          "content-type": "application/json",
+                          ...head,
+                        },
+                        body: JSON.stringify({
+                          dismissed: true,
+                        }),
+                        signal: abort.signal,
+                      }).catch(() => undefined)
+                      sessionStorage.setItem(key(conn.url), "1")
+                      showToast({
+                        description:
+                          "已关闭，如需将对话合并到新版本请参考https://aether.aiphys.cn中的常见问题。",
+                      })
+                    },
+                  },
+                ],
+              })
+            },
+          },
+        ],
+      })
     }
 
     void run()

--- a/packages/app/src/components/legacy-db-guard.tsx
+++ b/packages/app/src/components/legacy-db-guard.tsx
@@ -1,0 +1,103 @@
+import { createEffect, onCleanup } from "solid-js"
+import { useServer } from "@/context/server"
+import { useLayout } from "@/context/layout"
+import { useNavigate } from "@solidjs/router"
+import { base64Encode } from "@opencode-ai/util/encode"
+
+type Status = {
+  directory: string
+  has_legacy: boolean
+  message: string
+  legacy_count: number
+}
+
+type Merge = {
+  sessionID?: string
+}
+
+const retry_delays = [200, 400, 800, 1200, 1800, 2500]
+
+function auth(input: { url: string; username?: string; password?: string }) {
+  const head: Record<string, string> = {}
+  if (!input.password) return head
+  head.Authorization = `Basic ${btoa(`${input.username ?? "opencode"}:${input.password}`)}`
+  return head
+}
+
+function key(url: string, count: number) {
+  return `aether.legacy.prompt.${url}.${count}`
+}
+
+export function LegacyDBGuard() {
+  const server = useServer()
+  const layout = useLayout()
+  const navigate = useNavigate()
+  const abort = new AbortController()
+  let started = false
+
+  onCleanup(() => abort.abort())
+
+  createEffect(() => {
+    if (started) return
+    if (!server.current) return
+    if (!server.isLocal()) return
+    started = true
+
+    const run = async () => {
+      const conn = server.current?.http
+      if (!conn) return
+      const head = auth(conn)
+      const status = await (async () => {
+        for (let i = 0; i <= retry_delays.length; i++) {
+          const result = await fetch(`${conn.url}/database/legacy/status`, {
+            headers: head,
+            signal: abort.signal,
+          })
+            .then((x) => (x.ok ? x.json() : undefined))
+            .catch(() => undefined)
+          if (result) return result
+          if (i === retry_delays.length) return
+          await new Promise((resolve) => setTimeout(resolve, retry_delays[i]))
+          if (abort.signal.aborted) return
+        }
+      })()
+      if (!status) return
+      const info = status as Status
+      if (!info.has_legacy) return
+      if (localStorage.getItem(key(conn.url, info.legacy_count)) === "1") return
+
+      const yes = confirm("侦测到旧版本的数据文件，是否合并到新版本")
+      localStorage.setItem(key(conn.url, info.legacy_count), "1")
+      if (!yes) return
+
+      const merge = await fetch(`${conn.url}/database/legacy/merge`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          ...head,
+        },
+        body: JSON.stringify({
+          mode: "auto",
+          session: true,
+        }),
+        signal: abort.signal,
+      })
+        .then((x) => x.json())
+        .catch(() => undefined)
+      if (!merge) return
+      const sessionID = (merge as Merge).sessionID
+      layout.projects.open(info.directory)
+      server.projects.touch(info.directory)
+      const dir = base64Encode(info.directory)
+      if (!sessionID) {
+        navigate(`/${dir}`)
+        return
+      }
+      navigate(`/${dir}/session/${sessionID}`)
+    }
+
+    void run()
+  })
+
+  return null
+}

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "prepare": "effect-language-service patch || true",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "bun ../../node_modules/@typescript/native-preview/bin/tsgo.js --noEmit",
     "test": "bun test --timeout 30000",
     "build": "bun run script/build.ts",
     "dev": "bun run --conditions=browser ./src/index.ts",

--- a/packages/opencode/src/automation/legacy-repair.ts
+++ b/packages/opencode/src/automation/legacy-repair.ts
@@ -35,7 +35,7 @@ export namespace LegacyRepair {
     return [
       "侦测到旧版本数据库合并存在失败项，请执行兜底修复。",
       "仅处理当前目录顶层（不含子目录）中的 .db 文件。",
-      "目标是将用户历史信息汇总到 opencode-prod.db。",
+      "目标是将用户历史信息汇总到 aether-prod.db。",
       "优先策略：latest_wins（time_updated/updated_at/updated/time_created/created_at/created），时间相同时按来源优先级与文件名稳定排序。",
       "若遇到约束错误，请先识别缺失字段或依赖表并做最小修复后继续合并。",
       "不要移动或删除任何历史 db 文件。",

--- a/packages/opencode/src/automation/legacy-repair.ts
+++ b/packages/opencode/src/automation/legacy-repair.ts
@@ -1,0 +1,70 @@
+import z from "zod"
+import { SessionTask } from "@/automation/session-task"
+import { LegacyDB } from "@/storage/legacy-db"
+
+export namespace LegacyRepair {
+  export const Mode = z.enum(["auto", "controlled-only"])
+
+  export const Input = z.object({
+    mode: Mode.default("auto"),
+    force: z.boolean().default(false),
+    status: LegacyDB.Status,
+    merge: LegacyDB.Merge,
+  })
+
+  export const Output = z.object({
+    started: z.boolean(),
+    reason: z.string(),
+    sessionID: SessionTask.Output.shape.sessionID.optional(),
+  })
+
+  export type Input = z.infer<typeof Input>
+  export type Output = z.infer<typeof Output>
+
+  export function decide(raw: Input) {
+    const input = Input.parse(raw)
+    if (input.force) return { run: true, reason: "forced" }
+    if (input.mode === "controlled-only") return { run: false, reason: "mode=controlled-only" }
+    if (input.merge.errors.length > 0) return { run: true, reason: "merge-errors" }
+    return { run: false, reason: "no-merge-errors" }
+  }
+
+  function prompt(input: Input) {
+    const files = input.status.files.map((file) => `- ${file.path}`).join("\n")
+    const errs = input.merge.errors.map((err) => `- ${err}`).join("\n")
+    return [
+      "侦测到旧版本数据库合并存在失败项，请执行兜底修复。",
+      "仅处理当前目录顶层（不含子目录）中的 .db 文件。",
+      "目标是将用户历史信息汇总到 opencode-prod.db。",
+      "优先策略：latest_wins（time_updated/updated_at/updated/time_created/created_at/created），时间相同时按来源优先级与文件名稳定排序。",
+      "若遇到约束错误，请先识别缺失字段或依赖表并做最小修复后继续合并。",
+      "不要移动或删除任何历史 db 文件。",
+      "请输出最终报告：成功源库、失败源库、冲突数量、修复动作、剩余风险。",
+      "扫描到的库：",
+      files || "- 无",
+      "受控合并器失败信息：",
+      errs || "- 无",
+    ].join("\n")
+  }
+
+  export async function start(raw: Input): Promise<Output> {
+    const input = Input.parse(raw)
+    const next = decide(input)
+    if (!next.run) {
+      return {
+        started: false,
+        reason: next.reason,
+      }
+    }
+    const task = await SessionTask.start({
+      directory: input.status.directory,
+      title: "Legacy database repair",
+      prompt: prompt(input),
+    })
+    return {
+      started: true,
+      reason: next.reason,
+      sessionID: task.sessionID,
+    }
+  }
+}

--- a/packages/opencode/src/automation/legacy-repair.ts
+++ b/packages/opencode/src/automation/legacy-repair.ts
@@ -9,7 +9,9 @@ export namespace LegacyRepair {
     mode: Mode.default("auto"),
     force: z.boolean().default(false),
     status: LegacyDB.Status,
-    merge: LegacyDB.Merge,
+    merge: z.object({
+      errors: z.array(z.string()),
+    }),
   })
 
   export const Output = z.object({
@@ -60,7 +62,13 @@ export namespace LegacyRepair {
       directory: input.status.directory,
       title: "Legacy database repair",
       prompt: prompt(input),
-    })
+    }).catch(() => undefined)
+    if (!task) {
+      return {
+        started: false,
+        reason: "session-start-failed",
+      }
+    }
     return {
       started: true,
       reason: next.reason,

--- a/packages/opencode/src/automation/session-task.ts
+++ b/packages/opencode/src/automation/session-task.ts
@@ -21,7 +21,12 @@ export namespace SessionTask {
   export type Input = z.infer<typeof Input>
   export type Output = z.infer<typeof Output>
 
-  export async function start(raw: Input): Promise<Output> {
+  export type Running = {
+    sessionID: Output["sessionID"]
+    done: Promise<void>
+  }
+
+  export async function begin(raw: Input): Promise<Running> {
     const input = Input.parse(raw)
     return Instance.provide({
       directory: input.directory,
@@ -30,7 +35,7 @@ export namespace SessionTask {
         const session = await Session.create({
           title: input.title,
         })
-        SessionPrompt.prompt({
+        const done = SessionPrompt.prompt({
           sessionID: session.id,
           parts: [
             {
@@ -38,16 +43,27 @@ export namespace SessionTask {
               text: input.prompt,
             },
           ],
-        }).catch((error) => {
-          log.error("session task failed", {
-            sessionID: session.id,
-            error,
-          })
         })
+          .then(() => undefined)
+          .catch((error) => {
+            log.error("session task failed", {
+              sessionID: session.id,
+              error,
+            })
+            throw error
+          })
         return {
           sessionID: session.id,
+          done,
         }
       },
     })
+  }
+
+  export async function start(raw: Input): Promise<Output> {
+    const task = await begin(raw)
+    return {
+      sessionID: task.sessionID,
+    }
   }
 }

--- a/packages/opencode/src/automation/session-task.ts
+++ b/packages/opencode/src/automation/session-task.ts
@@ -1,0 +1,53 @@
+import { Session } from "@/session"
+import { SessionPrompt } from "@/session/prompt"
+import { Instance } from "@/project/instance"
+import { InstanceBootstrap } from "@/project/bootstrap"
+import { Log } from "@/util/log"
+import z from "zod"
+
+const log = Log.create({ service: "session-task" })
+
+export namespace SessionTask {
+  export const Input = z.object({
+    directory: z.string(),
+    prompt: z.string(),
+    title: z.string().optional(),
+  })
+
+  export const Output = z.object({
+    sessionID: Session.Info.shape.id,
+  })
+
+  export type Input = z.infer<typeof Input>
+  export type Output = z.infer<typeof Output>
+
+  export async function start(raw: Input): Promise<Output> {
+    const input = Input.parse(raw)
+    return Instance.provide({
+      directory: input.directory,
+      init: InstanceBootstrap,
+      async fn() {
+        const session = await Session.create({
+          title: input.title,
+        })
+        SessionPrompt.prompt({
+          sessionID: session.id,
+          parts: [
+            {
+              type: "text",
+              text: input.prompt,
+            },
+          ],
+        }).catch((error) => {
+          log.error("session task failed", {
+            sessionID: session.id,
+            error,
+          })
+        })
+        return {
+          sessionID: session.id,
+        }
+      },
+    })
+  }
+}

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -32,6 +32,7 @@ import { SessionCommand } from "./cli/cmd/session"
 import { DbCommand } from "./cli/cmd/db"
 import { JsonMigration } from "./storage/json-migration"
 import { Database } from "./storage/db"
+import { LegacyDB } from "./storage/legacy-db"
 
 process.on("unhandledRejection", (e) => {
   Log.Default.error("rejection", {
@@ -81,6 +82,11 @@ let cli = yargs(hideBin(process.argv))
       version: Installation.VERSION,
       args: process.argv.slice(2),
     })
+
+    const legacy = await LegacyDB.status()
+    if (legacy.has_legacy) {
+      process.stderr.write(`发现旧库: ${legacy.legacy_count} 个，可通过 /database/legacy/merge 触发合并。` + EOL)
+    }
 
     const marker = Database.currentPath()
     const seeded = marker !== ":memory:" && (await Filesystem.exists(marker))

--- a/packages/opencode/src/server/routes/database.ts
+++ b/packages/opencode/src/server/routes/database.ts
@@ -15,6 +15,7 @@ const MergeInput = z
 const MergeOutput = z.object({
   status: LegacyDB.Status,
   merge: LegacyDB.Merge,
+  archive: LegacyDB.Archive.optional(),
   sessionID: LegacyRepair.Output.shape.sessionID.optional(),
   fallback: LegacyRepair.Output,
 })
@@ -93,7 +94,7 @@ export const DatabaseRoutes = lazy(() =>
       "/legacy/merge",
       describeRoute({
         summary: "Merge legacy databases",
-        description: "Merge all legacy databases into opencode-prod.db without moving source files.",
+        description: "Merge all legacy databases into aether-prod.db and archive old database files.",
         operationId: "database.legacy.merge",
         responses: {
           200: {
@@ -110,6 +111,7 @@ export const DatabaseRoutes = lazy(() =>
         const body = MergeInput.parse(await c.req.json().catch(() => undefined))
         const status = await LegacyDB.status()
         const merge = await LegacyDB.merge()
+        const archive = merge.errors.length === 0 ? await LegacyDB.archive() : undefined
         const fallback = await LegacyRepair.start({
           mode: body?.mode ?? "auto",
           force: body?.session ?? false,
@@ -119,6 +121,7 @@ export const DatabaseRoutes = lazy(() =>
         return c.json({
           status,
           merge,
+          archive,
           sessionID: fallback.sessionID,
           fallback,
         })

--- a/packages/opencode/src/server/routes/database.ts
+++ b/packages/opencode/src/server/routes/database.ts
@@ -1,0 +1,80 @@
+import { Hono } from "hono"
+import { describeRoute, resolver } from "hono-openapi"
+import { lazy } from "@/util/lazy"
+import { LegacyDB } from "@/storage/legacy-db"
+import z from "zod"
+import { LegacyRepair } from "@/automation/legacy-repair"
+
+const MergeInput = z
+  .object({
+    session: z.boolean().default(false),
+    mode: LegacyRepair.Mode.default("auto"),
+  })
+  .optional()
+
+const MergeOutput = z.object({
+  status: LegacyDB.Status,
+  merge: LegacyDB.Merge,
+  sessionID: LegacyRepair.Output.shape.sessionID.optional(),
+  fallback: LegacyRepair.Output,
+})
+
+export const DatabaseRoutes = lazy(() =>
+  new Hono()
+    .get(
+      "/legacy/status",
+      describeRoute({
+        summary: "Scan legacy databases",
+        description: "Scan current data directory and report legacy database statistics.",
+        operationId: "database.legacy.status",
+        responses: {
+          200: {
+            description: "Legacy database scan status",
+            content: {
+              "application/json": {
+                schema: resolver(LegacyDB.Status),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        return c.json(await LegacyDB.status())
+      },
+    )
+    .post(
+      "/legacy/merge",
+      describeRoute({
+        summary: "Merge legacy databases",
+        description: "Merge all legacy databases into opencode-prod.db without moving source files.",
+        operationId: "database.legacy.merge",
+        responses: {
+          200: {
+            description: "Merge report",
+            content: {
+              "application/json": {
+                schema: resolver(MergeOutput),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        const body = MergeInput.parse(await c.req.json().catch(() => undefined))
+        const status = await LegacyDB.status()
+        const merge = await LegacyDB.merge()
+        const fallback = await LegacyRepair.start({
+          mode: body?.mode ?? "auto",
+          force: body?.session ?? false,
+          status,
+          merge,
+        })
+        return c.json({
+          status,
+          merge,
+          sessionID: fallback.sessionID,
+          fallback,
+        })
+      },
+    ),
+)

--- a/packages/opencode/src/server/routes/database.ts
+++ b/packages/opencode/src/server/routes/database.ts
@@ -19,6 +19,10 @@ const MergeOutput = z.object({
   fallback: LegacyRepair.Output,
 })
 
+const PreferenceInput = z.object({
+  dismissed: z.boolean(),
+})
+
 export const DatabaseRoutes = lazy(() =>
   new Hono()
     .get(
@@ -40,6 +44,49 @@ export const DatabaseRoutes = lazy(() =>
       }),
       async (c) => {
         return c.json(await LegacyDB.status())
+      },
+    )
+    .get(
+      "/legacy/preference",
+      describeRoute({
+        summary: "Get legacy merge prompt preference",
+        description: "Get whether legacy merge prompt is permanently dismissed.",
+        operationId: "database.legacy.preference.get",
+        responses: {
+          200: {
+            description: "Legacy prompt preference",
+            content: {
+              "application/json": {
+                schema: resolver(LegacyDB.Preference),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        return c.json(await LegacyDB.preference())
+      },
+    )
+    .patch(
+      "/legacy/preference",
+      describeRoute({
+        summary: "Update legacy merge prompt preference",
+        description: "Update whether legacy merge prompt is permanently dismissed.",
+        operationId: "database.legacy.preference.patch",
+        responses: {
+          200: {
+            description: "Updated legacy prompt preference",
+            content: {
+              "application/json": {
+                schema: resolver(LegacyDB.Preference),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        const body = PreferenceInput.parse(await c.req.json())
+        return c.json(await LegacyDB.setPreference(body))
       },
     )
     .post(

--- a/packages/opencode/src/server/routes/database.ts
+++ b/packages/opencode/src/server/routes/database.ts
@@ -3,21 +3,14 @@ import { describeRoute, resolver } from "hono-openapi"
 import { lazy } from "@/util/lazy"
 import { LegacyDB } from "@/storage/legacy-db"
 import z from "zod"
-import { LegacyRepair } from "@/automation/legacy-repair"
+import { SessionTask } from "@/automation/session-task"
 
-const MergeInput = z
-  .object({
-    session: z.boolean().default(false),
-    mode: LegacyRepair.Mode.default("auto"),
-  })
-  .optional()
+const MergeInput = z.object({}).optional()
 
 const MergeOutput = z.object({
   status: LegacyDB.Status,
-  merge: LegacyDB.Merge,
-  archive: LegacyDB.Archive.optional(),
-  sessionID: LegacyRepair.Output.shape.sessionID.optional(),
-  fallback: LegacyRepair.Output,
+  sessionID: SessionTask.Output.shape.sessionID,
+  archive_state: LegacyDB.ArchiveState,
 })
 
 const PreferenceInput = z.object({
@@ -90,11 +83,32 @@ export const DatabaseRoutes = lazy(() =>
         return c.json(await LegacyDB.setPreference(body))
       },
     )
+    .get(
+      "/legacy/archive/state",
+      describeRoute({
+        summary: "Get archive state",
+        description: "Get asynchronous archive task state after agent-driven merge.",
+        operationId: "database.legacy.archive.state",
+        responses: {
+          200: {
+            description: "Archive state",
+            content: {
+              "application/json": {
+                schema: resolver(LegacyDB.ArchiveState),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        return c.json(await LegacyDB.archiveState())
+      },
+    )
     .post(
       "/legacy/merge",
       describeRoute({
         summary: "Merge legacy databases",
-        description: "Merge all legacy databases into aether-prod.db and archive old database files.",
+        description: "Start agent-driven merge into aether-prod.db and run fixed archive after session completes.",
         operationId: "database.legacy.merge",
         responses: {
           200: {
@@ -108,22 +122,50 @@ export const DatabaseRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        const body = MergeInput.parse(await c.req.json().catch(() => undefined))
+        MergeInput.parse(await c.req.json().catch(() => undefined))
         const status = await LegacyDB.status()
-        const merge = await LegacyDB.merge()
-        const archive = merge.errors.length === 0 ? await LegacyDB.archive() : undefined
-        const fallback = await LegacyRepair.start({
-          mode: body?.mode ?? "auto",
-          force: body?.session ?? false,
-          status,
-          merge,
+        await LegacyDB.ensureTarget()
+        const files = status.files.map((file) => `- ${file.path}`).join("\n")
+        const task = await SessionTask.begin({
+          directory: status.directory,
+          title: "Legacy database merge",
+          prompt: [
+            "请识别当前目录顶层（不含子目录）中的所有 .db 文件。",
+            "请将用户历史对话信息合并到 aether-prod.db。",
+            "冲突策略：latest_wins（time_updated/updated_at/updated/time_created/created_at/created），时间相同按来源优先级与文件名稳定排序。",
+            "不要移动或删除任何历史 db 文件。",
+            "完成后请输出合并报告：成功库、失败库、冲突数。",
+            "文件列表：",
+            files || "- 无",
+          ].join("\n"),
         })
+
+        await LegacyDB.setArchiveState({
+          state: "running",
+          updated: Date.now(),
+        })
+
+        void task.done
+          .then(async () => {
+            const archive = await LegacyDB.archive()
+            await LegacyDB.setArchiveState({
+              state: "done",
+              updated: Date.now(),
+              result: archive,
+            })
+          })
+          .catch(async (error) => {
+            await LegacyDB.setArchiveState({
+              state: "error",
+              updated: Date.now(),
+              error: error instanceof Error ? error.message : String(error),
+            })
+          })
+
         return c.json({
           status,
-          merge,
-          archive,
-          sessionID: fallback.sessionID,
-          fallback,
+          sessionID: task.sessionID,
+          archive_state: await LegacyDB.archiveState(),
         })
       },
     ),

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -71,6 +71,7 @@ import { GlobalRoutes } from "./routes/global"
 import { KnowledgeRoutes } from "./routes/knowledge"
 import { WeChatRoutes } from "./routes/wechat"
 import { ReadingModeRoutes } from "./routes/reading-mode"
+import { DatabaseRoutes } from "./routes/database"
 import { MDNS } from "./mdns"
 import { lazy } from "@/util/lazy"
 import { initProjectors } from "./projectors"
@@ -80,6 +81,8 @@ globalThis.AI_SDK_LOG_WARNINGS = false
 
 const csp = (hash = "") =>
   `default-src 'self'; script-src 'self' 'wasm-unsafe-eval'${hash ? ` 'sha256-${hash}'` : ""}; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:`
+
+const web = process.env.AETHER_WEB_ORIGIN || process.env.OPENCODE_WEB_ORIGIN || "https://app.opencode.ai"
 
 initProjectors()
 
@@ -139,6 +142,7 @@ export namespace Server {
       })
       .use(
         cors({
+          credentials: true,
           origin(input) {
             if (!input) return
 
@@ -284,6 +288,7 @@ export namespace Server {
       .route("/permission", PermissionRoutes())
       .route("/question", QuestionRoutes())
       .route("/provider", ProviderRoutes())
+      .route("/database", DatabaseRoutes())
       .route("/", FileRoutes())
       .route("/", EventRoutes())
       .route("/mcp", McpRoutes())
@@ -658,11 +663,12 @@ export namespace Server {
         }
 
         // Fall back to remote proxy
-        const response = await proxy(`https://app.opencode.ai${reqPath}`, {
+        const remote = new URL(reqPath, web)
+        const response = await proxy(remote.toString(), {
           ...c.req,
           headers: {
             ...c.req.raw.headers,
-            host: "app.opencode.ai",
+            host: remote.host,
           },
         })
         const match = response.headers.get("content-type")?.includes("text/html")

--- a/packages/opencode/src/storage/legacy-db.ts
+++ b/packages/opencode/src/storage/legacy-db.ts
@@ -1,0 +1,296 @@
+import { Database as Sqlite } from "bun:sqlite"
+import fs from "fs/promises"
+import path from "path"
+import z from "zod"
+import { Global } from "@/global"
+import { Log } from "@/util/log"
+
+const log = Log.create({ service: "legacy-db" })
+
+const target_file = "opencode-prod.db"
+const time_cols = ["time_updated", "updated_at", "updated", "time_created", "created_at", "created"] as const
+const low = "-9223372036854775808"
+
+function q(name: string) {
+  return `"${name.replaceAll('"', '""')}"`
+}
+
+function lit(text: string) {
+  return `'${text.replaceAll("'", "''")}'`
+}
+
+function dbPath(name: string) {
+  return path.join(Global.Path.data, name)
+}
+
+function channel(name: string) {
+  const file = path.basename(name)
+  if (!file.toLowerCase().startsWith("opencode") || !file.toLowerCase().endsWith(".db")) return "unknown"
+  if (file.toLowerCase() === "opencode.db") return "latest"
+  if (file.toLowerCase() === target_file) return "prod"
+  const match = /^opencode-(.+)\.db$/i.exec(file)
+  if (!match) return "unknown"
+  return match[1]
+}
+
+function rank(name: string) {
+  const ch = channel(name)
+  if (ch === "local") return 0
+  if (ch === "dev") return 1
+  if (ch === "beta") return 2
+  if (ch === "latest") return 3
+  if (ch === "prod") return 4
+  return 2
+}
+
+async function mod(file: string) {
+  const stat = await fs.stat(file).catch(() => undefined)
+  return stat?.mtimeMs ?? 0
+}
+
+async function versions(file: string) {
+  const db = new Sqlite(file, { readonly: true })
+  try {
+    const rows = db
+      .query("select version, count(*) as count from session group by version")
+      .all() as { version: string | null; count: number }[]
+    return rows.reduce<Record<string, number>>((acc, row) => {
+      const key = row.version || "unknown"
+      acc[key] = (acc[key] ?? 0) + row.count
+      return acc
+    }, {})
+  } catch {
+    return {}
+  } finally {
+    db.close()
+  }
+}
+
+function pickTime(cols: string[]) {
+  return time_cols.find((col) => cols.includes(col))
+}
+
+function common(a: string[], b: string[]) {
+  const set = new Set(b)
+  return a.filter((item) => set.has(item))
+}
+
+function mergeSql(input: { table: string; cols: string[]; pks: string[]; time?: string }) {
+  const table = q(input.table)
+  const cols = input.cols.map(q)
+  const list = cols.join(", ")
+  const rows = input.cols.map((col) => `src.${table}.${q(col)}`).join(", ")
+
+  if (input.pks.length === 0) {
+    return `insert into main.${table} (${list}) select ${rows} from src.${table}`
+  }
+
+  const keys = input.pks.map(q).join(", ")
+  const updates = input.cols
+    .filter((col) => !input.pks.includes(col))
+    .map((col) => `${q(col)}=coalesce(excluded.${q(col)}, ${table}.${q(col)})`)
+
+  if (updates.length === 0) {
+    return `insert into main.${table} (${list}) select ${rows} from src.${table} where 1 on conflict (${keys}) do nothing`
+  }
+
+  const where = input.time
+    ? ` where coalesce(excluded.${q(input.time)}, ${low}) >= coalesce(${table}.${q(input.time)}, ${low})`
+    : ""
+
+  return `insert into main.${table} (${list}) select ${rows} from src.${table} where 1 on conflict (${keys}) do update set ${updates.join(", ")}${where}`
+}
+
+function tableInfo(db: Sqlite, schema: "main" | "src", table: string) {
+  return db.query(`pragma ${schema}.table_info(${lit(table)})`).all() as {
+    name: string
+    pk: number
+  }[]
+}
+
+function master(db: Sqlite, schema: "main" | "src") {
+  return db
+    .query(`select name, sql from ${schema}.sqlite_master where type='table' and name not like 'sqlite_%'`)
+    .all() as {
+    name: string
+    sql: string | null
+  }[]
+}
+
+function createSql(sql: string) {
+  return sql.replace(/^create\s+table\s+/i, "create table if not exists ")
+}
+
+export namespace LegacyDB {
+  export const target = target_file
+
+  export const File = z.object({
+    name: z.string(),
+    path: z.string(),
+    channel: z.string(),
+    mtime: z.number(),
+  })
+
+  export const Status = z.object({
+    directory: z.string(),
+    target: z.string(),
+    has_legacy: z.boolean(),
+    message: z.string(),
+    legacy_count: z.number(),
+    files: File.array(),
+    naming: z.record(z.string(), z.number()),
+    versions: z.record(z.string(), z.number()),
+  })
+
+  export const Merge = z.object({
+    target: z.string(),
+    merged: z.array(z.string()),
+    tables: z.number(),
+    changes: z.number(),
+    skipped: z.array(z.string()),
+    errors: z.array(z.string()),
+  })
+
+  export type Status = z.infer<typeof Status>
+  export type Merge = z.infer<typeof Merge>
+
+  export function targetPath() {
+    return dbPath(target_file)
+  }
+
+  export async function status(): Promise<Status> {
+    const dir = Global.Path.data
+    const rows = await fs.readdir(dir, { withFileTypes: true }).catch(() => [])
+    const files = await Promise.all(
+      rows
+        .filter((row) => row.isFile() && /^opencode.*\.db$/i.test(row.name))
+        .map(async (row) => {
+          const file = path.join(dir, row.name)
+          return {
+            name: row.name,
+            path: file,
+            channel: channel(row.name),
+            mtime: await mod(file),
+          }
+        }),
+    )
+    const old = files.filter((file) => file.name.toLowerCase() !== target_file)
+
+    const naming = old.reduce<Record<string, number>>((acc, file) => {
+      acc[file.channel] = (acc[file.channel] ?? 0) + 1
+      return acc
+    }, {})
+
+    const list = await Promise.all(old.map(async (file) => ({ file, versions: await versions(file.path) })))
+    const dist = list.reduce<Record<string, number>>((acc, item) => {
+      for (const [key, val] of Object.entries(item.versions)) {
+        acc[key] = (acc[key] ?? 0) + val
+      }
+      return acc
+    }, {})
+
+    return {
+      directory: dir,
+      target: targetPath(),
+      has_legacy: old.length > 0,
+      message: old.length > 0 ? "发现旧库" : "未发现旧库",
+      legacy_count: old.length,
+      files: old.sort((a, b) => a.name.localeCompare(b.name)),
+      naming,
+      versions: dist,
+    }
+  }
+
+  async function seed(files: Status["files"]) {
+    const target = targetPath()
+    const stat = await fs.stat(target).catch(() => undefined)
+    if (stat) return
+    if (files.length === 0) {
+      const db = new Sqlite(target)
+      db.close()
+      return
+    }
+    const list = [...files].sort((a, b) => a.mtime - b.mtime || rank(a.name) - rank(b.name) || a.name.localeCompare(b.name))
+    await fs.copyFile(list.at(-1)!.path, target)
+  }
+
+  export async function merge(): Promise<Merge> {
+    const info = await status()
+    await seed(info.files)
+    const target = targetPath()
+
+    const list = [...info.files].sort((a, b) => a.mtime - b.mtime || rank(a.name) - rank(b.name) || a.name.localeCompare(b.name))
+    const merged: string[] = []
+    const skipped: string[] = []
+    const errors: string[] = []
+
+    const db = new Sqlite(target)
+    db.exec("pragma busy_timeout = 5000")
+    let total = 0
+    let tabs = 0
+
+    try {
+      for (const file of list) {
+        if (path.resolve(file.path) === path.resolve(target)) continue
+        db.exec(`attach database ${lit(file.path)} as src`)
+        try {
+          const src = master(db, "src")
+          const main = new Set(master(db, "main").map((item) => item.name))
+
+          for (const tab of src) {
+            if (!tab.sql) {
+              skipped.push(`${file.name}:${tab.name}:missing-schema`)
+              continue
+            }
+            if (!main.has(tab.name)) {
+              db.exec(createSql(tab.sql))
+              main.add(tab.name)
+            }
+
+            const srcInfo = tableInfo(db, "src", tab.name)
+            const mainInfo = tableInfo(db, "main", tab.name)
+            const cols = common(
+              mainInfo.map((item) => item.name),
+              srcInfo.map((item) => item.name),
+            )
+            if (cols.length === 0) {
+              skipped.push(`${file.name}:${tab.name}:no-common-columns`)
+              continue
+            }
+
+            const srcPk = srcInfo.filter((item) => item.pk > 0).map((item) => item.name)
+            const mainPk = mainInfo.filter((item) => item.pk > 0).map((item) => item.name)
+            const pks = common(mainPk, srcPk)
+            const time = pickTime(cols)
+            const sql = mergeSql({ table: tab.name, cols, pks, time })
+
+            db.exec(sql)
+            const row = db.query("select changes() as c").get() as { c: number }
+            total += row.c
+            tabs += 1
+          }
+          merged.push(file.path)
+        } catch (error) {
+          errors.push(`${file.name}:${error instanceof Error ? error.message : String(error)}`)
+          log.warn("legacy merge source failed", {
+            source: file.path,
+            error,
+          })
+        } finally {
+          db.exec("detach database src")
+        }
+      }
+    } finally {
+      db.close()
+    }
+
+    return {
+      target,
+      merged,
+      tables: tabs,
+      changes: total,
+      skipped,
+      errors,
+    }
+  }
+}

--- a/packages/opencode/src/storage/legacy-db.ts
+++ b/packages/opencode/src/storage/legacy-db.ts
@@ -3,22 +3,10 @@ import fs from "fs/promises"
 import path from "path"
 import z from "zod"
 import { Global } from "@/global"
-import { Log } from "@/util/log"
-
-const log = Log.create({ service: "legacy-db" })
 
 const target_file = "aether-prod.db"
 const pref_file = "legacy-db.json"
-const time_cols = ["time_updated", "updated_at", "updated", "time_created", "created_at", "created"] as const
-const low = "-9223372036854775808"
-
-function q(name: string) {
-  return `"${name.replaceAll('"', '""')}"`
-}
-
-function lit(text: string) {
-  return `'${text.replaceAll("'", "''")}'`
-}
+const archive_file = "legacy-db-archive.json"
 
 function dbPath(name: string) {
   return path.join(Global.Path.data, name)
@@ -26,6 +14,10 @@ function dbPath(name: string) {
 
 function prefPath() {
   return path.join(Global.Path.state, pref_file)
+}
+
+function archivePath() {
+  return path.join(Global.Path.state, archive_file)
 }
 
 function isdb(name: string) {
@@ -75,60 +67,6 @@ async function versions(file: string) {
   }
 }
 
-function pickTime(cols: string[]) {
-  return time_cols.find((col) => cols.includes(col))
-}
-
-function common(a: string[], b: string[]) {
-  const set = new Set(b)
-  return a.filter((item) => set.has(item))
-}
-
-function mergeSql(input: { table: string; cols: string[]; pks: string[]; time?: string }) {
-  const table = q(input.table)
-  const cols = input.cols.map(q)
-  const list = cols.join(", ")
-  const rows = input.cols.map((col) => `src.${table}.${q(col)}`).join(", ")
-
-  if (input.pks.length === 0) {
-    return `insert into main.${table} (${list}) select ${rows} from src.${table}`
-  }
-
-  const keys = input.pks.map(q).join(", ")
-  const updates = input.cols
-    .filter((col) => !input.pks.includes(col))
-    .map((col) => `${q(col)}=coalesce(excluded.${q(col)}, ${table}.${q(col)})`)
-
-  if (updates.length === 0) {
-    return `insert into main.${table} (${list}) select ${rows} from src.${table} where 1 on conflict (${keys}) do nothing`
-  }
-
-  const where = input.time
-    ? ` where coalesce(excluded.${q(input.time)}, ${low}) >= coalesce(${table}.${q(input.time)}, ${low})`
-    : ""
-
-  return `insert into main.${table} (${list}) select ${rows} from src.${table} where 1 on conflict (${keys}) do update set ${updates.join(", ")}${where}`
-}
-
-function tableInfo(db: Sqlite, schema: "main" | "src", table: string) {
-  return db.query(`pragma ${schema}.table_info(${lit(table)})`).all() as {
-    name: string
-    pk: number
-  }[]
-}
-
-function master(db: Sqlite, schema: "main" | "src") {
-  return db
-    .query(`select name, sql from ${schema}.sqlite_master where type='table' and name not like 'sqlite_%'`)
-    .all() as {
-    name: string
-    sql: string | null
-  }[]
-}
-
-function createSql(sql: string) {
-  return sql.replace(/^create\s+table\s+/i, "create table if not exists ")
-}
 
 export namespace LegacyDB {
   export const target = target_file
@@ -156,15 +94,6 @@ export namespace LegacyDB {
     dismissed: z.boolean(),
   })
 
-  export const Merge = z.object({
-    target: z.string(),
-    merged: z.array(z.string()),
-    tables: z.number(),
-    changes: z.number(),
-    skipped: z.array(z.string()),
-    errors: z.array(z.string()),
-  })
-
   export const Archive = z.object({
     history: z.string(),
     moved: z.array(z.string()),
@@ -174,9 +103,16 @@ export namespace LegacyDB {
   })
 
   export type Status = z.infer<typeof Status>
-  export type Merge = z.infer<typeof Merge>
   export type Preference = z.infer<typeof Preference>
   export type Archive = z.infer<typeof Archive>
+
+  export const ArchiveState = z.object({
+    state: z.enum(["idle", "running", "done", "error"]),
+    updated: z.number(),
+    result: Archive.optional(),
+    error: z.string().optional(),
+  })
+  export type ArchiveState = z.infer<typeof ArchiveState>
 
   async function scan() {
     const dir = Global.Path.data
@@ -220,6 +156,54 @@ export namespace LegacyDB {
     return dbPath(target_file)
   }
 
+  export async function ensureTarget() {
+    const target = targetPath()
+    const stat = await fs.stat(target).catch(() => undefined)
+    if (stat) return target
+    const list = (await scan()).filter((item) => item.name.toLowerCase() !== target_file)
+    if (list.length === 0) {
+      const db = new Sqlite(target)
+      db.close()
+      return target
+    }
+    const pick = [...list].sort((a, b) => a.mtime - b.mtime || rank(a.name) - rank(b.name) || a.name.localeCompare(b.name)).at(-1)
+    if (pick) await fs.copyFile(pick.path, target)
+    return target
+  }
+
+  export async function archiveState(): Promise<ArchiveState> {
+    const raw = await fs.readFile(archivePath(), "utf-8").catch(() => "")
+    if (!raw) {
+      return {
+        state: "idle",
+        updated: Date.now(),
+      }
+    }
+    let json: unknown
+    try {
+      json = JSON.parse(raw)
+    } catch {
+      return {
+        state: "idle",
+        updated: Date.now(),
+      }
+    }
+    const next = ArchiveState.safeParse(json)
+    if (!next.success) {
+      return {
+        state: "idle",
+        updated: Date.now(),
+      }
+    }
+    return next.data
+  }
+
+  export async function setArchiveState(input: ArchiveState) {
+    const state = ArchiveState.parse(input)
+    await fs.writeFile(archivePath(), JSON.stringify(state, null, 2), "utf-8")
+    return state
+  }
+
   export async function status(): Promise<Status> {
     const dir = Global.Path.data
     const files = await scan()
@@ -250,99 +234,6 @@ export namespace LegacyDB {
       files: old.sort((a, b) => a.name.localeCompare(b.name)),
       naming,
       versions: dist,
-    }
-  }
-
-  async function seed(files: Status["files"]) {
-    const target = targetPath()
-    const stat = await fs.stat(target).catch(() => undefined)
-    if (stat) return
-    if (files.length === 0) {
-      const db = new Sqlite(target)
-      db.close()
-      return
-    }
-    const list = [...files].sort((a, b) => a.mtime - b.mtime || rank(a.name) - rank(b.name) || a.name.localeCompare(b.name))
-    await fs.copyFile(list.at(-1)!.path, target)
-  }
-
-  export async function merge(): Promise<Merge> {
-    const info = await status()
-    await seed(info.files)
-    const target = targetPath()
-
-    const list = [...info.files].sort((a, b) => a.mtime - b.mtime || rank(a.name) - rank(b.name) || a.name.localeCompare(b.name))
-    const merged: string[] = []
-    const skipped: string[] = []
-    const errors: string[] = []
-
-    const db = new Sqlite(target)
-    db.exec("pragma busy_timeout = 5000")
-    let total = 0
-    let tabs = 0
-
-    try {
-      for (const file of list) {
-        if (path.resolve(file.path) === path.resolve(target)) continue
-        db.exec(`attach database ${lit(file.path)} as src`)
-        try {
-          const src = master(db, "src")
-          const main = new Set(master(db, "main").map((item) => item.name))
-
-          for (const tab of src) {
-            if (!tab.sql) {
-              skipped.push(`${file.name}:${tab.name}:missing-schema`)
-              continue
-            }
-            if (!main.has(tab.name)) {
-              db.exec(createSql(tab.sql))
-              main.add(tab.name)
-            }
-
-            const srcInfo = tableInfo(db, "src", tab.name)
-            const mainInfo = tableInfo(db, "main", tab.name)
-            const cols = common(
-              mainInfo.map((item) => item.name),
-              srcInfo.map((item) => item.name),
-            )
-            if (cols.length === 0) {
-              skipped.push(`${file.name}:${tab.name}:no-common-columns`)
-              continue
-            }
-
-            const srcPk = srcInfo.filter((item) => item.pk > 0).map((item) => item.name)
-            const mainPk = mainInfo.filter((item) => item.pk > 0).map((item) => item.name)
-            const pks = common(mainPk, srcPk)
-            const time = pickTime(cols)
-            const sql = mergeSql({ table: tab.name, cols, pks, time })
-
-            db.exec(sql)
-            const row = db.query("select changes() as c").get() as { c: number }
-            total += row.c
-            tabs += 1
-          }
-          merged.push(file.path)
-        } catch (error) {
-          errors.push(`${file.name}:${error instanceof Error ? error.message : String(error)}`)
-          log.warn("legacy merge source failed", {
-            source: file.path,
-            error,
-          })
-        } finally {
-          db.exec("detach database src")
-        }
-      }
-    } finally {
-      db.close()
-    }
-
-    return {
-      target,
-      merged,
-      tables: tabs,
-      changes: total,
-      skipped,
-      errors,
     }
   }
 

--- a/packages/opencode/src/storage/legacy-db.ts
+++ b/packages/opencode/src/storage/legacy-db.ts
@@ -7,7 +7,7 @@ import { Log } from "@/util/log"
 
 const log = Log.create({ service: "legacy-db" })
 
-const target_file = "opencode-prod.db"
+const target_file = "aether-prod.db"
 const pref_file = "legacy-db.json"
 const time_cols = ["time_updated", "updated_at", "updated", "time_created", "created_at", "created"] as const
 const low = "-9223372036854775808"
@@ -28,11 +28,15 @@ function prefPath() {
   return path.join(Global.Path.state, pref_file)
 }
 
+function isdb(name: string) {
+  return /^(opencode|aether).*\.db$/i.test(name)
+}
+
 function channel(name: string) {
   const file = path.basename(name)
-  if (!file.toLowerCase().startsWith("opencode") || !file.toLowerCase().endsWith(".db")) return "unknown"
-  if (file.toLowerCase() === "opencode.db") return "latest"
   if (file.toLowerCase() === target_file) return "prod"
+  if (!isdb(file)) return "unknown"
+  if (file.toLowerCase() === "opencode.db") return "latest"
   const match = /^opencode-(.+)\.db$/i.exec(file)
   if (!match) return "unknown"
   return match[1]
@@ -161,9 +165,36 @@ export namespace LegacyDB {
     errors: z.array(z.string()),
   })
 
+  export const Archive = z.object({
+    history: z.string(),
+    moved: z.array(z.string()),
+    skipped: z.array(z.string()),
+    remaining: z.array(z.string()),
+    clean: z.boolean(),
+  })
+
   export type Status = z.infer<typeof Status>
   export type Merge = z.infer<typeof Merge>
   export type Preference = z.infer<typeof Preference>
+  export type Archive = z.infer<typeof Archive>
+
+  async function scan() {
+    const dir = Global.Path.data
+    const rows = await fs.readdir(dir, { withFileTypes: true }).catch(() => [])
+    return Promise.all(
+      rows
+        .filter((row) => row.isFile() && isdb(row.name))
+        .map(async (row) => {
+          const file = path.join(dir, row.name)
+          return {
+            name: row.name,
+            path: file,
+            channel: channel(row.name),
+            mtime: await mod(file),
+          }
+        }),
+    )
+  }
 
   export async function preference(): Promise<Preference> {
     const raw = await fs.readFile(prefPath(), "utf-8").catch(() => "")
@@ -191,20 +222,7 @@ export namespace LegacyDB {
 
   export async function status(): Promise<Status> {
     const dir = Global.Path.data
-    const rows = await fs.readdir(dir, { withFileTypes: true }).catch(() => [])
-    const files = await Promise.all(
-      rows
-        .filter((row) => row.isFile() && /^opencode.*\.db$/i.test(row.name))
-        .map(async (row) => {
-          const file = path.join(dir, row.name)
-          return {
-            name: row.name,
-            path: file,
-            channel: channel(row.name),
-            mtime: await mod(file),
-          }
-        }),
-    )
+    const files = await scan()
     const old = files.filter((file) => file.name.toLowerCase() !== target_file)
 
     const naming = old.reduce<Record<string, number>>((acc, file) => {
@@ -325,6 +343,46 @@ export namespace LegacyDB {
       changes: total,
       skipped,
       errors,
+    }
+  }
+
+  export async function archive(): Promise<Archive> {
+    const status = await LegacyDB.status()
+    const history = path.join(status.directory, "history_database")
+    await fs.mkdir(history, { recursive: true })
+    const moved: string[] = []
+    const skipped: string[] = []
+
+    const unique = async (file: string) => {
+      const ext = path.extname(file)
+      const name = path.basename(file, ext)
+      let next = path.join(history, file)
+      let i = 0
+      while (await fs.stat(next).then(() => true).catch(() => false)) {
+        i += 1
+        next = path.join(history, `${name}-${Date.now()}-${i}${ext}`)
+      }
+      return next
+    }
+
+    for (const file of status.files) {
+      const src = path.join(status.directory, file.name)
+      const dst = await unique(file.name)
+      try {
+        await fs.rename(src, dst)
+        moved.push(dst)
+      } catch {
+        skipped.push(src)
+      }
+    }
+
+    const rest = (await scan()).filter((item) => item.name.toLowerCase() !== target_file).map((item) => item.path)
+    return {
+      history,
+      moved,
+      skipped,
+      remaining: rest,
+      clean: rest.length === 0,
     }
   }
 }

--- a/packages/opencode/src/storage/legacy-db.ts
+++ b/packages/opencode/src/storage/legacy-db.ts
@@ -8,6 +8,7 @@ import { Log } from "@/util/log"
 const log = Log.create({ service: "legacy-db" })
 
 const target_file = "opencode-prod.db"
+const pref_file = "legacy-db.json"
 const time_cols = ["time_updated", "updated_at", "updated", "time_created", "created_at", "created"] as const
 const low = "-9223372036854775808"
 
@@ -21,6 +22,10 @@ function lit(text: string) {
 
 function dbPath(name: string) {
   return path.join(Global.Path.data, name)
+}
+
+function prefPath() {
+  return path.join(Global.Path.state, pref_file)
 }
 
 function channel(name: string) {
@@ -136,10 +141,15 @@ export namespace LegacyDB {
     target: z.string(),
     has_legacy: z.boolean(),
     message: z.string(),
+    dismissed: z.boolean(),
     legacy_count: z.number(),
     files: File.array(),
     naming: z.record(z.string(), z.number()),
     versions: z.record(z.string(), z.number()),
+  })
+
+  export const Preference = z.object({
+    dismissed: z.boolean(),
   })
 
   export const Merge = z.object({
@@ -153,6 +163,27 @@ export namespace LegacyDB {
 
   export type Status = z.infer<typeof Status>
   export type Merge = z.infer<typeof Merge>
+  export type Preference = z.infer<typeof Preference>
+
+  export async function preference(): Promise<Preference> {
+    const raw = await fs.readFile(prefPath(), "utf-8").catch(() => "")
+    if (!raw) return { dismissed: false }
+    let json: unknown
+    try {
+      json = JSON.parse(raw)
+    } catch {
+      return { dismissed: false }
+    }
+    const next = Preference.safeParse(json)
+    if (!next.success) return { dismissed: false }
+    return next.data
+  }
+
+  export async function setPreference(input: Preference) {
+    const pref = Preference.parse(input)
+    await fs.writeFile(prefPath(), JSON.stringify(pref, null, 2), "utf-8")
+    return pref
+  }
 
   export function targetPath() {
     return dbPath(target_file)
@@ -189,11 +220,14 @@ export namespace LegacyDB {
       return acc
     }, {})
 
+    const pref = await preference()
+
     return {
       directory: dir,
       target: targetPath(),
       has_legacy: old.length > 0,
       message: old.length > 0 ? "发现旧库" : "未发现旧库",
+      dismissed: pref.dismissed,
       legacy_count: old.length,
       files: old.sort((a, b) => a.name.localeCompare(b.name)),
       naming,

--- a/packages/opencode/test/automation/legacy-repair.test.ts
+++ b/packages/opencode/test/automation/legacy-repair.test.ts
@@ -6,6 +6,7 @@ const status = {
   target: "/tmp/opencode/opencode-prod.db",
   has_legacy: true,
   message: "发现旧库",
+  dismissed: false,
   legacy_count: 1,
   files: [
     {

--- a/packages/opencode/test/automation/legacy-repair.test.ts
+++ b/packages/opencode/test/automation/legacy-repair.test.ts
@@ -3,7 +3,7 @@ import { LegacyRepair } from "../../src/automation/legacy-repair"
 
 const status = {
   directory: "/tmp/opencode",
-  target: "/tmp/opencode/opencode-prod.db",
+  target: "/tmp/opencode/aether-prod.db",
   has_legacy: true,
   message: "发现旧库",
   dismissed: false,
@@ -27,11 +27,6 @@ describe("LegacyRepair.decide", () => {
       force: false,
       status,
       merge: {
-        target: status.target,
-        merged: [],
-        tables: 0,
-        changes: 0,
-        skipped: [],
         errors: ["bad db"],
       },
     })
@@ -45,11 +40,6 @@ describe("LegacyRepair.decide", () => {
       force: false,
       status,
       merge: {
-        target: status.target,
-        merged: [],
-        tables: 0,
-        changes: 0,
-        skipped: [],
         errors: ["bad db"],
       },
     })

--- a/packages/opencode/test/automation/legacy-repair.test.ts
+++ b/packages/opencode/test/automation/legacy-repair.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test"
+import { LegacyRepair } from "../../src/automation/legacy-repair"
+
+const status = {
+  directory: "/tmp/opencode",
+  target: "/tmp/opencode/opencode-prod.db",
+  has_legacy: true,
+  message: "发现旧库",
+  legacy_count: 1,
+  files: [
+    {
+      name: "opencode-dev.db",
+      path: "/tmp/opencode/opencode-dev.db",
+      channel: "dev",
+      mtime: 1,
+    },
+  ],
+  naming: { dev: 1 },
+  versions: { "0.1.0": 2 },
+}
+
+describe("LegacyRepair.decide", () => {
+  test("auto mode runs fallback when merge has errors", () => {
+    const next = LegacyRepair.decide({
+      mode: "auto",
+      force: false,
+      status,
+      merge: {
+        target: status.target,
+        merged: [],
+        tables: 0,
+        changes: 0,
+        skipped: [],
+        errors: ["bad db"],
+      },
+    })
+    expect(next.run).toBeTrue()
+    expect(next.reason).toBe("merge-errors")
+  })
+
+  test("controlled-only mode skips fallback", () => {
+    const next = LegacyRepair.decide({
+      mode: "controlled-only",
+      force: false,
+      status,
+      merge: {
+        target: status.target,
+        merged: [],
+        tables: 0,
+        changes: 0,
+        skipped: [],
+        errors: ["bad db"],
+      },
+    })
+    expect(next.run).toBeFalse()
+    expect(next.reason).toBe("mode=controlled-only")
+  })
+})

--- a/packages/opencode/test/storage/legacy-db.test.ts
+++ b/packages/opencode/test/storage/legacy-db.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Database as Sqlite } from "bun:sqlite"
+import { Global } from "../../src/global"
+import { LegacyDB } from "../../src/storage/legacy-db"
+
+async function clean() {
+  const rows = await fs.readdir(Global.Path.data, { withFileTypes: true }).catch(() => [])
+  await Promise.all(
+    rows
+      .filter((row) => row.isFile() && /^opencode.*\.db$/i.test(row.name))
+      .map((row) => fs.rm(path.join(Global.Path.data, row.name), { force: true })),
+  )
+}
+
+function create(file: string, rows: { id: string; title: string; version: string; time: number }[]) {
+  const db = new Sqlite(file)
+  db.exec(
+    "create table if not exists session (id text primary key, version text, title text, time_updated integer not null)",
+  )
+  const stmt = db.prepare("insert into session (id, version, title, time_updated) values (?, ?, ?, ?)")
+  for (const row of rows) stmt.run(row.id, row.version, row.title, row.time)
+  db.close()
+}
+
+describe("LegacyDB", () => {
+  beforeEach(async () => {
+    await clean()
+  })
+
+  test("reports legacy database stats", async () => {
+    create(path.join(Global.Path.data, "opencode-dev.db"), [
+      { id: "a", title: "dev", version: "0.1.0", time: 100 },
+    ])
+    create(path.join(Global.Path.data, "opencode-local.db"), [
+      { id: "b", title: "local", version: "0.2.0", time: 120 },
+    ])
+
+    const info = await LegacyDB.status()
+    expect(info.has_legacy).toBeTrue()
+    expect(info.legacy_count).toBe(2)
+    expect(info.naming["dev"]).toBe(1)
+    expect(info.naming["local"]).toBe(1)
+    expect(info.versions["0.1.0"]).toBe(1)
+    expect(info.versions["0.2.0"]).toBe(1)
+  })
+
+  test("merges into opencode-prod.db with latest_wins", async () => {
+    create(path.join(Global.Path.data, "opencode-dev.db"), [
+      { id: "s1", title: "old", version: "0.1.0", time: 100 },
+      { id: "s2", title: "keep", version: "0.1.0", time: 100 },
+    ])
+    create(path.join(Global.Path.data, "opencode-local.db"), [
+      { id: "s1", title: "new", version: "0.2.0", time: 200 },
+    ])
+
+    const report = await LegacyDB.merge()
+    expect(report.errors.length).toBe(0)
+    expect(report.merged.length).toBe(2)
+
+    const db = new Sqlite(LegacyDB.targetPath(), { readonly: true })
+    const row = db.query("select id, title, time_updated from session where id='s1'").get() as {
+      id: string
+      title: string
+      time_updated: number
+    }
+    const row2 = db.query("select id, title from session where id='s2'").get() as {
+      id: string
+      title: string
+    }
+    db.close()
+
+    expect(row.id).toBe("s1")
+    expect(row.title).toBe("new")
+    expect(row.time_updated).toBe(200)
+    expect(row2.title).toBe("keep")
+
+    const oldA = await fs.stat(path.join(Global.Path.data, "opencode-dev.db")).catch(() => undefined)
+    const oldB = await fs.stat(path.join(Global.Path.data, "opencode-local.db")).catch(() => undefined)
+    expect(!!oldA).toBeTrue()
+    expect(!!oldB).toBeTrue()
+  })
+})

--- a/packages/opencode/test/storage/legacy-db.test.ts
+++ b/packages/opencode/test/storage/legacy-db.test.ts
@@ -46,47 +46,11 @@ describe("LegacyDB", () => {
     expect(info.versions["0.2.0"]).toBe(1)
   })
 
-  test("merges into aether-prod.db with latest_wins", async () => {
-    create(path.join(Global.Path.data, "opencode-dev.db"), [
-      { id: "s1", title: "old", version: "0.1.0", time: 100 },
-      { id: "s2", title: "keep", version: "0.1.0", time: 100 },
-    ])
-    create(path.join(Global.Path.data, "opencode-local.db"), [
-      { id: "s1", title: "new", version: "0.2.0", time: 200 },
-    ])
-
-    const report = await LegacyDB.merge()
-    expect(report.errors.length).toBe(0)
-    expect(report.merged.length).toBe(2)
-
-    const db = new Sqlite(LegacyDB.targetPath(), { readonly: true })
-    const row = db.query("select id, title, time_updated from session where id='s1'").get() as {
-      id: string
-      title: string
-      time_updated: number
-    }
-    const row2 = db.query("select id, title from session where id='s2'").get() as {
-      id: string
-      title: string
-    }
-    db.close()
-
-    expect(row.id).toBe("s1")
-    expect(row.title).toBe("new")
-    expect(row.time_updated).toBe(200)
-    expect(row2.title).toBe("keep")
-
-    const oldA = await fs.stat(path.join(Global.Path.data, "opencode-dev.db")).catch(() => undefined)
-    const oldB = await fs.stat(path.join(Global.Path.data, "opencode-local.db")).catch(() => undefined)
-    expect(!!oldA).toBeTrue()
-    expect(!!oldB).toBeTrue()
-  })
-
   test("archives legacy db files after merge", async () => {
     create(path.join(Global.Path.data, "opencode-dev.db"), [{ id: "x", title: "dev", version: "0.1.0", time: 1 }])
     create(path.join(Global.Path.data, "opencode-local.db"), [{ id: "y", title: "local", version: "0.2.0", time: 2 }])
 
-    await LegacyDB.merge()
+    await LegacyDB.ensureTarget()
     const arc = await LegacyDB.archive()
     expect(arc.clean).toBeTrue()
     expect(arc.moved.length).toBe(2)

--- a/packages/opencode/test/storage/legacy-db.test.ts
+++ b/packages/opencode/test/storage/legacy-db.test.ts
@@ -9,7 +9,7 @@ async function clean() {
   const rows = await fs.readdir(Global.Path.data, { withFileTypes: true }).catch(() => [])
   await Promise.all(
     rows
-      .filter((row) => row.isFile() && /^opencode.*\.db$/i.test(row.name))
+      .filter((row) => row.isFile() && /^(opencode|aether).*\.db$/i.test(row.name))
       .map((row) => fs.rm(path.join(Global.Path.data, row.name), { force: true })),
   )
 }
@@ -46,7 +46,7 @@ describe("LegacyDB", () => {
     expect(info.versions["0.2.0"]).toBe(1)
   })
 
-  test("merges into opencode-prod.db with latest_wins", async () => {
+  test("merges into aether-prod.db with latest_wins", async () => {
     create(path.join(Global.Path.data, "opencode-dev.db"), [
       { id: "s1", title: "old", version: "0.1.0", time: 100 },
       { id: "s2", title: "keep", version: "0.1.0", time: 100 },
@@ -80,5 +80,20 @@ describe("LegacyDB", () => {
     const oldB = await fs.stat(path.join(Global.Path.data, "opencode-local.db")).catch(() => undefined)
     expect(!!oldA).toBeTrue()
     expect(!!oldB).toBeTrue()
+  })
+
+  test("archives legacy db files after merge", async () => {
+    create(path.join(Global.Path.data, "opencode-dev.db"), [{ id: "x", title: "dev", version: "0.1.0", time: 1 }])
+    create(path.join(Global.Path.data, "opencode-local.db"), [{ id: "y", title: "local", version: "0.2.0", time: 2 }])
+
+    await LegacyDB.merge()
+    const arc = await LegacyDB.archive()
+    expect(arc.clean).toBeTrue()
+    expect(arc.moved.length).toBe(2)
+
+    const left = await fs.readdir(Global.Path.data)
+    const dbs = left.filter((item) => item.endsWith(".db"))
+    expect(dbs.includes("aether-prod.db")).toBeTrue()
+    expect(dbs.length).toBe(1)
   })
 })


### PR DESCRIPTION
## Summary
- implement legacy database detection and migration guard for web startup: scan legacy `.db` files, show merge prompt in UI, and report naming/version distributions for mixed historical channels
- add agent-driven merge workflow that auto-opens the database directory as project context, creates a session, and sends merge instructions targeting `aether-prod.db` with `latest_wins` conflict policy guidance
- add fixed post-merge archive flow to move legacy databases into `history_database`, verify cleanup status, and surface archive completion/failure notifications to users
- add user prompt preference controls (`下一次提醒我` and persistent `不再询问`) with backend preference persistence and status APIs

## Included Work (Previous + Current)
- previous iteration: foundational legacy-db status/merge route scaffolding, auto session task helper, fallback orchestration, startup detection, and initial UI prompt integration
- current iteration: switch target database naming to `aether-prod.db`, finalize agent-first merge orchestration, asynchronous archive state tracking API, and final UX wording/interaction refinements

## Validation
- `bun test test/storage/legacy-db.test.ts test/automation/legacy-repair.test.ts` (packages/opencode)
- `bun typecheck` (packages/opencode)
- `bun ../../node_modules/@typescript/native-preview/bin/tsgo.js -b` (packages/app)

Closes #144