### PR TITLE
fix: update installer devtest package naming

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -172,7 +172,7 @@ jobs:
         with:
           name: release-web-linux
           path: |
-            packages/opencode/dist/aether-linux-x64-web.zip
+            packages/opencode/dist/aether-linux-x64.zip
             packages/opencode/dist/latest-web-linux.yml
             packages/opencode/dist/update_linux_web.sh
           if-no-files-found: error
@@ -197,7 +197,7 @@ jobs:
         with:
           name: release-web-windows
           path: |
-            packages/opencode/dist/aether-windows-x64-web.zip
+            packages/opencode/dist/aether-windows-x64.zip
             packages/opencode/dist/latest-web-windows.yml
             packages/opencode/dist/update_windows_web.bat
           if-no-files-found: error

--- a/RELEASE_UPLOAD_CHECKLIST.md
+++ b/RELEASE_UPLOAD_CHECKLIST.md
@@ -15,8 +15,8 @@
 | `release-linux-desktop.sh`    | `packages/desktop-electron/dist/*-linux-x64.AppImage`（或匹配 `*linux*x64*.AppImage`） | `packages/desktop-electron/dist/latest-linux.yml` |
 | `release-windows-desktop.bat` | `packages/desktop-electron/dist/aether-win-x64.exe`（或匹配 `*win*x64*.exe`）          | `packages/desktop-electron/dist/latest.yml`       |
 | `release-mac-web.sh`          | `packages/opencode/dist/aether-darwin-arm64-web.dmg`                                   | `packages/opencode/dist/latest-web-mac.yml`       |
-| `release-linux-web.sh`        | `packages/opencode/dist/aether-linux-x64-web.zip`                                      | `packages/opencode/dist/latest-web-linux.yml`     |
-| `release-windows-web.bat`     | `packages/opencode/dist/aether-windows-x64-web.zip`                                    | `packages/opencode/dist/latest-web-windows.yml`   |
+| `release-linux-web.sh`        | `packages/opencode/dist/aether-linux-x64.zip`                                          | `packages/opencode/dist/latest-web-linux.yml`     |
+| `release-windows-web.bat`     | `packages/opencode/dist/aether-windows-x64.zip`                                        | `packages/opencode/dist/latest-web-windows.yml`   |
 
 ## 上传策略
 
@@ -26,8 +26,8 @@
   - windows：`.exe` + `latest.yml`
 - `web` 渠道（`latest-web`）：上传 3 个 web 分发包 + 3 个 web `yml`
   - mac：`aether-darwin-arm64-web.dmg` + `latest-web-mac.yml`
-  - linux：`aether-linux-x64-web.zip` + `latest-web-linux.yml`
-  - windows：`aether-windows-x64-web.zip` + `latest-web-windows.yml`
+  - linux：`aether-linux-x64.zip` + `latest-web-linux.yml`
+  - windows：`aether-windows-x64.zip` + `latest-web-windows.yml`
 
 ## 发布前检查
 

--- a/Update/aether_linux_installer.sh
+++ b/Update/aether_linux_installer.sh
@@ -564,7 +564,7 @@ grab() {
   else
     pkg_ext=".$pkg_ext"
   fi
-  pkg_file="$dl/aether-linux-x64-web-$ver$pkg_ext"
+  pkg_file="$dl/aether-linux-x64-$ver$pkg_ext"
 
   need_pkg=1
   if [ -f "$pkg_file" ]; then
@@ -635,7 +635,7 @@ prune() {
   local arr n cut i list item
 
   shopt -s nullglob
-  arr=("$dl"/aether-linux-x64-web-*.*)
+  arr=("$dl"/aether-linux-x64-*.*)
   shopt -u nullglob
   n="${#arr[@]}"
   if [ "$n" -gt "$keep" ]; then

--- a/Update/aether_linux_installer_devtest.sh
+++ b/Update/aether_linux_installer_devtest.sh
@@ -574,7 +574,7 @@ grab() {
   else
     pkg_ext=".$pkg_ext"
   fi
-  pkg_file="$dl/aether-linux-x64-web-$ver$pkg_ext"
+  pkg_file="$dl/aether-linux-x64-$ver$pkg_ext"
 
   need_pkg=1
   if [ -f "$pkg_file" ]; then
@@ -645,7 +645,7 @@ prune() {
   local arr n cut i list item
 
   shopt -s nullglob
-  arr=("$dl"/aether-linux-x64-web-*.*)
+  arr=("$dl"/aether-linux-x64-*.*)
   shopt -u nullglob
   n="${#arr[@]}"
   if [ "$n" -gt "$keep" ]; then

--- a/Update/aether_windows_installer.bat
+++ b/Update/aether_windows_installer.bat
@@ -264,7 +264,7 @@ set "DL=%WORK%\downloads"
 if not exist "%DL%" mkdir "%DL%" >nul 2>nul || exit /b %DIR_ERR%
 
 for %%i in ("%PKG_NAME%") do set "PKG_EXT=%%~xi"
-set "PKG_FILE=%DL%\aether-windows-x64-web-%VER%%PKG_EXT%"
+set "PKG_FILE=%DL%\aether-windows-x64-%VER%%PKG_EXT%"
 set "INS_FILE="
 set "NEED_PKG=1"
 
@@ -309,7 +309,7 @@ exit /b 0
 
 :prune
 set "DL=%WORK%\downloads"
-powershell -NoProfile -Command "$dl=$env:DL; $keep=[int]$env:KEEP; if(-not (Test-Path $dl)){ exit 0 }; $a=Get-ChildItem -Path $dl -File -Filter 'aether-windows-x64-web-*' | Sort-Object Name; if($a.Count -gt $keep){ $a | Select-Object -First ($a.Count-$keep) | Remove-Item -Force }; $b=Get-ChildItem -Path $dl -File -Filter 'update_windows_web-*.bat' | Sort-Object Name; if($b.Count -gt $keep){ $b | Select-Object -First ($b.Count-$keep) | Remove-Item -Force }"
+powershell -NoProfile -Command "$dl=$env:DL; $keep=[int]$env:KEEP; if(-not (Test-Path $dl)){ exit 0 }; $a=Get-ChildItem -Path $dl -File -Filter 'aether-windows-x64-*' | Sort-Object Name; if($a.Count -gt $keep){ $a | Select-Object -First ($a.Count-$keep) | Remove-Item -Force }; $b=Get-ChildItem -Path $dl -File -Filter 'update_windows_web-*.bat' | Sort-Object Name; if($b.Count -gt $keep){ $b | Select-Object -First ($b.Count-$keep) | Remove-Item -Force }"
 exit /b 0
 
 :result

--- a/Update/aether_windows_installer_devtest.bat
+++ b/Update/aether_windows_installer_devtest.bat
@@ -267,7 +267,7 @@ set "DL=%WORK%\downloads"
 if not exist "%DL%" mkdir "%DL%" >nul 2>nul || exit /b %DIR_ERR%
 
 for %%i in ("%PKG_NAME%") do set "PKG_EXT=%%~xi"
-set "PKG_FILE=%DL%\aether-windows-x64-web-%VER%%PKG_EXT%"
+set "PKG_FILE=%DL%\aether-windows-x64-%VER%%PKG_EXT%"
 set "INS_FILE="
 set "NEED_PKG=1"
 
@@ -312,7 +312,7 @@ exit /b 0
 
 :prune
 set "DL=%WORK%\downloads"
-powershell -NoProfile -Command "$dl=$env:DL; $keep=[int]$env:KEEP; if(-not (Test-Path $dl)){ exit 0 }; $a=Get-ChildItem -Path $dl -File -Filter 'aether-windows-x64-web-*' | Sort-Object Name; if($a.Count -gt $keep){ $a | Select-Object -First ($a.Count-$keep) | Remove-Item -Force }; $b=Get-ChildItem -Path $dl -File -Filter 'update_windows_web-*.bat' | Sort-Object Name; if($b.Count -gt $keep){ $b | Select-Object -First ($b.Count-$keep) | Remove-Item -Force }"
+powershell -NoProfile -Command "$dl=$env:DL; $keep=[int]$env:KEEP; if(-not (Test-Path $dl)){ exit 0 }; $a=Get-ChildItem -Path $dl -File -Filter 'aether-windows-x64-*' | Sort-Object Name; if($a.Count -gt $keep){ $a | Select-Object -First ($a.Count-$keep) | Remove-Item -Force }; $b=Get-ChildItem -Path $dl -File -Filter 'update_windows_web-*.bat' | Sort-Object Name; if($b.Count -gt $keep){ $b | Select-Object -First ($b.Count-$keep) | Remove-Item -Force }"
 exit /b 0
 
 :result

--- a/Update/update_linux_web.sh
+++ b/Update/update_linux_web.sh
@@ -43,7 +43,7 @@ Behavior:
   - Updates current symlink to the latest installed version
 
 Package name pattern:
-  aether-linux-x64-web-<version>.*
+  aether-linux-x64-<version>.*
 
 Exit codes:
   0   install finished successfully
@@ -314,7 +314,7 @@ target="$work/aether_$ver"
 next="$work/.aether_$ver.next"
 
 shopt -s nullglob
-arr=("$dl"/aether-linux-x64-web-"$ver".*)
+arr=("$dl"/aether-linux-x64-"$ver".*)
 shopt -u nullglob
 if [ "${#arr[@]}" -eq 0 ]; then
   echo "[install] Package not found for version $ver in $dl"

--- a/Update/update_windows_web copy.bat
+++ b/Update/update_windows_web copy.bat
@@ -14,7 +14,7 @@ if /I "%~1"=="--no-pause" set "HOLD="
 
 set "SELF=%~dp0"
 if "%SELF:~-1%"=="\" set "SELF=%SELF:~0,-1%"
-set "CACHE=%SELF%\aether-windows-x64-web.zip"
+set "CACHE=%SELF%\aether-windows-x64.zip"
 set "STAMP=%SELF%\.aether_web_package_version"
 
 if exist "%SELF%\aether.exe" if exist "%SELF%\Aether.vbs" (
@@ -31,7 +31,7 @@ if exist "%SELF%\aether.exe" if exist "%SELF%\Aether.vbs" (
 set "STATE=%APP%\.aether_web_version"
 set "TMP=%TEMP%\aether-web-update-%RANDOM%%RANDOM%"
 set "META=%TMP%\latest-web-windows.yml"
-set "ZIP=%TMP%\aether-windows-x64-web.zip"
+set "ZIP=%TMP%\aether-windows-x64.zip"
 set "EXTRACT=%TMP%\extract"
 set "SRC_FILE=%TMP%\src.txt"
 set "NEXT=%TMP%\next"
@@ -57,7 +57,7 @@ if "%VER_REMOTE%"=="" (
   goto :fail
 )
 
-if "%URL_REMOTE%"=="" set "URL_REMOTE=aether-windows-x64-web.zip"
+if "%URL_REMOTE%"=="" set "URL_REMOTE=aether-windows-x64.zip"
 
 set "VER_LOCAL="
 if exist "%STATE%" set /p VER_LOCAL=<"%STATE%"

--- a/packages/app/public/pdf-viewer-aether.css
+++ b/packages/app/public/pdf-viewer-aether.css
@@ -50,6 +50,7 @@ body.aether-pdf-viewer {
   --aether-swap-right-icon: url("/pdfjs-ref/web/images/aether-swap-layout-right.svg");
   --aether-swap-left-icon: url("/pdfjs-ref/web/images/aether-swap-layout-left.svg");
   --aether-reading-mode-icon: url("/pdfjs-ref/web/images/aether-reading-mode.svg");
+  --aether-close-reading-mode-icon: url("/pdfjs-ref/web/images/aether-close-reading-mode.svg");
 }
 
 body.aether-pdf-viewer #aetherPdf2md {
@@ -75,6 +76,16 @@ body.aether-pdf-viewer #aetherPdf2md > span {
   padding: 0;
   text-indent: 0;
   white-space: nowrap;
+}
+
+body.aether-pdf-viewer #aetherCloseReadingMode {
+  min-width: 32px;
+  margin-inline-start: 6px;
+}
+
+body.aether-pdf-viewer #aetherCloseReadingMode::before {
+  -webkit-mask-image: var(--aether-close-reading-mode-icon);
+  mask-image: var(--aether-close-reading-mode-icon);
 }
 
 body.aether-pdf-viewer #aetherSwapLayout {

--- a/packages/app/public/pdf-viewer-aether.js
+++ b/packages/app/public/pdf-viewer-aether.js
@@ -547,6 +547,11 @@
       nightMode.setAttribute("aria-pressed", config.nightMode ? "true" : "false");
     }
 
+    const closeReadingMode = document.getElementById("aetherCloseReadingMode");
+    if (closeReadingMode) {
+      closeReadingMode.hidden = config.mode !== "full";
+    }
+
     const swapLayout = document.getElementById("aetherSwapLayout");
     if (swapLayout) {
       swapLayout.hidden = config.mode !== "full";
@@ -698,6 +703,13 @@
     if (readingSettings) {
       readingSettings.addEventListener("click", function () {
         post("opensettings");
+      });
+    }
+
+    const closeReadingMode = document.getElementById("aetherCloseReadingMode");
+    if (closeReadingMode) {
+      closeReadingMode.addEventListener("click", function () {
+        post("closereadingmode");
       });
     }
 

--- a/packages/app/public/pdf-viewer.html
+++ b/packages/app/public/pdf-viewer.html
@@ -290,6 +290,9 @@ See https://github.com/adobe-type-tools/cmap-resources
                 <button id="secondaryToolbarToggle" class="toolbarButton" title="Tools" tabindex="48" data-l10n-id="tools" aria-expanded="false" aria-controls="secondaryToolbar">
                   <span data-l10n-id="tools_label">Tools</span>
                 </button>
+                <button id="aetherCloseReadingMode" class="toolbarButton" title="Exit reading mode" hidden>
+                  <span>Exit reading mode</span>
+                </button>
               </div>
               <div id="toolbarViewerMiddle">
                 <div class="splitToolbarButton">

--- a/packages/app/public/pdfjs-ref/web/images/aether-close-reading-mode.svg
+++ b/packages/app/public/pdfjs-ref/web/images/aether-close-reading-mode.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none">
+  <path d="M5 5L15 15M15 5L5 15" stroke="#000" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/packages/app/src/components/pdf-viewer-shell-official.tsx
+++ b/packages/app/src/components/pdf-viewer-shell-official.tsx
@@ -52,6 +52,7 @@ export type PdfViewerShellProps = {
   onDocumentInfo?: (info: { totalPages: number }) => void
   onPdfToMarkdown?: () => void
   onOpenReadingMode?: () => void
+  onCloseReadingMode?: () => void
   onOpenSettings?: () => void
   onTextSelectionAction?: (input: { action: "copy" | "translate" | "ask"; page: number; text: string }) => void
   onImageSelectionAction?: (input: { action: "copy" | "translate" | "ask"; page: number; imageDataUrl: string }) => void
@@ -74,6 +75,7 @@ type ViewerMessage =
       imageDataUrl: string
     }
   | { channel: "aether-pdf-viewer"; type: "nightmode"; enabled: boolean }
+  | { channel: "aether-pdf-viewer"; type: "closereadingmode" }
   | { channel: "aether-pdf-viewer"; type: "swaplayout" }
 
 export const PdfViewerShell: Component<PdfViewerShellProps> = (props) => {
@@ -168,6 +170,11 @@ export const PdfViewerShell: Component<PdfViewerShellProps> = (props) => {
 
     if (event.data.type === "openreadingmode") {
       props.onOpenReadingMode?.()
+      return
+    }
+
+    if (event.data.type === "closereadingmode") {
+      props.onCloseReadingMode?.()
       return
     }
 

--- a/packages/app/src/components/reading-mode/reading-mode-panel.tsx
+++ b/packages/app/src/components/reading-mode/reading-mode-panel.tsx
@@ -24,9 +24,11 @@ export const ReadingModePanel: Component<{
   maxWidth: number
   layoutSwapped: boolean
   onSwapLayout?: () => void
+  onCloseReadingMode?: () => void
   onResizeWidth: (width: number) => void
   resizeHandleEnabled?: boolean
   sizing?: Sizing
+  overridePdfUrl?: string
 }> = (props) => {
   const rm = useReadingMode()
   const sdk = useSDK()
@@ -37,7 +39,7 @@ export const ReadingModePanel: Component<{
   const dialog = useDialog()
   const size = props.sizing ?? createSizing()
 
-  const pdfUrl = createMemo(() => `${sdk.url}/reading-mode/pdf?sessionID=${encodeURIComponent(props.sessionID)}`)
+  const pdfUrl = createMemo(() => props.overridePdfUrl ?? `${sdk.url}/reading-mode/pdf?sessionID=${encodeURIComponent(props.sessionID)}`)
   let restoredInitialPage = false
 
   createEffect(() => {
@@ -234,7 +236,9 @@ export const ReadingModePanel: Component<{
 
   return (
     <div class="relative h-full shrink-0 overflow-visible" style={{ width: `${props.width}px` }}>
-      <ReadingFirstReadGate sessionID={props.sessionID} />
+      <Show when={!props.overridePdfUrl}>
+        <ReadingFirstReadGate sessionID={props.sessionID} />
+      </Show>
       <div
         class="flex h-full flex-col overflow-hidden bg-surface-base"
         classList={{
@@ -247,6 +251,7 @@ export const ReadingModePanel: Component<{
             url={pdfUrl()}
             layoutSwapped={props.layoutSwapped}
             onSwapLayout={props.onSwapLayout}
+            onCloseReadingMode={props.onCloseReadingMode}
             onOpenSettings={handleOpenSettings}
             onTextSelectionAction={handleTextSelectionAction}
             onImageSelectionAction={handleImageSelectionAction}

--- a/packages/app/src/components/reading-mode/reading-pdf-viewer-official.tsx
+++ b/packages/app/src/components/reading-mode/reading-pdf-viewer-official.tsx
@@ -7,6 +7,7 @@ export const OfficialReadingPdfViewer: Component<{
   url: string
   layoutSwapped?: boolean
   onSwapLayout?: () => void
+  onCloseReadingMode?: () => void
   onOpenSettings?: () => void
   onTextSelectionAction?: (input: { action: "copy" | "translate" | "ask"; page: number; text: string }) => void
   onImageSelectionAction?: (input: { action: "copy" | "translate" | "ask"; page: number; imageDataUrl: string }) => void
@@ -30,6 +31,7 @@ export const OfficialReadingPdfViewer: Component<{
       layoutSwapped={props.layoutSwapped}
       onPageChange={(page) => rm.setPage(page)}
       onDocumentInfo={({ totalPages }) => rm.setTotalPages(totalPages)}
+      onCloseReadingMode={props.onCloseReadingMode}
       onOpenSettings={props.onOpenSettings}
       onTextSelectionAction={props.onTextSelectionAction}
       onImageSelectionAction={props.onImageSelectionAction}

--- a/packages/app/src/pages/reading-session.tsx
+++ b/packages/app/src/pages/reading-session.tsx
@@ -1,6 +1,6 @@
 import { type Component, createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js"
 import { createStore } from "solid-js/store"
-import { useParams } from "@solidjs/router"
+import { useNavigate, useParams, useSearchParams } from "@solidjs/router"
 import { ReadingModeProvider } from "@/context/reading-mode"
 import { ReadingModePanel } from "@/components/reading-mode/reading-mode-panel"
 import { TerminalProvider } from "@/context/terminal"
@@ -8,6 +8,7 @@ import { FileProvider } from "@/context/file"
 import { PromptProvider } from "@/context/prompt"
 import { CommentsProvider } from "@/context/comments"
 import { useLayout } from "@/context/layout"
+import { useSDK } from "@/context/sdk"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { createSizing } from "@/pages/session/helpers"
 import SessionPage from "./session"
@@ -51,9 +52,22 @@ const CHAT_RATIO_BOUNDS: Partial<Record<LayoutVariant, { min: number; max: numbe
 }
 
 const ReadingSession: Component = () => {
-  const params = useParams<{ id: string }>()
+  const params = useParams<{ id: string; dir?: string }>()
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const sdk = useSDK()
   const layout = useLayout()
   const { view } = useSessionLayout()
+
+  const overridePdfUrl = createMemo(() => {
+    const pdfPath = searchParams.pdf
+    if (!pdfPath) return undefined
+    return `${sdk.url}/file/raw?path=${encodeURIComponent(pdfPath)}&directory=${encodeURIComponent(sdk.directory)}`
+  })
+
+  const handleCloseReadingMode = () => {
+    navigate(`/${encodeURIComponent(params.dir ?? "")}/session/${params.id}`)
+  }
   const [containerWidth, setContainerWidth] = createSignal(0)
   const [layoutSwapped, setLayoutSwapped] = createSignal(false)
   const [layoutReady, setLayoutReady] = createSignal(false)
@@ -336,8 +350,10 @@ const ReadingSession: Component = () => {
                       maxWidth={Math.max(pdfMinWidth(), pdfMaxWidth())}
                       layoutSwapped={layoutSwapped()}
                     onSwapLayout={handleSwapLayout}
+                    onCloseReadingMode={handleCloseReadingMode}
                     onResizeWidth={handleResizeWidth}
                     resizeHandleEnabled={mode() !== "review-right" && mode() !== "review-tree-right"}
+                    overridePdfUrl={overridePdfUrl()}
                     sizing={sizing}
                   />
                   }

--- a/packages/app/src/pages/reading-session.tsx
+++ b/packages/app/src/pages/reading-session.tsx
@@ -60,7 +60,8 @@ const ReadingSession: Component = () => {
   const { view } = useSessionLayout()
 
   const overridePdfUrl = createMemo(() => {
-    const pdfPath = searchParams.pdf
+    const raw = searchParams.pdf
+    const pdfPath = Array.isArray(raw) ? raw[0] : raw
     if (!pdfPath) return undefined
     return `${sdk.url}/file/raw?path=${encodeURIComponent(pdfPath)}&directory=${encodeURIComponent(sdk.directory)}`
   })

--- a/packages/app/src/pages/session/file-tabs.tsx
+++ b/packages/app/src/pages/session/file-tabs.tsx
@@ -71,25 +71,6 @@ function FileCommentMenu(props: {
   )
 }
 
-type ReadingModeFromFileResponse = {
-  action: "existing" | "created"
-  session: Session
-}
-
-function readingModeText(language: ReturnType<typeof useLanguage>, key: string) {
-  const zh = language.locale() === "zh" || language.locale() === "zht"
-  switch (key) {
-    case "resume.title":
-      return zh ? "继续阅读模式" : "Continue reading mode"
-    case "resume.description":
-      return zh ? "这份 PDF 已经有阅读会话。你想继续之前的阅读对话，还是新建一条阅读会话？" : "This PDF already has a reading session. Continue the existing reading conversation or create a new one?"
-    case "resume.continue":
-      return zh ? "继续已有阅读" : "Continue existing reading"
-    case "resume.new":
-      return zh ? "新建阅读会话" : "Create new reading session"
-  }
-  return key
-}
 
 export function FileTabContent(props: { tab: string }) {
   const navigate = useNavigate()
@@ -413,100 +394,11 @@ export function FileTabContent(props: { tab: string }) {
     dialog.show(() => <DialogPdfToMarkdown pdfPath={p} />)
   }
 
-  const openPdfInReadingMode = async () => {
+  const openPdfInReadingMode = () => {
     const p = path()
-    const currentServer = server.current
-    if (!p || !currentServer) return
-
-    try {
-      const authHeaders: Record<string, string> = currentServer.http.password
-        ? { Authorization: `Basic ${btoa(`${currentServer.http.username ?? "opencode"}:${currentServer.http.password}`)}` }
-        : {}
-
-      const openFromFile = async (forceNew = false) => {
-        const response = await fetch(
-          `${currentServer.http.url}/reading-mode/session/from-file?directory=${encodeURIComponent(sdk.directory)}`,
-          {
-          method: "POST",
-          headers: {
-            ...authHeaders,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            path: p,
-            forceNew,
-          }),
-          },
-        )
-
-        if (!response.ok) {
-          const text = await response.text()
-          throw new Error(text || `HTTP ${response.status}`)
-        }
-
-        return (await response.json()) as ReadingModeFromFileResponse
-      }
-
-      const goToReadingSession = (sessionID: string) => {
-        navigate(`/${encodeURIComponent(params.dir ?? "")}/session/${sessionID}/reading`)
-      }
-
-      const mergeReadingSession = (session: Session) => {
-        sync.set("session", (items: Session[]) => upsertSessionList(items, session))
-      }
-
-      const result = await openFromFile()
-      mergeReadingSession(result.session)
-      if (result.action === "existing") {
-        dialog.show(() => (
-          <Dialog title={readingModeText(language, "resume.title")} fit>
-            <div class="flex flex-col gap-4 p-4">
-              <p class="text-sm text-text-base">{readingModeText(language, "resume.description")}</p>
-              <div class="flex justify-end gap-2">
-                <Button
-                  variant="ghost"
-                  onClick={() => {
-                    void (async () => {
-                      try {
-                        const created = await openFromFile(true)
-                        mergeReadingSession(created.session)
-                        dialog.close()
-                        goToReadingSession(created.session.id)
-                      } catch (error) {
-                        showToast({
-                          variant: "error",
-                          title: "Failed to open reading mode",
-                          description: String((error as Error)?.message ?? error),
-                        })
-                      }
-                    })()
-                  }}
-                >
-                  {readingModeText(language, "resume.new")}
-                </Button>
-                <Button
-                  onClick={() => {
-                    dialog.close()
-                    goToReadingSession(result.session.id)
-                  }}
-                >
-                  {readingModeText(language, "resume.continue")}
-                </Button>
-              </div>
-            </div>
-          </Dialog>
-        ))
-        return
-      }
-
-      goToReadingSession(result.session.id)
-    } catch (e) {
-      showToast({
-        variant: "error",
-        title: "Failed to open reading mode",
-        description: String((e as Error)?.message ?? e),
-      })
-    }
+    const id = params.id
+    if (!p || !id) return
+    navigate(`/${encodeURIComponent(params.dir ?? "")}/session/${id}/reading?pdf=${encodeURIComponent(p)}`)
   }
 
   const [isRunning, setIsRunning] = createSignal(false)

--- a/packing_scripts/release-linux-web.sh
+++ b/packing_scripts/release-linux-web.sh
@@ -33,7 +33,7 @@ if [ ! -f "$upd" ]; then
   exit 1
 fi
 
-pkg="aether-linux-x64-web"
+pkg="aether-linux-x64"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 out="$tmp/$pkg"
@@ -65,7 +65,7 @@ cat >"$out/README_FIRST.txt" <<'EOF'
 Aether Web (Linux x64)
 
 Quick start
-1) Extract this ZIP and copy the folder aether-linux-x64-web to a local path, for example: ~/Applications/Aether-Web
+1) Extract this ZIP and copy the folder aether-linux-x64 to a local path, for example: ~/Applications/Aether-Web
 2) Open Terminal in that folder and run: ./Aether.sh
 
 Offline update
@@ -73,7 +73,7 @@ Offline update
   https://aether.aiphys.cn/download
 EOF
 
-zip="dist/aether-linux-x64-web.zip"
+zip="dist/aether-linux-x64.zip"
 zip_path="$PWD/$zip"
 rm -f "$zip"
 (cd "$tmp" && zip -r "$zip_path" "$pkg")
@@ -84,7 +84,7 @@ size="$(wc -c <"$zip" | tr -d '[:space:]')"
 cat >dist/latest-web-linux.yml <<EOF
 version: $ver
 files:
-  - url: aether-linux-x64-web.zip
+  - url: aether-linux-x64.zip
     sha512: $sha
     size: $size
 releaseDate: '$date'

--- a/packing_scripts/release-windows-web.bat
+++ b/packing_scripts/release-windows-web.bat
@@ -21,7 +21,7 @@ if not exist "%SRC%" (
 
 set "UV=%SRC%\wechat-bridge\runtime\uv"
 set "UPD=%ROOT%\Update\update_windows_web.bat"
-set "PKG=aether-windows-x64-web"
+set "PKG=aether-windows-x64"
 set "TMP=%TEMP%\aether-web-pack-%RANDOM%%RANDOM%"
 set "OUT=%TMP%\%PKG%"
 if exist "%UV%" (
@@ -54,9 +54,9 @@ if exist "%INS%" (
 
 powershell -NoProfile -Command "& { [IO.File]::WriteAllText((Join-Path $env:OUT '.aether_web_version'), $env:VERSION) }" || exit /b 1
 
-powershell -NoProfile -Command "& { $crlf=[char]13+[char]10; $txt=@('Aether Web (Windows x64)','', 'Quick start', '1) Extract this ZIP and copy the folder aether-windows-x64-web to a local path, for example: C:\Aether-Web', '2) In that folder, double click Aether.vbs', '', 'Offline update', '- Run update_windows_web.bat to check and install newer versions from:', '  https://aether.aiphys.cn/download') -join $crlf; Set-Content -Path (Join-Path $env:OUT 'README_FIRST.txt') -Value ($txt + $crlf) -Encoding ascii }" || exit /b 1
+powershell -NoProfile -Command "& { $crlf=[char]13+[char]10; $txt=@('Aether Web (Windows x64)','', 'Quick start', '1) Extract this ZIP and copy the folder aether-windows-x64 to a local path, for example: C:\Aether-Web', '2) In that folder, double click Aether.vbs', '', 'Offline update', '- Run update_windows_web.bat to check and install newer versions from:', '  https://aether.aiphys.cn/download') -join $crlf; Set-Content -Path (Join-Path $env:OUT 'README_FIRST.txt') -Value ($txt + $crlf) -Encoding ascii }" || exit /b 1
 
-set "ZIP=%CD%\dist\aether-windows-x64-web.zip"
+set "ZIP=%CD%\dist\aether-windows-x64.zip"
 if exist "%ZIP%" del /f /q "%ZIP%"
 powershell -NoProfile -Command "& { Compress-Archive -Path $env:OUT -DestinationPath $env:ZIP -CompressionLevel Optimal }" || exit /b 1
 


### PR DESCRIPTION
### Issue for this PR

Closes #233

### Type of change

- [x] Bug fix

### What does this PR do?

Updates the Linux and Windows devtest installer scripts to match the current package naming without the `-web-` suffix, and adjusts cleanup patterns so old downloads are still pruned correctly.

### How did you verify your code works?

- `git diff --cached --stat` to confirm only the two installer scripts changed
- `git push -u origin fix/appname`, which ran the repo typecheck hook successfully

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR