### PR TITLE
fix(ui): include date in message timestamp format

### DIFF
--- a/packages/app/src/components/dialog-fork.tsx
+++ b/packages/app/src/components/dialog-fork.tsx
@@ -19,7 +19,8 @@ interface ForkableMessage {
 }
 
 function formatTime(date: Date): string {
-  return date.toLocaleTimeString(undefined, { timeStyle: "short" })
+  const pad = (n: number) => String(n).padStart(2, "0")
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}-${pad(date.getHours())}:${pad(date.getMinutes())}`
 }
 
 export const DialogFork: Component = () => {

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -910,12 +910,18 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
     const match = data.store.provider?.all?.find((p) => p.id === providerID)
     return match?.models?.[modelID]?.name ?? modelID
   })
-  const timefmt = createMemo(() => new Intl.DateTimeFormat(i18n.locale(), { timeStyle: "short" }))
+  const timefmt = createMemo(() => {
+    const pad = (n: number) => String(n).padStart(2, "0")
+    return (ms: number) => {
+      const d = new Date(ms)
+      return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}-${pad(d.getHours())}:${pad(d.getMinutes())}`
+    }
+  })
 
   const stamp = createMemo(() => {
     const created = props.message.time?.created
     if (typeof created !== "number") return ""
-    return timefmt().format(created)
+    return timefmt()(created)
   })
 
   const metaHead = createMemo(() => {


### PR DESCRIPTION
## Summary

- Replace time-only format (`HH:mm`, e.g. `12:53`) with full date-time format (`YYYY-MM-DD-HH:mm`, e.g. `2026-04-08-12:53`) in chat message headers and the fork dialog
- Use explicit date formatting instead of locale-dependent `Intl.DateTimeFormat` with `timeStyle: "short"` to ensure consistent, unambiguous output

Closes #209

## Changes

| File | Change |
|------|--------|
| `packages/ui/src/components/message-part.tsx` | Replace `Intl.DateTimeFormat({ timeStyle: "short" })` with custom `YYYY-MM-DD-HH:mm` formatter |
| `packages/app/src/components/dialog-fork.tsx` | Replace `toLocaleTimeString({ timeStyle: "short" })` with same `YYYY-MM-DD-HH:mm` format |