### PR TITLE
feat: 飞书群聊自然语言总结功能

### DIFF
--- a/docs/feishu-architecture.md
+++ b/docs/feishu-architecture.md
@@ -254,7 +254,10 @@ export const [feishuStatus, setFeishuStatus] = createSignal<FeishuStatus>("idle"
    a. 有映射 → 复用已映射的会话
    b. 无映射 → 复用最近的会话；若无任何会话则新建
 6. resolveModel(chatId) 解析本次使用的模型
-7. SessionPrompt.prompt() 将文本发送给 AI（携带模型参数）
+7. detectSummaryIntent(text) 检测是否为总结请求（含"总结/汇总/归纳"且含"群/今天/消息"等词）
+   a. 命中 → fetchChatHistory() 调用 larkClient.im.message.list() 拉取历史，拼入 prompt
+   b. 未命中 → 直接使用原始文本
+8. SessionPrompt.prompt() 将文本发送给 AI（携带模型参数）
 8. 提取 AI 回复的文本部分，拼接项目/会话标题头部
 9. larkClient.im.message.reply() 回复到飞书
 10. 如果任何步骤报错 → catch 中通过 replyText 将错误信息发回飞书
@@ -393,8 +396,12 @@ undefined → SessionPrompt 内部默认逻辑
 SDK 使用方式：
 - `lark.WSClient` — WebSocket 长连接客户端
 - `lark.EventDispatcher` — 事件注册和分发
-- `lark.Client` — REST API 客户端（发送回复消息）
+- `lark.Client` — REST API 客户端（发送回复消息、拉取消息历史）
 - `lark.LoggerLevel.debug` — 调试日志级别
+
+`lark.Client` 调用的 API：
+- `larkClient.im.message.reply()` — 回复消息
+- `larkClient.im.message.list()` — 拉取群聊消息历史（总结功能使用，需 `im:message.group_msg` 权限）
 
 ## 与微信连接的架构对比
 
@@ -431,3 +438,4 @@ SDK 使用方式：
 | 2026-04-06 19:17 | 取消隐藏改为双机制：飞书消息直接判断 + GlobalBus 监听 web 端活动 | `time.activity` 只在项目初始化时更新，不反映 session 消息，原方案对活跃项目无效 |
 | 2026-04-07 | 新增 `/session` 命令：查看/切换会话，数据源与微信端一致；`_chatSessions` 存储 per-chat 当前会话 | 微信端支持多会话切换，飞书端功能对齐 |
 | 2026-04-07 | 群聊中仅响应 @机器人 的消息，检查 `chat_type` 和 `mentions` 字段 | 之前群聊中所有消息都会触发回复，@一次后机器人对所有消息都回复 |
+| 2026-04-08 16:28 | 新增群聊总结功能：`detectSummaryIntent()` 关键词检测 + `fetchChatHistory()` 拉取历史注入 prompt | 用户可直接用自然语言（如"帮我总结今天的群聊"）触发，无需斜杠命令；需开启 `im:message.group_msg` 权限 |

--- a/docs/feishu-setup-guide.md
+++ b/docs/feishu-setup-guide.md
@@ -54,6 +54,7 @@ Aether 支持通过飞书进行对话，体验与微信连接一致：
 | `im:message` | 获取与发送消息 |
 | `im:message:send_as_bot` | 以机器人身份发送消息 |
 | `im:message.p2p_msg:readonly` | 读取私聊消息 |
+| `im:message.group_msg` | 读取群聊消息历史（总结功能需要） |
 
 ### 第五步：发布应用
 

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -409,10 +409,24 @@ class FeishuManagerImpl {
           const model = this.resolveModel(chatId)
           console.log("[feishu] using model:", model ?? "(default)")
 
+          // Detect summarization intent and inject chat history into prompt
+          let promptText = text
+          const intent = this.detectSummaryIntent(text)
+          if (intent.isSummary) {
+            console.log("[feishu] summary intent detected, fetching chat history...")
+            const history = await this.fetchChatHistory(chatId, { today: intent.today, count: intent.count })
+            if (history) {
+              promptText = `${text}\n\n以下是群聊记录，请据此进行总结：\n\n${history}`
+            } else {
+              await this.replyText(messageId, "⚠️ 未能获取群聊记录（可能需要在飞书开放平台开启 im:message.group_msg 权限）")
+              return
+            }
+          }
+
           console.log("[feishu] sending to aether, session:", sessionId)
           const msg = await SessionPrompt.prompt({
             sessionID: SessionID.make(sessionId),
-            parts: [{ type: "text", text }],
+            parts: [{ type: "text", text: promptText }],
             ...(model ? { model } : {}),
           })
           console.log("[feishu] aether responded, parts:", msg?.parts?.length)
@@ -440,6 +454,75 @@ class FeishuManagerImpl {
         const errMsg = err instanceof Error ? err.message : String(err)
         await this.replyText(messageId, `处理消息时出错: ${errMsg}`).catch(() => {})
       }
+    }
+  }
+
+  /** Detect if the user is asking for a chat summary and extract time range. */
+  private detectSummaryIntent(text: string): { isSummary: boolean; today: boolean; count: number } {
+    const summaryWords = ["总结", "汇总", "归纳", "概括", "summary"]
+    const contextWords = ["群", "聊天", "消息", "今天", "最近", "记录", "内容", "讨论"]
+    const lower = text.toLowerCase()
+    const hasSummary = summaryWords.some((w) => lower.includes(w))
+    const hasContext = contextWords.some((w) => lower.includes(w))
+    if (!hasSummary || !hasContext) return { isSummary: false, today: false, count: 50 }
+    const today = lower.includes("今天") || lower.includes("today")
+    const match = text.match(/(\d+)\s*条/)
+    const count = match ? Math.min(parseInt(match[1], 10), 100) : 50
+    return { isSummary: true, today, count }
+  }
+
+  /** Fetch recent messages from a chat and format as transcript. */
+  private async fetchChatHistory(chatId: string, opts: { today: boolean; count: number }): Promise<string | null> {
+    if (!this.larkClient) return null
+    try {
+      const params: Record<string, any> = {
+        container_id_type: "chat",
+        container_id: chatId,
+        page_size: Math.min(opts.count, 50),
+        sort_type: "ByCreateTimeDesc",
+      }
+      if (opts.today) {
+        const midnight = new Date()
+        midnight.setHours(0, 0, 0, 0)
+        params.start_time = String(Math.floor(midnight.getTime() / 1000))
+      }
+
+      const items: any[] = []
+      let pageToken: string | undefined
+      let remaining = opts.count
+      do {
+        const result = await this.larkClient.im.message.list({
+          params: { ...params, page_size: Math.min(remaining, 50), ...(pageToken ? { page_token: pageToken } : {}) },
+        })
+        const batch: any[] = result?.data?.items ?? []
+        items.push(...batch)
+        pageToken = result?.data?.has_more ? result.data.page_token : undefined
+        remaining -= batch.length
+      } while (pageToken && remaining > 0)
+
+      items.reverse()
+
+      const lines: string[] = []
+      for (const item of items) {
+        if (item.deleted || item.msg_type !== "text") continue
+        let content: string
+        try {
+          content = JSON.parse(item.body?.content || "{}").text ?? ""
+        } catch {
+          continue
+        }
+        if (!content.trim()) continue
+        const senderId = (item.sender?.sender_id?.open_id ?? "unknown").slice(-8)
+        const ts = parseInt(item.create_time ?? "0")
+        const time = new Date(ts).toLocaleTimeString("zh-CN", { hour: "2-digit", minute: "2-digit" })
+        lines.push(`[${time}] ${senderId}: ${content}`)
+      }
+
+      if (lines.length === 0) return null
+      return lines.join("\n")
+    } catch (err) {
+      console.error("[feishu] fetchChatHistory error:", err)
+      return null
     }
   }
 


### PR DESCRIPTION
Closes #201

## 变更内容

用户在飞书群聊中直接用自然语言请求总结（如「帮我总结今天的群聊」），机器人自动拉取历史消息并生成摘要，无需斜杠命令。

## 新增方法

- `detectSummaryIntent(text)` — 关键词检测，同时含"总结/汇总/归纳/概括"和"群/聊天/今天/消息"才触发
- `fetchChatHistory(chatId, opts)` — 调用 `larkClient.im.message.list()` 拉取历史，支持条数上限（默认50，最多100）和"今天"模式，格式化为 `[HH:mm] 用户xxx: 内容`

## 所需新权限

飞书开放平台需开启 `im:message.group_msg`

## 依赖

依赖 feishu/docs-permission 合并后生效