### PR TITLE
fix(wechat): allow lock recovery when page is closed without disconnect

### DIFF
--- a/packages/app/src/components/dialog-wechat.tsx
+++ b/packages/app/src/components/dialog-wechat.tsx
@@ -14,6 +14,7 @@ import {
   startBridge,
   stopBridge,
   logout,
+  forceTakeover,
   type WeChatStatus,
 } from "@/context/wechat"
 
@@ -39,9 +40,14 @@ export const DialogWeChat: Component = () => {
                   当前有另一个页面正在使用微信，请先在该页面断开连接
                 </p>
               </div>
-              <Button variant="secondary" onClick={() => dialog.close()}>
-                关闭
-              </Button>
+              <div class="flex gap-2">
+                <Button variant="secondary" onClick={() => dialog.close()}>
+                  关闭
+                </Button>
+                <Button variant="primary" onClick={() => forceTakeover(currentModelStr())}>
+                  强制接管
+                </Button>
+              </div>
             </div>
           </Match>
 

--- a/packages/app/src/context/wechat.ts
+++ b/packages/app/src/context/wechat.ts
@@ -195,7 +195,7 @@ export async function fetchStatus() {
   } catch {}
 }
 
-export async function startBridge(auto = false, modelStr?: string) {
+export async function startBridge(auto = false, modelStr?: string, force = false) {
   updateStatus("loading")
   setLoadingMsg("正在启动微信桥接...")
   setError(null)
@@ -208,7 +208,7 @@ export async function startBridge(auto = false, modelStr?: string) {
     const response = await fetch(`${url}/wechat/start`, {
       method: "POST",
       headers: { ...headers, "Content-Type": "application/json" },
-      body: JSON.stringify({ model: modelStr, autoInstall: auto, clientId }),
+      body: JSON.stringify({ model: modelStr, autoInstall: auto, clientId, force }),
     })
     const data = await response.json()
 
@@ -287,8 +287,19 @@ export async function logout() {
   setQrcode(null)
 }
 
+export function forceTakeover(modelStr?: string) {
+  return startBridge(true, modelStr, true)
+}
+
 export function initWechat() {
   if (initialized) return
   initialized = true
+  window.addEventListener("beforeunload", () => {
+    if (!clientId) return
+    try {
+      const { url } = api()
+      navigator.sendBeacon(`${url}/wechat/stop`, new Blob([JSON.stringify({ clientId })], { type: "application/json" }))
+    } catch {}
+  })
   fetchStatus()
 }

--- a/packages/opencode/src/server/routes/wechat.ts
+++ b/packages/opencode/src/server/routes/wechat.ts
@@ -42,7 +42,10 @@ export const WeChatRoutes = lazy(() =>
       async (c) => {
         const body = await c.req.json().catch(() => ({}))
         const clientId: string = body?.clientId || crypto.randomUUID()
-        if (!(await WeChatManager.tryLock(clientId))) {
+        const force: boolean = body?.force === true
+        if (force) {
+          await WeChatManager.forceLock(clientId)
+        } else if (!(await WeChatManager.tryLock(clientId))) {
           return c.json({ success: false, code: "locked", message: "微信已被其他客户端连接" })
         }
         const result = await WeChatManager.start(body?.model, body?.autoInstall === true)

--- a/packages/opencode/src/wechat/manager.ts
+++ b/packages/opencode/src/wechat/manager.ts
@@ -98,6 +98,11 @@ class WeChatManagerImpl {
     return this._error
   }
 
+  private isLockExpired(lock: { updatedAt?: number }): boolean {
+    if (!lock.updatedAt) return true
+    return Date.now() - lock.updatedAt > 30_000
+  }
+
   /** Read the current lock holder from disk. Returns null if no valid lock. */
   get lockHolder(): string | null {
     try {
@@ -107,6 +112,12 @@ class WeChatManagerImpl {
       try {
         process.kill(lock.pid, 0)
       } catch {
+        try {
+          unlinkSync(LOCK_FILE)
+        } catch {}
+        return null
+      }
+      if (this.isLockExpired(lock)) {
         try {
           unlinkSync(LOCK_FILE)
         } catch {}
@@ -127,6 +138,15 @@ class WeChatManagerImpl {
       return true
     }
     return false
+  }
+
+  /** Force-acquire the lock, removing any existing holder. */
+  async forceLock(clientId: string): Promise<void> {
+    await mkdir(WECHAT_DATA_DIR, { recursive: true })
+    try {
+      await rm(LOCK_FILE, { force: true })
+    } catch {}
+    await writeFile(LOCK_FILE, JSON.stringify({ clientId, pid: process.pid, updatedAt: Date.now() }))
   }
 
   /** Release the lock if held by this client. */


### PR DESCRIPTION
## Summary

Fixes #207

Three-pronged fix for the WeChat connection deadlock when a web page is closed without disconnecting:

### Backend (`packages/opencode`)

- **Lock expiry detection** (`manager.ts`): Added `isLockExpired()` — locks with `updatedAt` older than 30 seconds are automatically deleted when read via the `lockHolder` getter. Since the ping interval is 10s, 3 missed pings means the client is dead.
- **Force lock acquisition** (`manager.ts`): Added `forceLock(clientId)` — unconditionally deletes any existing lock and writes a new one for the requesting client.
- **Route support** (`wechat.ts`): `POST /wechat/start` now accepts a `force` body parameter. When `true`, calls `forceLock` instead of `tryLock`, bypassing the lock check entirely.

### Frontend (`packages/app`)

- **Force takeover** (`wechat.ts`): Added `forceTakeover()` export and `force` parameter to `startBridge()`. When invoked, sends `{ force: true }` to `/wechat/start`.
- **Force takeover button** (`dialog-wechat.tsx`): Added a "强制接管" (Force Takeover) button alongside the existing "关闭" button in the locked-state UI, allowing users to immediately reclaim the connection.
- **Lock release on page close** (`wechat.ts`): Registered a `beforeunload` event listener in `initWechat()` that calls `navigator.sendBeacon()` to POST `/wechat/stop` with the current `clientId`, releasing the lock when the page is closed.

### Behavior

| Scenario | Before | After |
|---|---|---|
| Page closed without disconnect | Deadlocked until server restart | Lock auto-expires after 30s; also released via `sendBeacon` |
| New page opens while lock is stale | "微信已被其他客户端连接" with no escape | Auto-recovers (expired lock) or manual "Force Takeover" button |
| Legitimate lock from active page | Works correctly | Unchanged — active ping keeps lock fresh |

## Test plan

- [ ] Open WeChat connection, close the tab, reopen → should auto-recover within 30s
- [ ] Open WeChat connection, close the tab, immediately reopen → "Force Takeover" button should work
- [ ] Two tabs: Tab A connected, Tab B tries to connect → Tab B sees locked state (not force)
- [ ] Tab A connected, Tab B clicks "Force Takeover" → Tab B takes over, Tab A gets "stolen" status on next ping