### PR TITLE
refactor: rename web updater assets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -150,7 +150,7 @@ jobs:
           path: |
             packages/opencode/dist/aether-darwin-arm64.dmg
             packages/opencode/dist/latest-web-mac.yml
-            packages/opencode/dist/update_darwin_web.command
+            packages/opencode/dist/update_darwin.command
           if-no-files-found: error
 
   build-web-linux:
@@ -174,7 +174,7 @@ jobs:
           path: |
             packages/opencode/dist/aether-linux-x64.zip
             packages/opencode/dist/latest-web-linux.yml
-            packages/opencode/dist/update_linux_web.sh
+            packages/opencode/dist/update_linux.sh
           if-no-files-found: error
 
   build-web-windows:
@@ -199,7 +199,7 @@ jobs:
           path: |
             packages/opencode/dist/aether-windows-x64.zip
             packages/opencode/dist/latest-web-windows.yml
-            packages/opencode/dist/update_windows_web.bat
+            packages/opencode/dist/update_windows.bat
           if-no-files-found: error
 
   publish:

--- a/Update/mac_flow.md
+++ b/Update/mac_flow.md
@@ -2,10 +2,10 @@
 
 - `packing_scripts/release-mac-web.sh`
   - 构建 web 二进制并裁剪 `wechat-bridge/runtime/uv` 仅保留 mac arm64 目标。
-  - 组装产物目录，包含运行文件、`update_darwin_web.command`、`aether_darwin_installer.command`、`.aether_web_version`、`README_FIRST.txt`。
-  - 修正执行权限（`aether`、`Aether.command`、`update_darwin_web.command`、installer）。
+  - 组装产物目录，包含运行文件、`update_darwin.command`、`aether_darwin_installer.command`、`.aether_web_version`、`README_FIRST.txt`。
+  - 修正执行权限（`aether`、`Aether.command`、`update_darwin.command`、installer）。
   - 打出 `dist/aether-darwin-arm64-web.dmg`，生成 `dist/latest-web-mac.yml`。
-  - 额外在 `dist/` 放一份 `update_darwin_web.command` 方便你上传远端。
+  - 额外在 `dist/` 放一份 `update_darwin.command` 方便你上传远端。
 
 - `Update/aether_darwin_installer.command`（入口脚本）
   - 支持 `init | auto <current-version> | manual <target-version>`，支持 `--path`、`--no-pause`。
@@ -13,13 +13,13 @@
   - 拉取远端 manifest，下载包和对应版本 update 脚本到 `Aether/downloads`。
   - 本地文件名统一版本化并与远端命名解耦：
     - `aether-darwin-arm64-web-<ver>.dmg`
-    - `update_darwin_web-<ver>.command`
+    - `update_darwin-<ver>.command`
   - 已有同版本文件会复用，不重复下载；并清理旧缓存（默认保留最近 3 个版本）。
   - `init` 下载后会自动执行版本化 update 脚本完成安装。
   - 仅 `init` 会创建 `~/Aether_Database`。
   - `auto/manual` 只下载并写 `downloads/last-result.yml` 供 Aether 后台流程使用。
 
-- `Update/update_darwin_web.command`（本地安装脚本）
+- `Update/update_darwin.command`（本地安装脚本）
   - 只接受固定目录规范：`.../Aether/downloads` 执行，且 `.../Aether` 下需有 installer。
   - 从 `downloads` 选择对应版本 DMG，安装到 `Aether/aether_<ver>`。
   - 权限处理：
@@ -38,5 +38,5 @@
 - Aether 内自动更新联动（你现在实测使用的链路）
   - 启动/定时检查：后台静默触发 installer `auto` 下载。
   - 下载完成：立即弹“更新并重启”。
-  - 点击更新：后端执行 `update_darwin_web-<ver>.command --restart`。
+  - 点击更新：后端执行 `update_darwin-<ver>.command --restart`。
   - 防降级：即使远端误把旧版本标为 latest，也不会提示从新版本降到旧版本。

--- a/Update/release-and-upload-mac-web.sh
+++ b/Update/release-and-upload-mac-web.sh
@@ -24,7 +24,7 @@ root="$(cd "$(dirname "$0")/.." && pwd)"
 dist="$root/packages/opencode/dist"
 src="$dist/aether-darwin-arm64/bin"
 dmg="$dist/aether-darwin-arm64-web.dmg"
-updater="$root/Update/update_darwin_web.command"
+updater="$root/Update/update_darwin.command"
 upload_url="https://aether.aiphys.cn/api/download/admin/upload"
 
 # ── 1. Build ────────────────────────────────────────────────────────
@@ -53,8 +53,8 @@ printf "%s\n" "$ver" > "$pkg/.aether_version"
 
 # Include updater script
 if [ -f "$updater" ]; then
-  cp "$updater" "$pkg/update_darwin_web.command"
-  chmod +x "$pkg/update_darwin_web.command"
+  cp "$updater" "$pkg/update_darwin.command"
+  chmod +x "$pkg/update_darwin.command"
 fi
 
 # Ensure executables are +x
@@ -79,7 +79,7 @@ Troubleshooting
   chmod +x ./aether ./Aether.command
 
 Offline update
-- Run ./update_darwin_web.command
+- Run ./update_darwin.command
 EOFREADME
 
 rm -f "$dmg"

--- a/Update/update_darwin_web.md
+++ b/Update/update_darwin_web.md
@@ -1,11 +1,11 @@
-# update_darwin_web.command（macOS Web 更新执行脚本）
+# update_darwin.command（macOS Web 更新执行脚本）
 
 这个脚本只负责**本地已下载安装包的版本安装**，不负责远端检查、下载、校验。
 
 与 `aether_darwin_installer.command` 的职责分离如下：
 
 - `aether_darwin_installer.command`：拉取元数据、下载包和安装器、写 `last-result.yml`
-- `update_darwin_web.command`：消费本地 dmg，执行版本目录安装与切换
+- `update_darwin.command`：消费本地 dmg，执行版本目录安装与切换
 
 ## 输入与前提
 
@@ -45,8 +45,8 @@
 
 ```bash
 # 自动选择脚本目录中最高版本 dmg
-./update_darwin_web.command
+./update_darwin.command
 
 # 指定安装版本（脚本目录中必须有对应 dmg）
-./update_darwin_web.command 0.3.1
+./update_darwin.command 0.3.1
 ```

--- a/docs/aether-download-admin-upload.md
+++ b/docs/aether-download-admin-upload.md
@@ -78,9 +78,9 @@ POST https://aether.aiphys.cn/api/download2/admin/upload
 
 | 字段 | 含义 |
 | --- | --- |
-| `macInstaller` | macOS 可选更新脚本文件，发布为 `update_darwin_web.command` |
-| `winInstaller` | Windows 可选更新脚本文件，发布为 `update_windows_web.bat` |
-| `linuxInstaller` | Linux 可选更新脚本文件，发布为 `update_linux_web.sh` |
+| `macInstaller` | macOS 可选更新脚本文件，发布为 `update_darwin.command` |
+| `winInstaller` | Windows 可选更新脚本文件，发布为 `update_windows.bat` |
+| `linuxInstaller` | Linux 可选更新脚本文件，发布为 `update_linux.sh` |
 
 ### macOS 额外可选字段
 
@@ -96,9 +96,9 @@ POST https://aether.aiphys.cn/api/download2/admin/upload
 | 主字段 | 兼容别名 |
 | --- | --- |
 | `macos` | `darwin`、`mac`、`macPackage`、`aether-darwin-arm64.dmg` |
-| `macInstaller` | `macCommand`、`installer`、`command`、`update_darwin_web.command` |
-| `winInstaller` | `windowsInstaller`、`update_windows_web.bat` |
-| `linuxInstaller` | `update_linux_web.sh` |
+| `macInstaller` | `macCommand`、`installer`、`command`、`update_darwin.command` |
+| `winInstaller` | `windowsInstaller`、`update_windows.bat` |
+| `linuxInstaller` | `update_linux.sh` |
 | `macNotesUrl` | `notesUrl`、`notes_url` |
 | `macVersion` | `darwinVersion`、`mac_version` |
 | `windowsVersion` | `winVersion`、`windows_version` |
@@ -113,7 +113,7 @@ curl -X POST https://aether.aiphys.cn/api/download/admin/upload \
   -H 'x-download-admin-password: <your-password>' \
   -F 'macVersion=1.3.3' \
   -F 'macos=@aether-darwin-arm64.dmg' \
-  -F 'macInstaller=@update_darwin_web.command' \
+  -F 'macInstaller=@update_darwin.command' \
   -F 'macNotesUrl=https://aether.aiphys.cn/release-notes/1.3.3'
 ```
 
@@ -124,13 +124,13 @@ curl -X POST https://aether.aiphys.cn/api/download/admin/upload \
   -F 'password=<your-password>' \
   -F 'macVersion=1.3.3' \
   -F 'macos=@aether-darwin-arm64.dmg' \
-  -F 'macInstaller=@update_darwin_web.command' \
+  -F 'macInstaller=@update_darwin.command' \
   -F 'linuxVersion=1.3.4' \
   -F 'linux=@aether-linux-x64.zip' \
-  -F 'linuxInstaller=@update_linux_web.sh' \
+  -F 'linuxInstaller=@update_linux.sh' \
   -F 'windowsVersion=1.3.5' \
   -F 'windows=@aether-windows-x64.zip' \
-  -F 'winInstaller=@update_windows_web.bat'
+  -F 'winInstaller=@update_windows.bat'
 ```
 
 ## 开发者私有测试上传接口
@@ -151,7 +151,7 @@ curl -X POST https://aether.aiphys.cn/api/download2/admin/upload \
   -H 'x-download-admin-password: <your-password>' \
   -F 'macVersion=1.4.1-dev' \
   -F 'macos=@aether-darwin-arm64.dmg' \
-  -F 'macInstaller=@update_darwin_web.command'
+  -F 'macInstaller=@update_darwin.command'
 ```
 
 ## 上传成功后的行为
@@ -210,7 +210,7 @@ curl -X POST https://aether.aiphys.cn/api/download2/admin/upload \
       "latestManifestUrl": "/api/download2/latest/mac-arm64.yml",
       "sha512": "<base64-sha512>",
       "size": 93444053,
-      "latestInstallerUrl": "/api/download2/latest/update_darwin_web.command",
+      "latestInstallerUrl": "/api/download2/latest/update_darwin.command",
       "notesUrl": null
     }
   ]
@@ -235,8 +235,8 @@ curl -X POST https://aether.aiphys.cn/api/download2/admin/upload \
       "latestManifestUrl": "/download/latest/mac-arm64.yml",
       "sha512": "<base64-sha512>",
       "size": 93444053,
-      "installerUrl": "/download/1.3.3/update_darwin_web.command",
-      "latestInstallerUrl": "/download/latest/update_darwin_web.command",
+      "installerUrl": "/download/1.3.3/update_darwin.command",
+      "latestInstallerUrl": "/download/latest/update_darwin.command",
       "notesUrl": "https://aether.aiphys.cn/release-notes/1.3.3"
     }
   ]
@@ -263,11 +263,11 @@ curl -X POST https://aether.aiphys.cn/api/download2/admin/upload \
 对应安装包：
 
 - `/download/latest/aether-darwin-arm64.dmg`
-- `/download/latest/update_darwin_web.command`
+- `/download/latest/update_darwin.command`
 - `/download/latest/aether-windows-x64.zip`
-- `/download/latest/update_windows_web.bat`
+- `/download/latest/update_windows.bat`
 - `/download/latest/aether-linux-x64.zip`
-- `/download/latest/update_linux_web.sh`
+- `/download/latest/update_linux.sh`
 
 解析规则：
 
@@ -286,11 +286,11 @@ curl -X POST https://aether.aiphys.cn/api/download2/admin/upload \
 对应安装包：
 
 - `/download/<version>/aether-darwin-arm64.dmg`
-- `/download/<version>/update_darwin_web.command`
+- `/download/<version>/update_darwin.command`
 - `/download/<version>/aether-windows-x64.zip`
-- `/download/<version>/update_windows_web.bat`
+- `/download/<version>/update_windows.bat`
 - `/download/<version>/aether-linux-x64.zip`
-- `/download/<version>/update_linux_web.sh`
+- `/download/<version>/update_linux.sh`
 
 ### 兼容旧地址
 
@@ -300,11 +300,11 @@ curl -X POST https://aether.aiphys.cn/api/download2/admin/upload \
 - `/download/latest-web-windows.yml`
 - `/download/latest-web-linux.yml`
 - `/download/aether-darwin-arm64.dmg`
-- `/download/update_darwin_web.command`
+- `/download/update_darwin.command`
 - `/download/aether-windows-x64.zip`
-- `/download/update_windows_web.bat`
+- `/download/update_windows.bat`
 - `/download/aether-linux-x64.zip`
-- `/download/update_linux_web.sh`
+- `/download/update_linux.sh`
 
 ## macOS Manifest 协议
 
@@ -331,7 +331,7 @@ package:
   sha512: <base64-sha512>
   size: 93444053
 installer:
-  url: update_darwin_web.command
+  url: update_darwin.command
   size: 4096
 notes_url: 'https://aether.aiphys.cn/release-notes/1.3.3'
 files:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -91,7 +91,7 @@ packages/opencode/dist/
 
 | 平台 | 格式 | 内容 |
 |------|------|------|
-| macOS | `.dmg` | `aether` + `web/` + `Aether.command` + `update_darwin_web.command` + `README_FIRST.txt` |
+| macOS | `.dmg` | `aether` + `web/` + `Aether.command` + `update_darwin.command` + `README_FIRST.txt` |
 | Linux | `.tar.gz` | `aether` + `web/` + `Aether.sh` |
 | Windows | `.zip` | `aether.exe` + `web/` + `Aether.vbs` |
 
@@ -142,7 +142,7 @@ curl -X POST https://aether.aiphys.cn/api/download/admin/upload \
   -H 'x-download-admin-password: <password>' \
   -F 'macVersion=0.2.3' \
   -F 'macos=@aether-darwin-arm64-web.dmg' \
-  -F 'macInstaller=@Update/update_darwin_web.command' \
+  -F 'macInstaller=@Update/update_darwin.command' \
   -F 'macNotesUrl=https://aether.aiphys.cn/release-notes/0.2.3'
 ```
 
@@ -152,13 +152,13 @@ curl -X POST https://aether.aiphys.cn/api/download/admin/upload \
 
 ### 4.1 macOS 离线更新脚本
 
-**文件**：`Update/update_darwin_web.command`
+**文件**：`Update/update_darwin.command`
 
 用户双击即可检查并安装更新，流程：
 
 ```mermaid
 flowchart TD
-    A[运行 update_darwin_web.command] --> B[从 aether.aiphys.cn 获取 latest-web-mac.yml]
+    A[运行 update_darwin.command] --> B[从 aether.aiphys.cn 获取 latest-web-mac.yml]
     B --> C{本地版本 == 远端版本?}
     C -->|是| D[已是最新，退出]
     C -->|否| E[下载新版本 DMG]
@@ -192,8 +192,8 @@ flowchart TD
 | Web 前端版本读取 | `packages/app/src/entry.tsx` |
 | macOS 构建+上传脚本 | `Update/release-and-upload-mac-web.sh` |
 | macOS 打包脚本 | `packing_scripts/release-mac-web.sh` |
-| macOS 更新脚本 | `Update/update_darwin_web.command` |
-| Linux 更新脚本 | `Update/update_linux_web.sh` |
-| Windows 更新脚本 | `Update/update_windows_web.bat` |
+| macOS 更新脚本 | `Update/update_darwin.command` |
+| Linux 更新脚本 | `Update/update_linux.sh` |
+| Windows 更新脚本 | `Update/update_windows.bat` |
 | 打包指南（详细） | `PACKAGING.md` |
 | 打包指南（Web 版） | `PACKAGING-1.md` |

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -54,9 +54,9 @@ const INSTALLER_SCRIPT: Record<string, string> = {
 }
 
 const UPDATE_SCRIPT: Record<string, string> = {
-  darwin: "update_darwin_web.command",
-  linux: "update_linux_web.sh",
-  windows: "update_windows_web.bat",
+  darwin: "update_darwin.command",
+  linux: "update_linux.sh",
+  windows: "update_windows.bat",
 }
 
 const UPDATE_PKG_EXT: Record<string, string> = {

--- a/packing_scripts/release-linux-web.sh
+++ b/packing_scripts/release-linux-web.sh
@@ -16,7 +16,7 @@ if [ ! -d "$src" ]; then
 fi
 
 uv="$src/wechat-bridge/runtime/uv"
-upd="$root/Update/update_linux_web.sh"
+upd="$root/Update/update_linux.sh"
 
 if [ -d "$uv" ]; then
   for dir in "$uv"/*; do
@@ -41,10 +41,10 @@ out="$tmp/$pkg"
 mkdir -p "$out"
 cp -R "$src"/. "$out"/
 
-cp "$upd" "$out/update_linux_web.sh"
-chmod +x "$out/update_linux_web.sh"
-cp "$upd" "dist/update_linux_web.sh"
-chmod +x "dist/update_linux_web.sh"
+cp "$upd" "$out/update_linux.sh"
+chmod +x "$out/update_linux.sh"
+cp "$upd" "dist/update_linux.sh"
+chmod +x "dist/update_linux.sh"
 
 ins="$root/Update/aether_linux_installer.sh"
 if [ -f "$ins" ]; then
@@ -69,7 +69,7 @@ Quick start
 2) Open Terminal in that folder and run: ./Aether.sh
 
 Offline update
-- Run ./update_linux_web.sh to check and install newer versions from:
+- Run ./update_linux.sh to check and install newer versions from:
   https://aether.aiphys.cn/download
 EOF
 
@@ -94,6 +94,6 @@ popd >/dev/null
 
 echo "Done"
 echo "Asset: packages/opencode/$zip"
-echo "Updater: packages/opencode/dist/update_linux_web.sh"
+echo "Updater: packages/opencode/dist/update_linux.sh"
 echo "YML:   packages/opencode/dist/latest-web-linux.yml"
 echo "Note:  ZIP includes folder $pkg"

--- a/packing_scripts/release-mac-web.sh
+++ b/packing_scripts/release-mac-web.sh
@@ -32,7 +32,7 @@ pkg="aether-darwin-arm64"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 out="$tmp/$pkg"
-upd="$root/Update/update_darwin_web.command"
+upd="$root/Update/update_darwin.command"
 
 mkdir -p "$out"
 cp -R "$src"/. "$out"/
@@ -41,7 +41,7 @@ if [ ! -f "$upd" ]; then
   echo "Missing updater script: $upd"
   exit 1
 fi
-cp "$upd" "$out/update_darwin_web.command"
+cp "$upd" "$out/update_darwin.command"
 
 ins="$root/Update/aether_darwin_installer.command"
 if [ -f "$ins" ]; then
@@ -59,9 +59,9 @@ if [ -f "$out/Aether.command" ]; then
   chmod +x "$out/Aether.command"
 fi
 
-chmod +x "$out/update_darwin_web.command"
-cp "$upd" "dist/update_darwin_web.command"
-chmod +x "dist/update_darwin_web.command"
+chmod +x "$out/update_darwin.command"
+cp "$upd" "dist/update_darwin.command"
+chmod +x "dist/update_darwin.command"
 
 cat >"$out/README_FIRST.txt" <<'EOF'
 Aether Web (macOS arm64)
@@ -86,7 +86,7 @@ Troubleshooting
   System Settings -> Privacy & Security -> scroll down and allow the blocked item, then retry Open
 
 Offline update
-- Run ./update_darwin_web.command to check and install newer versions from:
+- Run ./update_darwin.command to check and install newer versions from:
   https://aether.aiphys.cn/download
 EOF
 
@@ -109,6 +109,6 @@ popd >/dev/null
 
 echo "Done"
 echo "Asset: packages/opencode/$dmg"
-echo "Updater: packages/opencode/dist/update_darwin_web.command"
+echo "Updater: packages/opencode/dist/update_darwin.command"
 echo "YML:   packages/opencode/dist/latest-web-mac.yml"
-echo "Note:  DMG includes README_FIRST.txt and update_darwin_web.command"
+echo "Note:  DMG includes README_FIRST.txt and update_darwin.command"

--- a/packing_scripts/release-windows-web.bat
+++ b/packing_scripts/release-windows-web.bat
@@ -20,7 +20,7 @@ if not exist "%SRC%" (
 )
 
 set "UV=%SRC%\wechat-bridge\runtime\uv"
-set "UPD=%ROOT%\Update\update_windows_web.bat"
+set "UPD=%ROOT%\Update\update_windows.bat"
 set "PKG=aether-windows-x64"
 set "TMP=%TEMP%\aether-web-pack-%RANDOM%%RANDOM%"
 set "OUT=%TMP%\%PKG%"
@@ -44,8 +44,8 @@ if %RC% GEQ 8 (
   exit /b 1
 )
 
-copy /y "%UPD%" "%OUT%\update_windows_web.bat" >nul || exit /b 1
-copy /y "%UPD%" "%CD%\dist\update_windows_web.bat" >nul || exit /b 1
+copy /y "%UPD%" "%OUT%\update_windows.bat" >nul || exit /b 1
+copy /y "%UPD%" "%CD%\dist\update_windows.bat" >nul || exit /b 1
 
 set "INS=%ROOT%\Update\aether_windows_installer.bat"
 if exist "%INS%" (
@@ -54,7 +54,7 @@ if exist "%INS%" (
 
 powershell -NoProfile -Command "& { [IO.File]::WriteAllText((Join-Path $env:OUT '.aether_web_version'), $env:VERSION) }" || exit /b 1
 
-powershell -NoProfile -Command "& { $crlf=[char]13+[char]10; $txt=@('Aether Web (Windows x64)','', 'Quick start', '1) Extract this ZIP and copy the folder aether-windows-x64 to a local path, for example: C:\Aether-Web', '2) In that folder, double click Aether.vbs', '', 'Offline update', '- Run update_windows_web.bat to check and install newer versions from:', '  https://aether.aiphys.cn/download') -join $crlf; Set-Content -Path (Join-Path $env:OUT 'README_FIRST.txt') -Value ($txt + $crlf) -Encoding ascii }" || exit /b 1
+powershell -NoProfile -Command "& { $crlf=[char]13+[char]10; $txt=@('Aether Web (Windows x64)','', 'Quick start', '1) Extract this ZIP and copy the folder aether-windows-x64 to a local path, for example: C:\Aether-Web', '2) In that folder, double click Aether.vbs', '', 'Offline update', '- Run update_windows.bat to check and install newer versions from:', '  https://aether.aiphys.cn/download') -join $crlf; Set-Content -Path (Join-Path $env:OUT 'README_FIRST.txt') -Value ($txt + $crlf) -Encoding ascii }" || exit /b 1
 
 set "ZIP=%CD%\dist\aether-windows-x64.zip"
 if exist "%ZIP%" del /f /q "%ZIP%"
@@ -69,6 +69,6 @@ rmdir /s /q "%TMP%" >nul 2>nul
 
 echo Done
 echo Asset: %ZIP%
-echo Updater: %CD%\dist\update_windows_web.bat
+echo Updater: %CD%\dist\update_windows.bat
 echo YML:   %YML%
 echo Note:  ZIP includes folder %PKG%


### PR DESCRIPTION
### Issue for this PR

Closes #254

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Rename web updater asset names from `*_web.*` to unified names across packaging scripts, API routing, publish workflow, and docs. This keeps generated artifacts, upload/download docs, and runtime mappings aligned.

### How did you verify your code works?

The `git push` command triggered the repository typecheck hook and it completed successfully.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
