### PR TITLE
fix: improve offline update flow across platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ __pycache__/
 */__pycache__/
 .opencode/skills/aether-issue-pr
 nul
+Update/test_installer_init_flow.sh

--- a/Update/aether_darwin_installer.command
+++ b/Update/aether_darwin_installer.command
@@ -80,7 +80,7 @@ keep="3"
 done_hold() {
   if [ "$hold" = "1" ]; then
     echo
-    read -r -p "Press Enter to close..." _
+    read -r -p "按回车关闭..." _
   fi
 }
 
@@ -236,6 +236,43 @@ installed() {
   done
   shopt -u nullglob
   printf "%s" "$best_ver"
+}
+
+cache_paths() {
+  dl="$work/downloads"
+  [ -n "$pkg_name" ] || return 1
+  local pkg_ext ins_ext
+  pkg_ext="${pkg_name##*.}"
+  if [ "$pkg_ext" = "$pkg_name" ]; then
+    pkg_ext=""
+  else
+    pkg_ext=".$pkg_ext"
+  fi
+  pkg_file="$dl/aether-darwin-arm64-$ver$pkg_ext"
+  ins_file=""
+  if [ -n "$ins_url" ] && [ -n "$ins_name" ]; then
+    ins_ext="${ins_name##*.}"
+    if [ "$ins_ext" = "$ins_name" ]; then
+      ins_ext=""
+    else
+      ins_ext=".$ins_ext"
+    fi
+    ins_file="$dl/update_darwin-$ver$ins_ext"
+  fi
+}
+
+cached_ready() {
+  [ -d "$work/downloads" ] || return 1
+  cache_paths || return 1
+  [ -f "$pkg_file" ] || return 1
+  if [ -n "$sha" ]; then
+    local sum
+    sum="$(openssl dgst -sha512 -binary "$pkg_file" | openssl base64 -A || true)"
+    [ "$sum" = "$sha" ] || return 1
+  fi
+  [ -n "$ins_file" ] || return 1
+  [ -f "$ins_file" ] || return 1
+  chmod +x "$ins_file" 2>/dev/null || true
 }
 
 fetch_meta() {
@@ -417,31 +454,31 @@ prune() {
 
 help() {
   cat <<EOF
-Aether Darwin Installer
+Aether macOS 安装器
 
-Usage:
+用法:
   $(basename "$0") [--no-pause] [--path <dir>] init
   $(basename "$0") [--no-pause] auto <current-version>
   $(basename "$0") [--no-pause] manual <target-version>
 
-Remote manifests:
+远端清单:
   $base/$latest
   $base/1.2.3/mac-arm64.yml
 
-Result file:
+结果文件:
   work_dir/downloads/last-result.yml
 
-Exit codes:
-  0   init finished successfully
-  10  latest update downloaded and ready
-  11  requested version downloaded and ready
-  20  already up to date
-  21  requested version not found
-  30  manifest or network error
-  31  download failed
-  32  checksum mismatch
-  40  work directory error
-  50  argument error
+退出码:
+  0   初始化安装成功完成
+  10  最新更新已下载，等待安装
+  11  指定版本已下载，等待安装
+  20  已是最新版本
+  21  未找到指定版本
+  30  清单或网络错误
+  31  下载失败
+  32  校验和不匹配
+  40  工作目录错误
+  50  参数错误
 EOF
 }
 
@@ -451,16 +488,16 @@ if [ "$mode" = "help" ] || [ "$mode" = "--help" ] || [ "$mode" = "-h" ]; then
 fi
 
 if [ "$mode" = "init" ]; then
-  echo "Aether Darwin Installer"
+  echo "Aether macOS 安装器"
   echo
   work="$(normalize_work "${path_arg:-$default}")"
-  echo "Install directory:"
+  echo "安装目录:"
   echo "  $work"
   prep "$work" || {
     res="dir_error"
     result
     echo
-    echo "Work directory failed."
+    echo "工作目录处理失败。"
     fail "$dir_err"
   }
   local_self="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
@@ -470,7 +507,7 @@ if [ "$mode" = "init" ]; then
       res="dir_error"
       result
       echo
-      echo "Failed to copy installer to $work"
+      echo "复制安装器到 $work 失败"
       fail "$dir_err"
     }
   fi
@@ -479,52 +516,62 @@ if [ "$mode" = "init" ]; then
     res="meta_error"
     result
     echo
-    echo "Manifest check failed."
+    echo "获取清单失败。"
     fail "$meta_err"
   }
+  echo
+  echo "最新版本: $ver"
+  echo
   cur="$(installed "$work")"
   if [ -n "$cur" ] && [ "$(cmp "$cur" "$ver")" = "eq" ]; then
     res="up_to_date"
     result
     echo
-    echo "Current version: $cur"
-    echo "Remote version: $ver"
-    echo "Already up to date."
+    echo "当前版本: $cur"
+    echo "远端版本: $ver"
+    echo "已经是最新版本。"
     done_hold
     exit "$latest_ok"
   fi
-  grab || {
-    code="$?"
-    res="download_error"
-    [ "$code" = "$sum_err" ] && res="checksum_error"
-    result
-    echo
-    echo "Download failed."
-    fail "$code"
-  }
+  if cached_ready; then
+    echo "Using cached package:"
+    echo "  $pkg_file"
+    echo "Using cached installer:"
+    echo "  $ins_file"
+  else
+    grab || {
+      code="$?"
+      res="download_error"
+      [ "$code" = "$sum_err" ] && res="checksum_error"
+      result
+      echo
+      echo "下载失败。"
+      fail "$code"
+    }
+  fi
   res="init_ready"
   result
   echo
-  echo "Download finished."
-  echo "Version:   $ver"
-  echo "Package:   $pkg_file"
-  echo "Installer: $ins_file"
-  echo "Result:    $res_file"
+  echo "下载完成。"
+  echo "版本:     $ver"
+  echo "安装包:   $pkg_file"
+  echo "安装脚本: $ins_file"
+  echo "结果文件: $res_file"
   echo
   if [ -n "$ins_file" ]; then
-    echo "[init] Running installer script..."
+    echo "[init] 正在运行安装脚本..."
     if ! (cd "$work/downloads" && bash "$(basename "$ins_file")" "$ver"); then
       res="run_error"
       result
       echo
-      echo "Install step failed while running: $ins_file"
+      echo "执行安装步骤失败: $ins_file"
       fail "$run_err"
     fi
   else
     res="run_error"
     result
     echo
-    echo "Install step failed: installer script missing in manifest."
+    echo "执行安装步骤失败：清单中缺少安装脚本。"
     fail "$run_err"
   fi
 
@@ -536,8 +583,8 @@ fi
 
 if [ "$mode" = "auto" ]; then
   [ -n "$arg" ] || {
-    echo "auto mode needs current version."
-    echo "Example: $(basename "$0") auto 1.2.3"
+    echo "auto 模式需要当前版本号。"
+    echo "示例: $(basename "$0") auto 1.2.3"
     res="arg_error"
     work="$(workdir)"
     result
@@ -550,7 +597,7 @@ if [ "$mode" = "auto" ]; then
     res="dir_error"
     result
     echo
-    echo "Work directory failed."
+    echo "工作目录处理失败。"
     exit "$dir_err"
   }
   manifest_url="$base/$latest"
@@ -558,28 +605,31 @@ if [ "$mode" = "auto" ]; then
     res="meta_error"
     result
     echo
-    echo "Manifest check failed."
+    echo "获取清单失败。"
     exit "$meta_err"
   }
+  echo
+  echo "最新版本: $ver"
+  echo
   if [ "$(cmp "$cur" "$ver")" = "lt" ]; then
-    echo "Current version: $cur"
-    echo "Remote version: $ver"
+    echo "当前版本: $cur"
+    echo "远端版本: $ver"
     grab || {
       code="$?"
       res="download_error"
       [ "$code" = "$sum_err" ] && res="checksum_error"
       result
       echo
-      echo "Download failed."
+      echo "下载失败。"
       exit "$code"
     }
     res="update_ready"
     result
     exit "$ready"
   fi
-  echo "Current version: $cur"
-  echo "Remote version: $ver"
-  echo "Already up to date."
+  echo "当前版本: $cur"
+  echo "远端版本: $ver"
+  echo "已经是最新版本。"
   res="up_to_date"
   result
   exit "$latest_ok"
@@ -587,8 +637,8 @@ fi
 
 if [ "$mode" = "manual" ]; then
   [ -n "$arg" ] || {
-    echo "manual mode needs a version."
-    echo "Example: $(basename "$0") manual 1.2.3"
+    echo "manual 模式需要版本号。"
+    echo "示例: $(basename "$0") manual 1.2.3"
     res="arg_error"
     work="$(workdir)"
     result
@@ -601,7 +651,7 @@ if [ "$mode" = "manual" ]; then
     res="dir_error"
     result
     echo
-    echo "Work directory failed."
+    echo "工作目录处理失败。"
     exit "$dir_err"
   }
   manifest_url="$base/$req/mac-arm64.yml"
@@ -616,18 +666,18 @@ if [ "$mode" = "manual" ]; then
     res="meta_error"
     result
     echo
-    echo "Manifest check failed."
+    echo "获取清单失败。"
     exit "$meta_err"
   fi
-  echo "Requested version: $req"
-  echo "Resolved version:  $ver"
+  echo "请求版本: $req"
+  echo "解析版本: $ver"
   grab || {
     code="$?"
     res="download_error"
     [ "$code" = "$sum_err" ] && res="checksum_error"
     result
     echo
-    echo "Download failed."
+    echo "下载失败。"
     exit "$code"
   }
   res="manual_ready"

--- a/Update/aether_darwin_installer.command
+++ b/Update/aether_darwin_installer.command
@@ -203,6 +203,41 @@ cmp() {
   echo eq
 }
 
+installed() {
+  local root name best best_ver dir ver
+  root="$1"
+  if [ -f "$root/.aether_web_version" ]; then
+    ver="$(tr -d '[:space:]' <"$root/.aether_web_version")"
+    if [ -n "$ver" ]; then
+      printf "%s" "$ver"
+      return 0
+    fi
+  fi
+
+  name="$(basename "$root")"
+  if [[ "$name" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
+    printf "%s" "${BASH_REMATCH[1]}"
+    return 0
+  fi
+
+  best=""
+  best_ver=""
+  shopt -s nullglob
+  for dir in "$root"/aether_* "$root"/aether-*; do
+    [ -d "$dir" ] || continue
+    name="$(basename "$dir")"
+    if [[ "$name" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
+      ver="${BASH_REMATCH[1]}"
+      if [ -z "$best_ver" ] || [ "$(cmp "$best_ver" "$ver")" = "lt" ]; then
+        best="$dir"
+        best_ver="$ver"
+      fi
+    fi
+  done
+  shopt -u nullglob
+  printf "%s" "$best_ver"
+}
+
 fetch_meta() {
   local url="$1"
   local out="$2"
@@ -447,6 +482,17 @@ if [ "$mode" = "init" ]; then
     echo "Manifest check failed."
     fail "$meta_err"
   }
+  cur="$(installed "$work")"
+  if [ -n "$cur" ] && [ "$(cmp "$cur" "$ver")" = "eq" ]; then
+    res="up_to_date"
+    result
+    echo
+    echo "Current version: $cur"
+    echo "Remote version: $ver"
+    echo "Already up to date."
+    done_hold
+    exit "$latest_ok"
+  fi
   grab || {
     code="$?"
     res="download_error"

--- a/Update/aether_darwin_installer_devtest.command
+++ b/Update/aether_darwin_installer_devtest.command
@@ -82,7 +82,7 @@ keep="3"
 done_hold() {
   if [ "$hold" = "1" ]; then
     echo
-    read -r -p "Press Enter to close..." _
+    read -r -p "按回车关闭..." _
   fi
 }
 
@@ -203,6 +203,78 @@ cmp() {
     fi
   done
   echo eq
+}
+
+installed() {
+  local root name best best_ver dir ver
+  root="$1"
+  if [ -f "$root/.aether_web_version" ]; then
+    ver="$(tr -d '[:space:]' <"$root/.aether_web_version")"
+    if [ -n "$ver" ]; then
+      printf "%s" "$ver"
+      return 0
+    fi
+  fi
+
+  name="$(basename "$root")"
+  if [[ "$name" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
+    printf "%s" "${BASH_REMATCH[1]}"
+    return 0
+  fi
+
+  best=""
+  best_ver=""
+  shopt -s nullglob
+  for dir in "$root"/aether_* "$root"/aether-*; do
+    [ -d "$dir" ] || continue
+    name="$(basename "$dir")"
+    if [[ "$name" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
+      ver="${BASH_REMATCH[1]}"
+      if [ -z "$best_ver" ] || [ "$(cmp "$best_ver" "$ver")" = "lt" ]; then
+        best="$dir"
+        best_ver="$ver"
+      fi
+    fi
+  done
+  shopt -u nullglob
+  printf "%s" "$best_ver"
+}
+
+cache_paths() {
+  dl="$work/downloads"
+  [ -n "$pkg_name" ] || return 1
+  local pkg_ext ins_ext
+  pkg_ext="${pkg_name##*.}"
+  if [ "$pkg_ext" = "$pkg_name" ]; then
+    pkg_ext=""
+  else
+    pkg_ext=".$pkg_ext"
+  fi
+  pkg_file="$dl/aether-darwin-arm64-$ver$pkg_ext"
+  ins_file=""
+  if [ -n "$ins_url" ] && [ -n "$ins_name" ]; then
+    ins_ext="${ins_name##*.}"
+    if [ "$ins_ext" = "$ins_name" ]; then
+      ins_ext=""
+    else
+      ins_ext=".$ins_ext"
+    fi
+    ins_file="$dl/update_darwin-$ver$ins_ext"
+  fi
+}
+
+cached_ready() {
+  [ -d "$work/downloads" ] || return 1
+  cache_paths || return 1
+  [ -f "$pkg_file" ] || return 1
+  if [ -n "$sha" ]; then
+    local sum
+    sum="$(openssl dgst -sha512 -binary "$pkg_file" | openssl base64 -A || true)"
+    [ "$sum" = "$sha" ] || return 1
+  fi
+  [ -n "$ins_file" ] || return 1
+  [ -f "$ins_file" ] || return 1
+  chmod +x "$ins_file" 2>/dev/null || true
 }
 
 fetch_meta() {
@@ -384,31 +456,31 @@ prune() {
 
 help() {
   cat <<EOF
-Aether Darwin Installer
+Aether macOS 安装器
 
-Usage:
+用法:
   $(basename "$0") [--no-pause] [--path <dir>] init
   $(basename "$0") [--no-pause] auto <current-version>
   $(basename "$0") [--no-pause] manual <target-version>
 
-Remote manifests:
+远端清单:
   $base/$latest
   $base/1.2.3/mac-arm64.yml
 
-Result file:
+结果文件:
   work_dir/downloads/last-result.yml
 
-Exit codes:
-  0   init finished successfully
-  10  latest update downloaded and ready
-  11  requested version downloaded and ready
-  20  already up to date
-  21  requested version not found
-  30  manifest or network error
-  31  download failed
-  32  checksum mismatch
-  40  work directory error
-  50  argument error
+退出码:
+  0   初始化安装成功完成
+  10  最新更新已下载，等待安装
+  11  指定版本已下载，等待安装
+  20  已是最新版本
+  21  未找到指定版本
+  30  清单或网络错误
+  31  下载失败
+  32  校验和不匹配
+  40  工作目录错误
+  50  参数错误
 EOF
 }
 
@@ -449,15 +521,34 @@ if [ "$mode" = "init" ]; then
     echo "Manifest check failed."
     fail "$meta_err"
   }
-  grab || {
-    code="$?"
-    res="download_error"
-    [ "$code" = "$sum_err" ] && res="checksum_error"
+  echo "Latest version: $ver"
+  cur="$(installed "$work")"
+  if [ -n "$cur" ] && [ "$(cmp "$cur" "$ver")" = "eq" ]; then
+    res="up_to_date"
     result
     echo
-    echo "Download failed."
-    fail "$code"
-  }
+    echo "Current version: $cur"
+    echo "Remote version: $ver"
+    echo "Already up to date."
+    done_hold
+    exit "$latest_ok"
+  fi
+  if cached_ready; then
+    echo "Using cached package:"
+    echo "  $pkg_file"
+    echo "Using cached installer:"
+    echo "  $ins_file"
+  else
+    grab || {
+      code="$?"
+      res="download_error"
+      [ "$code" = "$sum_err" ] && res="checksum_error"
+      result
+      echo
+      echo "Download failed."
+      fail "$code"
+    }
+  fi
   res="init_ready"
   result
   echo
@@ -517,6 +608,7 @@ if [ "$mode" = "auto" ]; then
     echo "Manifest check failed."
     exit "$meta_err"
   }
+  echo "Latest version: $ver"
   if [ "$(cmp "$cur" "$ver")" = "lt" ]; then
     echo "Current version: $cur"
     echo "Remote version: $ver"

--- a/Update/aether_linux_installer.sh
+++ b/Update/aether_linux_installer.sh
@@ -785,7 +785,7 @@ if [ "$mode" = "init" ]; then
 
   mkdir -p "$HOME/Aether_Database" 2>/dev/null || true
 
-  ensure_libssl "$work/current"
+  ensure_libssl "$work/aether_$ver"
 
   desktop_hint
 

--- a/Update/aether_linux_installer.sh
+++ b/Update/aether_linux_installer.sh
@@ -238,6 +238,47 @@ installed() {
   printf "%s" "$best_ver"
 }
 
+cache_paths() {
+  dl="$work/downloads"
+  [ -n "$pkg_name" ] || return 1
+  local pkg_ext ins_ext
+  pkg_ext="${pkg_name##*.}"
+  if [ "$pkg_ext" = "$pkg_name" ]; then
+    pkg_ext=""
+  else
+    pkg_ext=".$pkg_ext"
+  fi
+  pkg_file="$dl/aether-linux-x64-$ver$pkg_ext"
+  ins_file=""
+  if [ -n "$ins_url" ] && [ -n "$ins_name" ]; then
+    ins_ext="${ins_name##*.}"
+    if [ "$ins_ext" = "$ins_name" ]; then
+      ins_ext=""
+    else
+      ins_ext=".$ins_ext"
+    fi
+    ins_file="$dl/update_linux-$ver$ins_ext"
+  fi
+}
+
+cached_ready() {
+  [ -d "$work/downloads" ] || return 1
+  cache_paths || return 1
+  [ -f "$pkg_file" ] || return 1
+  if [ -n "$sha" ]; then
+    local sum
+    sum="$(compute_sha512_base64 "$pkg_file" || true)"
+    if [ "$sum" = "__NOHASH__" ] || [ "$sum" = "__NOBASE64__" ]; then
+      :
+    else
+      [ "$sum" = "$sha" ] || return 1
+    fi
+  fi
+  [ -n "$ins_file" ] || return 1
+  [ -f "$ins_file" ] || return 1
+  chmod +x "$ins_file" 2>/dev/null || true
+}
+
 ensure_libssl() {
   local app_dir="$1"
   local ssl1_path=""
@@ -781,6 +822,7 @@ if [ "$mode" = "init" ]; then
     echo "Manifest check failed."
     fail "$meta_err"
   }
+  echo "Latest version: $ver"
   cur="$(installed "$work")"
   if [ -n "$cur" ] && [ "$(cmp "$cur" "$ver")" = "eq" ]; then
     res="up_to_date"
@@ -792,15 +834,22 @@ if [ "$mode" = "init" ]; then
     done_hold
     exit "$latest_ok"
   fi
-  grab || {
-    code="$?"
-    res="download_error"
-    [ "$code" = "$sum_err" ] && res="checksum_error"
-    result
-    echo
-    echo "Download failed."
-    fail "$code"
-  }
+  if cached_ready; then
+    echo "Using cached package:"
+    echo "  $pkg_file"
+    echo "Using cached installer:"
+    echo "  $ins_file"
+  else
+    grab || {
+      code="$?"
+      res="download_error"
+      [ "$code" = "$sum_err" ] && res="checksum_error"
+      result
+      echo
+      echo "Download failed."
+      fail "$code"
+    }
+  fi
   res="init_ready"
   result
   echo
@@ -864,6 +913,7 @@ if [ "$mode" = "auto" ]; then
     echo "Manifest check failed."
     exit "$meta_err"
   }
+  echo "Latest version: $ver"
   if [ "$(cmp "$cur" "$ver")" = "lt" ]; then
     echo "Current version: $cur"
     echo "Remote version: $ver"

--- a/Update/aether_linux_installer.sh
+++ b/Update/aether_linux_installer.sh
@@ -205,6 +205,39 @@ compute_sha512_base64() {
   fi
 }
 
+installed() {
+  local root name best_ver dir ver
+  root="$1"
+  if [ -f "$root/.aether_web_version" ]; then
+    ver="$(tr -d '[:space:]' <"$root/.aether_web_version")"
+    if [ -n "$ver" ]; then
+      printf "%s" "$ver"
+      return 0
+    fi
+  fi
+
+  name="$(basename "$root")"
+  if [[ "$name" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
+    printf "%s" "${BASH_REMATCH[1]}"
+    return 0
+  fi
+
+  best_ver=""
+  shopt -s nullglob
+  for dir in "$root"/aether_* "$root"/aether-*; do
+    [ -d "$dir" ] || continue
+    name="$(basename "$dir")"
+    if [[ "$name" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
+      ver="${BASH_REMATCH[1]}"
+      if [ -z "$best_ver" ] || [ "$(cmp "$best_ver" "$ver")" = "lt" ]; then
+        best_ver="$ver"
+      fi
+    fi
+  done
+  shopt -u nullglob
+  printf "%s" "$best_ver"
+}
+
 ensure_libssl() {
   local app_dir="$1"
   local ssl1_path=""
@@ -748,6 +781,17 @@ if [ "$mode" = "init" ]; then
     echo "Manifest check failed."
     fail "$meta_err"
   }
+  cur="$(installed "$work")"
+  if [ -n "$cur" ] && [ "$(cmp "$cur" "$ver")" = "eq" ]; then
+    res="up_to_date"
+    result
+    echo
+    echo "Current version: $cur"
+    echo "Remote version: $ver"
+    echo "Already up to date."
+    done_hold
+    exit "$latest_ok"
+  fi
   grab || {
     code="$?"
     res="download_error"

--- a/Update/aether_linux_installer_devtest.sh
+++ b/Update/aether_linux_installer_devtest.sh
@@ -207,6 +207,80 @@ compute_sha512_base64() {
   fi
 }
 
+installed() {
+  local root name best_ver dir ver
+  root="$1"
+  if [ -f "$root/.aether_web_version" ]; then
+    ver="$(tr -d '[:space:]' <"$root/.aether_web_version")"
+    if [ -n "$ver" ]; then
+      printf "%s" "$ver"
+      return 0
+    fi
+  fi
+
+  name="$(basename "$root")"
+  if [[ "$name" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
+    printf "%s" "${BASH_REMATCH[1]}"
+    return 0
+  fi
+
+  best_ver=""
+  shopt -s nullglob
+  for dir in "$root"/aether_* "$root"/aether-*; do
+    [ -d "$dir" ] || continue
+    name="$(basename "$dir")"
+    if [[ "$name" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
+      ver="${BASH_REMATCH[1]}"
+      if [ -z "$best_ver" ] || [ "$(cmp "$best_ver" "$ver")" = "lt" ]; then
+        best_ver="$ver"
+      fi
+    fi
+  done
+  shopt -u nullglob
+  printf "%s" "$best_ver"
+}
+
+cache_paths() {
+  dl="$work/downloads"
+  [ -n "$pkg_name" ] || return 1
+  local pkg_ext ins_ext
+  pkg_ext="${pkg_name##*.}"
+  if [ "$pkg_ext" = "$pkg_name" ]; then
+    pkg_ext=""
+  else
+    pkg_ext=".$pkg_ext"
+  fi
+  pkg_file="$dl/aether-linux-x64-$ver$pkg_ext"
+  ins_file=""
+  if [ -n "$ins_url" ] && [ -n "$ins_name" ]; then
+    ins_ext="${ins_name##*.}"
+    if [ "$ins_ext" = "$ins_name" ]; then
+      ins_ext=""
+    else
+      ins_ext=".$ins_ext"
+    fi
+    ins_file="$dl/update_linux-$ver$ins_ext"
+  fi
+}
+
+cached_ready() {
+  [ -d "$work/downloads" ] || return 1
+  cache_paths || return 1
+  [ -f "$pkg_file" ] || return 1
+  if [ -n "$sha" ]; then
+    local sum
+    sum="$(compute_sha512_base64 "$pkg_file" || true)"
+    if [ "$sum" = "__NOHASH__" ] || [ "$sum" = "__NOBASE64__" ]; then
+      :
+    else
+      [ "$sum" = "$sha" ] || return 1
+    fi
+  fi
+  [ -n "$ins_file" ] || return 1
+  [ -f "$ins_file" ] || return 1
+  chmod +x "$ins_file" 2>/dev/null || true
+}
+
 ensure_libssl() {
   local app_dir="$1"
   local ssl1_path=""
@@ -750,15 +824,34 @@ if [ "$mode" = "init" ]; then
     echo "Manifest check failed."
     fail "$meta_err"
   }
-  grab || {
-    code="$?"
-    res="download_error"
-    [ "$code" = "$sum_err" ] && res="checksum_error"
+  echo "Latest version: $ver"
+  cur="$(installed "$work")"
+  if [ -n "$cur" ] && [ "$(cmp "$cur" "$ver")" = "eq" ]; then
+    res="up_to_date"
     result
     echo
-    echo "Download failed."
-    fail "$code"
-  }
+    echo "Current version: $cur"
+    echo "Remote version: $ver"
+    echo "Already up to date."
+    done_hold
+    exit "$latest_ok"
+  fi
+  if cached_ready; then
+    echo "Using cached package:"
+    echo "  $pkg_file"
+    echo "Using cached installer:"
+    echo "  $ins_file"
+  else
+    grab || {
+      code="$?"
+      res="download_error"
+      [ "$code" = "$sum_err" ] && res="checksum_error"
+      result
+      echo
+      echo "Download failed."
+      fail "$code"
+    }
+  fi
   res="init_ready"
   result
   echo
@@ -787,7 +880,7 @@ if [ "$mode" = "init" ]; then
 
   mkdir -p "$HOME/Aether_Database" 2>/dev/null || true
 
-  ensure_libssl "$work/current"
+  ensure_libssl "$work/aether_$ver"
 
   desktop_hint
 
@@ -822,6 +915,7 @@ if [ "$mode" = "auto" ]; then
     echo "Manifest check failed."
     exit "$meta_err"
   }
+  echo "Latest version: $ver"
   if [ "$(cmp "$cur" "$ver")" = "lt" ]; then
     echo "Current version: $cur"
     echo "Remote version: $ver"

--- a/Update/aether_windows_installer.bat
+++ b/Update/aether_windows_installer.bat
@@ -121,7 +121,7 @@ set "SELF=%~f0"
 set "DST=%WORK%\%~nx0"
 if /I not "%SELF%"=="%DST%" (
   copy /y "%~f0" "%DST%" >nul || (
-    echo Failed to copy installer to %WORK%
+    call :print_copy_fail "%WORK%"
     goto :dir_fail
   )
 )
@@ -129,44 +129,41 @@ copy /y "%~f0" "%WORK%\aether_windows_installer.bat" >nul
 
 set "CUR="
 call :latest || goto :meta_fail
+call :print_latest
 call :installed "%WORK%" CUR
 if defined CUR (
   call :cmp "%CUR%" "%VER%"
-  if /I "%CMP%"=="eq" (
+  if /I "!CMP!"=="eq" (
     set "RES=up_to_date"
     call :result
-    echo.
-    echo Current version: %CUR%
-    echo Remote version: %VER%
-    echo Already up to date.
+    call :print_uptodate "!CUR!" "%VER%"
     goto :done
   )
 )
-call :grab || goto :dl_fail
+call :cached_ready
+if errorlevel 1 (
+  call :grab || goto :dl_fail
+) else (
+  call :print_cached
+)
 set "RES=init_ready"
 call :result
 
-echo.
-echo Download finished.
-echo Version:   %VER%
-echo Package:   %PKG_FILE%
-echo Installer: %INS_FILE%
-echo Result:    %RES_FILE%
-echo.
+call :print_downloaded
 
 if "%INS_FILE%"=="" (
   set "RES=run_error"
   call :result
-  echo Install step failed: installer script missing in manifest.
+  call :print_install_missing
   goto :run_fail
 )
 
-echo [init] Running installer script...
+call :print_init_run
 call cmd /c ""%INS_FILE%" %VER%"
 if errorlevel 1 (
   set "RES=run_error"
   call :result
-  echo Install step failed while running: %INS_FILE%
+  call :print_install_fail "%INS_FILE%"
   goto :run_fail
 )
 
@@ -176,34 +173,30 @@ goto :done
 
 :auto
 if "%ARG%"=="" (
-  echo auto mode needs current version.
-  echo Example: %~nx0 auto 1.2.3
+  call :print_auto_arg
   goto :bad
 )
 set "CUR=%ARG%"
 call :work WORK
 call :prep "%WORK%" || goto :dir_fail
 call :latest || goto :meta_fail
+call :print_latest
 call :cmp "%CUR%" "%VER%"
 if /I "%CMP%"=="lt" (
-  echo Current version: %CUR%
-  echo Remote version: %VER%
+  call :print_versions "%CUR%" "%VER%"
   call :grab || goto :dl_fail
   set "RES=update_ready"
   call :result
   exit /b %READY%
 )
-echo Current version: %CUR%
-echo Remote version: %VER%
-echo Already up to date.
+call :print_uptodate "%CUR%" "%VER%"
 set "RES=up_to_date"
 call :result
 exit /b %LATEST_OK%
 
 :manual
 if "%ARG%"=="" (
-  echo manual mode needs a version.
-  echo Example: %~nx0 manual 1.2.3
+  call :print_manual_arg
   goto :bad
 )
 set "CUR="
@@ -219,8 +212,7 @@ if "%RC%"=="%MISS%" (
   exit /b %MISS%
 )
 if not "%RC%"=="0" goto :meta_fail
-echo Requested version: %REQ%
-echo Resolved version:  %VER%
+call :print_manual_versions "%REQ%" "%VER%"
 call :grab || goto :dl_fail
 set "RES=manual_ready"
 call :result
@@ -376,17 +368,106 @@ exit /b 0
 :installed
 set "%~2="
 set "DIR=%~1"
+set "RV="
 if exist "%DIR%\.aether_web_version" (
   set /p RV=<"%DIR%\.aether_web_version"
-  if defined RV (
-    set "%~2=%RV%"
-    exit /b 0
-  )
+)
+if defined RV (
+  set "%~2=!RV!"
+  exit /b 0
 )
 for %%i in ("%DIR%") do set "NAME=%%~nxi"
 for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$name=$env:NAME; if($name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ [Console]::Write($matches[1]) }"`) do set "%~2=%%i"
 if defined %~2 exit /b 0
 for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$root=$env:DIR; $best=Get-ChildItem -Path $root -Directory -ErrorAction SilentlyContinue | ForEach-Object { if($_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ [PSCustomObject]@{ Ver=$matches[1] } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending | Select-Object -First 1 -ExpandProperty Ver; if($best){ [Console]::Write($best) }"`) do set "%~2=%%i"
+exit /b 0
+
+:cache_paths
+for %%i in ("%PKG_NAME%") do set "PKG_EXT=%%~xi"
+set "PKG_FILE=%WORK%\downloads\aether-windows-x64-%VER%%PKG_EXT%"
+set "INS_FILE="
+if defined INS_URL if defined INS_NAME (
+  for %%i in ("%INS_NAME%") do set "INS_EXT=%%~xi"
+  set "INS_FILE=%WORK%\downloads\update_windows-%VER%%INS_EXT%"
+)
+exit /b 0
+
+:cached_ready
+call :cache_paths
+if not exist "%WORK%\downloads" exit /b 1
+if not exist "%PKG_FILE%" exit /b 1
+if defined SHA (
+  set "SUM="
+  for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$h=[Security.Cryptography.SHA512]::Create().ComputeHash([IO.File]::ReadAllBytes($env:PKG_FILE)); [Convert]::ToBase64String($h)"`) do set "SUM=%%i"
+  if /I not "!SUM!"=="!SHA!" exit /b 1
+)
+if not defined INS_FILE exit /b 1
+if not exist "%INS_FILE%" exit /b 1
+exit /b 0
+
+:print_latest
+echo.
+echo Latest version: %VER%
+echo.
+exit /b 0
+
+:print_versions
+echo Current version: %~1
+echo Remote version: %~2
+exit /b 0
+
+:print_uptodate
+echo.
+call :print_versions "%~1" "%~2"
+echo Already up to date.
+exit /b 0
+
+:print_downloaded
+echo.
+echo Download finished.
+echo Version:   %VER%
+echo Package:   %PKG_FILE%
+echo Installer: %INS_FILE%
+echo Result:    %RES_FILE%
+echo.
+exit /b 0
+
+:print_cached
+echo Using cached package:
+echo   %PKG_FILE%
+echo Using cached installer:
+echo   %INS_FILE%
+exit /b 0
+
+:print_install_missing
+echo Install step failed: installer script missing in manifest.
+exit /b 0
+
+:print_init_run
+echo [init] Running installer script...
+exit /b 0
+
+:print_install_fail
+echo Install step failed while running: %~1
+exit /b 0
+
+:print_auto_arg
+echo auto mode needs current version.
+echo Example: %~nx0 auto 1.2.3
+exit /b 0
+
+:print_manual_arg
+echo manual mode needs a version.
+echo Example: %~nx0 manual 1.2.3
+exit /b 0
+
+:print_manual_versions
+echo Requested version: %~1
+echo Resolved version:  %~2
+exit /b 0
+
+:print_copy_fail
+echo Failed to copy installer to %~1
 exit /b 0
 
 :abs

--- a/Update/aether_windows_installer.bat
+++ b/Update/aether_windows_installer.bat
@@ -129,6 +129,19 @@ copy /y "%~f0" "%WORK%\aether_windows_installer.bat" >nul
 
 set "CUR="
 call :latest || goto :meta_fail
+call :installed "%WORK%" CUR
+if defined CUR (
+  call :cmp "%CUR%" "%VER%"
+  if /I "%CMP%"=="eq" (
+    set "RES=up_to_date"
+    call :result
+    echo.
+    echo Current version: %CUR%
+    echo Remote version: %VER%
+    echo Already up to date.
+    goto :done
+  )
+)
 call :grab || goto :dl_fail
 set "RES=init_ready"
 call :result
@@ -358,6 +371,22 @@ exit /b 0
 
 :full
 for %%i in ("%~2") do set "%~1=%%~fi"
+exit /b 0
+
+:installed
+set "%~2="
+set "DIR=%~1"
+if exist "%DIR%\.aether_web_version" (
+  set /p RV=<"%DIR%\.aether_web_version"
+  if defined RV (
+    set "%~2=%RV%"
+    exit /b 0
+  )
+)
+for %%i in ("%DIR%") do set "NAME=%%~nxi"
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$name=$env:NAME; if($name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ [Console]::Write($matches[1]) }"`) do set "%~2=%%i"
+if defined %~2 exit /b 0
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$root=$env:DIR; $best=Get-ChildItem -Path $root -Directory -ErrorAction SilentlyContinue | ForEach-Object { if($_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ [PSCustomObject]@{ Ver=$matches[1] } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending | Select-Object -First 1 -ExpandProperty Ver; if($best){ [Console]::Write($best) }"`) do set "%~2=%%i"
 exit /b 0
 
 :abs

--- a/Update/aether_windows_installer_devtest.bat
+++ b/Update/aether_windows_installer_devtest.bat
@@ -123,7 +123,7 @@ set "SELF=%~f0"
 set "DST=%WORK%\%~nx0"
 if /I not "%SELF%"=="%DST%" (
   copy /y "%~f0" "%DST%" >nul || (
-    echo Failed to copy installer to %WORK%
+    call :print_copy_fail "%WORK%"
     goto :dir_fail
   )
 )
@@ -131,31 +131,41 @@ copy /y "%~f0" "%WORK%\aether_windows_installer.bat" >nul
 
 set "CUR="
 call :latest || goto :meta_fail
-call :grab || goto :dl_fail
+call :print_latest
+call :installed "%WORK%" CUR
+if defined CUR (
+  call :cmp "%CUR%" "%VER%"
+  if /I "!CMP!"=="eq" (
+    set "RES=up_to_date"
+    call :result
+    call :print_uptodate "!CUR!" "%VER%"
+    goto :done
+  )
+)
+call :cached_ready
+if errorlevel 1 (
+  call :grab || goto :dl_fail
+) else (
+  call :print_cached
+)
 set "RES=init_ready"
 call :result
 
-echo.
-echo Download finished.
-echo Version:   %VER%
-echo Package:   %PKG_FILE%
-echo Installer: %INS_FILE%
-echo Result:    %RES_FILE%
-echo.
+call :print_downloaded
 
 if "%INS_FILE%"=="" (
   set "RES=run_error"
   call :result
-  echo Install step failed: installer script missing in manifest.
+  call :print_install_missing
   goto :run_fail
 )
 
-echo [init] Running installer script...
+call :print_init_run
 call cmd /c ""%INS_FILE%" %VER%"
 if errorlevel 1 (
   set "RES=run_error"
   call :result
-  echo Install step failed while running: %INS_FILE%
+  call :print_install_fail "%INS_FILE%"
   goto :run_fail
 )
 
@@ -165,34 +175,30 @@ goto :done
 
 :auto
 if "%ARG%"=="" (
-  echo auto mode needs current version.
-  echo Example: %~nx0 auto 1.2.3
+  call :print_auto_arg
   goto :bad
 )
 set "CUR=%ARG%"
 call :work WORK
 call :prep "%WORK%" || goto :dir_fail
 call :latest || goto :meta_fail
+call :print_latest
 call :cmp "%CUR%" "%VER%"
 if /I "%CMP%"=="lt" (
-  echo Current version: %CUR%
-  echo Remote version: %VER%
+  call :print_versions "%CUR%" "%VER%"
   call :grab || goto :dl_fail
   set "RES=update_ready"
   call :result
   exit /b %READY%
 )
-echo Current version: %CUR%
-echo Remote version: %VER%
-echo Already up to date.
+call :print_uptodate "%CUR%" "%VER%"
 set "RES=up_to_date"
 call :result
 exit /b %LATEST_OK%
 
 :manual
 if "%ARG%"=="" (
-  echo manual mode needs a version.
-  echo Example: %~nx0 manual 1.2.3
+  call :print_manual_arg
   goto :bad
 )
 set "CUR="
@@ -208,8 +214,7 @@ if "%RC%"=="%MISS%" (
   exit /b %MISS%
 )
 if not "%RC%"=="0" goto :meta_fail
-echo Requested version: %REQ%
-echo Resolved version:  %VER%
+call :print_manual_versions "%REQ%" "%VER%"
 call :grab || goto :dl_fail
 set "RES=manual_ready"
 call :result
@@ -360,6 +365,111 @@ exit /b 0
 
 :full
 for %%i in ("%~2") do set "%~1=%%~fi"
+exit /b 0
+
+:installed
+set "%~2="
+set "DIR=%~1"
+set "RV="
+if exist "%DIR%\.aether_web_version" (
+  set /p RV=<"%DIR%\.aether_web_version"
+)
+if defined RV (
+  set "%~2=!RV!"
+  exit /b 0
+)
+for %%i in ("%DIR%") do set "NAME=%%~nxi"
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$name=$env:NAME; if($name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ [Console]::Write($matches[1]) }"`) do set "%~2=%%i"
+if defined %~2 exit /b 0
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$root=$env:DIR; $best=Get-ChildItem -Path $root -Directory -ErrorAction SilentlyContinue | ForEach-Object { if($_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ [PSCustomObject]@{ Ver=$matches[1] } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending | Select-Object -First 1 -ExpandProperty Ver; if($best){ [Console]::Write($best) }"`) do set "%~2=%%i"
+exit /b 0
+
+:cache_paths
+for %%i in ("%PKG_NAME%") do set "PKG_EXT=%%~xi"
+set "PKG_FILE=%WORK%\downloads\aether-windows-x64-%VER%%PKG_EXT%"
+set "INS_FILE="
+if defined INS_URL if defined INS_NAME (
+  for %%i in ("%INS_NAME%") do set "INS_EXT=%%~xi"
+  set "INS_FILE=%WORK%\downloads\update_windows-%VER%%INS_EXT%"
+)
+exit /b 0
+
+:cached_ready
+call :cache_paths
+if not exist "%WORK%\downloads" exit /b 1
+if not exist "%PKG_FILE%" exit /b 1
+if defined SHA (
+  set "SUM="
+  for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$h=[Security.Cryptography.SHA512]::Create().ComputeHash([IO.File]::ReadAllBytes($env:PKG_FILE)); [Convert]::ToBase64String($h)"`) do set "SUM=%%i"
+  if /I not "!SUM!"=="!SHA!" exit /b 1
+)
+if not defined INS_FILE exit /b 1
+if not exist "%INS_FILE%" exit /b 1
+exit /b 0
+
+:print_latest
+echo.
+echo Latest version: %VER%
+echo.
+exit /b 0
+
+:print_versions
+echo Current version: %~1
+echo Remote version: %~2
+exit /b 0
+
+:print_uptodate
+echo.
+call :print_versions "%~1" "%~2"
+echo Already up to date.
+exit /b 0
+
+:print_downloaded
+echo.
+echo Download finished.
+echo Version:   %VER%
+echo Package:   %PKG_FILE%
+echo Installer: %INS_FILE%
+echo Result:    %RES_FILE%
+echo.
+exit /b 0
+
+:print_cached
+echo Using cached package:
+echo   %PKG_FILE%
+echo Using cached installer:
+echo   %INS_FILE%
+exit /b 0
+
+:print_install_missing
+echo Install step failed: installer script missing in manifest.
+exit /b 0
+
+:print_init_run
+echo [init] Running installer script...
+exit /b 0
+
+:print_install_fail
+echo Install step failed while running: %~1
+exit /b 0
+
+:print_auto_arg
+echo auto mode needs current version.
+echo Example: %~nx0 auto 1.2.3
+exit /b 0
+
+:print_manual_arg
+echo manual mode needs a version.
+echo Example: %~nx0 manual 1.2.3
+exit /b 0
+
+:print_manual_versions
+echo Requested version: %~1
+echo Resolved version:  %~2
+exit /b 0
+
+:print_copy_fail
+echo Failed to copy installer to %~1
 exit /b 0
 
 :abs

--- a/Update/update_darwin.command
+++ b/Update/update_darwin.command
@@ -164,7 +164,9 @@ prune_versions() {
 
   for dir in "$hold" "$cur"; do
     [ -n "${dir:-}" ] || continue
-    has_dir "$dir" "${keepers[@]}" && continue
+    if [ "${#keepers[@]}" -gt 0 ] && has_dir "$dir" "${keepers[@]}"; then
+      continue
+    fi
     for item in "${items[@]}"; do
       if [ "${item#*|}" = "$dir" ]; then
         keepers+=("$dir")
@@ -178,13 +180,17 @@ prune_versions() {
       break
     fi
     dir="${item#*|}"
-    has_dir "$dir" "${keepers[@]}" && continue
+    if [ "${#keepers[@]}" -gt 0 ] && has_dir "$dir" "${keepers[@]}"; then
+      continue
+    fi
     keepers+=("$dir")
   done
 
   for item in "${items[@]}"; do
     dir="${item#*|}"
-    has_dir "$dir" "${keepers[@]}" && continue
+    if [ "${#keepers[@]}" -gt 0 ] && has_dir "$dir" "${keepers[@]}"; then
+      continue
+    fi
     rm -rf "$dir"
     if [ ! -d "$dir" ]; then
       prune=$((prune + 1))

--- a/Update/update_darwin.command
+++ b/Update/update_darwin.command
@@ -91,18 +91,29 @@ pick_pkg() {
   return 1
 }
 
-active_dir() {
-  local root link rel dir v
+latest_dir() {
+  local root best best_ver dir ver
   root="$1"
-  link="$root/current"
-  if [ -L "$link" ]; then
-    rel="$(readlink "$link")"
-    dir="$root/$rel"
-    if [ -d "$dir" ] && [ -f "$dir/.aether_web_version" ]; then
-      printf "%s" "$dir"
-      return 0
+  best=""
+  best_ver=""
+  shopt -s nullglob
+  for dir in "$root"/aether_*; do
+    [ -d "$dir" ] || continue
+    [ -f "$dir/.aether_web_version" ] || continue
+    ver="$(tr -d '[:space:]' <"$dir/.aether_web_version")"
+    [ -n "$ver" ] || continue
+    if [ -z "$best" ] || [ "$(cmp "$best_ver" "$ver")" = "lt" ]; then
+      best="$dir"
+      best_ver="$ver"
     fi
-  fi
+  done
+  shopt -u nullglob
+  printf "%s" "$best"
+}
+
+active_dir() {
+  local root dir v
+  root="$1"
   if [ -f "$root/.aether_web_version" ]; then
     v="$(tr -d '[:space:]' <"$root/.aether_web_version")"
     if [ -n "$v" ] && [ -d "$root/aether_$v" ]; then
@@ -110,7 +121,7 @@ active_dir() {
       return 0
     fi
   fi
-  printf ""
+  printf "%s" "$(latest_dir "$root")"
 }
 
 has_dir() {
@@ -126,21 +137,13 @@ has_dir() {
 }
 
 prune_versions() {
-  local root keep hold cur rel dir ver item tmp i j
+  local root keep hold dir ver item tmp i j
   local -a items=()
   local -a keepers=()
   root="$1"
   keep="$2"
   hold="$3"
   prune="0"
-
-  if [ -L "$root/current" ]; then
-    rel="$(readlink "$root/current")"
-    dir="$root/$rel"
-    if [ -d "$dir" ]; then
-      cur="$dir"
-    fi
-  fi
 
   shopt -s nullglob
   for dir in "$root"/aether_*; do
@@ -162,7 +165,7 @@ prune_versions() {
     done
   done
 
-  for dir in "$hold" "$cur"; do
+  for dir in "$hold"; do
     [ -n "${dir:-}" ] || continue
     if [ "${#keepers[@]}" -gt 0 ] && has_dir "$dir" "${keepers[@]}"; then
       continue
@@ -201,7 +204,7 @@ prune_versions() {
 write_launch() {
   local root target
   root="$1"
-  build_app() {
+build_app() {
     local dir app bin
     dir="$1"
     app="$dir/Aether.app"
@@ -213,10 +216,58 @@ write_launch() {
 set -euo pipefail
 
 root="$root"
-cur="\$root/current"
+cmp() {
+  local a="\${1#v}"
+  local b="\${2#v}"
+  a="\${a%%-*}"
+  b="\${b%%-*}"
+  local aa bb i x y
+  IFS=. read -r -a aa <<<"\$a"
+  IFS=. read -r -a bb <<<"\$b"
+  for i in 0 1 2 3; do
+    x="\${aa[\$i]:-0}"
+    y="\${bb[\$i]:-0}"
+    x=\$((10#\$x))
+    y=\$((10#\$y))
+    if [ "\$x" -lt "\$y" ]; then
+      echo lt
+      return 0
+    fi
+    if [ "\$x" -gt "\$y" ]; then
+      echo gt
+      return 0
+    fi
+  done
+  echo eq
+}
 
-if [ -L "\$cur" ] && [ -f "\$cur/Aether.command" ]; then
-  nohup "\$cur/Aether.command" >/dev/null 2>&1 &
+pick() {
+  local dir ver best best_ver item
+  if [ -f "\$root/.aether_web_version" ]; then
+    ver="\$(tr -d '[:space:]' <"\$root/.aether_web_version")"
+    if [ -n "\$ver" ] && [ -f "\$root/aether_\$ver/Aether.command" ]; then
+      printf "%s" "\$root/aether_\$ver"
+      return 0
+    fi
+  fi
+  shopt -s nullglob
+  for item in "\$root"/aether_*; do
+    [ -d "\$item" ] || continue
+    [ -f "\$item/.aether_web_version" ] || continue
+    ver="\$(tr -d '[:space:]' <"\$item/.aether_web_version")"
+    [ -n "\$ver" ] || continue
+    if [ -z "\${best:-}" ] || [ "\$(cmp "\$best_ver" "\$ver")" = "lt" ]; then
+      best="\$item"
+      best_ver="\$ver"
+    fi
+  done
+  shopt -u nullglob
+  printf "%s" "\${best:-}"
+}
+
+app="\$(pick)"
+if [ -n "\$app" ] && [ -f "\$app/Aether.command" ]; then
+  nohup "\$app/Aether.command" >/dev/null 2>&1 &
   exit 0
 fi
 
@@ -343,7 +394,7 @@ fi
 printf "%s\n" "$ver" >"$target/.aether_web_version"
 printf "%s\n" "$ver" >"$work/.aether_web_version"
 
-ln -sfn "aether_$ver" "$work/current"
+rm -rf "$work/current" >/dev/null 2>&1 || true
 write_launch "$work"
 prune_versions "$work" 5 "$target"
 
@@ -353,10 +404,10 @@ if [ "$restart" = "1" ]; then
     pkill -f "$old/aether web" >/dev/null 2>&1 || true
     pkill -f "$old/aether serve" >/dev/null 2>&1 || true
   fi
-  pkill -f "$work/current/Aether.command" >/dev/null 2>&1 || true
-  pkill -f "$work/current/aether web" >/dev/null 2>&1 || true
-  pkill -f "$work/current/aether serve" >/dev/null 2>&1 || true
-  nohup "$work/current/Aether.command" >/dev/null 2>&1 &
+  pkill -f "$target/Aether.command" >/dev/null 2>&1 || true
+  pkill -f "$target/aether web" >/dev/null 2>&1 || true
+  pkill -f "$target/aether serve" >/dev/null 2>&1 || true
+  nohup "$target/Aether.command" >/dev/null 2>&1 &
 fi
 
 if [ "$prune" -gt 0 ]; then

--- a/Update/update_linux.sh
+++ b/Update/update_linux.sh
@@ -41,7 +41,7 @@ Usage:
 Behavior:
   - Local install only; no network download
   - Installs to a versioned directory: aether_<version>
-  - Updates current symlink to the latest installed version
+  - Marks the latest installed version in .aether_web_version
 
 Package name pattern:
   aether-linux-x64-<version>.*
@@ -135,6 +135,39 @@ has_dir() {
   return 1
 }
 
+latest_dir() {
+  local root best best_ver dir ver
+  root="$1"
+  best=""
+  best_ver=""
+  shopt -s nullglob
+  for dir in "$root"/aether_*; do
+    [ -d "$dir" ] || continue
+    [ -f "$dir/.aether_web_version" ] || continue
+    ver="$(tr -d '[:space:]' <"$dir/.aether_web_version")"
+    [ -n "$ver" ] || continue
+    if [ -z "$best" ] || [ "$(cmp "$best_ver" "$ver")" = "lt" ]; then
+      best="$dir"
+      best_ver="$ver"
+    fi
+  done
+  shopt -u nullglob
+  printf "%s" "$best"
+}
+
+active_dir() {
+  local root dir ver
+  root="$1"
+  if [ -f "$root/.aether_web_version" ]; then
+    ver="$(tr -d '[:space:]' <"$root/.aether_web_version")"
+    if [ -n "$ver" ] && [ -d "$root/aether_$ver" ]; then
+      printf "%s" "$root/aether_$ver"
+      return 0
+    fi
+  fi
+  printf "%s" "$(latest_dir "$root")"
+}
+
 prune_versions() {
   local root keep hold dir ver item tmp i j
   local -a items=()
@@ -189,22 +222,6 @@ prune_versions() {
       prune=$((prune + 1))
     fi
   done
-}
-
-set_current() {
-  local work="$1"
-  local target="$2"
-  local link="$work/current"
-
-  ln -sfn "$(basename "$target")" "$link" 2>/dev/null || true
-  if [ -f "$link/Aether.sh" ]; then
-    return 0
-  fi
-
-  rm -rf "$link" 2>/dev/null || true
-  mkdir -p "$link"
-  cp -R "$target"/. "$link" || return 1
-  [ -f "$link/Aether.sh" ]
 }
 
 list_ssl() {
@@ -366,14 +383,66 @@ write_launch() {
   home="$(pick_home)"
   local desk="$home/Desktop"
   local launch="$desk/Aether.sh"
-  local app="$work/current/Aether.sh"
-
-  [ -f "$app" ] || return 1
   mkdir -p "$desk" || return 1
 
   cat > "$launch" <<EOF
 #!/usr/bin/env bash
-exec "$app" "\$@"
+set -euo pipefail
+
+root="$work"
+
+cmp() {
+  local a="\${1#v}"
+  local b="\${2#v}"
+  local aa bb i x y
+  a="\${a%%-*}"
+  b="\${b%%-*}"
+  IFS=. read -r -a aa <<<"\$a"
+  IFS=. read -r -a bb <<<"\$b"
+  for i in 0 1 2 3; do
+    x="\${aa[\$i]:-0}"
+    y="\${bb[\$i]:-0}"
+    x=\$((10#\$x))
+    y=\$((10#\$y))
+    if [ "\$x" -lt "\$y" ]; then
+      echo lt
+      return 0
+    fi
+    if [ "\$x" -gt "\$y" ]; then
+      echo gt
+      return 0
+    fi
+  done
+  echo eq
+}
+
+pick() {
+  local dir ver best best_ver item
+  if [ -f "\$root/.aether_web_version" ]; then
+    ver="\$(tr -d '[:space:]' <"\$root/.aether_web_version")"
+    if [ -n "\$ver" ] && [ -f "\$root/aether_\$ver/Aether.sh" ]; then
+      printf "%s" "\$root/aether_\$ver"
+      return 0
+    fi
+  fi
+  shopt -s nullglob
+  for item in "\$root"/aether_*; do
+    [ -d "\$item" ] || continue
+    [ -f "\$item/.aether_web_version" ] || continue
+    ver="\$(tr -d '[:space:]' <"\$item/.aether_web_version")"
+    [ -n "\$ver" ] || continue
+    if [ -z "\${best:-}" ] || [ "\$(cmp "\$best_ver" "\$ver")" = "lt" ]; then
+      best="\$item"
+      best_ver="\$ver"
+    fi
+  done
+  shopt -u nullglob
+  printf "%s" "\${best:-}"
+}
+
+app="\$(pick)"
+[ -n "\$app" ] || exit 1
+exec "\$app/Aether.sh" "\$@"
 EOF
   chmod +x "$launch" || return 1
   printf "%s" "$launch"
@@ -466,10 +535,7 @@ chmod +x "$target/aether" "$target/Aether.sh" 2>/dev/null || true
 printf "%s\n" "$ver" > "$target/.aether_web_version"
 printf "%s\n" "$ver" > "$work/.aether_web_version"
 
-set_current "$work" "$target" || {
-  echo "[install] Failed to update current link"
-  exit "$run_err"
-}
+rm -rf "$work/current" 2>/dev/null || true
 
 fix_libssl "$target"
 prune_versions "$work" 5 "$target"
@@ -480,7 +546,7 @@ if [ -n "$launch" ]; then
   echo "[install] To start Aether, right-click the Aether.sh file on your desktop and choose Run as a Program."
 else
   echo "[install] Warning: failed to create Desktop launcher."
-  echo "[install] To start Aether, open $work/current, right-click Aether.sh, and choose Run as a Program."
+  echo "[install] To start Aether, open $target, right-click Aether.sh, and choose Run as a Program."
 fi
 
 if [ "$prune" -gt 0 ]; then
@@ -490,5 +556,5 @@ else
 fi
 
 echo "[4/4] Done"
-echo "Current: $work/current"
+echo "Version directory: $target"
 exit "$ok"

--- a/Update/update_linux.sh
+++ b/Update/update_linux.sh
@@ -173,13 +173,17 @@ prune_versions() {
       break
     fi
     dir="${item#*|}"
-    has_dir "$dir" "${keepers[@]}" && continue
+    if [ "${#keepers[@]}" -gt 0 ] && has_dir "$dir" "${keepers[@]}"; then
+      continue
+    fi
     keepers+=("$dir")
   done
 
   for item in "${items[@]}"; do
     dir="${item#*|}"
-    has_dir "$dir" "${keepers[@]}" && continue
+    if [ "${#keepers[@]}" -gt 0 ] && has_dir "$dir" "${keepers[@]}"; then
+      continue
+    fi
     rm -rf "$dir"
     if [ ! -d "$dir" ]; then
       prune=$((prune + 1))

--- a/Update/update_windows.bat
+++ b/Update/update_windows.bat
@@ -69,7 +69,8 @@ move "%NEXT%" "%TARGET%" >nul || goto :fail
 echo %VER%>"%TARGET%\.aether_web_version"
 echo %VER%>"%WORK%\.aether_web_version"
 
-call :set_current || goto :fail
+if exist "%WORK%\current" rmdir "%WORK%\current" >nul 2>nul
+if exist "%WORK%\current" rmdir /s /q "%WORK%\current" >nul 2>nul
 
 call :write_launch
 call :prune_versions || goto :fail
@@ -92,21 +93,43 @@ call :clean_tmp
 exit /b 0
 
 :write_launch
-set "DESK=%USERPROFILE%\Desktop"
+set "DESK="
+set "DESK_COMMON="
+set "MENU="
+set "MENU_COMMON="
+for /f "usebackq tokens=1,2,3,4 delims=|" %%i in (`powershell -NoProfile -Command "$desk=[Environment]::GetFolderPath('DesktopDirectory'); $desk2=[Environment]::GetFolderPath('CommonDesktopDirectory'); $menu=[Environment]::GetFolderPath('Programs'); $menu2=[Environment]::GetFolderPath('CommonPrograms'); [Console]::Write(([string]$desk) + '|' + ([string]$desk2) + '|' + ([string]$menu) + '|' + ([string]$menu2))"`) do (
+  set "DESK=%%i"
+  set "DESK_COMMON=%%j"
+  set "MENU=%%k"
+  set "MENU_COMMON=%%l"
+)
+if not defined DESK set "DESK=%USERPROFILE%\Desktop"
+if not defined MENU set "MENU=%APPDATA%\Microsoft\Windows\Start Menu\Programs"
+if not defined DESK_COMMON set "DESK_COMMON=%PUBLIC%\Desktop"
+if not defined MENU_COMMON set "MENU_COMMON=%ProgramData%\Microsoft\Windows\Start Menu\Programs"
 if not exist "%DESK%" mkdir "%DESK%"
-set "LNK=%DESK%\Aether.lnk"
-set "MENU=%APPDATA%\Microsoft\Windows\Start Menu\Programs"
 if not exist "%MENU%" mkdir "%MENU%"
+set "LNK=%DESK%\Aether.lnk"
 set "MLNK=%MENU%\Aether.lnk"
-set "CMD=%WORK%\current\Aether.vbs"
+set "CLNK=%DESK_COMMON%\Aether.lnk"
+set "CMLNK=%MENU_COMMON%\Aether.lnk"
+set "CMD=%TARGET%\Aether.vbs"
 if exist "%LNK%" del /f /q "%LNK%" >nul 2>nul
 if exist "%MLNK%" del /f /q "%MLNK%" >nul 2>nul
-powershell -NoProfile -Command "$w=New-Object -ComObject WScript.Shell; $mk={ param($p,$t) $s=$w.CreateShortcut($p); $s.TargetPath=$t; $s.WorkingDirectory=(Split-Path -Parent $t); $s.Save() }; & $mk $env:LNK $env:CMD; & $mk $env:MLNK $env:CMD"
+powershell -NoProfile -Command "$w=New-Object -ComObject WScript.Shell; $mk={ param($p,$t) if(-not $p){ return $false }; $dir=Split-Path -Parent $p; if($dir -and -not (Test-Path $dir)){ New-Item -ItemType Directory -Path $dir -Force | Out-Null }; try { $s=$w.CreateShortcut($p); $s.TargetPath=$t; $s.WorkingDirectory=(Split-Path -Parent $t); $s.Save() } catch { try { if(Test-Path $p){ Remove-Item -LiteralPath $p -Force -ErrorAction Stop }; $s=$w.CreateShortcut($p); $s.TargetPath=$t; $s.WorkingDirectory=(Split-Path -Parent $t); $s.Save() } catch { return $false } }; if(-not (Test-Path $p)){ return $false }; try { $hit=$w.CreateShortcut($p); return $hit.TargetPath -eq $t } catch { return $false } }; $ok1=& $mk $env:LNK $env:CMD; $ok2=& $mk $env:MLNK $env:CMD; $ok3=$false; $ok4=$false; if($env:CLNK){ if((Test-Path $env:CLNK) -or -not [string]::Equals($env:CLNK,$env:LNK,[System.StringComparison]::OrdinalIgnoreCase)){ $ok3=& $mk $env:CLNK $env:CMD } }; if($env:CMLNK){ if((Test-Path $env:CMLNK) -or -not [string]::Equals($env:CMLNK,$env:MLNK,[System.StringComparison]::OrdinalIgnoreCase)){ $ok4=& $mk $env:CMLNK $env:CMD } }; if(-not ($ok1 -or $ok2 -or $ok3 -or $ok4)){ exit 1 }"
 if exist "%LNK%" (
   set "LAUNCH=%LNK%"
   set "NOTE=双击桌面上的 Aether.vbs 文件运行。"
+  if /I not "%CLNK%"=="%LNK%" if exist "%CLNK%" set "NOTE=双击桌面上的 Aether.vbs 文件运行。公共桌面快捷方式也已同步更新。"
 ) else if exist "%MLNK%" (
   set "LAUNCH=%MLNK%"
+  set "NOTE=从开始菜单的 Aether.vbs 文件运行。"
+  if /I not "%CMLNK%"=="%MLNK%" if exist "%CMLNK%" set "NOTE=从开始菜单的 Aether.vbs 文件运行。公共开始菜单快捷方式也已同步更新。"
+) else if exist "%CLNK%" (
+  set "LAUNCH=%CLNK%"
+  set "NOTE=双击桌面上的 Aether.vbs 文件运行。"
+) else if exist "%CMLNK%" (
+  set "LAUNCH=%CMLNK%"
   set "NOTE=从开始菜单的 Aether.vbs 文件运行。"
 ) else (
   set "LAUNCH=%CMD%"
@@ -115,17 +138,13 @@ if exist "%LNK%" (
 exit /b 0
 
 :restart
-powershell -NoProfile -Command "& { $names=@('aether.exe','wscript.exe','cscript.exe','node.exe','bun.exe'); $roots=@(); if($env:OLD){ $roots += [IO.Path]::GetFullPath($env:OLD) }; $roots += [IO.Path]::GetFullPath($env:WORK + '\current'); if($env:TARGET){ $roots += [IO.Path]::GetFullPath($env:TARGET) }; $roots += (Get-ChildItem -Path $env:WORK -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }); $roots=$roots | Where-Object { $_ } | Select-Object -Unique; Get-CimInstance Win32_Process | Where-Object { $n=$_.Name.ToLowerInvariant(); if($names -notcontains $n){ return $false }; $cmd=$_.CommandLine; $exe=$_.ExecutablePath; foreach($r in $roots){ if(($cmd -and $cmd -like ('*' + $r + '*')) -or ($exe -and $exe -like ($r + '*'))){ return $true } }; return $false } | Sort-Object ProcessId -Descending | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue } }"
+powershell -NoProfile -Command "& { $names=@('aether.exe','wscript.exe','cscript.exe','node.exe','bun.exe'); $roots=@(); if($env:OLD){ $roots += [IO.Path]::GetFullPath($env:OLD) }; if($env:TARGET){ $roots += [IO.Path]::GetFullPath($env:TARGET) }; $roots += (Get-ChildItem -Path $env:WORK -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }); $roots=$roots | Where-Object { $_ } | Select-Object -Unique; Get-CimInstance Win32_Process | Where-Object { $n=$_.Name.ToLowerInvariant(); if($names -notcontains $n){ return $false }; $cmd=$_.CommandLine; $exe=$_.ExecutablePath; foreach($r in $roots){ if(($cmd -and $cmd -like ('*' + $r + '*')) -or ($exe -and $exe -like ($r + '*'))){ return $true } }; return $false } | Sort-Object ProcessId -Descending | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue } }"
 timeout /t 1 /nobreak >nul
-start "" "%WORK%\current\Aether.vbs"
+start "" "%TARGET%\Aether.vbs"
 exit /b 0
 
 :active_dir
 set "OLD="
-if exist "%WORK%\current\.aether_web_version" (
-  set "OLD=%WORK%\current"
-  exit /b 0
-)
 if exist "%WORK%\.aether_web_version" (
   set /p RV=<"%WORK%\.aether_web_version"
   if exist "%WORK%\aether_%RV%\.aether_web_version" (
@@ -133,6 +152,8 @@ if exist "%WORK%\.aether_web_version" (
     exit /b 0
   )
 )
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$root=$env:WORK; $pick=Get-ChildItem -Path $root -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | Where-Object { Test-Path (Join-Path $_.FullName '.aether_web_version') } | ForEach-Object { $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim(); if($ver){ [PSCustomObject]@{ Dir=$_.FullName; Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending | Select-Object -First 1 -ExpandProperty Dir; if($pick){ [Console]::Write($pick) }"`) do set "OLD=%%i"
+if defined OLD exit /b 0
 for /d %%i in ("%WORK%\aether_*") do (
   if exist "%%~fi\.aether_web_version" (
     set "OLD=%%~fi"
@@ -147,7 +168,15 @@ set "W=%~2"
 set "PKG="
 set "VER="
 set "PKG_NAME="
-for /f "usebackq tokens=1,2,3 delims=|" %%i in (`powershell -NoProfile -Command "$dir=$env:DIR; $want=$env:W; $hits=Get-ChildItem -Path $dir -File -Filter '*.zip' | ForEach-Object { if($_.BaseName -match '([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ [PSCustomObject]@{Path=$_.FullName;Name=$_.Name;Ver=$matches[1]} } } | Where-Object { $_ }; if($want){ $hits=$hits | Where-Object { $_.Ver -eq $want } }; if(-not $hits){ exit 1 }; $pick=$hits | Sort-Object { [version](($_.Ver -replace '^v','').Split('-')[0]) } | Select-Object -Last 1; Write-Output ($pick.Path + '|' + $pick.Ver + '|' + $pick.Name)"`) do (
+if defined W (
+  set "PKG=%DIR%\aether-windows-x64-%W%.zip"
+  if exist "%PKG%" (
+    set "VER=%W%"
+    for %%i in ("%PKG%") do set "PKG_NAME=%%~nxi"
+    exit /b 0
+  )
+)
+for /f "usebackq tokens=1,2,3 delims=|" %%i in (`powershell -NoProfile -Command "$dir=$env:DIR; $hits=Get-ChildItem -Path $dir -File -Filter 'aether-windows-x64-*.zip' | ForEach-Object { $name='aether-windows-x64-'; if($_.BaseName.Length -gt $name.Length){ [PSCustomObject]@{Path=$_.FullName;Name=$_.Name;Ver=$_.BaseName.Substring($name.Length)} } } | Where-Object { $_ -and $_.Ver }; if(-not $hits){ exit 1 }; $pick=$hits | Sort-Object { [version](($_.Ver -replace '^v','').Split('-')[0]) } | Select-Object -Last 1; Write-Output ($pick.Path + '|' + $pick.Ver + '|' + $pick.Name)"`) do (
   set "PKG=%%i"
   set "VER=%%j"
   set "PKG_NAME=%%k"
@@ -165,20 +194,7 @@ if exist "%TMP%" rmdir /s /q "%TMP%" >nul 2>nul
 if exist "%NEXT%" rmdir /s /q "%NEXT%" >nul 2>nul
 exit /b 0
 
-:set_current
-if exist "%WORK%\current" rmdir "%WORK%\current" >nul 2>nul
-if exist "%WORK%\current" rmdir /s /q "%WORK%\current" >nul 2>nul
-mklink /J "%WORK%\current" "%TARGET%" >nul 2>nul
-if exist "%WORK%\current\Aether.vbs" exit /b 0
-
-mkdir "%WORK%\current" >nul 2>nul
-robocopy "%TARGET%" "%WORK%\current" /MIR /NFL /NDL /NJH /NJS /NP >nul
-set "RC=%ERRORLEVEL%"
-if %RC% GEQ 8 exit /b 1
-if not exist "%WORK%\current\Aether.vbs" exit /b 1
-exit /b 0
-
 :prune_versions
-for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "& { $root=$env:WORK; $keep=5; $hold=[IO.Path]::GetFullPath($env:TARGET); $cur=''; if(Test-Path (Join-Path $root 'current')){ try { $cur=(Get-Item (Join-Path $root 'current')).FullName } catch {} }; $items=Get-ChildItem -Path $root -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | Where-Object { Test-Path (Join-Path $_.FullName '.aether_web_version') } | ForEach-Object { $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim(); if($ver){ [PSCustomObject]@{ Dir=$_.FullName; Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending; $keepers=New-Object System.Collections.Generic.List[string]; foreach($dir in @($hold,$cur)){ if($dir -and ($items | Where-Object { $_.Dir -eq $dir }) -and -not $keepers.Contains($dir)){ $keepers.Add($dir) } }; foreach($item in $items){ if($keepers.Count -ge $keep){ break }; if(-not $keepers.Contains($item.Dir)){ $keepers.Add($item.Dir) } }; $gone=0; foreach($item in $items){ if($keepers.Contains($item.Dir)){ continue }; Remove-Item $item.Dir -Recurse -Force -ErrorAction SilentlyContinue; if(-not (Test-Path $item.Dir)){ $gone++ } }; Write-Output $gone }"`) do set "PRUNE=%%i"
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "& { $root=$env:WORK; $keep=5; $hold=[IO.Path]::GetFullPath($env:TARGET); $items=Get-ChildItem -Path $root -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | Where-Object { Test-Path (Join-Path $_.FullName '.aether_web_version') } | ForEach-Object { $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim(); if($ver){ [PSCustomObject]@{ Dir=$_.FullName; Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending; $keepers=New-Object System.Collections.Generic.List[string]; foreach($dir in @($hold)){ if($dir -and ($items | Where-Object { $_.Dir -eq $dir }) -and -not $keepers.Contains($dir)){ $keepers.Add($dir) } }; foreach($item in $items){ if($keepers.Count -ge $keep){ break }; if(-not $keepers.Contains($item.Dir)){ $keepers.Add($item.Dir) } }; $gone=0; foreach($item in $items){ if($keepers.Contains($item.Dir)){ continue }; Remove-Item $item.Dir -Recurse -Force -ErrorAction SilentlyContinue; if(-not (Test-Path $item.Dir)){ $gone++ } }; Write-Output $gone }"`) do set "PRUNE=%%i"
 if not defined PRUNE set "PRUNE=0"
 exit /b 0

--- a/Update/update_windows.bat
+++ b/Update/update_windows.bat
@@ -1,4 +1,4 @@
-﻿@echo off
+@echo off
 chcp 65001 >nul
 setlocal EnableExtensions EnableDelayedExpansion
 
@@ -14,30 +14,30 @@ set "LAUNCH="
 set "NOTE="
 
 if /I not "%BASE%"=="downloads" (
-  echo 规范错误：update_windows.bat 必须放在 ...\aether\downloads 目录。当前: %SELF%
+  echo Spec error: update_windows.bat must be placed in ...\aether\downloads. Current: %SELF%
   exit /b 1
 )
 for %%i in ("%WORK%") do set "WORK_NAME=%%~nxi"
 if /I not "%WORK_NAME%"=="aether" (
-  echo 规范错误：工作目录必须是 ...\aether。当前: %WORK%
+  echo Spec error: work directory must be ...\aether. Current: %WORK%
   exit /b 1
 )
 if not exist "%WORK%\aether_windows_installer.bat" (
-  echo 规范错误：缺少 ...\aether\aether_windows_installer.bat
+  echo Spec error: missing ...\aether\aether_windows_installer.bat
   exit /b 1
 )
 
-echo [0/4] 工作目录: %WORK%
+echo [0/4] Work directory: %WORK%
 
 call :pick_pkg "%SELF%" "%WANT%"
 if errorlevel 1 (
-  echo 未在 ...\aether\downloads 找到可用 zip（文件名需包含版本号）
+  echo No usable zip found in ...\aether\downloads; filename must include a version
   exit /b 1
 )
 
 set "TARGET=%WORK%\aether_%VER%"
-echo [1/4] 安装包: %PKG_NAME%
-echo       目标版本: %VER%
+echo [1/4] Package: %PKG_NAME%
+echo       Target version: %VER%
 
 set "TMP=%TEMP%\aether-install-%RANDOM%%RANDOM%"
 set "EX=%TMP%\extract"
@@ -53,11 +53,11 @@ powershell -NoProfile -Command "& { Expand-Archive -Path $env:PKG -DestinationPa
 set "SRC="
 if exist "%SRC_FILE%" set /p SRC=<"%SRC_FILE%"
 if "%SRC%"=="" (
-  echo 安装包内容缺少 aether.exe 或 Aether.vbs
+  echo Package contents missing aether.exe or Aether.vbs
   goto :fail
 )
 
-echo [2/4] 解包并安装到: %TARGET%
+echo [2/4] Extracting and installing to: %TARGET%
 robocopy "%SRC%" "%NEXT%" /MIR /NFL /NDL /NJH /NJS /NP >nul
 set "RC=%ERRORLEVEL%"
 if %RC% GEQ 8 goto :fail
@@ -77,64 +77,41 @@ call :prune_versions || goto :fail
 
 if "%RESTART%"=="1" call :restart
 
-if not "%PRUNE%"=="0" (
-  echo [3/4] 保留最近 5 个版本，已清理 %PRUNE% 个旧版本目录
-) else (
-  echo [3/4] 保留最近 5 个版本，无需清理旧版本目录
-)
+call :print_prune
 
-echo [4/4] 完成
-echo 当前版本: %VER%
-echo 版本目录: %TARGET%
-echo 启动入口: %LAUNCH%
+echo [4/4] Done
+echo Current version: %VER%
+echo Version directory: %TARGET%
+echo Launch entry: %LAUNCH%
 if defined NOTE echo %NOTE%
 
 call :clean_tmp
 exit /b 0
 
 :write_launch
-set "DESK="
-set "DESK_COMMON="
-set "MENU="
-set "MENU_COMMON="
-for /f "usebackq tokens=1,2,3,4 delims=|" %%i in (`powershell -NoProfile -Command "$desk=[Environment]::GetFolderPath('DesktopDirectory'); $desk2=[Environment]::GetFolderPath('CommonDesktopDirectory'); $menu=[Environment]::GetFolderPath('Programs'); $menu2=[Environment]::GetFolderPath('CommonPrograms'); [Console]::Write(([string]$desk) + '|' + ([string]$desk2) + '|' + ([string]$menu) + '|' + ([string]$menu2))"`) do (
-  set "DESK=%%i"
-  set "DESK_COMMON=%%j"
-  set "MENU=%%k"
-  set "MENU_COMMON=%%l"
-)
-if not defined DESK set "DESK=%USERPROFILE%\Desktop"
-if not defined MENU set "MENU=%APPDATA%\Microsoft\Windows\Start Menu\Programs"
-if not defined DESK_COMMON set "DESK_COMMON=%PUBLIC%\Desktop"
-if not defined MENU_COMMON set "MENU_COMMON=%ProgramData%\Microsoft\Windows\Start Menu\Programs"
-if not exist "%DESK%" mkdir "%DESK%"
-if not exist "%MENU%" mkdir "%MENU%"
-set "LNK=%DESK%\Aether.lnk"
-set "MLNK=%MENU%\Aether.lnk"
-set "CLNK=%DESK_COMMON%\Aether.lnk"
-set "CMLNK=%MENU_COMMON%\Aether.lnk"
 set "CMD=%TARGET%\Aether.vbs"
-if exist "%LNK%" del /f /q "%LNK%" >nul 2>nul
-if exist "%MLNK%" del /f /q "%MLNK%" >nul 2>nul
-powershell -NoProfile -Command "$w=New-Object -ComObject WScript.Shell; $mk={ param($p,$t) if(-not $p){ return $false }; $dir=Split-Path -Parent $p; if($dir -and -not (Test-Path $dir)){ New-Item -ItemType Directory -Path $dir -Force | Out-Null }; try { $s=$w.CreateShortcut($p); $s.TargetPath=$t; $s.WorkingDirectory=(Split-Path -Parent $t); $s.Save() } catch { try { if(Test-Path $p){ Remove-Item -LiteralPath $p -Force -ErrorAction Stop }; $s=$w.CreateShortcut($p); $s.TargetPath=$t; $s.WorkingDirectory=(Split-Path -Parent $t); $s.Save() } catch { return $false } }; if(-not (Test-Path $p)){ return $false }; try { $hit=$w.CreateShortcut($p); return $hit.TargetPath -eq $t } catch { return $false } }; $ok1=& $mk $env:LNK $env:CMD; $ok2=& $mk $env:MLNK $env:CMD; $ok3=$false; $ok4=$false; if($env:CLNK){ if((Test-Path $env:CLNK) -or -not [string]::Equals($env:CLNK,$env:LNK,[System.StringComparison]::OrdinalIgnoreCase)){ $ok3=& $mk $env:CLNK $env:CMD } }; if($env:CMLNK){ if((Test-Path $env:CMLNK) -or -not [string]::Equals($env:CMLNK,$env:MLNK,[System.StringComparison]::OrdinalIgnoreCase)){ $ok4=& $mk $env:CMLNK $env:CMD } }; if(-not ($ok1 -or $ok2 -or $ok3 -or $ok4)){ exit 1 }"
-if exist "%LNK%" (
-  set "LAUNCH=%LNK%"
-  set "NOTE=双击桌面上的 Aether.vbs 文件运行。"
-  if /I not "%CLNK%"=="%LNK%" if exist "%CLNK%" set "NOTE=双击桌面上的 Aether.vbs 文件运行。公共桌面快捷方式也已同步更新。"
-) else if exist "%MLNK%" (
-  set "LAUNCH=%MLNK%"
-  set "NOTE=从开始菜单的 Aether.vbs 文件运行。"
-  if /I not "%CMLNK%"=="%MLNK%" if exist "%CMLNK%" set "NOTE=从开始菜单的 Aether.vbs 文件运行。公共开始菜单快捷方式也已同步更新。"
-) else if exist "%CLNK%" (
-  set "LAUNCH=%CLNK%"
-  set "NOTE=双击桌面上的 Aether.vbs 文件运行。"
-) else if exist "%CMLNK%" (
-  set "LAUNCH=%CMLNK%"
-  set "NOTE=从开始菜单的 Aether.vbs 文件运行。"
-) else (
-  set "LAUNCH=%CMD%"
-  set "NOTE=创建快捷方式失败，请打开文件管理器找到该路径对应的文件，双击运行。"
+set "OUT=%TEMP%\aether-launch-%RANDOM%%RANDOM%.txt"
+if exist "%OUT%" del /f /q "%OUT%" >nul 2>nul
+powershell -NoProfile -Command "$cmd=$env:CMD; $out=$env:OUT; $w=New-Object -ComObject WScript.Shell; $desk=[Environment]::GetFolderPath('DesktopDirectory'); if(-not $desk){ $desk=$w.SpecialFolders.Item('Desktop') }; $menu=[Environment]::GetFolderPath('Programs'); if(-not $menu){ $menu=Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs' }; $desk2=[Environment]::GetFolderPath('CommonDesktopDirectory'); $menu2=[Environment]::GetFolderPath('CommonPrograms'); $all=@($desk,$menu,$desk2,$menu2) | Where-Object { $_ } | Select-Object -Unique; foreach($dir in $all){ $lnk=Join-Path $dir 'Aether.lnk'; try { if(Test-Path $lnk){ Remove-Item -LiteralPath $lnk -Force -ErrorAction Stop } } catch {} }; $mk={ param($path,$target) try { $dir=Split-Path -Parent $path; if($dir -and -not (Test-Path $dir)){ New-Item -ItemType Directory -Path $dir -Force | Out-Null }; if(Test-Path $path){ Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue }; $s=$w.CreateShortcut($path); $s.TargetPath=$target; $s.WorkingDirectory=(Split-Path -Parent $target); $s.Save(); if(-not (Test-Path $path)){ return $false }; $hit=$w.CreateShortcut($path); return $hit.TargetPath -eq $target } catch { return $false } }; $launch=''; $note=''; $desk_ok=$false; $menu_ok=$false; if($desk){ $desk_ok=& $mk (Join-Path $desk 'Aether.lnk') $cmd }; if($menu){ $menu_ok=& $mk (Join-Path $menu 'Aether.lnk') $cmd }; if($desk_ok){ $launch=Join-Path $desk 'Aether.lnk'; $note='Double-click Aether.vbs on your desktop to run it.' } elseif($menu_ok){ $launch=Join-Path $menu 'Aether.lnk'; $note='Run Aether.vbs from the Start Menu.' } else { $launch=$cmd; $note='Shortcut creation failed. Open File Explorer, find this path, and double-click the file to run it.' }; [IO.File]::WriteAllLines($out, @($launch,$note))"
+set "LAUNCH=%CMD%"
+set "NOTE=Shortcut creation failed. Open File Explorer, find this path, and double-click the file to run it."
+if exist "%OUT%" (
+  set /p LAUNCH=<"%OUT%"
+  for /f "usebackq skip=1 delims=" %%i in ("%OUT%") do (
+    set "NOTE=%%i"
+    goto :write_launch_done
+  )
 )
+:write_launch_done
+if exist "%OUT%" del /f /q "%OUT%" >nul 2>nul
+exit /b 0
+
+:print_prune
+if "%PRUNE%"=="0" (
+  echo [3/4] Keeping the latest 5 versions; no older version directories needed removal.
+  exit /b 0
+)
+echo [3/4] Keeping the latest 5 versions; removed %PRUNE% older version directories.
 exit /b 0
 
 :restart


### PR DESCRIPTION
### Issue for this PR

Closes #257

### Type of change

- [x] Bug fix
- [x] Refactor / code improvement
- [ ] New feature
- [ ] Documentation

### What does this PR do?

This fixes multiple issues in the offline/web update flow across platforms:

1. **Empty keepers array crash** — `prune_versions()` used `"${keepers[@]}"` under `set -u`, which fails on macOS Bash 3.2 when the array is empty. Now guarded with `${#keepers[@]} -gt 0` checks.

2. **Removed `current` directory dependency** — The `current` symlink/junction was redundant. Update scripts now resolve the active version from `.aether_web_version` with fallback to the latest `aether_*` directory. Launchers (desktop shortcuts, .app wrapper) were updated accordingly.

3. **Skip reinstall when already up to date** — Installer scripts now detect the installed version before downloading. If it matches the remote latest, no download or install runs. If only the package+installer are cached, download is skipped but install proceeds.

4. **Cache validation requires both package and installer** — The "skip download" path now verifies both the package file and update script exist (and checksum matches) before using the cache.

5. **Windows batch stability** — Reverted all user-facing output to ASCII-only English to avoid `cmd.exe` encoding issues. Fixed delayed expansion bugs where `%CMP%` and `%RV%` were expanded before `call :cmp` or `set /p` had executed inside bracket blocks. Fixed `[3/4]`/`[4/4]` output by moving to `:print_prune` subroutine. Fixed shortcut creation to explicitly delete old `.lnk` before recreating.

6. **Installer naming sync** — Release installers now use the same file naming, cache pruning rules, and URL resolution as devtest installers. The only remaining differences are the download base URL and auth headers.

7. **Latest version display** — All installers now print the remote latest version with blank lines before and after for visibility.

### How did you verify your code works?

- Ran `bash -n` on all shell update/installer scripts
- Ran local darwin installer simulation test (`Update/test_installer_init_flow.sh`)
- Verified Windows installers contain no non-ASCII lines
- Tested on Windows: init flow with already-installed version correctly skips download and install
- Tested on macOS: installer and update flows work without the `current` directory

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR