### PR TITLE
feat(reading-mode): 在当前会话中打开阅读模式，添加退出按钮

### DIFF
--- a/packages/app/public/pdf-viewer-aether.css
+++ b/packages/app/public/pdf-viewer-aether.css
@@ -50,6 +50,7 @@ body.aether-pdf-viewer {
   --aether-swap-right-icon: url("/pdfjs-ref/web/images/aether-swap-layout-right.svg");
   --aether-swap-left-icon: url("/pdfjs-ref/web/images/aether-swap-layout-left.svg");
   --aether-reading-mode-icon: url("/pdfjs-ref/web/images/aether-reading-mode.svg");
+  --aether-close-reading-mode-icon: url("/pdfjs-ref/web/images/aether-close-reading-mode.svg");
 }
 
 body.aether-pdf-viewer #aetherPdf2md {
@@ -75,6 +76,16 @@ body.aether-pdf-viewer #aetherPdf2md > span {
   padding: 0;
   text-indent: 0;
   white-space: nowrap;
+}
+
+body.aether-pdf-viewer #aetherCloseReadingMode {
+  min-width: 32px;
+  margin-inline-start: 6px;
+}
+
+body.aether-pdf-viewer #aetherCloseReadingMode::before {
+  -webkit-mask-image: var(--aether-close-reading-mode-icon);
+  mask-image: var(--aether-close-reading-mode-icon);
 }
 
 body.aether-pdf-viewer #aetherSwapLayout {

--- a/packages/app/public/pdf-viewer-aether.js
+++ b/packages/app/public/pdf-viewer-aether.js
@@ -547,6 +547,11 @@
       nightMode.setAttribute("aria-pressed", config.nightMode ? "true" : "false");
     }
 
+    const closeReadingMode = document.getElementById("aetherCloseReadingMode");
+    if (closeReadingMode) {
+      closeReadingMode.hidden = config.mode !== "full";
+    }
+
     const swapLayout = document.getElementById("aetherSwapLayout");
     if (swapLayout) {
       swapLayout.hidden = config.mode !== "full";
@@ -698,6 +703,13 @@
     if (readingSettings) {
       readingSettings.addEventListener("click", function () {
         post("opensettings");
+      });
+    }
+
+    const closeReadingMode = document.getElementById("aetherCloseReadingMode");
+    if (closeReadingMode) {
+      closeReadingMode.addEventListener("click", function () {
+        post("closereadingmode");
       });
     }
 

--- a/packages/app/public/pdf-viewer.html
+++ b/packages/app/public/pdf-viewer.html
@@ -290,6 +290,9 @@ See https://github.com/adobe-type-tools/cmap-resources
                 <button id="secondaryToolbarToggle" class="toolbarButton" title="Tools" tabindex="48" data-l10n-id="tools" aria-expanded="false" aria-controls="secondaryToolbar">
                   <span data-l10n-id="tools_label">Tools</span>
                 </button>
+                <button id="aetherCloseReadingMode" class="toolbarButton" title="Exit reading mode" hidden>
+                  <span>Exit reading mode</span>
+                </button>
               </div>
               <div id="toolbarViewerMiddle">
                 <div class="splitToolbarButton">

--- a/packages/app/public/pdfjs-ref/web/images/aether-close-reading-mode.svg
+++ b/packages/app/public/pdfjs-ref/web/images/aether-close-reading-mode.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none">
+  <path d="M5 5L15 15M15 5L5 15" stroke="#000" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/packages/app/src/components/pdf-viewer-shell-official.tsx
+++ b/packages/app/src/components/pdf-viewer-shell-official.tsx
@@ -52,6 +52,7 @@ export type PdfViewerShellProps = {
   onDocumentInfo?: (info: { totalPages: number }) => void
   onPdfToMarkdown?: () => void
   onOpenReadingMode?: () => void
+  onCloseReadingMode?: () => void
   onOpenSettings?: () => void
   onTextSelectionAction?: (input: { action: "copy" | "translate" | "ask"; page: number; text: string }) => void
   onImageSelectionAction?: (input: { action: "copy" | "translate" | "ask"; page: number; imageDataUrl: string }) => void
@@ -74,6 +75,7 @@ type ViewerMessage =
       imageDataUrl: string
     }
   | { channel: "aether-pdf-viewer"; type: "nightmode"; enabled: boolean }
+  | { channel: "aether-pdf-viewer"; type: "closereadingmode" }
   | { channel: "aether-pdf-viewer"; type: "swaplayout" }
 
 export const PdfViewerShell: Component<PdfViewerShellProps> = (props) => {
@@ -168,6 +170,11 @@ export const PdfViewerShell: Component<PdfViewerShellProps> = (props) => {
 
     if (event.data.type === "openreadingmode") {
       props.onOpenReadingMode?.()
+      return
+    }
+
+    if (event.data.type === "closereadingmode") {
+      props.onCloseReadingMode?.()
       return
     }
 

--- a/packages/app/src/components/reading-mode/reading-mode-panel.tsx
+++ b/packages/app/src/components/reading-mode/reading-mode-panel.tsx
@@ -24,9 +24,11 @@ export const ReadingModePanel: Component<{
   maxWidth: number
   layoutSwapped: boolean
   onSwapLayout?: () => void
+  onCloseReadingMode?: () => void
   onResizeWidth: (width: number) => void
   resizeHandleEnabled?: boolean
   sizing?: Sizing
+  overridePdfUrl?: string
 }> = (props) => {
   const rm = useReadingMode()
   const sdk = useSDK()
@@ -37,7 +39,7 @@ export const ReadingModePanel: Component<{
   const dialog = useDialog()
   const size = props.sizing ?? createSizing()
 
-  const pdfUrl = createMemo(() => `${sdk.url}/reading-mode/pdf?sessionID=${encodeURIComponent(props.sessionID)}`)
+  const pdfUrl = createMemo(() => props.overridePdfUrl ?? `${sdk.url}/reading-mode/pdf?sessionID=${encodeURIComponent(props.sessionID)}`)
   let restoredInitialPage = false
 
   createEffect(() => {
@@ -234,7 +236,9 @@ export const ReadingModePanel: Component<{
 
   return (
     <div class="relative h-full shrink-0 overflow-visible" style={{ width: `${props.width}px` }}>
-      <ReadingFirstReadGate sessionID={props.sessionID} />
+      <Show when={!props.overridePdfUrl}>
+        <ReadingFirstReadGate sessionID={props.sessionID} />
+      </Show>
       <div
         class="flex h-full flex-col overflow-hidden bg-surface-base"
         classList={{
@@ -247,6 +251,7 @@ export const ReadingModePanel: Component<{
             url={pdfUrl()}
             layoutSwapped={props.layoutSwapped}
             onSwapLayout={props.onSwapLayout}
+            onCloseReadingMode={props.onCloseReadingMode}
             onOpenSettings={handleOpenSettings}
             onTextSelectionAction={handleTextSelectionAction}
             onImageSelectionAction={handleImageSelectionAction}

--- a/packages/app/src/components/reading-mode/reading-pdf-viewer-official.tsx
+++ b/packages/app/src/components/reading-mode/reading-pdf-viewer-official.tsx
@@ -7,6 +7,7 @@ export const OfficialReadingPdfViewer: Component<{
   url: string
   layoutSwapped?: boolean
   onSwapLayout?: () => void
+  onCloseReadingMode?: () => void
   onOpenSettings?: () => void
   onTextSelectionAction?: (input: { action: "copy" | "translate" | "ask"; page: number; text: string }) => void
   onImageSelectionAction?: (input: { action: "copy" | "translate" | "ask"; page: number; imageDataUrl: string }) => void
@@ -30,6 +31,7 @@ export const OfficialReadingPdfViewer: Component<{
       layoutSwapped={props.layoutSwapped}
       onPageChange={(page) => rm.setPage(page)}
       onDocumentInfo={({ totalPages }) => rm.setTotalPages(totalPages)}
+      onCloseReadingMode={props.onCloseReadingMode}
       onOpenSettings={props.onOpenSettings}
       onTextSelectionAction={props.onTextSelectionAction}
       onImageSelectionAction={props.onImageSelectionAction}

--- a/packages/app/src/pages/reading-session.tsx
+++ b/packages/app/src/pages/reading-session.tsx
@@ -1,6 +1,6 @@
 import { type Component, createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js"
 import { createStore } from "solid-js/store"
-import { useParams } from "@solidjs/router"
+import { useNavigate, useParams, useSearchParams } from "@solidjs/router"
 import { ReadingModeProvider } from "@/context/reading-mode"
 import { ReadingModePanel } from "@/components/reading-mode/reading-mode-panel"
 import { TerminalProvider } from "@/context/terminal"
@@ -8,6 +8,7 @@ import { FileProvider } from "@/context/file"
 import { PromptProvider } from "@/context/prompt"
 import { CommentsProvider } from "@/context/comments"
 import { useLayout } from "@/context/layout"
+import { useSDK } from "@/context/sdk"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { createSizing } from "@/pages/session/helpers"
 import SessionPage from "./session"
@@ -51,9 +52,22 @@ const CHAT_RATIO_BOUNDS: Partial<Record<LayoutVariant, { min: number; max: numbe
 }
 
 const ReadingSession: Component = () => {
-  const params = useParams<{ id: string }>()
+  const params = useParams<{ id: string; dir?: string }>()
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const sdk = useSDK()
   const layout = useLayout()
   const { view } = useSessionLayout()
+
+  const overridePdfUrl = createMemo(() => {
+    const pdfPath = searchParams.pdf
+    if (!pdfPath) return undefined
+    return `${sdk.url}/file/raw?path=${encodeURIComponent(pdfPath)}&directory=${encodeURIComponent(sdk.directory)}`
+  })
+
+  const handleCloseReadingMode = () => {
+    navigate(`/${encodeURIComponent(params.dir ?? "")}/session/${params.id}`)
+  }
   const [containerWidth, setContainerWidth] = createSignal(0)
   const [layoutSwapped, setLayoutSwapped] = createSignal(false)
   const [layoutReady, setLayoutReady] = createSignal(false)
@@ -336,8 +350,10 @@ const ReadingSession: Component = () => {
                       maxWidth={Math.max(pdfMinWidth(), pdfMaxWidth())}
                       layoutSwapped={layoutSwapped()}
                     onSwapLayout={handleSwapLayout}
+                    onCloseReadingMode={handleCloseReadingMode}
                     onResizeWidth={handleResizeWidth}
                     resizeHandleEnabled={mode() !== "review-right" && mode() !== "review-tree-right"}
+                    overridePdfUrl={overridePdfUrl()}
                     sizing={sizing}
                   />
                   }

--- a/packages/app/src/pages/reading-session.tsx
+++ b/packages/app/src/pages/reading-session.tsx
@@ -60,7 +60,8 @@ const ReadingSession: Component = () => {
   const { view } = useSessionLayout()
 
   const overridePdfUrl = createMemo(() => {
-    const pdfPath = searchParams.pdf
+    const raw = searchParams.pdf
+    const pdfPath = Array.isArray(raw) ? raw[0] : raw
     if (!pdfPath) return undefined
     return `${sdk.url}/file/raw?path=${encodeURIComponent(pdfPath)}&directory=${encodeURIComponent(sdk.directory)}`
   })

--- a/packages/app/src/pages/session/file-tabs.tsx
+++ b/packages/app/src/pages/session/file-tabs.tsx
@@ -71,25 +71,6 @@ function FileCommentMenu(props: {
   )
 }
 
-type ReadingModeFromFileResponse = {
-  action: "existing" | "created"
-  session: Session
-}
-
-function readingModeText(language: ReturnType<typeof useLanguage>, key: string) {
-  const zh = language.locale() === "zh" || language.locale() === "zht"
-  switch (key) {
-    case "resume.title":
-      return zh ? "继续阅读模式" : "Continue reading mode"
-    case "resume.description":
-      return zh ? "这份 PDF 已经有阅读会话。你想继续之前的阅读对话，还是新建一条阅读会话？" : "This PDF already has a reading session. Continue the existing reading conversation or create a new one?"
-    case "resume.continue":
-      return zh ? "继续已有阅读" : "Continue existing reading"
-    case "resume.new":
-      return zh ? "新建阅读会话" : "Create new reading session"
-  }
-  return key
-}
 
 export function FileTabContent(props: { tab: string }) {
   const navigate = useNavigate()
@@ -413,100 +394,11 @@ export function FileTabContent(props: { tab: string }) {
     dialog.show(() => <DialogPdfToMarkdown pdfPath={p} />)
   }
 
-  const openPdfInReadingMode = async () => {
+  const openPdfInReadingMode = () => {
     const p = path()
-    const currentServer = server.current
-    if (!p || !currentServer) return
-
-    try {
-      const authHeaders: Record<string, string> = currentServer.http.password
-        ? { Authorization: `Basic ${btoa(`${currentServer.http.username ?? "opencode"}:${currentServer.http.password}`)}` }
-        : {}
-
-      const openFromFile = async (forceNew = false) => {
-        const response = await fetch(
-          `${currentServer.http.url}/reading-mode/session/from-file?directory=${encodeURIComponent(sdk.directory)}`,
-          {
-          method: "POST",
-          headers: {
-            ...authHeaders,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            path: p,
-            forceNew,
-          }),
-          },
-        )
-
-        if (!response.ok) {
-          const text = await response.text()
-          throw new Error(text || `HTTP ${response.status}`)
-        }
-
-        return (await response.json()) as ReadingModeFromFileResponse
-      }
-
-      const goToReadingSession = (sessionID: string) => {
-        navigate(`/${encodeURIComponent(params.dir ?? "")}/session/${sessionID}/reading`)
-      }
-
-      const mergeReadingSession = (session: Session) => {
-        sync.set("session", (items: Session[]) => upsertSessionList(items, session))
-      }
-
-      const result = await openFromFile()
-      mergeReadingSession(result.session)
-      if (result.action === "existing") {
-        dialog.show(() => (
-          <Dialog title={readingModeText(language, "resume.title")} fit>
-            <div class="flex flex-col gap-4 p-4">
-              <p class="text-sm text-text-base">{readingModeText(language, "resume.description")}</p>
-              <div class="flex justify-end gap-2">
-                <Button
-                  variant="ghost"
-                  onClick={() => {
-                    void (async () => {
-                      try {
-                        const created = await openFromFile(true)
-                        mergeReadingSession(created.session)
-                        dialog.close()
-                        goToReadingSession(created.session.id)
-                      } catch (error) {
-                        showToast({
-                          variant: "error",
-                          title: "Failed to open reading mode",
-                          description: String((error as Error)?.message ?? error),
-                        })
-                      }
-                    })()
-                  }}
-                >
-                  {readingModeText(language, "resume.new")}
-                </Button>
-                <Button
-                  onClick={() => {
-                    dialog.close()
-                    goToReadingSession(result.session.id)
-                  }}
-                >
-                  {readingModeText(language, "resume.continue")}
-                </Button>
-              </div>
-            </div>
-          </Dialog>
-        ))
-        return
-      }
-
-      goToReadingSession(result.session.id)
-    } catch (e) {
-      showToast({
-        variant: "error",
-        title: "Failed to open reading mode",
-        description: String((e as Error)?.message ?? e),
-      })
-    }
+    const id = params.id
+    if (!p || !id) return
+    navigate(`/${encodeURIComponent(params.dir ?? "")}/session/${id}/reading?pdf=${encodeURIComponent(p)}`)
   }
 
   const [isRunning, setIsRunning] = createSignal(false)


### PR DESCRIPTION
## 关联 Issue

Closes #235

## 变更说明

### 问题 1：点击阅读模式不再新开会话

修改 `file-tabs.tsx` 中的 `openPdfInReadingMode`：移除 API 调用（不再创建新 reading mode session），直接导航到当前 session 的阅读路由并携带文件路径参数：

```
/:dir/session/:currentId/reading?pdf=<encodedFilePath>
```

### 问题 2：添加退出按钮（工具栏最右侧）

- `pdf-viewer.html` + `pdf-viewer-aether.js`：在 `toolbarViewerRight` 末尾添加 `aetherCloseReadingMode` 按钮，full 模式下显示
- `pdf-viewer-aether.css` + `aether-close-reading-mode.svg`：为退出按钮添加样式和 ✕ 图标
- `pdf-viewer-shell-official.tsx`：处理 `closereadingmode` postMessage，触发 `onCloseReadingMode` 回调
- `reading-pdf-viewer-official.tsx` / `reading-mode-panel.tsx`：透传 `onCloseReadingMode` prop
- `reading-session.tsx`：点击退出时导航回 `/:dir/session/:id`，reading-session 的 cleanup 逻辑会自动恢复之前的审阅面板和文件树状态

### `overridePdfUrl` 机制

`reading-session.tsx` 读取 `?pdf` 参数并构造文件 URL 传给 `ReadingModePanel`：
- PDF 直接从文件路径提供，不经过 reading-mode session API
- `ReadingFirstReadGate`（AI 预读）在 override 模式下跳过

## Test Plan

- [ ] 在文件 Tab 中打开 PDF，点击「打开阅读模式」图标，确认停留在当前会话（不跳转到新会话）
- [ ] 进入阅读模式后，确认工具栏最右侧出现 ✕ 退出按钮
- [ ] 点击退出按钮，确认回到普通会话视图
- [ ] 若之前审阅面板（审查 Tab）已打开，退出后确认其恢复展开状态
- [ ] 文本选中 → Ask 操作仍正常工作（发送到当前会话）

🤖 Generated with [Claude Code](https://claude.com/claude-code)