### PR TITLE
fix: update installer devtest package naming

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -172,7 +172,7 @@ jobs:
         with:
           name: release-web-linux
           path: |
-            packages/opencode/dist/aether-linux-x64-web.zip
+            packages/opencode/dist/aether-linux-x64.zip
             packages/opencode/dist/latest-web-linux.yml
             packages/opencode/dist/update_linux_web.sh
           if-no-files-found: error
@@ -197,7 +197,7 @@ jobs:
         with:
           name: release-web-windows
           path: |
-            packages/opencode/dist/aether-windows-x64-web.zip
+            packages/opencode/dist/aether-windows-x64.zip
             packages/opencode/dist/latest-web-windows.yml
             packages/opencode/dist/update_windows_web.bat
           if-no-files-found: error

--- a/RELEASE_UPLOAD_CHECKLIST.md
+++ b/RELEASE_UPLOAD_CHECKLIST.md
@@ -15,8 +15,8 @@
 | `release-linux-desktop.sh`    | `packages/desktop-electron/dist/*-linux-x64.AppImage`（或匹配 `*linux*x64*.AppImage`） | `packages/desktop-electron/dist/latest-linux.yml` |
 | `release-windows-desktop.bat` | `packages/desktop-electron/dist/aether-win-x64.exe`（或匹配 `*win*x64*.exe`）          | `packages/desktop-electron/dist/latest.yml`       |
 | `release-mac-web.sh`          | `packages/opencode/dist/aether-darwin-arm64-web.dmg`                                   | `packages/opencode/dist/latest-web-mac.yml`       |
-| `release-linux-web.sh`        | `packages/opencode/dist/aether-linux-x64-web.zip`                                      | `packages/opencode/dist/latest-web-linux.yml`     |
-| `release-windows-web.bat`     | `packages/opencode/dist/aether-windows-x64-web.zip`                                    | `packages/opencode/dist/latest-web-windows.yml`   |
+| `release-linux-web.sh`        | `packages/opencode/dist/aether-linux-x64.zip`                                          | `packages/opencode/dist/latest-web-linux.yml`     |
+| `release-windows-web.bat`     | `packages/opencode/dist/aether-windows-x64.zip`                                        | `packages/opencode/dist/latest-web-windows.yml`   |
 
 ## 上传策略
 
@@ -26,8 +26,8 @@
   - windows：`.exe` + `latest.yml`
 - `web` 渠道（`latest-web`）：上传 3 个 web 分发包 + 3 个 web `yml`
   - mac：`aether-darwin-arm64-web.dmg` + `latest-web-mac.yml`
-  - linux：`aether-linux-x64-web.zip` + `latest-web-linux.yml`
-  - windows：`aether-windows-x64-web.zip` + `latest-web-windows.yml`
+  - linux：`aether-linux-x64.zip` + `latest-web-linux.yml`
+  - windows：`aether-windows-x64.zip` + `latest-web-windows.yml`
 
 ## 发布前检查
 

--- a/Update/aether_linux_installer.sh
+++ b/Update/aether_linux_installer.sh
@@ -564,7 +564,7 @@ grab() {
   else
     pkg_ext=".$pkg_ext"
   fi
-  pkg_file="$dl/aether-linux-x64-web-$ver$pkg_ext"
+  pkg_file="$dl/aether-linux-x64-$ver$pkg_ext"
 
   need_pkg=1
   if [ -f "$pkg_file" ]; then
@@ -635,7 +635,7 @@ prune() {
   local arr n cut i list item
 
   shopt -s nullglob
-  arr=("$dl"/aether-linux-x64-web-*.*)
+  arr=("$dl"/aether-linux-x64-*.*)
   shopt -u nullglob
   n="${#arr[@]}"
   if [ "$n" -gt "$keep" ]; then

--- a/Update/aether_linux_installer_devtest.sh
+++ b/Update/aether_linux_installer_devtest.sh
@@ -574,7 +574,7 @@ grab() {
   else
     pkg_ext=".$pkg_ext"
   fi
-  pkg_file="$dl/aether-linux-x64-web-$ver$pkg_ext"
+  pkg_file="$dl/aether-linux-x64-$ver$pkg_ext"
 
   need_pkg=1
   if [ -f "$pkg_file" ]; then
@@ -645,7 +645,7 @@ prune() {
   local arr n cut i list item
 
   shopt -s nullglob
-  arr=("$dl"/aether-linux-x64-web-*.*)
+  arr=("$dl"/aether-linux-x64-*.*)
   shopt -u nullglob
   n="${#arr[@]}"
   if [ "$n" -gt "$keep" ]; then

--- a/Update/aether_windows_installer.bat
+++ b/Update/aether_windows_installer.bat
@@ -264,7 +264,7 @@ set "DL=%WORK%\downloads"
 if not exist "%DL%" mkdir "%DL%" >nul 2>nul || exit /b %DIR_ERR%
 
 for %%i in ("%PKG_NAME%") do set "PKG_EXT=%%~xi"
-set "PKG_FILE=%DL%\aether-windows-x64-web-%VER%%PKG_EXT%"
+set "PKG_FILE=%DL%\aether-windows-x64-%VER%%PKG_EXT%"
 set "INS_FILE="
 set "NEED_PKG=1"
 
@@ -309,7 +309,7 @@ exit /b 0
 
 :prune
 set "DL=%WORK%\downloads"
-powershell -NoProfile -Command "$dl=$env:DL; $keep=[int]$env:KEEP; if(-not (Test-Path $dl)){ exit 0 }; $a=Get-ChildItem -Path $dl -File -Filter 'aether-windows-x64-web-*' | Sort-Object Name; if($a.Count -gt $keep){ $a | Select-Object -First ($a.Count-$keep) | Remove-Item -Force }; $b=Get-ChildItem -Path $dl -File -Filter 'update_windows_web-*.bat' | Sort-Object Name; if($b.Count -gt $keep){ $b | Select-Object -First ($b.Count-$keep) | Remove-Item -Force }"
+powershell -NoProfile -Command "$dl=$env:DL; $keep=[int]$env:KEEP; if(-not (Test-Path $dl)){ exit 0 }; $a=Get-ChildItem -Path $dl -File -Filter 'aether-windows-x64-*' | Sort-Object Name; if($a.Count -gt $keep){ $a | Select-Object -First ($a.Count-$keep) | Remove-Item -Force }; $b=Get-ChildItem -Path $dl -File -Filter 'update_windows_web-*.bat' | Sort-Object Name; if($b.Count -gt $keep){ $b | Select-Object -First ($b.Count-$keep) | Remove-Item -Force }"
 exit /b 0
 
 :result

--- a/Update/aether_windows_installer_devtest.bat
+++ b/Update/aether_windows_installer_devtest.bat
@@ -267,7 +267,7 @@ set "DL=%WORK%\downloads"
 if not exist "%DL%" mkdir "%DL%" >nul 2>nul || exit /b %DIR_ERR%
 
 for %%i in ("%PKG_NAME%") do set "PKG_EXT=%%~xi"
-set "PKG_FILE=%DL%\aether-windows-x64-web-%VER%%PKG_EXT%"
+set "PKG_FILE=%DL%\aether-windows-x64-%VER%%PKG_EXT%"
 set "INS_FILE="
 set "NEED_PKG=1"
 
@@ -312,7 +312,7 @@ exit /b 0
 
 :prune
 set "DL=%WORK%\downloads"
-powershell -NoProfile -Command "$dl=$env:DL; $keep=[int]$env:KEEP; if(-not (Test-Path $dl)){ exit 0 }; $a=Get-ChildItem -Path $dl -File -Filter 'aether-windows-x64-web-*' | Sort-Object Name; if($a.Count -gt $keep){ $a | Select-Object -First ($a.Count-$keep) | Remove-Item -Force }; $b=Get-ChildItem -Path $dl -File -Filter 'update_windows_web-*.bat' | Sort-Object Name; if($b.Count -gt $keep){ $b | Select-Object -First ($b.Count-$keep) | Remove-Item -Force }"
+powershell -NoProfile -Command "$dl=$env:DL; $keep=[int]$env:KEEP; if(-not (Test-Path $dl)){ exit 0 }; $a=Get-ChildItem -Path $dl -File -Filter 'aether-windows-x64-*' | Sort-Object Name; if($a.Count -gt $keep){ $a | Select-Object -First ($a.Count-$keep) | Remove-Item -Force }; $b=Get-ChildItem -Path $dl -File -Filter 'update_windows_web-*.bat' | Sort-Object Name; if($b.Count -gt $keep){ $b | Select-Object -First ($b.Count-$keep) | Remove-Item -Force }"
 exit /b 0
 
 :result

--- a/Update/update_linux_web.sh
+++ b/Update/update_linux_web.sh
@@ -43,7 +43,7 @@ Behavior:
   - Updates current symlink to the latest installed version
 
 Package name pattern:
-  aether-linux-x64-web-<version>.*
+  aether-linux-x64-<version>.*
 
 Exit codes:
   0   install finished successfully
@@ -314,7 +314,7 @@ target="$work/aether_$ver"
 next="$work/.aether_$ver.next"
 
 shopt -s nullglob
-arr=("$dl"/aether-linux-x64-web-"$ver".*)
+arr=("$dl"/aether-linux-x64-"$ver".*)
 shopt -u nullglob
 if [ "${#arr[@]}" -eq 0 ]; then
   echo "[install] Package not found for version $ver in $dl"

--- a/Update/update_windows_web copy.bat
+++ b/Update/update_windows_web copy.bat
@@ -14,7 +14,7 @@ if /I "%~1"=="--no-pause" set "HOLD="
 
 set "SELF=%~dp0"
 if "%SELF:~-1%"=="\" set "SELF=%SELF:~0,-1%"
-set "CACHE=%SELF%\aether-windows-x64-web.zip"
+set "CACHE=%SELF%\aether-windows-x64.zip"
 set "STAMP=%SELF%\.aether_web_package_version"
 
 if exist "%SELF%\aether.exe" if exist "%SELF%\Aether.vbs" (
@@ -31,7 +31,7 @@ if exist "%SELF%\aether.exe" if exist "%SELF%\Aether.vbs" (
 set "STATE=%APP%\.aether_web_version"
 set "TMP=%TEMP%\aether-web-update-%RANDOM%%RANDOM%"
 set "META=%TMP%\latest-web-windows.yml"
-set "ZIP=%TMP%\aether-windows-x64-web.zip"
+set "ZIP=%TMP%\aether-windows-x64.zip"
 set "EXTRACT=%TMP%\extract"
 set "SRC_FILE=%TMP%\src.txt"
 set "NEXT=%TMP%\next"
@@ -57,7 +57,7 @@ if "%VER_REMOTE%"=="" (
   goto :fail
 )
 
-if "%URL_REMOTE%"=="" set "URL_REMOTE=aether-windows-x64-web.zip"
+if "%URL_REMOTE%"=="" set "URL_REMOTE=aether-windows-x64.zip"
 
 set "VER_LOCAL="
 if exist "%STATE%" set /p VER_LOCAL=<"%STATE%"

--- a/packing_scripts/release-linux-web.sh
+++ b/packing_scripts/release-linux-web.sh
@@ -33,7 +33,7 @@ if [ ! -f "$upd" ]; then
   exit 1
 fi
 
-pkg="aether-linux-x64-web"
+pkg="aether-linux-x64"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 out="$tmp/$pkg"
@@ -65,7 +65,7 @@ cat >"$out/README_FIRST.txt" <<'EOF'
 Aether Web (Linux x64)
 
 Quick start
-1) Extract this ZIP and copy the folder aether-linux-x64-web to a local path, for example: ~/Applications/Aether-Web
+1) Extract this ZIP and copy the folder aether-linux-x64 to a local path, for example: ~/Applications/Aether-Web
 2) Open Terminal in that folder and run: ./Aether.sh
 
 Offline update
@@ -73,7 +73,7 @@ Offline update
   https://aether.aiphys.cn/download
 EOF
 
-zip="dist/aether-linux-x64-web.zip"
+zip="dist/aether-linux-x64.zip"
 zip_path="$PWD/$zip"
 rm -f "$zip"
 (cd "$tmp" && zip -r "$zip_path" "$pkg")
@@ -84,7 +84,7 @@ size="$(wc -c <"$zip" | tr -d '[:space:]')"
 cat >dist/latest-web-linux.yml <<EOF
 version: $ver
 files:
-  - url: aether-linux-x64-web.zip
+  - url: aether-linux-x64.zip
     sha512: $sha
     size: $size
 releaseDate: '$date'

--- a/packing_scripts/release-windows-web.bat
+++ b/packing_scripts/release-windows-web.bat
@@ -21,7 +21,7 @@ if not exist "%SRC%" (
 
 set "UV=%SRC%\wechat-bridge\runtime\uv"
 set "UPD=%ROOT%\Update\update_windows_web.bat"
-set "PKG=aether-windows-x64-web"
+set "PKG=aether-windows-x64"
 set "TMP=%TEMP%\aether-web-pack-%RANDOM%%RANDOM%"
 set "OUT=%TMP%\%PKG%"
 if exist "%UV%" (
@@ -54,9 +54,9 @@ if exist "%INS%" (
 
 powershell -NoProfile -Command "& { [IO.File]::WriteAllText((Join-Path $env:OUT '.aether_web_version'), $env:VERSION) }" || exit /b 1
 
-powershell -NoProfile -Command "& { $crlf=[char]13+[char]10; $txt=@('Aether Web (Windows x64)','', 'Quick start', '1) Extract this ZIP and copy the folder aether-windows-x64-web to a local path, for example: C:\Aether-Web', '2) In that folder, double click Aether.vbs', '', 'Offline update', '- Run update_windows_web.bat to check and install newer versions from:', '  https://aether.aiphys.cn/download') -join $crlf; Set-Content -Path (Join-Path $env:OUT 'README_FIRST.txt') -Value ($txt + $crlf) -Encoding ascii }" || exit /b 1
+powershell -NoProfile -Command "& { $crlf=[char]13+[char]10; $txt=@('Aether Web (Windows x64)','', 'Quick start', '1) Extract this ZIP and copy the folder aether-windows-x64 to a local path, for example: C:\Aether-Web', '2) In that folder, double click Aether.vbs', '', 'Offline update', '- Run update_windows_web.bat to check and install newer versions from:', '  https://aether.aiphys.cn/download') -join $crlf; Set-Content -Path (Join-Path $env:OUT 'README_FIRST.txt') -Value ($txt + $crlf) -Encoding ascii }" || exit /b 1
 
-set "ZIP=%CD%\dist\aether-windows-x64-web.zip"
+set "ZIP=%CD%\dist\aether-windows-x64.zip"
 if exist "%ZIP%" del /f /q "%ZIP%"
 powershell -NoProfile -Command "& { Compress-Archive -Path $env:OUT -DestinationPath $env:ZIP -CompressionLevel Optimal }" || exit /b 1
 


### PR DESCRIPTION
### Issue for this PR

Closes #233

### Type of change

- [x] Refactor / code improvement

### What does this PR do?

This PR renames the Linux and Windows web installer/package artifacts from `aether-*-web` to `aether-*`, so the generated ZIP files, updater scripts, release workflow, and upload checklist all use the same package naming.

It updates:
- release artifact paths in `.github/workflows/publish.yml`
- upload guidance in `RELEASE_UPLOAD_CHECKLIST.md`
- Linux installer and updater package matching
- Windows installer and updater package matching
- Linux and Windows web packaging scripts

### How did you verify your code works?

I reviewed the branch diff against `dev` and confirmed the naming changes are consistent across the packaging, updater, and release files.

### Screenshots / recordings

Not applicable.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR