### PR TITLE
feat: add gpt-5.4 model support and LLM call chain documentation

### DIFF
--- a/docs/llm-call-chain.md
+++ b/docs/llm-call-chain.md
@@ -1,0 +1,269 @@
+# Aether LLM 调用链路文档
+
+## 概览
+
+Aether 通过 **Vercel AI SDK (`ai` 5.x)** 统一抽象层与 20+ 家大模型供应商对话。核心设计思路：模型元数据来自 `models.dev`，SDK 适配器按 npm 包名动态加载，所有请求最终汇聚到 `streamText()` 一个调用点。
+
+## 调用链路全景
+
+```mermaid
+sequenceDiagram
+    participant User as 用户/客户端
+    participant Route as HTTP Route<br/>(session.ts)
+    participant Session as Session.chat()
+    participant Processor as SessionProcessor
+    participant LLM as LLM.stream()<br/>唯一入口
+    participant Provider as Provider<br/>(getLanguage/getSDK)
+    participant Transform as ProviderTransform<br/>(消息适配)
+    participant AISDK as Vercel AI SDK<br/>(streamText)
+    participant API as 供应商 API
+
+    User->>Route: POST /session/:id/message
+    Route->>Session: 创建消息 & 处理器
+    Session->>Processor: process(streamInput)
+
+    loop 工具调用循环
+        Processor->>LLM: stream(messages, tools, model, ...)
+        LLM->>Provider: getLanguage(model)
+        Provider->>Provider: getSDK(model)<br/>创建/缓存 SDK 实例
+        Provider-->>LLM: LanguageModelV2
+
+        LLM->>LLM: 组装 system prompt<br/>合并 provider options
+        LLM->>AISDK: streamText({ model, messages, tools })
+
+        Note over AISDK,Transform: wrapLanguageModel 中间件<br/>调用 ProviderTransform.message()
+        AISDK->>Transform: transformParams(prompt)
+        Transform->>Transform: unsupportedParts()<br/>normalizeMessages()<br/>applyCaching()
+        Transform-->>AISDK: 适配后的消息
+
+        AISDK->>API: HTTP 流式请求 (SSE)
+        API-->>AISDK: 流式响应 chunks
+        AISDK-->>Processor: fullStream 事件流
+
+        Processor->>Processor: 处理事件<br/>(text/reasoning/tool-call)
+
+        alt 有工具调用
+            Processor->>Processor: 执行工具 → 注入结果
+            Note over Processor: 继续下一轮循环
+        else 无工具调用
+            Processor-->>Session: 完成
+        end
+    end
+
+    Session-->>User: SSE 推送结果
+```
+
+## 关键断点详解
+
+### 1. `LLM.stream()` — 唯一 LLM 调用入口
+
+**文件**: `packages/opencode/src/session/llm.ts`
+
+所有 Agent（general/plan/explore/build/compaction/title/summary）最终都通过此函数发起 LLM 调用。它负责：
+
+- 组装 system prompt（Agent prompt + Provider prompt + 用户自定义 prompt）
+- 获取 `LanguageModelV2` 实例（`Provider.getLanguage()`）
+- 合并 provider options（基础选项 + 模型选项 + Agent 选项 + variant 选项）
+- 调用 Vercel AI SDK 的 `streamText()` 发起流式请求
+- 应用 `wrapLanguageModel` 中间件，在发送前通过 `ProviderTransform.message()` 转换消息格式
+
+### 2. `Provider.getLanguage()` — SDK 实例化 & 模型获取
+
+**文件**: `packages/opencode/src/provider/provider.ts`
+
+```mermaid
+flowchart LR
+    A["Provider.getLanguage(model)"] --> B["getSDK(model)"]
+    B --> C{内置 bundled?}
+    C -->|是| D["BUNDLED_PROVIDERS[npm](options)"]
+    C -->|否| E["BunProc.install(npm)"]
+    E --> F["import(installedPath)"]
+    D --> G["SDK 实例 (缓存)"]
+    F --> G
+    G --> H{有 customModelLoader?}
+    H -->|是| I["modelLoader(sdk, apiID, options)"]
+    H -->|否| J["sdk.languageModel(apiID)"]
+    I --> K["LanguageModelV2"]
+    J --> K
+```
+
+### 3. `getSDK()` — 供应商 SDK 实例创建
+
+**文件**: `packages/opencode/src/provider/provider.ts`
+
+```mermaid
+flowchart TB
+    A["getSDK(model)"] --> B["获取 provider 配置"]
+    B --> C["解析 baseURL<br/>(变量替换: ${AZURE_RESOURCE_NAME} 等)"]
+    C --> D["注入自定义 fetch"]
+    D --> D1["代理支持 (HTTP_PROXY)"]
+    D --> D2["SSE chunk 超时"]
+    D --> D3["OpenAI itemId 清理"]
+    D --> E{npm 包在 BUNDLED_PROVIDERS 中?}
+    E -->|是| F["直接调用 bundled 创建函数"]
+    E -->|否| G{file:// 路径?}
+    G -->|是| H["直接 import 本地包"]
+    G -->|否| I["bun install npm@latest"]
+    I --> J["import 安装路径"]
+    F --> K["缓存 SDK 实例"]
+    H --> K
+    J --> K
+```
+
+### 4. `ProviderTransform` — 请求/响应适配层
+
+**文件**: `packages/opencode/src/provider/transform.ts`
+
+```mermaid
+flowchart LR
+    subgraph "ProviderTransform.message()"
+        A["原始消息"] --> B["unsupportedParts()"]
+        B --> C["normalizeMessages()"]
+        C --> D{是 Anthropic/Claude?}
+        D -->|是| E["applyCaching()"]
+        D -->|否| F["跳过"]
+        E --> G["remapProviderOptions()"]
+        F --> G
+        G --> H["适配后消息"]
+    end
+
+    subgraph "normalizeMessages() 分支"
+        C1["Anthropic: 过滤空消息"]
+        C2["Claude: 清洗 toolCallId"]
+        C3["Mistral: 修复消息序列<br/>(tool→user 间插入 assistant)"]
+        C4["interleaved: reasoning→providerOptions"]
+    end
+```
+
+| 转换函数 | 说明 |
+|----------|------|
+| `unsupportedParts()` | 将模型不支持的 modality（图片/音频/PDF）替换为错误文本 |
+| `normalizeMessages()` | Anthropic 过滤空消息；Claude 清洗 toolCallId；Mistral 修复消息序列 |
+| `applyCaching()` | 为 Anthropic/Bedrock/OpenRouter 等添加 cache control 标记 |
+| `options()` | 按供应商设置 thinking/reasoning config、store、promptCacheKey 等 |
+| `variants()` | 为 reasoning 模型生成 effort 级别选项（low/medium/high/max） |
+| `providerOptions()` | 将选项映射到 AI SDK 期望的 namespace key |
+
+## 支持的供应商 & 适配方式
+
+### 内置 Bundled Providers（直接打包）
+
+| 供应商 | npm 包 | SDK 创建函数 | 模型获取方式 |
+|--------|--------|-------------|-------------|
+| Anthropic | `@ai-sdk/anthropic` | `createAnthropic` | `sdk.languageModel(id)` |
+| OpenAI | `@ai-sdk/openai` | `createOpenAI` | `sdk.responses(id)` |
+| Google | `@ai-sdk/google` | `createGoogleGenerativeAI` | `sdk.languageModel(id)` |
+| Google Vertex | `@ai-sdk/google-vertex` | `createVertex` | `sdk.languageModel(id)` |
+| Google Vertex Anthropic | `@ai-sdk/google-vertex/anthropic` | `createVertexAnthropic` | `sdk.languageModel(id)` |
+| Azure | `@ai-sdk/azure` | `createAzure` | `sdk.responses(id)` / `sdk.chat(id)` |
+| Amazon Bedrock | `@ai-sdk/amazon-bedrock` | `createAmazonBedrock` | `sdk.languageModel(id)` + 区域前缀 |
+| OpenRouter | `@openrouter/ai-sdk-provider` | `createOpenRouter` | `sdk.languageModel(id)` |
+| xAI | `@ai-sdk/xai` | `createXai` | `sdk.responses(id)` |
+| Mistral | `@ai-sdk/mistral` | `createMistral` | `sdk.languageModel(id)` |
+| Groq | `@ai-sdk/groq` | `createGroq` | `sdk.languageModel(id)` |
+| DeepInfra | `@ai-sdk/deepinfra` | `createDeepInfra` | `sdk.languageModel(id)` |
+| Cerebras | `@ai-sdk/cerebras` | `createCerebras` | `sdk.languageModel(id)` |
+| Cohere | `@ai-sdk/cohere` | `createCohere` | `sdk.languageModel(id)` |
+| TogetherAI | `@ai-sdk/togetherai` | `createTogetherAI` | `sdk.languageModel(id)` |
+| Perplexity | `@ai-sdk/perplexity` | `createPerplexity` | `sdk.languageModel(id)` |
+| Vercel | `@ai-sdk/vercel` | `createVercel` | `sdk.languageModel(id)` |
+| AI Gateway | `@ai-sdk/gateway` | `createGateway` | `sdk.languageModel(id)` |
+| GitLab | `gitlab-ai-provider` | `createGitLab` | `sdk.agenticChat(id)` / `sdk.workflowChat(id)` |
+| GitHub Copilot | 自定义 copilot SDK | `createGitHubCopilotOpenAICompatible` | `sdk.responses(id)` / `sdk.chat(id)` |
+| OpenAI Compatible | `@ai-sdk/openai-compatible` | `createOpenAICompatible` | `sdk.languageModel(id)` (兜底) |
+
+### 动态安装 Providers
+
+不在内置列表中的 npm 包会通过 `BunProc.install(npm, "latest")` 动态安装后加载（如 `venice-ai-sdk-provider`、`@jerome-benoit/sap-ai-provider-v2` 等）。也支持 `file://` 本地路径加载自定义 provider。
+
+### 特殊 Custom Loaders
+
+部分供应商需要额外逻辑，通过 `CUSTOM_LOADERS` 注册（`packages/opencode/src/provider/provider.ts`）：
+
+| 供应商 | 特殊处理 |
+|--------|---------|
+| `anthropic` | 注入 `anthropic-beta` header（interleaved-thinking、fine-grained-tool-streaming） |
+| `opencode` | 无 API Key 时过滤付费模型，允许 `apiKey: "public"` 免费使用 |
+| `openai` / `xai` | 使用 `sdk.responses()` 而非 `sdk.languageModel()` |
+| `github-copilot` | GPT-5+ 使用 `sdk.responses()`，其余用 `sdk.chat()` |
+| `azure` | 支持 `resourceName` 配置，completionUrls 模式切换 |
+| `amazon-bedrock` | AWS 凭证链（profile/accessKey/bearerToken/webIdentity）、跨区域推理前缀 |
+| `google-vertex` | GCP OAuth token 注入、project/location 配置 |
+| `gitlab` | OAuth/PAT 认证、workflow model 发现、agentic chat |
+| `cloudflare-workers-ai` | accountId + apiKey 认证 |
+| `cloudflare-ai-gateway` | Unified API 格式（`provider/model`） |
+| `sap-ai-core` | AICORE_SERVICE_KEY 认证 |
+
+## 模型元数据来源
+
+```mermaid
+flowchart TB
+    A["models.dev/api.json<br/>(远程)"] -->|定时刷新 每小时| B["~/.cache/opencode/models.json<br/>(本地缓存)"]
+    C["provider/models-snapshot.js<br/>(构建时快照)"] -->|备用| D["ModelsDev.get()"]
+    B --> D
+    D --> E["Provider.state() 初始化"]
+
+    F["Config (opencode.json)<br/>provider 字段"] --> E
+    G["Auth (API Key / OAuth)"] --> E
+    H["Custom Loaders<br/>(autoload / options)"] --> E
+    I["Plugin auth loaders"] --> E
+
+    E --> J["最终 providers 列表<br/>(含所有可用模型)"]
+
+    J --> K{激活检查}
+    K -->|不在 disabled_providers| L["可用"]
+    K -->|在 enabled_providers 白名单| L
+    K -->|不满足条件| M["过滤"]
+```
+
+## Provider 激活条件
+
+一个供应商被激活需满足以下任一条件：
+
+1. **环境变量**: provider 定义的 `env` 字段对应的环境变量存在（如 `ANTHROPIC_API_KEY`）
+2. **API Key 认证**: 通过 `opencode auth <provider>` 设置了 API Key
+3. **配置文件**: `opencode.json` 中 `provider` 字段配置了该供应商
+4. **Custom Loader autoload**: loader 返回 `autoload: true`（如 Bedrock 检测到 AWS 凭证）
+5. **Plugin 认证**: 插件提供的 auth loader 返回了有效配置
+
+同时不能在 `disabled_providers` 列表中，且若配置了 `enabled_providers` 白名单则必须在其中。
+
+## 流式响应处理
+
+```mermaid
+flowchart TB
+    A["streamText() 返回 fullStream"] --> B{事件类型}
+
+    B -->|reasoning-start| C["创建 ReasoningPart"]
+    B -->|reasoning-delta| D["增量追加 reasoning 文本"]
+    B -->|reasoning-end| E["完成 ReasoningPart"]
+
+    B -->|text-delta| F["增量追加 TextPart"]
+
+    B -->|tool-call-start| G["创建 ToolPart<br/>(state: pending)"]
+    B -->|tool-call-delta| H["更新 ToolPart 参数"]
+    B -->|tool-call| I["执行工具<br/>(state: running → completed)"]
+
+    B -->|step-start| J["记录 StepStartPart<br/>(创建快照)"]
+    B -->|step-finish| K["记录 StepFinishPart<br/>(token 统计 & 费用)"]
+
+    B -->|error| L["重试逻辑<br/>(最多 3 次)"]
+
+    I --> M{还有工具调用?}
+    M -->|是| N["注入工具结果<br/>继续下一轮 LLM 循环"]
+    M -->|否| O["处理完成"]
+
+    N --> A
+```
+
+`SessionProcessor` 消费 `streamText` 返回的 `fullStream`，逐事件处理并通过事件总线推送到客户端：
+
+| 事件类型 | 处理 |
+|----------|------|
+| `reasoning-start/delta/end` | 创建/更新/完成 ReasoningPart |
+| `text-delta` | 增量追加 TextPart |
+| `tool-call-start/delta` | 创建 ToolPart (pending → running) |
+| `step-start/finish` | 记录 StepStart/StepFinish Part（含 token 统计和费用） |
+| `error` | 重试逻辑（最多 3 次自动重试） |
+
+工具调用完成后，processor 将结果注入消息，继续下一轮 LLM 循环，直到模型不再请求工具调用。

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1326,6 +1326,22 @@ export namespace Provider {
         const combined = signals.length === 0 ? null : signals.length === 1 ? signals[0] : AbortSignal.any(signals)
         if (combined) opts.signal = combined
 
+        // For openai-compatible providers using chat completions API with newer OpenAI models
+        // (gpt-5+, o-series), replace max_tokens with max_completion_tokens.
+        // The @ai-sdk/openai-compatible package always sends max_tokens, but newer OpenAI
+        // models only accept max_completion_tokens.
+        if (model.api.npm === "@ai-sdk/openai-compatible" && opts.body && opts.method === "POST") {
+          const body = JSON.parse(opts.body as string)
+          if (body.max_tokens != null && body.max_completion_tokens == null) {
+            const id = (body.model ?? model.api.id).toLowerCase()
+            if (/^(gpt-5|o[1-9])/.test(id) && !id.startsWith("gpt-5-chat")) {
+              body.max_completion_tokens = body.max_tokens
+              delete body.max_tokens
+              opts.body = JSON.stringify(body)
+            }
+          }
+        }
+
         // Strip openai itemId metadata following what codex does
         // Codex uses #[serde(skip_serializing)] on id fields for all item types:
         // Message, Reasoning, FunctionCall, LocalShellCall, CustomToolCall, WebSearchCall

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -509,6 +509,11 @@ export namespace ProviderTransform {
         if (id.includes("gpt-5-") || id === "gpt-5") {
           azureEfforts.unshift("minimal")
         }
+        if (id.includes("gpt-5.4")) {
+          return Object.fromEntries(
+            azureEfforts.map((effort) => [effort, { reasoningEffort: effort }]),
+          )
+        }
         return Object.fromEntries(
           azureEfforts.map((effort) => [
             effort,
@@ -522,6 +527,21 @@ export namespace ProviderTransform {
       case "@ai-sdk/openai":
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/openai
         if (id === "gpt-5-pro") return {}
+        if (id.includes("gpt-5.4")) {
+          const openaiEfforts = iife(() => {
+            const arr = [...WIDELY_SUPPORTED_EFFORTS]
+            if (model.release_date >= "2025-11-13") {
+              arr.unshift("none")
+            }
+            if (model.release_date >= "2025-12-04") {
+              arr.push("xhigh")
+            }
+            return arr
+          })
+          return Object.fromEntries(
+            openaiEfforts.map((effort) => [effort, { reasoningEffort: effort }]),
+          )
+        }
         const openaiEfforts = iife(() => {
           if (id.includes("codex")) {
             if (id.includes("5.2") || id.includes("5.3")) return [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
@@ -828,7 +848,7 @@ export namespace ProviderTransform {
     }
 
     if (input.model.api.id.includes("gpt-5") && !input.model.api.id.includes("gpt-5-chat")) {
-      if (!input.model.api.id.includes("gpt-5-pro")) {
+      if (!input.model.api.id.includes("gpt-5-pro") && !input.model.api.id.includes("gpt-5.4")) {
         result["reasoningEffort"] = "medium"
         result["reasoningSummary"] = "auto"
       }
@@ -846,8 +866,10 @@ export namespace ProviderTransform {
 
       if (input.model.providerID.startsWith("opencode")) {
         result["promptCacheKey"] = input.sessionID
-        result["include"] = ["reasoning.encrypted_content"]
-        result["reasoningSummary"] = "auto"
+        if (!input.model.api.id.includes("gpt-5.4")) {
+          result["include"] = ["reasoning.encrypted_content"]
+          result["reasoningSummary"] = "auto"
+        }
       }
     }
 


### PR DESCRIPTION
- Handle gpt-5.4 reasoning variants for Azure and OpenAI providers (no reasoningSummary or encrypted_content support)
- Fix max_tokens → max_completion_tokens for openai-compatible providers with newer OpenAI models (gpt-5+, o-series)
- Add comprehensive LLM call chain documentation (docs/llm-call-chain.md)

### Issue for this PR

Closes #16 #228 

### Type of change

- [x] Bug fix
- [x] New feature
- [x] Documentation

### What does this PR do?

**1. gpt-5.4 model support (`transform.ts`)**

gpt-5.4 models don't support `reasoningSummary` or `reasoning.encrypted_content` (unlike gpt-5/gpt-5-mini). Three places were updated to handle this:

- **Azure variants**: gpt-5.4 returns `{ reasoningEffort }` only, without `reasoningSummary`/`include` fields.
- **OpenAI variants**: same treatment — effort-only options, with `none`/`xhigh` gated by `release_date`.
- **Default options**: gpt-5.4 is excluded from the default `reasoningEffort: "medium"` / `reasoningSummary: "auto"` that other gpt-5 models get, and from `include: ["reasoning.encrypted_content"]` under the opencode provider.

**2. max_tokens → max_completion_tokens fix (`provider.ts`)**

The `@ai-sdk/openai-compatible` package always sends `max_tokens`, but newer OpenAI models (gpt-5+, o-series) only accept `max_completion_tokens`. Added a fetch-level interceptor that detects these models by regex (`/^(gpt-5|o[1-9])/`, excluding `gpt-5-chat`) and swaps the field in the request body before it hits the API.

**3. LLM call chain documentation (`docs/llm-call-chain.md`)**

Added a comprehensive doc covering the full LLM call chain: `Session.chat()` → `LLM.stream()` → `Provider.getLanguage()` → `ProviderTransform` → `streamText()` → API. Includes Mermaid diagrams, provider table, activation conditions, and streaming event handling.

### How did you verify your code works?

- Tested gpt-5.4 model calls through both OpenAI and Azure providers, confirmed no `reasoningSummary`/`encrypted_content` errors.
- Verified openai-compatible provider correctly sends `max_completion_tokens` for gpt-5+ and o-series models.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
