### PR TITLE
fix: harden legacy database migration flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ Aether-wechat-bridge/.venv/
 __pycache__/
 *.pyc
 */__pycache__/
+.opencode/skills/aether-issue-pr

--- a/packages/app/src/components/legacy-db-guard.tsx
+++ b/packages/app/src/components/legacy-db-guard.tsx
@@ -134,6 +134,8 @@ export function LegacyDBGuard() {
 
       showToast({
         persistent: true,
+        placement: "top-center",
+        guarded: true,
         icon: "download",
         title: "侦测到旧版本的对话记录",
         description: "是否全部合并到新版本的对话中?",
@@ -174,6 +176,8 @@ export function LegacyDBGuard() {
             onClick: () => {
               showToast({
                 persistent: true,
+                placement: "top-center",
+                guarded: true,
                 icon: "download",
                 title: "侦测到旧版本的对话记录",
                 description: "已取消，是否下次开启Aether时执行对话记录合并。",

--- a/packages/app/src/components/legacy-db-guard.tsx
+++ b/packages/app/src/components/legacy-db-guard.tsx
@@ -7,36 +7,29 @@ import { showToast } from "@opencode-ai/ui/toast"
 
 type Status = {
   directory: string
-  has_legacy: boolean
-  message: string
-  dismissed: boolean
-  legacy_count: number
+  should_merge: boolean
+  source_count: number
 }
 
 type Merge = {
+  mode: "noop" | "copy" | "agent"
   sessionID?: string
 }
 
 type ArchiveState = {
   state: "idle" | "running" | "done" | "error"
-  result?: {
-    history: string
-    clean: boolean
-  }
+  updated: number
   error?: string
+  details?: string[]
 }
 
-const retry_delays = [200, 400, 800, 1200, 1800, 2500]
+const retry = [200, 400, 800, 1200, 1800, 2500]
 
-function auth(input: { url: string; username?: string; password?: string }) {
+function auth(input: { username?: string; password?: string }) {
   const head: Record<string, string> = {}
   if (!input.password) return head
   head.Authorization = `Basic ${btoa(`${input.username ?? "opencode"}:${input.password}`)}`
   return head
-}
-
-function key(url: string) {
-  return `aether.legacy.prompt.once.${url}`
 }
 
 export function LegacyDBGuard() {
@@ -45,6 +38,8 @@ export function LegacyDBGuard() {
   const navigate = useNavigate()
   const abort = new AbortController()
   let started = false
+
+  const done = (stamp: number) => `aether.legacy.done.${stamp}`
 
   onCleanup(() => abort.abort())
 
@@ -59,162 +54,128 @@ export function LegacyDBGuard() {
       if (!conn) return
       const head = auth(conn)
       const status = await (async () => {
-        for (let i = 0; i <= retry_delays.length; i++) {
+        for (let i = 0; i <= retry.length; i++) {
           const result = await fetch(`${conn.url}/database/legacy/status`, {
             headers: head,
             signal: abort.signal,
           })
             .then((x) => (x.ok ? x.json() : undefined))
             .catch(() => undefined)
-          if (result) return result
-          if (i === retry_delays.length) return
-          await new Promise((resolve) => setTimeout(resolve, retry_delays[i]))
+          if (result) return result as Status
+          if (i === retry.length) return
+          await new Promise((resolve) => setTimeout(resolve, retry[i]))
           if (abort.signal.aborted) return
         }
       })()
-      if (!status) return
-      const info = status as Status
-      if (!info.has_legacy) return
-      if (info.dismissed) return
-      if (sessionStorage.getItem(key(conn.url)) === "1") return
 
-      const open = (sessionID?: string) => {
-        layout.projects.open(info.directory)
-        server.projects.touch(info.directory)
-        const dir = base64Encode(info.directory)
-        if (!sessionID) {
-          navigate(`/${dir}`)
-          return
-        }
-        navigate(`/${dir}/session/${sessionID}`)
-      }
-
-      const watch = async () => {
-        for (let i = 0; i < 120; i++) {
-          const state = await fetch(`${conn.url}/database/legacy/archive/state`, {
-            headers: head,
+      const complete = async () => {
+        const state = await fetch(`${conn.url}/database/legacy/merge/state`, {
+          headers: head,
+          signal: abort.signal,
+        })
+          .then((x) => (x.ok ? x.json() : undefined))
+          .catch(() => undefined)
+        if (!state) return false
+        const next = state as ArchiveState
+        if (next.state === "done") {
+          if (!sessionStorage.getItem(done(next.updated))) {
+            sessionStorage.setItem(done(next.updated), "1")
+            showToast({
+              title: "旧会话记录整合到了新版本，请重启软件",
+            })
+          }
+          await fetch(`${conn.url}/database/legacy/merge/state/reset`, {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              ...head,
+            },
+            body: "{}",
             signal: abort.signal,
-          })
-            .then((x) => (x.ok ? x.json() : undefined))
-            .catch(() => undefined)
-          if (!state) {
-            await new Promise((resolve) => setTimeout(resolve, 2000))
-            continue
-          }
-          const info = state as ArchiveState
-          if (info.state === "running") {
-            await new Promise((resolve) => setTimeout(resolve, 2000))
-            continue
-          }
-          if (info.state === "done" && info.result?.history) {
-            showToast({
-              title: "旧会话记录已归档",
-              description: `旧会话记录被归档至 ${info.result.history}`,
-            })
-            if (!info.result.clean) {
-              showToast({
-                variant: "error",
-                title: "旧数据库文件未完全归档",
-                description: "请查看数据库目录并手动检查剩余 .db 文件。",
-              })
-            }
-            return
-          }
-          if (info.state === "error") {
-            showToast({
-              variant: "error",
-              title: "旧数据库归档失败",
-              description: info.error || "请查看后端服务日志。",
-            })
-            return
-          }
-          return
+          }).catch(() => undefined)
+          return true
         }
+        if (next.state === "error") {
+          showToast({
+            variant: "error",
+            title: "旧会话记录整合失败",
+            description: next.details?.[0] || next.error || "请查看后端服务日志。",
+          })
+          await fetch(`${conn.url}/database/legacy/merge/state/reset`, {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              ...head,
+            },
+            body: "{}",
+            signal: abort.signal,
+          }).catch(() => undefined)
+          return true
+        }
+        return false
       }
 
-      showToast({
-        persistent: true,
-        placement: "top-center",
-        guarded: true,
-        icon: "download",
-        title: "侦测到旧版本的对话记录",
-        description: "是否全部合并到新版本的对话中?",
-        actions: [
-          {
-            label: "立即合并",
-            onClick: async () => {
-              const merge = await fetch(`${conn.url}/database/legacy/merge`, {
-                method: "POST",
-                headers: {
-                  "content-type": "application/json",
-                  ...head,
-                },
-                body: JSON.stringify({
-                  mode: "auto",
-                  session: true,
-                }),
-                signal: abort.signal,
-              })
-                .then((x) => (x.ok ? x.json() : undefined))
-                .catch(() => undefined)
-              if (!merge) {
-                showToast({
-                  variant: "error",
-                  title: "数据库合并启动失败",
-                  description: "请稍后重试或检查后端服务日志。",
-                })
-                return
-              }
-              sessionStorage.setItem(key(conn.url), "1")
-              const info = merge as Merge
-              void watch()
-              open(info.sessionID)
-            },
-          },
-          {
-            label: "取消",
-            onClick: () => {
-              showToast({
-                persistent: true,
-                placement: "top-center",
-                guarded: true,
-                icon: "download",
-                title: "侦测到旧版本的对话记录",
-                description: "已取消，是否下次开启Aether时执行对话记录合并。",
-                actions: [
-                  {
-                    label: "下一次提醒我",
-                    onClick: () => {
-                      sessionStorage.setItem(key(conn.url), "1")
-                    },
-                  },
-                  {
-                    label: "不再询问",
-                    onClick: async () => {
-                      await fetch(`${conn.url}/database/legacy/preference`, {
-                        method: "PATCH",
-                        headers: {
-                          "content-type": "application/json",
-                          ...head,
-                        },
-                        body: JSON.stringify({
-                          dismissed: true,
-                        }),
-                        signal: abort.signal,
-                      }).catch(() => undefined)
-                      sessionStorage.setItem(key(conn.url), "1")
-                      showToast({
-                        description:
-                          "已关闭询问，如需将对话合并到新版本请参考https://aether.aiphys.cn中的常见问题。",
-                      })
-                    },
-                  },
-                ],
-              })
-            },
-          },
-        ],
+      if (!status?.should_merge) {
+        const ready = await complete()
+        if (ready) return
+      }
+
+      const merge = status?.should_merge
+        ? await fetch(`${conn.url}/database/legacy/merge`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          ...head,
+        },
+        body: JSON.stringify({}),
+        signal: abort.signal,
       })
+        .then((x) => (x.ok ? x.json() : undefined))
+        .catch(() => undefined)
+        : undefined
+      if (status?.should_merge && !merge) {
+        showToast({
+          variant: "error",
+          title: "数据库整合启动失败",
+          description: "请查看后端服务日志。",
+        })
+        return
+      }
+
+      const info = merge as Merge | undefined
+      if (status && info?.mode === "agent" && info.sessionID) {
+        layout.projects.open(status.directory)
+        server.projects.touch(status.directory)
+        const dir = base64Encode(status.directory)
+        navigate(`/${dir}/session/${info.sessionID}`)
+      }
+
+      while (!abort.signal.aborted) {
+        const state = await fetch(`${conn.url}/database/legacy/merge/state`, {
+          headers: head,
+          signal: abort.signal,
+        })
+          .then((x) => (x.ok ? x.json() : undefined))
+          .catch(() => undefined)
+        if (!state) {
+          await new Promise((resolve) => setTimeout(resolve, 2000))
+          continue
+        }
+        const next = state as ArchiveState
+        if (next.state === "running") {
+          await new Promise((resolve) => setTimeout(resolve, 2000))
+          continue
+        }
+        if (next.state === "done") {
+          await complete()
+          return
+        }
+        if (next.state === "error") {
+          await complete()
+          return
+        }
+        await new Promise((resolve) => setTimeout(resolve, 2000))
+      }
     }
 
     void run()

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -171,6 +171,8 @@ export const SettingsGeneral: Component = () => {
 
         showToast({
           persistent: true,
+          placement: "top-center",
+          guarded: true,
           icon: "download",
           title: language.t("toast.update.title"),
           description: language.t("toast.update.description", { version: result.version ?? "" }),

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -2647,7 +2647,13 @@ export default function Layout(props: ParentProps) {
         </div>
         {import.meta.env.DEV && <DebugBar />}
       </div>
-      <Toast.Region />
+      <Toast.Region regionId="bottom-right" data-placement="bottom-right" />
+      <Toast.Region
+        regionId="top-center"
+        data-placement="top-center"
+        swipeDirection="right"
+        swipeThreshold={100000}
+      />
     </div>
   )
 }

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -393,38 +393,40 @@ export default function Layout(props: ParentProps) {
       const showUpdateToast = (version?: string) => {
         if (toastId !== undefined) return
         toastId = showToast({
-          persistent: true,
-          icon: "download",
-          title: language.t("toast.update.title"),
-          description: language.t("toast.update.description", { version: version ?? "" }),
-          actions:
-            platform.platform === "web"
-              ? [
-                  {
-                    label: language.t("update.install"),
-                    onClick: async () => {
-                      await platform.update!()
-                      await platform.restart!()
+            persistent: true,
+            placement: "top-center",
+            guarded: true,
+            icon: "download",
+            title: language.t("toast.update.title"),
+            description: language.t("toast.update.description", { version: version ?? "" }),
+            actions:
+              platform.platform === "web"
+                ? [
+                    {
+                      label: language.t("update.install"),
+                      onClick: async () => {
+                        await platform.update!()
+                        await platform.restart!()
+                      },
                     },
-                  },
-                  {
-                    label: language.t("toast.update.action.notYet"),
-                    onClick: "dismiss",
-                  },
-                ]
-              : [
-                  {
-                    label: language.t("toast.update.action.installRestart"),
-                    onClick: async () => {
-                      await platform.update!()
-                      await platform.restart!()
+                    {
+                      label: language.t("toast.update.action.notYet"),
+                      onClick: "dismiss",
                     },
-                  },
-                  {
-                    label: language.t("toast.update.action.notYet"),
-                    onClick: "dismiss",
-                  },
-                ],
+                  ]
+                : [
+                    {
+                      label: language.t("toast.update.action.installRestart"),
+                      onClick: async () => {
+                        await platform.update!()
+                        await platform.restart!()
+                      },
+                    },
+                    {
+                      label: language.t("toast.update.action.notYet"),
+                      onClick: "dismiss",
+                    },
+                  ],
         })
       }
 
@@ -551,6 +553,8 @@ export default function Layout(props: ParentProps) {
 
         const toastId = showToast({
           persistent: true,
+          placement: "top-center",
+          guarded: true,
           icon,
           title,
           description,
@@ -1741,6 +1745,8 @@ export default function Layout(props: ParentProps) {
     dismiss()
 
     showToast({
+      placement: "top-center",
+      guarded: true,
       title: language.t("workspace.reset.success.title"),
       description: language.t("workspace.reset.success.description"),
       actions: [

--- a/packages/opencode/src/automation/session-task.ts
+++ b/packages/opencode/src/automation/session-task.ts
@@ -23,7 +23,9 @@ export namespace SessionTask {
 
   export type Running = {
     sessionID: Output["sessionID"]
-    done: Promise<void>
+    done: Promise<{
+      aborted: boolean
+    }>
   }
 
   export async function begin(raw: Input): Promise<Running> {
@@ -44,7 +46,9 @@ export namespace SessionTask {
             },
           ],
         })
-          .then(() => undefined)
+          .then((result) => ({
+            aborted: JSON.stringify(result).includes("User aborted the command"),
+          }))
           .catch((error) => {
             log.error("session task failed", {
               sessionID: session.id,

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -84,6 +84,31 @@ let cli = yargs(hideBin(process.argv))
     })
 
     const legacy = await LegacyDB.status()
+    await LegacyDB.setBootState({
+      should_merge: legacy.should_merge,
+      source_count: legacy.source_count,
+      updated: Date.now(),
+    })
+    if (legacy.should_merge && legacy.source_count === 1) {
+      try {
+        await LegacyDB.copySource()
+        await LegacyDB.setBootState({
+          should_merge: false,
+          source_count: legacy.source_count,
+          updated: Date.now(),
+        })
+        await LegacyDB.setMergeState({
+          state: "done",
+          updated: Date.now(),
+        })
+      } catch (error) {
+        await LegacyDB.setMergeState({
+          state: "error",
+          updated: Date.now(),
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
     if (legacy.has_legacy) {
       process.stderr.write(`发现旧库: ${legacy.legacy_count} 个，可通过 /database/legacy/merge 触发合并。` + EOL)
     }

--- a/packages/opencode/src/server/routes/database.ts
+++ b/packages/opencode/src/server/routes/database.ts
@@ -2,19 +2,17 @@ import { Hono } from "hono"
 import { describeRoute, resolver } from "hono-openapi"
 import { lazy } from "@/util/lazy"
 import { LegacyDB } from "@/storage/legacy-db"
-import z from "zod"
+import { LegacyVerify } from "@/storage/legacy-verify"
 import { SessionTask } from "@/automation/session-task"
+import z from "zod"
 
 const MergeInput = z.object({}).optional()
 
 const MergeOutput = z.object({
   status: LegacyDB.Status,
-  sessionID: SessionTask.Output.shape.sessionID,
-  archive_state: LegacyDB.ArchiveState,
-})
-
-const PreferenceInput = z.object({
-  dismissed: z.boolean(),
+  mode: z.enum(["noop", "copy", "agent"]),
+  sessionID: SessionTask.Output.shape.sessionID.optional(),
+  merge_state: LegacyDB.MergeState,
 })
 
 export const DatabaseRoutes = lazy(() =>
@@ -23,7 +21,7 @@ export const DatabaseRoutes = lazy(() =>
       "/legacy/status",
       describeRoute({
         summary: "Scan legacy databases",
-        description: "Scan current data directory and report legacy database statistics.",
+        description: "Scan current data directory and report auto-merge status.",
         operationId: "database.legacy.status",
         responses: {
           200: {
@@ -36,83 +34,55 @@ export const DatabaseRoutes = lazy(() =>
           },
         },
       }),
-      async (c) => {
-        return c.json(await LegacyDB.status())
-      },
+      async (c) => c.json(await LegacyDB.status()),
     )
     .get(
-      "/legacy/preference",
+      "/legacy/merge/state",
       describeRoute({
-        summary: "Get legacy merge prompt preference",
-        description: "Get whether legacy merge prompt is permanently dismissed.",
-        operationId: "database.legacy.preference.get",
+        summary: "Get merge state",
+        description: "Get merge state after auto merge.",
+        operationId: "database.legacy.merge.state",
         responses: {
           200: {
-            description: "Legacy prompt preference",
+            description: "Merge state",
             content: {
               "application/json": {
-                schema: resolver(LegacyDB.Preference),
+                schema: resolver(LegacyDB.MergeState),
               },
             },
           },
         },
       }),
-      async (c) => {
-        return c.json(await LegacyDB.preference())
-      },
+      async (c) => c.json(await LegacyDB.mergeState()),
     )
-    .patch(
-      "/legacy/preference",
+    .post(
+      "/legacy/merge/state/reset",
       describeRoute({
-        summary: "Update legacy merge prompt preference",
-        description: "Update whether legacy merge prompt is permanently dismissed.",
-        operationId: "database.legacy.preference.patch",
+        summary: "Reset merge state",
+        description: "Mark merge completion state as consumed so restart will not re-show the completion toast.",
+        operationId: "database.legacy.merge.state.reset",
         responses: {
           200: {
-            description: "Updated legacy prompt preference",
+            description: "Reset merge state",
             content: {
               "application/json": {
-                schema: resolver(LegacyDB.Preference),
+                schema: resolver(LegacyDB.MergeState),
               },
             },
           },
         },
       }),
-      async (c) => {
-        const body = PreferenceInput.parse(await c.req.json())
-        return c.json(await LegacyDB.setPreference(body))
-      },
-    )
-    .get(
-      "/legacy/archive/state",
-      describeRoute({
-        summary: "Get archive state",
-        description: "Get asynchronous archive task state after agent-driven merge.",
-        operationId: "database.legacy.archive.state",
-        responses: {
-          200: {
-            description: "Archive state",
-            content: {
-              "application/json": {
-                schema: resolver(LegacyDB.ArchiveState),
-              },
-            },
-          },
-        },
-      }),
-      async (c) => {
-        return c.json(await LegacyDB.archiveState())
-      },
+      async (c) => c.json(await LegacyDB.clearMergeState()),
     )
     .post(
       "/legacy/merge",
       describeRoute({
-        summary: "Merge legacy databases",
-        description: "Start agent-driven merge into aether-prod.db and run fixed archive after session completes.",
+        summary: "Start legacy merge",
+        description: "Automatically copy or agent-merge old opencode databases into the new target database.",
         operationId: "database.legacy.merge",
         responses: {
           200: {
-            description: "Merge report",
+            description: "Merge kickoff result",
             content: {
               "application/json": {
                 schema: resolver(MergeOutput),
@@ -124,38 +94,83 @@ export const DatabaseRoutes = lazy(() =>
       async (c) => {
         MergeInput.parse(await c.req.json().catch(() => undefined))
         const status = await LegacyDB.status()
+        const merge = await LegacyDB.mergeState()
+        if (merge.state === "running" || merge.state === "done") {
+          return c.json({
+            status,
+            mode: "noop",
+            merge_state: merge,
+          })
+        }
+        if (!status.should_merge) {
+          return c.json({
+            status,
+            mode: "noop",
+            merge_state: merge,
+          })
+        }
+
         await LegacyDB.ensureTarget()
-        const files = status.files.map((file) => `- ${file.path}`).join("\n")
+        await LegacyDB.setBootState({
+          should_merge: false,
+          source_count: status.source_count,
+          updated: Date.now(),
+        })
+        const files = status.files.filter((file) => file.name.startsWith("opencode")).map((file) => `- ${file.path}`).join("\n")
         const task = await SessionTask.begin({
           directory: status.directory,
           title: "Legacy database merge",
           prompt: [
-            "请识别当前目录顶层（不含子目录）中的所有 .db 文件。",
-            "请将用户历史对话信息合并到 aether-prod.db。",
-            "冲突策略：latest_wins（time_updated/updated_at/updated/time_created/created_at/created），时间相同按来源优先级与文件名稳定排序。",
+            "请识别当前目录顶层（不含子目录）中的所有 opencode*.db 文件。",
+            `请先将用户历史对话信息合并到临时文件 ${status.directory}/aether_temp.db。`,
+            `只有在临时文件验收通过后，才允许再将 ${status.directory}/aether_temp.db 的结果整合进 ${status.target}。`,
+            `不要删除、替换或移动当前正在使用的 ${status.target} 数据库文件；必须保留它，并以增量整合的方式写入。`,
+            "请使用 latest_wins：time_updated/updated_at/updated/time_created/created_at/created 更晚者覆盖；时间相同按来源优先级与文件名稳定排序。",
+            "project/workspace/session 必须按关系一致性合并，不能只按主键覆盖。",
+            "规则1：project 的真实身份以 worktree 为先；只有 project.id 和 worktree 都一致时，才允许视为同一 project。",
+            "规则2：如果不同源库中的 project.id 相同但 worktree 不同，必须为其中一方生成新的 project.id，并重写该源库中关联的 workspace.project_id、session.project_id、permission.project_id。",
+            "规则3：workspace 的真实身份以 project/worktree + type + branch + directory 为先；如果 workspace.id 相同但这些信息不同，必须生成新的 workspace.id，并重写关联的 session.workspace_id。",
+            "规则4：session.project_id 必须继续指向正确的 project；session.workspace_id 若存在，必须继续指向与该 session 同属项目的 workspace。",
+            "合并完成后，请执行严格验收，不满足则不要宣布完成。",
+            "验收要求1：先对 aether_temp.db 做验收，确认它可正常打开，关键表（至少 session、message、project、workspace，若源库存在）结构可查询。",
+            "验收要求2：对每个源库统计关键表行数并与 aether_temp.db 比对，确认不存在明显丢失。",
+            "验收要求3：抽样比对多个具体会话内容，确认源库中的历史对话在 aether_temp.db 中可找到。",
+            "验收要求4：检查 session -> project -> workspace 关联关系是否正确，确认不会把会话挂到错误 worktree。",
+            "验收要求5：对发生冲突的记录，核对结果是否符合 latest_wins。",
+            "验收要求6：只有 aether_temp.db 验收通过后，才允许把它整合进 aether-prod.db。",
+            "验收要求7：给出明确结论：通过 / 不通过；若不通过请说明问题并继续修复。",
             "不要移动或删除任何历史 db 文件。",
-            "完成后请输出合并报告：成功库、失败库、冲突数。",
+            "完成后输出合并与校验报告：成功库、失败库、冲突数、临时库验收结果、最终整合结果。",
             "文件列表：",
             files || "- 无",
           ].join("\n"),
         })
 
-        await LegacyDB.setArchiveState({
+        const merge_state = await LegacyDB.setMergeState({
           state: "running",
           updated: Date.now(),
         })
 
         void task.done
-          .then(async () => {
-            const archive = await LegacyDB.archive()
-            await LegacyDB.setArchiveState({
-              state: "done",
+          .then(async (result) => {
+            if (result.aborted) {
+              await LegacyDB.setMergeState({
+                state: "error",
+                updated: Date.now(),
+                error: "merge-interrupted",
+              })
+              return
+            }
+            const report = await LegacyVerify.run()
+            await LegacyDB.setMergeState({
+              state: report.ok ? "done" : "error",
               updated: Date.now(),
-              result: archive,
+              error: report.ok ? undefined : "consistency-check-failed",
+              details: report.ok ? undefined : report.errors.slice(0, 20),
             })
           })
           .catch(async (error) => {
-            await LegacyDB.setArchiveState({
+            await LegacyDB.setMergeState({
               state: "error",
               updated: Date.now(),
               error: error instanceof Error ? error.message : String(error),
@@ -164,8 +179,9 @@ export const DatabaseRoutes = lazy(() =>
 
         return c.json({
           status,
+          mode: "agent",
           sessionID: task.sessionID,
-          archive_state: await LegacyDB.archiveState(),
+          merge_state,
         })
       },
     ),

--- a/packages/opencode/src/storage/legacy-db.ts
+++ b/packages/opencode/src/storage/legacy-db.ts
@@ -3,10 +3,17 @@ import fs from "fs/promises"
 import path from "path"
 import z from "zod"
 import { Global } from "@/global"
+import { Flag } from "@/flag/flag"
 
-const target_file = "aether-prod.db"
 const pref_file = "legacy-db.json"
-const archive_file = "legacy-db-archive.json"
+const merge_file = "legacy-db-merge.json"
+const boot_file = "legacy-db-boot.json"
+
+function targetFile() {
+  const file = Flag.OPENCODE_DB
+  if (!file || file === ":memory:") return "aether-prod.db"
+  return path.basename(file)
+}
 
 function dbPath(name: string) {
   return path.join(Global.Path.data, name)
@@ -16,32 +23,31 @@ function prefPath() {
   return path.join(Global.Path.state, pref_file)
 }
 
-function archivePath() {
-  return path.join(Global.Path.state, archive_file)
+function mergePath() {
+  return path.join(Global.Path.state, merge_file)
 }
+
+function bootPath() {
+  return path.join(Global.Path.state, boot_file)
+}
+
 
 function isdb(name: string) {
   return /^(opencode|aether).*\.db$/i.test(name)
 }
 
+function sourceDb(name: string) {
+  return /^opencode.*\.db$/i.test(name)
+}
+
 function channel(name: string) {
   const file = path.basename(name)
-  if (file.toLowerCase() === target_file) return "prod"
+  if (file.toLowerCase() === targetFile().toLowerCase()) return "prod"
   if (!isdb(file)) return "unknown"
   if (file.toLowerCase() === "opencode.db") return "latest"
   const match = /^opencode-(.+)\.db$/i.exec(file)
   if (!match) return "unknown"
   return match[1]
-}
-
-function rank(name: string) {
-  const ch = channel(name)
-  if (ch === "local") return 0
-  if (ch === "dev") return 1
-  if (ch === "beta") return 2
-  if (ch === "latest") return 3
-  if (ch === "prod") return 4
-  return 2
 }
 
 async function mod(file: string) {
@@ -67,10 +73,7 @@ async function versions(file: string) {
   }
 }
 
-
 export namespace LegacyDB {
-  export const target = target_file
-
   export const File = z.object({
     name: z.string(),
     path: z.string(),
@@ -84,6 +87,8 @@ export namespace LegacyDB {
     has_legacy: z.boolean(),
     message: z.string(),
     dismissed: z.boolean(),
+    should_merge: z.boolean(),
+    source_count: z.number(),
     legacy_count: z.number(),
     files: File.array(),
     naming: z.record(z.string(), z.number()),
@@ -94,25 +99,23 @@ export namespace LegacyDB {
     dismissed: z.boolean(),
   })
 
-  export const Archive = z.object({
-    history: z.string(),
-    moved: z.array(z.string()),
-    skipped: z.array(z.string()),
-    remaining: z.array(z.string()),
-    clean: z.boolean(),
+  export const MergeState = z.object({
+    state: z.enum(["idle", "running", "done", "error"]),
+    updated: z.number(),
+    error: z.string().optional(),
+    details: z.array(z.string()).optional(),
   })
 
   export type Status = z.infer<typeof Status>
   export type Preference = z.infer<typeof Preference>
-  export type Archive = z.infer<typeof Archive>
+  export type MergeState = z.infer<typeof MergeState>
 
-  export const ArchiveState = z.object({
-    state: z.enum(["idle", "running", "done", "error"]),
+  export const BootState = z.object({
+    should_merge: z.boolean(),
+    source_count: z.number(),
     updated: z.number(),
-    result: Archive.optional(),
-    error: z.string().optional(),
   })
-  export type ArchiveState = z.infer<typeof ArchiveState>
+  export type BootState = z.infer<typeof BootState>
 
   async function scan() {
     const dir = Global.Path.data
@@ -120,15 +123,12 @@ export namespace LegacyDB {
     return Promise.all(
       rows
         .filter((row) => row.isFile() && isdb(row.name))
-        .map(async (row) => {
-          const file = path.join(dir, row.name)
-          return {
-            name: row.name,
-            path: file,
-            channel: channel(row.name),
-            mtime: await mod(file),
-          }
-        }),
+        .map(async (row) => ({
+          name: row.name,
+          path: path.join(dir, row.name),
+          channel: channel(row.name),
+          mtime: await mod(path.join(dir, row.name)),
+        })),
     )
   }
 
@@ -153,61 +153,84 @@ export namespace LegacyDB {
   }
 
   export function targetPath() {
-    return dbPath(target_file)
+    return dbPath(targetFile())
+  }
+
+  export async function copySource() {
+    const files = (await scan()).filter((item) => sourceDb(item.name))
+    if (files.length !== 1) return
+    await fs.copyFile(files[0].path, targetPath())
+    return files[0].path
   }
 
   export async function ensureTarget() {
     const target = targetPath()
     const stat = await fs.stat(target).catch(() => undefined)
     if (stat) return target
-    const list = (await scan()).filter((item) => item.name.toLowerCase() !== target_file)
-    if (list.length === 0) {
+    const files = (await scan()).filter((item) => sourceDb(item.name))
+    if (files.length === 0) {
       const db = new Sqlite(target)
       db.close()
       return target
     }
-    const pick = [...list].sort((a, b) => a.mtime - b.mtime || rank(a.name) - rank(b.name) || a.name.localeCompare(b.name)).at(-1)
-    if (pick) await fs.copyFile(pick.path, target)
+    await fs.copyFile(files[0].path, target)
     return target
   }
 
-  export async function archiveState(): Promise<ArchiveState> {
-    const raw = await fs.readFile(archivePath(), "utf-8").catch(() => "")
-    if (!raw) {
-      return {
-        state: "idle",
-        updated: Date.now(),
-      }
-    }
+  export async function mergeState(): Promise<MergeState> {
+    const raw = await fs.readFile(mergePath(), "utf-8").catch(() => "")
+    if (!raw) return { state: "idle", updated: Date.now() }
     let json: unknown
     try {
       json = JSON.parse(raw)
     } catch {
-      return {
-        state: "idle",
-        updated: Date.now(),
-      }
+      return { state: "idle", updated: Date.now() }
     }
-    const next = ArchiveState.safeParse(json)
-    if (!next.success) {
-      return {
-        state: "idle",
-        updated: Date.now(),
-      }
-    }
+    const next = MergeState.safeParse(json)
+    if (!next.success) return { state: "idle", updated: Date.now() }
     return next.data
   }
 
-  export async function setArchiveState(input: ArchiveState) {
-    const state = ArchiveState.parse(input)
-    await fs.writeFile(archivePath(), JSON.stringify(state, null, 2), "utf-8")
+  export async function setMergeState(input: MergeState) {
+    const state = MergeState.parse(input)
+    await fs.writeFile(mergePath(), JSON.stringify(state, null, 2), "utf-8")
+    return state
+  }
+
+  export async function clearMergeState() {
+    return setMergeState({
+      state: "idle",
+      updated: Date.now(),
+    })
+  }
+
+  export async function bootState(): Promise<BootState | undefined> {
+    const raw = await fs.readFile(bootPath(), "utf-8").catch(() => "")
+    if (!raw) return
+    let json: unknown
+    try {
+      json = JSON.parse(raw)
+    } catch {
+      return
+    }
+    const next = BootState.safeParse(json)
+    if (!next.success) return
+    return next.data
+  }
+
+  export async function setBootState(input: BootState) {
+    const state = BootState.parse(input)
+    await fs.writeFile(bootPath(), JSON.stringify(state, null, 2), "utf-8")
     return state
   }
 
   export async function status(): Promise<Status> {
     const dir = Global.Path.data
     const files = await scan()
-    const old = files.filter((file) => file.name.toLowerCase() !== target_file)
+    const target = targetFile().toLowerCase()
+    const old = files.filter((file) => file.name.toLowerCase() !== target)
+    const src = files.filter((file) => sourceDb(file.name))
+    const hasTarget = files.some((file) => file.name.toLowerCase() === target)
 
     const naming = old.reduce<Record<string, number>>((acc, file) => {
       acc[file.channel] = (acc[file.channel] ?? 0) + 1
@@ -222,14 +245,15 @@ export namespace LegacyDB {
       return acc
     }, {})
 
-    const pref = await preference()
-
+    const boot = await bootState()
     return {
       directory: dir,
       target: targetPath(),
       has_legacy: old.length > 0,
       message: old.length > 0 ? "发现旧库" : "未发现旧库",
-      dismissed: pref.dismissed,
+      dismissed: false,
+      should_merge: src.length > 0 && (boot?.should_merge || !hasTarget),
+      source_count: src.length,
       legacy_count: old.length,
       files: old.sort((a, b) => a.name.localeCompare(b.name)),
       naming,
@@ -237,43 +261,4 @@ export namespace LegacyDB {
     }
   }
 
-  export async function archive(): Promise<Archive> {
-    const status = await LegacyDB.status()
-    const history = path.join(status.directory, "history_database")
-    await fs.mkdir(history, { recursive: true })
-    const moved: string[] = []
-    const skipped: string[] = []
-
-    const unique = async (file: string) => {
-      const ext = path.extname(file)
-      const name = path.basename(file, ext)
-      let next = path.join(history, file)
-      let i = 0
-      while (await fs.stat(next).then(() => true).catch(() => false)) {
-        i += 1
-        next = path.join(history, `${name}-${Date.now()}-${i}${ext}`)
-      }
-      return next
-    }
-
-    for (const file of status.files) {
-      const src = path.join(status.directory, file.name)
-      const dst = await unique(file.name)
-      try {
-        await fs.rename(src, dst)
-        moved.push(dst)
-      } catch {
-        skipped.push(src)
-      }
-    }
-
-    const rest = (await scan()).filter((item) => item.name.toLowerCase() !== target_file).map((item) => item.path)
-    return {
-      history,
-      moved,
-      skipped,
-      remaining: rest,
-      clean: rest.length === 0,
-    }
-  }
 }

--- a/packages/opencode/src/storage/legacy-verify.ts
+++ b/packages/opencode/src/storage/legacy-verify.ts
@@ -1,0 +1,190 @@
+import { Database as Sqlite } from "bun:sqlite"
+import fs from "fs/promises"
+import path from "path"
+import z from "zod"
+import { Global } from "@/global"
+import { LegacyDB } from "@/storage/legacy-db"
+
+const ranks = {
+  local: 0,
+  dev: 1,
+  beta: 2,
+  latest: 3,
+}
+
+function source(name: string) {
+  return /^opencode.*\.db$/i.test(name)
+}
+
+function rank(name: string) {
+  const file = path.basename(name).toLowerCase()
+  if (file === "opencode.db") return ranks.latest
+  const hit = /^opencode-(.+)\.db$/i.exec(file)?.[1] || ""
+  return ranks[hit as keyof typeof ranks] ?? 2
+}
+
+function has(db: Sqlite, name: string) {
+  const row = db.query("select 1 as ok from sqlite_master where type='table' and name=?").get(name) as { ok: number } | null
+  return !!row
+}
+
+function open(file: string) {
+  return new Sqlite(file, { readonly: true })
+}
+
+function sessionRows(db: Sqlite) {
+  if (!has(db, "session")) return []
+  return db.query("select id, project_id, workspace_id, directory, title, version, time_created, time_updated from session").all() as {
+    id: string
+    project_id: string
+    workspace_id: string | null
+    directory: string
+    title: string
+    version: string
+    time_created: number
+    time_updated: number
+  }[]
+}
+
+function projectRows(db: Sqlite) {
+  if (!has(db, "project")) return []
+  return db.query("select id, worktree, vcs, name from project").all() as {
+    id: string
+    worktree: string
+    vcs: string | null
+    name: string | null
+  }[]
+}
+
+function workspaceRows(db: Sqlite) {
+  if (!has(db, "workspace")) return []
+  return db.query("select id, project_id, type, branch, name, directory from workspace").all() as {
+    id: string
+    project_id: string
+    type: string
+    branch: string | null
+    name: string | null
+    directory: string | null
+  }[]
+}
+
+function messageCount(db: Sqlite) {
+  if (!has(db, "message")) return new Map<string, number>()
+  const rows = db.query("select session_id, count(*) as count from message group by session_id").all() as {
+    session_id: string
+    count: number
+  }[]
+  return new Map(rows.map((row) => [row.session_id, row.count]))
+}
+
+function better(a: Candidate, b: Candidate) {
+  if (a.row.time_updated !== b.row.time_updated) return a.row.time_updated > b.row.time_updated
+  if (a.row.time_created !== b.row.time_created) return a.row.time_created > b.row.time_created
+  if (rank(a.file) !== rank(b.file)) return rank(a.file) > rank(b.file)
+  return a.file.localeCompare(b.file) > 0
+}
+
+type Candidate = {
+  file: string
+  row: ReturnType<typeof sessionRows>[number]
+  project?: ReturnType<typeof projectRows>[number]
+  workspace?: ReturnType<typeof workspaceRows>[number]
+  messages: number
+}
+
+export namespace LegacyVerify {
+  export const Report = z.object({
+    ok: z.boolean(),
+    sessions: z.number(),
+    checked: z.number(),
+    errors: z.array(z.string()),
+  })
+  export type Report = z.infer<typeof Report>
+
+  export async function run(): Promise<Report> {
+    const dir = Global.Path.data
+    const rows = await fs.readdir(dir, { withFileTypes: true }).catch(() => [])
+    const files = rows.filter((row) => row.isFile() && source(row.name)).map((row) => path.join(dir, row.name))
+    const target = LegacyDB.targetPath()
+    const targetDb = open(target)
+    try {
+      const targetSessions = new Map(sessionRows(targetDb).map((row) => [row.id, row]))
+      const targetProjects = new Map(projectRows(targetDb).map((row) => [row.id, row]))
+      const targetWorkspaces = new Map(workspaceRows(targetDb).map((row) => [row.id, row]))
+      const targetMessages = messageCount(targetDb)
+      const all = new Map<string, Candidate[]>()
+
+      for (const file of files) {
+        const db = open(file)
+        try {
+          const projects = new Map(projectRows(db).map((row) => [row.id, row]))
+          const spaces = new Map(workspaceRows(db).map((row) => [row.id, row]))
+          const counts = messageCount(db)
+          for (const row of sessionRows(db)) {
+            const item: Candidate = {
+              file,
+              row,
+              project: projects.get(row.project_id),
+              workspace: row.workspace_id ? spaces.get(row.workspace_id) : undefined,
+              messages: counts.get(row.id) ?? 0,
+            }
+            const list = all.get(row.id) ?? []
+            list.push(item)
+            all.set(row.id, list)
+          }
+        } finally {
+          db.close()
+        }
+      }
+
+      const errors: string[] = []
+      for (const [id, list] of all) {
+        const win = list.reduce((best, item) => (better(item, best) ? item : best))
+        const row = targetSessions.get(id)
+        if (!row) {
+          errors.push(`missing-session:${id}`)
+          continue
+        }
+        if (row.directory !== win.row.directory) errors.push(`session-directory-mismatch:${id}`)
+        if (row.title !== win.row.title) errors.push(`session-title-mismatch:${id}`)
+        if (row.version !== win.row.version) errors.push(`session-version-mismatch:${id}`)
+
+        const project = targetProjects.get(row.project_id)
+        if (!project) {
+          errors.push(`missing-project:${id}`)
+          continue
+        }
+        if (win.project && project.worktree !== win.project.worktree) {
+          errors.push(`project-worktree-mismatch:${id}`)
+        }
+
+        if (win.workspace) {
+          const space = row.workspace_id ? targetWorkspaces.get(row.workspace_id) : undefined
+          if (!space) {
+            errors.push(`missing-workspace:${id}`)
+          } else {
+            if (space.type !== win.workspace.type) errors.push(`workspace-type-mismatch:${id}`)
+            if ((space.branch || "") !== (win.workspace.branch || "")) errors.push(`workspace-branch-mismatch:${id}`)
+            if ((space.directory || "") !== (win.workspace.directory || "")) errors.push(`workspace-directory-mismatch:${id}`)
+            const parent = targetProjects.get(space.project_id)
+            if (!parent || win.project?.worktree && parent.worktree !== win.project.worktree) {
+              errors.push(`workspace-project-mismatch:${id}`)
+            }
+          }
+        }
+
+        const targetCount = targetMessages.get(id) ?? 0
+        if (targetCount < win.messages) errors.push(`message-count-mismatch:${id}`)
+      }
+
+      return {
+        ok: errors.length === 0,
+        sessions: all.size,
+        checked: all.size - errors.filter((item) => item.startsWith("missing-session:")).length,
+        errors,
+      }
+    } finally {
+      targetDb.close()
+    }
+  }
+}

--- a/packages/opencode/test/automation/legacy-repair.test.ts
+++ b/packages/opencode/test/automation/legacy-repair.test.ts
@@ -7,6 +7,8 @@ const status = {
   has_legacy: true,
   message: "发现旧库",
   dismissed: false,
+  should_merge: true,
+  source_count: 1,
   legacy_count: 1,
   files: [
     {

--- a/packages/opencode/test/storage/legacy-db.test.ts
+++ b/packages/opencode/test/storage/legacy-db.test.ts
@@ -29,35 +29,34 @@ describe("LegacyDB", () => {
     await clean()
   })
 
-  test("reports legacy database stats", async () => {
-    create(path.join(Global.Path.data, "opencode-dev.db"), [
-      { id: "a", title: "dev", version: "0.1.0", time: 100 },
-    ])
-    create(path.join(Global.Path.data, "opencode-local.db"), [
-      { id: "b", title: "local", version: "0.2.0", time: 120 },
-    ])
-
+  test("reports auto-merge status when target is missing", async () => {
+    create(path.join(Global.Path.data, "opencode-dev.db"), [{ id: "a", title: "dev", version: "0.1.0", time: 1 }])
     const info = await LegacyDB.status()
-    expect(info.has_legacy).toBeTrue()
-    expect(info.legacy_count).toBe(2)
-    expect(info.naming["dev"]).toBe(1)
-    expect(info.naming["local"]).toBe(1)
-    expect(info.versions["0.1.0"]).toBe(1)
-    expect(info.versions["0.2.0"]).toBe(1)
+    expect(info.should_merge).toBeTrue()
+    expect(info.source_count).toBe(1)
+    expect(info.target.endsWith("aether-prod.db")).toBeTrue()
   })
 
-  test("archives legacy db files after merge", async () => {
-    create(path.join(Global.Path.data, "opencode-dev.db"), [{ id: "x", title: "dev", version: "0.1.0", time: 1 }])
-    create(path.join(Global.Path.data, "opencode-local.db"), [{ id: "y", title: "local", version: "0.2.0", time: 2 }])
-
-    await LegacyDB.ensureTarget()
-    const arc = await LegacyDB.archive()
-    expect(arc.clean).toBeTrue()
-    expect(arc.moved.length).toBe(2)
-
+  test("copies single source into target and keeps source db intact", async () => {
+    create(path.join(Global.Path.data, "opencode-dev.db"), [{ id: "a", title: "dev", version: "0.1.0", time: 1 }])
+    await LegacyDB.copySource()
+    const db = new Sqlite(LegacyDB.targetPath(), { readonly: true })
+    const row = db.query("select id, title from session where id='a'").get() as { id: string; title: string }
+    db.close()
+    expect(row.title).toBe("dev")
     const left = await fs.readdir(Global.Path.data)
     const dbs = left.filter((item) => item.endsWith(".db"))
     expect(dbs.includes("aether-prod.db")).toBeTrue()
-    expect(dbs.length).toBe(1)
+    expect(dbs.includes("opencode-dev.db")).toBeTrue()
+    expect(dbs.length).toBe(2)
+  })
+
+  test("does not re-trigger merge once target exists and boot flag is cleared", async () => {
+    create(path.join(Global.Path.data, "opencode-dev.db"), [{ id: "a", title: "dev", version: "0.1.0", time: 1 }])
+    await LegacyDB.setBootState({ should_merge: true, source_count: 1, updated: Date.now() })
+    await LegacyDB.copySource()
+    await LegacyDB.setBootState({ should_merge: false, source_count: 1, updated: Date.now() })
+    const info = await LegacyDB.status()
+    expect(info.should_merge).toBeFalse()
   })
 })

--- a/packages/opencode/test/storage/legacy-verify.test.ts
+++ b/packages/opencode/test/storage/legacy-verify.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Database as Sqlite } from "bun:sqlite"
+import { Global } from "../../src/global"
+import { LegacyVerify } from "../../src/storage/legacy-verify"
+
+async function clean() {
+  const rows = await fs.readdir(Global.Path.data, { withFileTypes: true }).catch(() => [])
+  await Promise.all(
+    rows
+      .filter((row) => row.isFile() && /^(opencode|aether).*\.db$/i.test(row.name))
+      .map((row) => fs.rm(path.join(Global.Path.data, row.name), { force: true })),
+  )
+}
+
+function create(file: string, input: { worktree: string; project: string; workspace?: string }) {
+  const db = new Sqlite(file)
+  db.exec("create table if not exists project (id text primary key, worktree text not null, vcs text, name text)")
+  db.exec("create table if not exists workspace (id text primary key, type text not null, branch text, name text, directory text, extra text, project_id text not null)")
+  db.exec("create table if not exists session (id text primary key, project_id text not null, workspace_id text, slug text not null, directory text not null, title text not null, version text not null, time_created integer not null, time_updated integer not null)")
+  db.exec("create table if not exists message (id text primary key, session_id text not null, time_created integer not null, time_updated integer not null, data text not null)")
+  db.prepare("insert into project (id, worktree, vcs, name) values (?, ?, ?, ?)").run(input.project, input.worktree, "git", "proj")
+  if (input.workspace) {
+    db.prepare("insert into workspace (id, type, branch, name, directory, project_id) values (?, ?, ?, ?, ?, ?)").run(input.workspace, "git", "dev", "wk", input.worktree, input.project)
+  }
+  db.prepare("insert into session (id, project_id, workspace_id, slug, directory, title, version, time_created, time_updated) values (?, ?, ?, ?, ?, ?, ?, ?, ?)").run("s1", input.project, input.workspace || null, "slug", input.worktree, "title", "0.1.0", 1, 2)
+  db.prepare("insert into message (id, session_id, time_created, time_updated, data) values (?, ?, ?, ?, ?)").run("m1", "s1", 1, 1, "{}")
+  db.close()
+}
+
+describe("LegacyVerify", () => {
+  beforeEach(async () => {
+    await clean()
+  })
+
+  test("passes when session/project/workspace mapping stays consistent", async () => {
+    create(path.join(Global.Path.data, "opencode-dev.db"), { worktree: "/tmp/a", project: "p1", workspace: "w1" })
+    create(path.join(Global.Path.data, "aether-prod.db"), { worktree: "/tmp/a", project: "p1", workspace: "w1" })
+    const report = await LegacyVerify.run()
+    expect(report.ok).toBeTrue()
+    expect(report.errors.length).toBe(0)
+  })
+
+  test("fails when merged session points at project with wrong worktree", async () => {
+    create(path.join(Global.Path.data, "opencode-dev.db"), { worktree: "/tmp/a", project: "p1", workspace: "w1" })
+    create(path.join(Global.Path.data, "aether-prod.db"), { worktree: "/tmp/b", project: "p1", workspace: "w1" })
+    const report = await LegacyVerify.run()
+    expect(report.ok).toBeFalse()
+    expect(report.errors.some((item) => item === "project-worktree-mismatch:s1")).toBeTrue()
+  })
+})

--- a/packages/ui/src/components/toast.css
+++ b/packages/ui/src/components/toast.css
@@ -27,6 +27,22 @@
       display: none;
     }
   }
+
+  &[data-placement="top-center"] {
+    top: 72px;
+    left: 50%;
+    right: auto;
+    bottom: auto;
+    width: min(520px, calc(100vw - 24px));
+    max-width: min(520px, calc(100vw - 24px));
+    transform: translateX(-50%);
+    max-height: calc(100dvh - 120px);
+    overflow: visible;
+
+    [data-slot="toast-list"] {
+      overflow: visible;
+    }
+  }
 }
 
 [data-component="toast"] {
@@ -54,6 +70,10 @@
 
   &[data-opened] {
     animation: toastPopIn 150ms ease-out;
+  }
+
+  &[data-opened][data-shifted="true"] {
+    animation: none;
   }
 
   &[data-closed] {
@@ -204,26 +224,18 @@
   }
 
   &[data-placement="top-center"] {
-    position: fixed;
-    top: 72px;
-    left: 50%;
-    right: auto;
-    width: min(520px, calc(100vw - 24px));
-    max-width: min(520px, calc(100vw - 24px));
-    transform: translateX(-50%);
-    z-index: 1100;
+    width: 100%;
+    max-width: none;
   }
 
-  &[data-placement="top-center"][data-swipe="move"] {
-    transform: translateX(calc(-50% + var(--kb-toast-swipe-move-x)));
+  &[data-draggable="true"] {
+    cursor: grab;
+    user-select: none;
   }
 
-  &[data-placement="top-center"][data-swipe="cancel"] {
-    transform: translateX(-50%);
-  }
-
-  &[data-placement="top-center"][data-swipe="end"] {
-    animation: toastSwipeOutTop 100ms ease-out forwards;
+  &[data-dragging="true"] {
+    cursor: grabbing;
+    transition: none;
   }
 }
 
@@ -255,14 +267,5 @@
   }
   to {
     transform: translateX(100%);
-  }
-}
-
-@keyframes toastSwipeOutTop {
-  from {
-    transform: translateX(calc(-50% + var(--kb-toast-swipe-end-x)));
-  }
-  to {
-    transform: translateX(calc(-50% + 100%));
   }
 }

--- a/packages/ui/src/components/toast.css
+++ b/packages/ui/src/components/toast.css
@@ -202,6 +202,29 @@
     background-color: var(--color-primary);
     transition: width 250ms linear;
   }
+
+  &[data-placement="top-center"] {
+    position: fixed;
+    top: 72px;
+    left: 50%;
+    right: auto;
+    width: min(520px, calc(100vw - 24px));
+    max-width: min(520px, calc(100vw - 24px));
+    transform: translateX(-50%);
+    z-index: 1100;
+  }
+
+  &[data-placement="top-center"][data-swipe="move"] {
+    transform: translateX(calc(-50% + var(--kb-toast-swipe-move-x)));
+  }
+
+  &[data-placement="top-center"][data-swipe="cancel"] {
+    transform: translateX(-50%);
+  }
+
+  &[data-placement="top-center"][data-swipe="end"] {
+    animation: toastSwipeOutTop 100ms ease-out forwards;
+  }
 }
 
 @keyframes toastPopIn {
@@ -232,5 +255,14 @@
   }
   to {
     transform: translateX(100%);
+  }
+}
+
+@keyframes toastSwipeOutTop {
+  from {
+    transform: translateX(calc(-50% + var(--kb-toast-swipe-end-x)));
+  }
+  to {
+    transform: translateX(calc(-50% + 100%));
   }
 }

--- a/packages/ui/src/components/toast.tsx
+++ b/packages/ui/src/components/toast.tsx
@@ -1,8 +1,10 @@
+/** @jsxImportSource solid-js */
 import { Toast as Kobalte, toaster } from "@kobalte/core/toast"
 import type { ToastRootProps, ToastCloseButtonProps, ToastTitleProps, ToastDescriptionProps } from "@kobalte/core/toast"
 import type { ComponentProps, JSX } from "solid-js"
 import { Show } from "solid-js"
 import { Portal } from "solid-js/web"
+import { createStore } from "solid-js/store"
 import { useI18n } from "../context/i18n"
 import { Icon, type IconProps } from "./icon"
 import { IconButton } from "./icon-button"
@@ -102,7 +104,11 @@ export type ToastVariant = "default" | "success" | "error" | "loading"
 
 export interface ToastAction {
   label: string
-  onClick: "dismiss" | (() => void)
+  onClick:
+    | "dismiss"
+    | ((input: { toastId: number; placement?: ToastOptions["placement"]; offset: { x: number; y: number } }) =>
+        | void
+        | Promise<void>)
 }
 
 export interface ToastOptions {
@@ -114,43 +120,132 @@ export interface ToastOptions {
   persistent?: boolean
   placement?: "bottom-right" | "top-center"
   guarded?: boolean
+  offset?: { x: number; y: number }
   actions?: ToastAction[]
 }
 
-export function showToast(options: ToastOptions | string) {
-  const opts = typeof options === "string" ? { description: options } : options
+type Context = {
+  placement?: ToastOptions["placement"]
+  offset: { x: number; y: number }
+}
+
+let current: Context | undefined
+
+function region(placement: ToastOptions["placement"]) {
+  return placement === "top-center" ? "top-center" : "bottom-right"
+}
+
+function shift(input: { placement?: ToastOptions["placement"]; x: number; y: number }) {
+  return `translate(${input.x}px, ${input.y}px)`
+}
+
+function ToastItem(props: { toastId: number; opts: ToastOptions }) {
+  const [drag, setDrag] = createStore({
+    x: props.opts.offset?.x ?? 0,
+    y: props.opts.offset?.y ?? 0,
+    on: false,
+    px: 0,
+    py: 0,
+    id: -1,
+  })
+
   const stop = (event: Event) => event.preventDefault()
-  return toaster.show((props) => (
+  const draggable = props.opts.guarded && props.opts.placement === "top-center"
+
+  const down: JSX.EventHandlerUnion<HTMLElement, PointerEvent> = (event) => {
+    if (!draggable) return
+    const node = event.target as HTMLElement | null
+    if (node?.closest("[data-slot='toast-action']")) return
+    setDrag({
+      on: true,
+      px: event.clientX,
+      py: event.clientY,
+      id: event.pointerId,
+    })
+    event.currentTarget.setPointerCapture?.(event.pointerId)
+    event.preventDefault()
+    event.stopPropagation()
+  }
+
+  const move: JSX.EventHandlerUnion<HTMLElement, PointerEvent> = (event) => {
+    if (!drag.on) return
+    if (event.pointerId !== drag.id) return
+    setDrag({
+      x: drag.x + event.clientX - drag.px,
+      y: drag.y + event.clientY - drag.py,
+      px: event.clientX,
+      py: event.clientY,
+    })
+    event.preventDefault()
+    event.stopPropagation()
+  }
+
+  const up: JSX.EventHandlerUnion<HTMLElement, PointerEvent> = (event) => {
+    if (!drag.on) return
+    if (event.pointerId !== drag.id) return
+    setDrag({ on: false, id: -1 })
+    if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+      event.currentTarget.releasePointerCapture?.(event.pointerId)
+    }
+    event.preventDefault()
+    event.stopPropagation()
+  }
+
+  return (
     <Toast
       toastId={props.toastId}
-      duration={opts.duration}
-      persistent={opts.persistent}
-      onEscapeKeyDown={opts.guarded ? stop : undefined}
-      onSwipeStart={opts.guarded ? stop : undefined}
-      onSwipeMove={opts.guarded ? stop : undefined}
-      onSwipeCancel={opts.guarded ? stop : undefined}
-      onSwipeEnd={opts.guarded ? stop : undefined}
-      data-variant={opts.variant ?? "default"}
-      data-placement={opts.placement ?? "bottom-right"}
+      duration={props.opts.duration}
+      persistent={props.opts.persistent}
+      onEscapeKeyDown={props.opts.guarded ? stop : undefined}
+      onSwipeStart={props.opts.guarded ? stop : undefined}
+      onSwipeMove={props.opts.guarded ? stop : undefined}
+      onSwipeCancel={props.opts.guarded ? stop : undefined}
+      onSwipeEnd={props.opts.guarded ? stop : undefined}
+      onPointerDown={down}
+      onPointerMove={move}
+      onPointerUp={up}
+      data-variant={props.opts.variant ?? "default"}
+      data-placement={props.opts.placement ?? "bottom-right"}
+      data-draggable={draggable ? "true" : undefined}
+      data-dragging={drag.on ? "true" : undefined}
+      data-shifted={drag.x !== 0 || drag.y !== 0 ? "true" : undefined}
+      style={{ transform: shift({ placement: props.opts.placement, x: drag.x, y: drag.y }) }}
     >
-      <Show when={opts.icon}>
-        <Toast.Icon name={opts.icon!} />
+      <Show when={props.opts.icon}>
+        <Toast.Icon name={props.opts.icon!} />
       </Show>
       <Toast.Content>
-        <Show when={opts.title}>
-          <Toast.Title>{opts.title}</Toast.Title>
+        <Show when={props.opts.title}>
+          <Toast.Title>{props.opts.title}</Toast.Title>
         </Show>
-        <Show when={opts.description}>
-          <Toast.Description>{opts.description}</Toast.Description>
+        <Show when={props.opts.description}>
+          <Toast.Description>{props.opts.description}</Toast.Description>
         </Show>
-        <Show when={opts.actions?.length}>
+        <Show when={props.opts.actions?.length}>
           <Toast.Actions>
-            {opts.actions!.map((action) => (
+            {props.opts.actions!.map((action) => (
               <button
                 data-slot="toast-action"
                 onClick={() => {
+                  current = {
+                    placement: props.opts.placement,
+                    offset: { x: drag.x, y: drag.y },
+                  }
                   if (typeof action.onClick === "function") {
-                    action.onClick()
+                    const result = action.onClick({
+                      toastId: props.toastId,
+                      placement: props.opts.placement,
+                      offset: { x: drag.x, y: drag.y },
+                    })
+                    if (result && typeof (result as Promise<unknown>).finally === "function") {
+                      ;(result as Promise<unknown>).finally(() => {
+                        current = undefined
+                      })
+                    } else {
+                      current = undefined
+                    }
+                  } else {
+                    current = undefined
                   }
                   toaster.dismiss(props.toastId)
                 }}
@@ -161,11 +256,25 @@ export function showToast(options: ToastOptions | string) {
           </Toast.Actions>
         </Show>
       </Toast.Content>
-      <Show when={!opts.guarded}>
+      <Show when={!props.opts.guarded}>
         <Toast.CloseButton />
       </Show>
     </Toast>
-  ))
+  )
+}
+
+export function showToast(options: ToastOptions | string) {
+  const raw = typeof options === "string" ? { description: options } : options
+  const opts =
+    raw.offset || !current || raw.placement !== current.placement
+      ? raw
+      : {
+          ...raw,
+          offset: current.offset,
+        }
+  return toaster.show((props) => <ToastItem toastId={props.toastId} opts={opts} />, {
+    region: region(opts.placement),
+  })
 }
 
 export interface ToastPromiseOptions<T, U = unknown> {

--- a/packages/ui/src/components/toast.tsx
+++ b/packages/ui/src/components/toast.tsx
@@ -112,17 +112,26 @@ export interface ToastOptions {
   variant?: ToastVariant
   duration?: number
   persistent?: boolean
+  placement?: "bottom-right" | "top-center"
+  guarded?: boolean
   actions?: ToastAction[]
 }
 
 export function showToast(options: ToastOptions | string) {
   const opts = typeof options === "string" ? { description: options } : options
+  const stop = (event: Event) => event.preventDefault()
   return toaster.show((props) => (
     <Toast
       toastId={props.toastId}
       duration={opts.duration}
       persistent={opts.persistent}
+      onEscapeKeyDown={opts.guarded ? stop : undefined}
+      onSwipeStart={opts.guarded ? stop : undefined}
+      onSwipeMove={opts.guarded ? stop : undefined}
+      onSwipeCancel={opts.guarded ? stop : undefined}
+      onSwipeEnd={opts.guarded ? stop : undefined}
       data-variant={opts.variant ?? "default"}
+      data-placement={opts.placement ?? "bottom-right"}
     >
       <Show when={opts.icon}>
         <Toast.Icon name={opts.icon!} />
@@ -152,7 +161,9 @@ export function showToast(options: ToastOptions | string) {
           </Toast.Actions>
         </Show>
       </Toast.Content>
-      <Toast.CloseButton />
+      <Show when={!opts.guarded}>
+        <Toast.CloseButton />
+      </Show>
     </Toast>
   ))
 }


### PR DESCRIPTION
### Issue for this PR

Closes #212

### Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an automatic legacy database migration path for first-run product launches. Single-source legacy databases are copied directly into `aether-prod.db`; multi-source migrations are delegated to an agent workflow with stricter merge instructions, temporary-database staging, and post-merge relation validation for `project`, `workspace`, and `session` consistency.

It also updates the web flow so migration starts automatically when required, surfaces one-time completion/failure feedback, and avoids re-triggering after the target database is created.

### How did you verify your code works?

- Ran `bun test test/storage/legacy-db.test.ts test/storage/legacy-verify.test.ts test/automation/legacy-repair.test.ts` in `packages/opencode`
- Ran `bun typecheck` in `packages/opencode`
- Ran `bun ../../node_modules/@typescript/native-preview/bin/tsgo.js -b` in `packages/app`
- Ran local smoke/e2e checks for single-source copy flow, multi-source agent kickoff flow, and relation-consistency verification

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR