### PR TITLE
refactor: simplify directory dialog and improve list filter UX

### DIFF
--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -365,9 +365,19 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
 
   const items = async (value: string) => {
     const recentRows = recentProjects() // sync before await — tracks expanded() via memo
+
+    const raw = normalizeDriveRoot(cleanInput(value))
+    const isAbs = raw && rootOf(raw)
+    const filteredRecent = isAbs
+      ? recentRows.filter((row) => {
+          if (row.isExpander || row.isCollapser) return true
+          return row.absolute.toLowerCase().startsWith(trimTrailing(raw).toLowerCase())
+        })
+      : recentRows
+
     const results = await directories(value)
     const directoryRows = results.map((absolute) => toRow(absolute, home(), "folders"))
-    const rows = uniqueRows([...recentRows, ...directoryRows])
+    const rows = uniqueRows([...filteredRecent, ...directoryRows])
 
     if (value) {
       const resolved = resolveNewPath(value, home(), start() ?? "")
@@ -439,8 +449,8 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
         }}
         groupHeader={(group) => {
           if (group.category === "create") return language.t("dialog.newProject.createGroup")
-          if (group.category === "recent") return language.t("home.recentProjects")
-          return language.t("command.project.open")
+          if (group.category === "recent") return language.t("dialog.directory.existingProjects")
+          return language.t("dialog.newProject.title")
         }}
         ref={(r) => (list = r)}
         onFilter={(value) => {

--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -25,10 +25,9 @@ interface DialogSelectDirectoryProps {
 type Row = {
   absolute: string
   search: string
-  group: "recent" | "folders" | "create"
+  group: "recent" | "folders"
   isExpander?: true
   isCollapser?: true
-  isCreate?: true
   expanderCount?: number
 }
 
@@ -134,23 +133,6 @@ function uniqueRows(rows: Row[]) {
     seen.add(row.absolute)
     return true
   })
-}
-
-function resolveNewPath(value: string, home: string, start: string) {
-  const raw = normalizeDriveRoot(value.trim())
-  if (!raw) return undefined
-  let absolute: string
-  if (raw === "~" || raw.startsWith("~/")) {
-    absolute = trimTrailing(raw === "~" ? home : joinPath(home, raw.slice(2)))
-  } else if (rootOf(raw)) {
-    absolute = trimTrailing(raw)
-  } else {
-    absolute = trimTrailing(joinPath(start, raw))
-  }
-  const name = getFilename(absolute)
-  if (!name) return undefined
-  const parent = parentOf(absolute)
-  return { parent, name, full: absolute }
 }
 
 function useDirectorySearch(args: {
@@ -288,10 +270,8 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
   const layout = useLayout()
 
   const [filter, setFilter] = createSignal("")
-  const [selectedPath, setSelectedPath] = createSignal<string | null>(null)
   const [browsing, setBrowsing] = createSignal(false)
   const [expanded, setExpanded] = createSignal(false)
-  const [creating, setCreating] = createSignal(false)
   let list: ListRef | undefined
 
   const missingBase = createMemo(() => !(sync.data.path.home || sync.data.path.directory))
@@ -323,7 +303,6 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
     const value = cleanInput(props.initial ?? "")
     if (!value) return
     list?.setFilter(value)
-    setSelectedPath(trimTrailing(normalizeDriveRoot(value)))
   })
   const recentProjects = createMemo(() => {
     const isExpanded = expanded()
@@ -377,15 +356,7 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
 
     const results = await directories(value)
     const directoryRows = results.map((absolute) => toRow(absolute, home(), "folders"))
-    const rows = uniqueRows([...filteredRecent, ...directoryRows])
-
-    if (value) {
-      const resolved = resolveNewPath(value, home(), start() ?? "")
-      if (resolved && !rows.find((r) => r.absolute === resolved.full)) {
-        return [{ absolute: resolved.full, search: value, group: "create" as const, isCreate: true as const }, ...rows]
-      }
-    }
-    return rows
+    return uniqueRows([...filteredRecent, ...directoryRows])
   }
 
   function resolve(absolute: string) {
@@ -401,21 +372,32 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
     list?.setFilter(parent ?? "")
   }
 
+  function openOrCreate() {
+    const raw = normalizeDriveRoot(cleanInput(filter()))
+    if (!raw) return
+    let absolute: string
+    if (raw === "~" || raw.startsWith("~/")) {
+      absolute = trimTrailing(raw === "~" ? home() : joinPath(home(), raw.slice(2)))
+    } else if (rootOf(raw)) {
+      absolute = trimTrailing(raw)
+    } else {
+      absolute = trimTrailing(joinPath(start() ?? "", raw))
+    }
+    resolve(absolute)
+  }
+
   return (
     <Dialog title={props.title ?? language.t("command.project.open")} persistent={props.persistent}>
       <List
         search={{
           placeholder: language.t("dialog.directory.search.placeholder"),
           autofocus: true,
-          action: (
+          prefix: (
             <div class="flex items-center gap-1">
-              <Show when={filter()}>
-                <Button icon="arrow-left" size="small" variant="ghost" onClick={goUp} />
-              </Show>
               <Button
                 icon="folder"
                 size="small"
-                variant="secondary"
+                variant="ghost"
                 disabled={browsing()}
                 onClick={async () => {
                   if (browsing()) return
@@ -423,32 +405,36 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
                   try {
                     const result = await sdk.client.file.pickFolder()
                     const path = picked(result.data, showToast, language.t("common.requestFailed"))
-                    if (path) {
-                      list?.setFilter(path)
-                      setSelectedPath(path)
-                    }
+                    if (path) list?.setFilter(path)
                   } finally {
                     setBrowsing(false)
                   }
                 }}
               >
-                {language.t("dialog.newProject.browse")}
+                {language.t("dialog.directory.browse")}
               </Button>
+              <Show when={filter()}>
+                <Button icon="arrow-up" size="small" variant="ghost" onClick={goUp} />
+              </Show>
             </div>
+          ),
+          action: (
+            <Button size="small" variant="secondary" disabled={!filter()} onClick={openOrCreate}>
+              {language.t("dialog.directory.confirm")}
+            </Button>
           ),
         }}
         emptyMessage={language.t("dialog.directory.empty")}
         loadingMessage={language.t("common.loading")}
         items={items}
-        key={(x) => (x.isCreate ? "__create__" : x.absolute)}
+        key={(x) => x.absolute}
         filterKeys={["search"]}
         groupBy={(item) => item.group}
         sortGroupsBy={(a, b) => {
-          const order = { create: 0, recent: 1, folders: 2 }
-          return (order[a.category as keyof typeof order] ?? 3) - (order[b.category as keyof typeof order] ?? 3)
+          const order = { recent: 0, folders: 1 }
+          return (order[a.category as keyof typeof order] ?? 2) - (order[b.category as keyof typeof order] ?? 2)
         }}
         groupHeader={(group) => {
-          if (group.category === "create") return language.t("dialog.newProject.createGroup")
           if (group.category === "recent") return language.t("dialog.directory.existingProjects")
           return language.t("dialog.newProject.title")
         }}
@@ -461,7 +447,7 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
         onKeyEvent={(e, item) => {
           if (e.key !== "Tab") return
           if (e.shiftKey) return
-          if (!item || item.isExpander || item.isCollapser || item.isCreate) return
+          if (!item || item.isExpander || item.isCollapser) return
 
           e.preventDefault()
           e.stopPropagation()
@@ -479,42 +465,11 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
             setExpanded(false)
             return
           }
-          if (path.isCreate) {
-            if (creating()) return
-            const resolved = resolveNewPath(filter(), home(), start() ?? "")
-            if (!resolved) return
-            setCreating(true)
-            sdk.client.file
-              .create({ directory: resolved.parent, path: resolved.name, type: "directory" })
-              .then(() => resolve(resolved.full))
-              .catch(() => {})
-              .finally(() => setCreating(false))
-            return
-          }
-          // Navigate into the clicked directory (same as Tab key)
           const value = displayPath(path.absolute, filter(), home())
           list?.setFilter(value.endsWith("/") ? value : value + "/")
-          setSelectedPath(path.absolute)
         }}
       >
         {(item) => {
-          if (item.isCreate) {
-            const resolved = createMemo(() => resolveNewPath(filter(), home(), start() ?? ""))
-            const display = createMemo(() => {
-              const r = resolved()
-              if (!r) return ""
-              return `${tildeOf(r.parent, home()) || r.parent}/${r.name}`
-            })
-            return (
-              <div class="w-full flex items-center gap-x-3 rounded-md">
-                <FileIcon node={{ path: item.absolute, type: "directory" }} class="shrink-0 size-4" />
-                <div class="flex items-center gap-2 text-14-regular min-w-0 grow">
-                  <span class="text-text-strong whitespace-nowrap">{language.t("dialog.newProject.createFolder")}</span>
-                  <span class="text-text-weak font-mono truncate min-w-0">{display()}</span>
-                </div>
-              </div>
-            )
-          }
           if (item.isExpander) {
             return (
               <div class="w-full flex items-center gap-x-3 text-14-regular text-text-weak">
@@ -557,16 +512,6 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
           )
         }}
       </List>
-      <Show when={selectedPath()}>
-        <div class="flex items-center justify-between gap-3 px-4 py-3 border-t border-border-base">
-          <span class="text-12-mono text-text-weak truncate flex-1">
-            {displayPath(selectedPath()!, filter(), home())}
-          </span>
-          <Button size="small" onClick={() => resolve(selectedPath()!)}>
-            {language.t("dialog.directory.select")}
-          </Button>
-        </div>
-      </Show>
     </Dialog>
   )
 }

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -280,6 +280,7 @@ export const dict = {
   "dialog.fork.empty": "لا توجد رسائل للتفرع منها",
   "dialog.directory.search.placeholder": "البحث في المجلدات",
   "dialog.directory.empty": "لم يتم العثور على مجلدات",
+  "dialog.directory.existingProjects": "المشاريع الموجودة",
   "dialog.server.title": "الخوادم",
   "dialog.server.description": "تبديل خادم OpenCode الذي يتصل به هذا التطبيق.",
   "dialog.server.search.placeholder": "البحث في الخوادم",

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -281,6 +281,8 @@ export const dict = {
   "dialog.directory.search.placeholder": "البحث في المجلدات",
   "dialog.directory.empty": "لم يتم العثور على مجلدات",
   "dialog.directory.existingProjects": "المشاريع الموجودة",
+  "dialog.directory.browse": "استعراض",
+  "dialog.directory.confirm": "تأكيد",
   "dialog.server.title": "الخوادم",
   "dialog.server.description": "تبديل خادم OpenCode الذي يتصل به هذا التطبيق.",
   "dialog.server.search.placeholder": "البحث في الخوادم",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -281,6 +281,8 @@ export const dict = {
   "dialog.directory.search.placeholder": "Buscar pastas",
   "dialog.directory.empty": "Nenhuma pasta encontrada",
   "dialog.directory.existingProjects": "Projetos existentes",
+  "dialog.directory.browse": "Procurar",
+  "dialog.directory.confirm": "Confirmar",
   "dialog.server.title": "Servidores",
   "dialog.server.description": "Trocar para qual servidor OpenCode este aplicativo se conecta.",
   "dialog.server.search.placeholder": "Buscar servidores",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -280,6 +280,7 @@ export const dict = {
   "dialog.fork.empty": "Nenhuma mensagem para bifurcar",
   "dialog.directory.search.placeholder": "Buscar pastas",
   "dialog.directory.empty": "Nenhuma pasta encontrada",
+  "dialog.directory.existingProjects": "Projetos existentes",
   "dialog.server.title": "Servidores",
   "dialog.server.description": "Trocar para qual servidor OpenCode este aplicativo se conecta.",
   "dialog.server.search.placeholder": "Buscar servidores",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -307,6 +307,8 @@ export const dict = {
   "dialog.directory.search.placeholder": "Pretraži foldere",
   "dialog.directory.empty": "Nema pronađenih foldera",
   "dialog.directory.existingProjects": "Postojeći projekti",
+  "dialog.directory.browse": "Pregledaj",
+  "dialog.directory.confirm": "Potvrdi",
 
   "dialog.server.title": "Serveri",
   "dialog.server.description": "Promijeni na koji se OpenCode server ova aplikacija povezuje.",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -306,6 +306,7 @@ export const dict = {
 
   "dialog.directory.search.placeholder": "Pretraži foldere",
   "dialog.directory.empty": "Nema pronađenih foldera",
+  "dialog.directory.existingProjects": "Postojeći projekti",
 
   "dialog.server.title": "Serveri",
   "dialog.server.description": "Promijeni na koji se OpenCode server ova aplikacija povezuje.",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -305,6 +305,8 @@ export const dict = {
   "dialog.directory.search.placeholder": "Søg mapper",
   "dialog.directory.empty": "Ingen mapper fundet",
   "dialog.directory.existingProjects": "Eksisterende projekter",
+  "dialog.directory.browse": "Gennemse",
+  "dialog.directory.confirm": "Bekræft",
 
   "dialog.server.title": "Servere",
   "dialog.server.description": "Skift hvilken OpenCode-server denne app forbinder til.",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -304,6 +304,7 @@ export const dict = {
 
   "dialog.directory.search.placeholder": "Søg mapper",
   "dialog.directory.empty": "Ingen mapper fundet",
+  "dialog.directory.existingProjects": "Eksisterende projekter",
 
   "dialog.server.title": "Servere",
   "dialog.server.description": "Skift hvilken OpenCode-server denne app forbinder til.",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -286,6 +286,8 @@ export const dict = {
   "dialog.directory.search.placeholder": "Ordner durchsuchen",
   "dialog.directory.empty": "Keine Ordner gefunden",
   "dialog.directory.existingProjects": "Bestehende Projekte",
+  "dialog.directory.browse": "Durchsuchen",
+  "dialog.directory.confirm": "Bestätigen",
   "dialog.server.title": "Server",
   "dialog.server.description": "Wechseln Sie den OpenCode-Server, mit dem sich diese App verbindet.",
   "dialog.server.search.placeholder": "Server durchsuchen",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -285,6 +285,7 @@ export const dict = {
   "dialog.fork.empty": "Keine Nachrichten zum Abzweigen vorhanden",
   "dialog.directory.search.placeholder": "Ordner durchsuchen",
   "dialog.directory.empty": "Keine Ordner gefunden",
+  "dialog.directory.existingProjects": "Bestehende Projekte",
   "dialog.server.title": "Server",
   "dialog.server.description": "Wechseln Sie den OpenCode-Server, mit dem sich diese App verbindet.",
   "dialog.server.search.placeholder": "Server durchsuchen",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -319,6 +319,7 @@ export const dict = {
   "dialog.directory.search.placeholder": "Search folders",
   "dialog.directory.empty": "No folders found",
   "dialog.directory.select": "Select folder",
+  "dialog.directory.existingProjects": "Existing projects",
 
   "app.server.unreachable": "Could not reach {{server}}",
   "app.server.retrying": "Retrying automatically...",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -320,6 +320,8 @@ export const dict = {
   "dialog.directory.empty": "No folders found",
   "dialog.directory.select": "Select folder",
   "dialog.directory.existingProjects": "Existing projects",
+  "dialog.directory.browse": "Browse",
+  "dialog.directory.confirm": "Confirm",
 
   "app.server.unreachable": "Could not reach {{server}}",
   "app.server.retrying": "Retrying automatically...",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -305,6 +305,7 @@ export const dict = {
 
   "dialog.directory.search.placeholder": "Buscar carpetas",
   "dialog.directory.empty": "No se encontraron carpetas",
+  "dialog.directory.existingProjects": "Proyectos existentes",
 
   "dialog.server.title": "Servidores",
   "dialog.server.description": "Cambiar a qué servidor de OpenCode se conecta esta app.",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -306,6 +306,8 @@ export const dict = {
   "dialog.directory.search.placeholder": "Buscar carpetas",
   "dialog.directory.empty": "No se encontraron carpetas",
   "dialog.directory.existingProjects": "Proyectos existentes",
+  "dialog.directory.browse": "Examinar",
+  "dialog.directory.confirm": "Confirmar",
 
   "dialog.server.title": "Servidores",
   "dialog.server.description": "Cambiar a qué servidor de OpenCode se conecta esta app.",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -281,6 +281,7 @@ export const dict = {
   "dialog.fork.empty": "Aucun message à partir duquel bifurquer",
   "dialog.directory.search.placeholder": "Rechercher des dossiers",
   "dialog.directory.empty": "Aucun dossier trouvé",
+  "dialog.directory.existingProjects": "Projets existants",
   "dialog.server.title": "Serveurs",
   "dialog.server.description": "Changez le serveur OpenCode auquel cette application se connecte.",
   "dialog.server.search.placeholder": "Rechercher des serveurs",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -282,6 +282,8 @@ export const dict = {
   "dialog.directory.search.placeholder": "Rechercher des dossiers",
   "dialog.directory.empty": "Aucun dossier trouvé",
   "dialog.directory.existingProjects": "Projets existants",
+  "dialog.directory.browse": "Parcourir",
+  "dialog.directory.confirm": "Confirmer",
   "dialog.server.title": "Serveurs",
   "dialog.server.description": "Changez le serveur OpenCode auquel cette application se connecte.",
   "dialog.server.search.placeholder": "Rechercher des serveurs",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -280,6 +280,8 @@ export const dict = {
   "dialog.directory.search.placeholder": "フォルダを検索",
   "dialog.directory.empty": "フォルダが見つかりません",
   "dialog.directory.existingProjects": "既存のプロジェクト",
+  "dialog.directory.browse": "参照",
+  "dialog.directory.confirm": "確認",
   "dialog.server.title": "サーバー",
   "dialog.server.description": "このアプリが接続するOpenCodeサーバーを切り替えます。",
   "dialog.server.search.placeholder": "サーバーを検索",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -279,6 +279,7 @@ export const dict = {
   "dialog.fork.empty": "フォーク元のメッセージがありません",
   "dialog.directory.search.placeholder": "フォルダを検索",
   "dialog.directory.empty": "フォルダが見つかりません",
+  "dialog.directory.existingProjects": "既存のプロジェクト",
   "dialog.server.title": "サーバー",
   "dialog.server.description": "このアプリが接続するOpenCodeサーバーを切り替えます。",
   "dialog.server.search.placeholder": "サーバーを検索",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -284,6 +284,8 @@ export const dict = {
   "dialog.directory.search.placeholder": "폴더 검색",
   "dialog.directory.empty": "폴더 없음",
   "dialog.directory.existingProjects": "기존 프로젝트",
+  "dialog.directory.browse": "찾아보기",
+  "dialog.directory.confirm": "확인",
   "dialog.server.title": "서버",
   "dialog.server.description": "이 앱이 연결할 OpenCode 서버를 전환합니다.",
   "dialog.server.search.placeholder": "서버 검색",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -283,6 +283,7 @@ export const dict = {
   "dialog.fork.empty": "분기할 메시지 없음",
   "dialog.directory.search.placeholder": "폴더 검색",
   "dialog.directory.empty": "폴더 없음",
+  "dialog.directory.existingProjects": "기존 프로젝트",
   "dialog.server.title": "서버",
   "dialog.server.description": "이 앱이 연결할 OpenCode 서버를 전환합니다.",
   "dialog.server.search.placeholder": "서버 검색",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -307,6 +307,7 @@ export const dict = {
 
   "dialog.directory.search.placeholder": "Søk etter mapper",
   "dialog.directory.empty": "Ingen mapper funnet",
+  "dialog.directory.existingProjects": "Eksisterende prosjekter",
 
   "dialog.server.title": "Servere",
   "dialog.server.description": "Bytt hvilken OpenCode-server denne appen kobler til.",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -308,6 +308,8 @@ export const dict = {
   "dialog.directory.search.placeholder": "Søk etter mapper",
   "dialog.directory.empty": "Ingen mapper funnet",
   "dialog.directory.existingProjects": "Eksisterende prosjekter",
+  "dialog.directory.browse": "Bla gjennom",
+  "dialog.directory.confirm": "Bekreft",
 
   "dialog.server.title": "Servere",
   "dialog.server.description": "Bytt hvilken OpenCode-server denne appen kobler til.",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -282,6 +282,8 @@ export const dict = {
   "dialog.directory.search.placeholder": "Szukaj folderów",
   "dialog.directory.empty": "Nie znaleziono folderów",
   "dialog.directory.existingProjects": "Istniejące projekty",
+  "dialog.directory.browse": "Przeglądaj",
+  "dialog.directory.confirm": "Potwierdź",
   "dialog.server.title": "Serwery",
   "dialog.server.description": "Przełącz serwer OpenCode, z którym łączy się ta aplikacja.",
   "dialog.server.search.placeholder": "Szukaj serwerów",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -281,6 +281,7 @@ export const dict = {
   "dialog.fork.empty": "Brak wiadomości do rozwidlenia",
   "dialog.directory.search.placeholder": "Szukaj folderów",
   "dialog.directory.empty": "Nie znaleziono folderów",
+  "dialog.directory.existingProjects": "Istniejące projekty",
   "dialog.server.title": "Serwery",
   "dialog.server.description": "Przełącz serwer OpenCode, z którym łączy się ta aplikacja.",
   "dialog.server.search.placeholder": "Szukaj serwerów",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -306,6 +306,8 @@ export const dict = {
   "dialog.directory.search.placeholder": "Поиск папок",
   "dialog.directory.empty": "Папки не найдены",
   "dialog.directory.existingProjects": "Существующие проекты",
+  "dialog.directory.browse": "Обзор",
+  "dialog.directory.confirm": "Подтвердить",
 
   "dialog.server.title": "Серверы",
   "dialog.server.description": "Переключите сервер OpenCode к которому подключается приложение.",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -305,6 +305,7 @@ export const dict = {
 
   "dialog.directory.search.placeholder": "Поиск папок",
   "dialog.directory.empty": "Папки не найдены",
+  "dialog.directory.existingProjects": "Существующие проекты",
 
   "dialog.server.title": "Серверы",
   "dialog.server.description": "Переключите сервер OpenCode к которому подключается приложение.",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -305,6 +305,7 @@ export const dict = {
 
   "dialog.directory.search.placeholder": "ค้นหาโฟลเดอร์",
   "dialog.directory.empty": "ไม่พบโฟลเดอร์",
+  "dialog.directory.existingProjects": "โปรเจกต์ที่มีอยู่",
 
   "dialog.server.title": "เซิร์ฟเวอร์",
   "dialog.server.description": "สลับเซิร์ฟเวอร์ OpenCode ที่แอปนี้เชื่อมต่อด้วย",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -306,6 +306,8 @@ export const dict = {
   "dialog.directory.search.placeholder": "ค้นหาโฟลเดอร์",
   "dialog.directory.empty": "ไม่พบโฟลเดอร์",
   "dialog.directory.existingProjects": "โปรเจกต์ที่มีอยู่",
+  "dialog.directory.browse": "เรียกดู",
+  "dialog.directory.confirm": "ยืนยัน",
 
   "dialog.server.title": "เซิร์ฟเวอร์",
   "dialog.server.description": "สลับเซิร์ฟเวอร์ OpenCode ที่แอปนี้เชื่อมต่อด้วย",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -309,6 +309,7 @@ export const dict = {
 
   "dialog.directory.search.placeholder": "Klasör ara",
   "dialog.directory.empty": "Klasör bulunamadı",
+  "dialog.directory.existingProjects": "Mevcut projeler",
 
   "dialog.server.title": "Sunucular",
   "dialog.server.description": "Bu uygulamanın hangi OpenCode sunucusuna bağlanacağını değiştirin.",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -310,6 +310,8 @@ export const dict = {
   "dialog.directory.search.placeholder": "Klasör ara",
   "dialog.directory.empty": "Klasör bulunamadı",
   "dialog.directory.existingProjects": "Mevcut projeler",
+  "dialog.directory.browse": "Gözat",
+  "dialog.directory.confirm": "Onayla",
 
   "dialog.server.title": "Sunucular",
   "dialog.server.description": "Bu uygulamanın hangi OpenCode sunucusuna bağlanacağını değiştirin.",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -336,6 +336,8 @@ export const dict = {
   "dialog.directory.empty": "未找到文件夹",
   "dialog.directory.select": "选择文件夹",
   "dialog.directory.existingProjects": "已有项目",
+  "dialog.directory.browse": "浏览",
+  "dialog.directory.confirm": "确认",
 
   "dialog.server.title": "服务器",
   "dialog.server.description": "切换此应用连接的 OpenCode 服务器。",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -335,6 +335,7 @@ export const dict = {
   "dialog.directory.search.placeholder": "搜索文件夹",
   "dialog.directory.empty": "未找到文件夹",
   "dialog.directory.select": "选择文件夹",
+  "dialog.directory.existingProjects": "已有项目",
 
   "dialog.server.title": "服务器",
   "dialog.server.description": "切换此应用连接的 OpenCode 服务器。",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -304,6 +304,7 @@ export const dict = {
 
   "dialog.directory.search.placeholder": "搜尋資料夾",
   "dialog.directory.empty": "找不到資料夾",
+  "dialog.directory.existingProjects": "已有專案",
 
   "dialog.server.title": "伺服器",
   "dialog.server.description": "切換此應用程式連線的 OpenCode 伺服器。",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -305,6 +305,8 @@ export const dict = {
   "dialog.directory.search.placeholder": "搜尋資料夾",
   "dialog.directory.empty": "找不到資料夾",
   "dialog.directory.existingProjects": "已有專案",
+  "dialog.directory.browse": "瀏覽",
+  "dialog.directory.confirm": "確認",
 
   "dialog.server.title": "伺服器",
   "dialog.server.description": "切換此應用程式連線的 OpenCode 伺服器。",

--- a/packages/ui/src/components/list.tsx
+++ b/packages/ui/src/components/list.tsx
@@ -18,6 +18,7 @@ export interface ListSearchProps {
   autofocus?: boolean
   hideIcon?: boolean
   class?: string
+  prefix?: JSX.Element
   action?: JSX.Element
 }
 
@@ -89,6 +90,7 @@ export function List<T>(props: ListProps<T> & { ref?: (ref: ListRef) => void }) 
   const { filter, grouped, flat, active, setActive, onKeyDown, onInput, refetch } = useFilteredList<T>(props)
 
   const searchProps = () => (typeof props.search === "object" ? props.search : {})
+  const searchPrefix = () => searchProps().prefix
   const searchAction = () => searchProps().action
   const addProps = () => props.add
   const showAdd = () => !!addProps()
@@ -263,6 +265,7 @@ export function List<T>(props: ListProps<T> & { ref?: (ref: ListRef) => void }) 
     <div data-component="list" classList={{ [props.class ?? ""]: !!props.class }}>
       <Show when={!!props.search}>
         <div data-slot="list-search-wrapper">
+          {searchPrefix()}
           <div
             data-slot="list-search"
             classList={{ [searchProps().class ?? ""]: !!searchProps().class }}

--- a/packages/ui/src/components/list.tsx
+++ b/packages/ui/src/components/list.tsx
@@ -308,7 +308,7 @@ export function List<T>(props: ListProps<T> & { ref?: (ref: ListRef) => void }) 
                 icon="circle-x"
                 variant="ghost"
                 onClick={() => {
-                  setInternalFilter("")
+                  applyFilter("")
                   queueMicrotask(() => inputRef?.focus())
                 }}
                 aria-label={i18n.t("ui.list.clearFilter")}


### PR DESCRIPTION
## Summary

Closes #191

- Remove inline create folder flow from directory dialog, replace with a "Confirm" button in the search bar
- Filter recent projects by typed absolute path prefix
- Fix list clear filter to use `applyFilter` instead of `setInternalFilter`
- Add dedicated i18n keys (`existingProjects`, `browse`, `confirm`) for directory dialog
- Add `prefix` slot to `List` component for placing buttons before the search input

## Changes

| Commit | Description |
|--------|-------------|
| `64cf5a325` | Filter recent projects by path prefix and update group header labels |
| `b6d694267` | Remove inline create flow and add confirm button with browse/prefix layout |
| `8fa70044c` | Fix list clear filter to use `applyFilter` |