### PR TITLE
fix: remove update scripts from web releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -150,7 +150,6 @@ jobs:
           path: |
             packages/opencode/dist/aether-darwin-arm64.dmg
             packages/opencode/dist/latest-web-mac.yml
-            packages/opencode/dist/update_darwin.command
           if-no-files-found: error
 
   build-web-linux:
@@ -174,7 +173,6 @@ jobs:
           path: |
             packages/opencode/dist/aether-linux-x64.zip
             packages/opencode/dist/latest-web-linux.yml
-            packages/opencode/dist/update_linux.sh
           if-no-files-found: error
 
   build-web-windows:
@@ -199,7 +197,6 @@ jobs:
           path: |
             packages/opencode/dist/aether-windows-x64.zip
             packages/opencode/dist/latest-web-windows.yml
-            packages/opencode/dist/update_windows.bat
           if-no-files-found: error
 
   publish:

--- a/RELEASE_UPLOAD_CHECKLIST.md
+++ b/RELEASE_UPLOAD_CHECKLIST.md
@@ -28,6 +28,7 @@
   - mac：`aether-darwin-arm64-web.dmg` + `latest-web-mac.yml`
   - linux：`aether-linux-x64.zip` + `latest-web-linux.yml`
   - windows：`aether-windows-x64.zip` + `latest-web-windows.yml`
+- `web` release asset 不再上传 `update_*` 脚本；在线更新继续由包内 `aether_*_installer.*` 触发
 
 ## 发布前检查
 

--- a/Update/mac_flow.md
+++ b/Update/mac_flow.md
@@ -2,10 +2,10 @@
 
 - `packing_scripts/release-mac-web.sh`
   - 构建 web 二进制并裁剪 `wechat-bridge/runtime/uv` 仅保留 mac arm64 目标。
-  - 组装产物目录，包含运行文件、`update_darwin.command`、`aether_darwin_installer.command`、`.aether_web_version`、`README_FIRST.txt`。
-  - 修正执行权限（`aether`、`Aether.command`、`update_darwin.command`、installer）。
+  - 组装产物目录，包含运行文件、`aether_darwin_installer.command`、`.aether_web_version`、`README_FIRST.txt`。
+  - 修正执行权限（`aether`、`Aether.command`、installer）。
   - 打出 `dist/aether-darwin-arm64-web.dmg`，生成 `dist/latest-web-mac.yml`。
-  - 额外在 `dist/` 放一份 `update_darwin.command` 方便你上传远端。
+  - 不再额外在 `dist/` 放 `update_darwin.command`；初始分发包也不再包含该脚本。
 
 - `Update/aether_darwin_installer.command`（入口脚本）
   - 支持 `init | auto <current-version> | manual <target-version>`，支持 `--path`、`--no-pause`。

--- a/Update/release-and-upload-mac-web.sh
+++ b/Update/release-and-upload-mac-web.sh
@@ -51,10 +51,10 @@ cp -R "$src"/. "$pkg"/
 # Write version file
 printf "%s\n" "$ver" > "$pkg/.aether_version"
 
-# Include updater script
-if [ -f "$updater" ]; then
-  cp "$updater" "$pkg/update_darwin.command"
-  chmod +x "$pkg/update_darwin.command"
+ins="$root/Update/aether_darwin_installer.command"
+if [ -f "$ins" ]; then
+  cp "$ins" "$pkg/aether_darwin_installer.command"
+  chmod +x "$pkg/aether_darwin_installer.command"
 fi
 
 # Ensure executables are +x
@@ -78,8 +78,8 @@ Troubleshooting
 - Permission denied:
   chmod +x ./aether ./Aether.command
 
-Offline update
-- Run ./update_darwin.command
+Updates
+- Use Aether's in-app update flow to download and install newer versions.
 EOFREADME
 
 rm -f "$dmg"

--- a/docs/aether-download-admin-upload.md
+++ b/docs/aether-download-admin-upload.md
@@ -166,6 +166,7 @@ curl -X POST https://aether.aiphys.cn/api/download2/admin/upload \
 
 补充说明：
 
+- 当前 GitHub Release 与 web 初始分发包默认不再携带 `update_*` 脚本；这些字段主要供下载服务托管 installer 在运行时拉取的更新脚本使用
 - 当前上传实现仍会写入 `downloads/latest/` 作为镜像目录
 - 但客户端下载 `latest` 时，应将其视为“当前最新公开版本”的路由别名，而不是依赖某个固定物理目录
 - 如需测试“已上传 latest 但暂不公开发布”的产物，开发者可使用 `/api/download2/...`；该路由直接读取 `downloads2/`，并要求提供 `x-download-admin-password` 请求头或 `?password=` 参数
@@ -263,10 +264,13 @@ curl -X POST https://aether.aiphys.cn/api/download2/admin/upload \
 对应安装包：
 
 - `/download/latest/aether-darwin-arm64.dmg`
-- `/download/latest/update_darwin.command`
 - `/download/latest/aether-windows-x64.zip`
-- `/download/latest/update_windows.bat`
 - `/download/latest/aether-linux-x64.zip`
+
+如果服务端托管了更新脚本，installer 还会额外访问：
+
+- `/download/latest/update_darwin.command`
+- `/download/latest/update_windows.bat`
 - `/download/latest/update_linux.sh`
 
 解析规则：
@@ -286,10 +290,13 @@ curl -X POST https://aether.aiphys.cn/api/download2/admin/upload \
 对应安装包：
 
 - `/download/<version>/aether-darwin-arm64.dmg`
-- `/download/<version>/update_darwin.command`
 - `/download/<version>/aether-windows-x64.zip`
-- `/download/<version>/update_windows.bat`
 - `/download/<version>/aether-linux-x64.zip`
+
+如果服务端托管了更新脚本，installer 还会额外访问：
+
+- `/download/<version>/update_darwin.command`
+- `/download/<version>/update_windows.bat`
 - `/download/<version>/update_linux.sh`
 
 ### 兼容旧地址

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -91,13 +91,13 @@ packages/opencode/dist/
 
 | 平台 | 格式 | 内容 |
 |------|------|------|
-| macOS | `.dmg` | `aether` + `web/` + `Aether.command` + `update_darwin.command` + `README_FIRST.txt` |
-| Linux | `.tar.gz` | `aether` + `web/` + `Aether.sh` |
-| Windows | `.zip` | `aether.exe` + `web/` + `Aether.vbs` |
+| macOS | `.dmg` | `aether` + `web/` + `Aether.command` + `aether_darwin_installer.command` + `README_FIRST.txt` |
+| Linux | `.tar.gz` | `aether` + `web/` + `Aether.sh` + `aether_linux_installer.sh` |
+| Windows | `.zip` | `aether.exe` + `web/` + `Aether.vbs` + `aether_windows_installer.bat` |
 
 ### 3.2 macOS DMG 打包
 
-macOS 使用 DMG 格式分发，内含更新脚本和说明文档。
+macOS 使用 DMG 格式分发，内含 installer 和说明文档。
 
 **macOS 上打包**（使用 `hdiutil`）：
 
@@ -114,7 +114,7 @@ sudo apt install genisoimage   # 首次安装
 genisoimage -V "Aether Web" -D -R -apple -no-pad -o output.dmg <source-folder>
 ```
 
-DMG 打包后同时生成 `latest-web-mac.yml` 元数据文件（含 sha512 和文件大小），供客户端更新脚本校验。
+DMG 打包后同时生成 `latest-web-mac.yml` 元数据文件（含 sha512 和文件大小），供客户端更新流程校验。
 
 ### 3.3 一键构建 + 上传（macOS Web 版）
 
@@ -131,7 +131,7 @@ DMG 打包后同时生成 `latest-web-mac.yml` 元数据文件（含 sha512 和�
 1. `OPENCODE_VERSION=<version> bun run build` 全平台构建
 2. 将 `dist/aether-darwin-arm64/bin/` 打包为 DMG（自动检测 `hdiutil` 或 `genisoimage`）
 3. 生成 `latest-web-mac.yml` 元数据
-4. `curl` 上传 DMG 和更新脚本到 `aether.aiphys.cn`
+4. `curl` 上传 DMG，并按需上传供 installer 使用的更新脚本到 `aether.aiphys.cn`
 
 ### 3.4 分发服务器
 
@@ -150,24 +150,25 @@ curl -X POST https://aether.aiphys.cn/api/download/admin/upload \
 
 ## 4. 客户端更新
 
-### 4.1 macOS 离线更新脚本
+### 4.1 macOS 更新流程
 
-**文件**：`Update/update_darwin.command`
+**入口文件**：`Update/aether_darwin_installer.command`
 
-用户双击即可检查并安装更新，流程：
+应用内更新会先调用 installer，再由 installer 下载版本化 `update_darwin.command` 完成安装，流程：
 
 ```mermaid
 flowchart TD
-    A[运行 update_darwin.command] --> B[从 aether.aiphys.cn 获取 latest-web-mac.yml]
+    A[运行 aether_darwin_installer.command] --> B[从 aether.aiphys.cn 获取 latest-web-mac.yml]
     B --> C{本地版本 == 远端版本?}
     C -->|是| D[已是最新，退出]
-    C -->|否| E[下载新版本 DMG]
+    C -->|否| E[下载新版本 DMG 和版本化 update_darwin.command]
     E --> F[校验 sha512]
     F -->|失败| G[停止更新]
-    F -->|通过| H[挂载 DMG，复制文件到临时目录]
-    H --> I[原子替换：旧目录 → .old，新目录 → 安装位置]
-    I --> J[写入 .aether_web_version]
-    J --> K[删除旧版本，完成]
+    F -->|通过| H[执行下载后的 update_darwin.command]
+    H --> I[挂载 DMG，复制文件到临时目录]
+    I --> J[原子替换：旧目录 → .old，新目录 → 安装位置]
+    J --> K[写入 .aether_web_version]
+    K --> L[删除旧版本，完成]
 ```
 
 版本比对依据：
@@ -192,8 +193,8 @@ flowchart TD
 | Web 前端版本读取 | `packages/app/src/entry.tsx` |
 | macOS 构建+上传脚本 | `Update/release-and-upload-mac-web.sh` |
 | macOS 打包脚本 | `packing_scripts/release-mac-web.sh` |
-| macOS 更新脚本 | `Update/update_darwin.command` |
-| Linux 更新脚本 | `Update/update_linux.sh` |
-| Windows 更新脚本 | `Update/update_windows.bat` |
+| macOS installer | `Update/aether_darwin_installer.command` |
+| Linux installer | `Update/aether_linux_installer.sh` |
+| Windows installer | `Update/aether_windows_installer.bat` |
 | 打包指南（详细） | `PACKAGING.md` |
 | 打包指南（Web 版） | `PACKAGING-1.md` |

--- a/packing_scripts/release-linux-web.sh
+++ b/packing_scripts/release-linux-web.sh
@@ -16,7 +16,6 @@ if [ ! -d "$src" ]; then
 fi
 
 uv="$src/wechat-bridge/runtime/uv"
-upd="$root/Update/update_linux.sh"
 
 if [ -d "$uv" ]; then
   for dir in "$uv"/*; do
@@ -28,11 +27,6 @@ if [ -d "$uv" ]; then
   done
 fi
 
-if [ ! -f "$upd" ]; then
-  echo "Missing updater script: $upd"
-  exit 1
-fi
-
 pkg="aether-linux-x64"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
@@ -40,11 +34,6 @@ out="$tmp/$pkg"
 
 mkdir -p "$out"
 cp -R "$src"/. "$out"/
-
-cp "$upd" "$out/update_linux.sh"
-chmod +x "$out/update_linux.sh"
-cp "$upd" "dist/update_linux.sh"
-chmod +x "dist/update_linux.sh"
 
 ins="$root/Update/aether_linux_installer.sh"
 if [ -f "$ins" ]; then
@@ -68,9 +57,8 @@ Quick start
 1) Extract this ZIP and copy the folder aether-linux-x64 to a local path, for example: ~/Applications/Aether-Web
 2) Open Terminal in that folder and run: ./Aether.sh
 
-Offline update
-- Run ./update_linux.sh to check and install newer versions from:
-  https://aether.aiphys.cn/download
+Updates
+- Use Aether's in-app update flow to download and install newer versions.
 EOF
 
 zip="dist/aether-linux-x64.zip"
@@ -94,6 +82,5 @@ popd >/dev/null
 
 echo "Done"
 echo "Asset: packages/opencode/$zip"
-echo "Updater: packages/opencode/dist/update_linux.sh"
 echo "YML:   packages/opencode/dist/latest-web-linux.yml"
-echo "Note:  ZIP includes folder $pkg"
+echo "Note:  ZIP includes folder $pkg and aether_linux_installer.sh"

--- a/packing_scripts/release-mac-web.sh
+++ b/packing_scripts/release-mac-web.sh
@@ -32,16 +32,9 @@ pkg="aether-darwin-arm64"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 out="$tmp/$pkg"
-upd="$root/Update/update_darwin.command"
 
 mkdir -p "$out"
 cp -R "$src"/. "$out"/
-
-if [ ! -f "$upd" ]; then
-  echo "Missing updater script: $upd"
-  exit 1
-fi
-cp "$upd" "$out/update_darwin.command"
 
 ins="$root/Update/aether_darwin_installer.command"
 if [ -f "$ins" ]; then
@@ -58,10 +51,6 @@ fi
 if [ -f "$out/Aether.command" ]; then
   chmod +x "$out/Aether.command"
 fi
-
-chmod +x "$out/update_darwin.command"
-cp "$upd" "dist/update_darwin.command"
-chmod +x "dist/update_darwin.command"
 
 cat >"$out/README_FIRST.txt" <<'EOF'
 Aether Web (macOS arm64)
@@ -85,9 +74,8 @@ Troubleshooting
 - If Gatekeeper still blocks it:
   System Settings -> Privacy & Security -> scroll down and allow the blocked item, then retry Open
 
-Offline update
-- Run ./update_darwin.command to check and install newer versions from:
-  https://aether.aiphys.cn/download
+Updates
+- Use Aether's in-app update flow to download and install newer versions.
 EOF
 
 rm -f "$dmg"
@@ -109,6 +97,5 @@ popd >/dev/null
 
 echo "Done"
 echo "Asset: packages/opencode/$dmg"
-echo "Updater: packages/opencode/dist/update_darwin.command"
 echo "YML:   packages/opencode/dist/latest-web-mac.yml"
-echo "Note:  DMG includes README_FIRST.txt and update_darwin.command"
+echo "Note:  DMG includes README_FIRST.txt and aether_darwin_installer.command"

--- a/packing_scripts/release-windows-web.bat
+++ b/packing_scripts/release-windows-web.bat
@@ -20,17 +20,11 @@ if not exist "%SRC%" (
 )
 
 set "UV=%SRC%\wechat-bridge\runtime\uv"
-set "UPD=%ROOT%\Update\update_windows.bat"
 set "PKG=aether-windows-x64"
 set "TMP=%TEMP%\aether-web-pack-%RANDOM%%RANDOM%"
 set "OUT=%TMP%\%PKG%"
 if exist "%UV%" (
   powershell -NoProfile -Command "& { $uv=$env:UV; Get-ChildItem -Path $uv -Directory | Where-Object { $_.Name -notlike '*x86_64-pc-windows-msvc*' } | Remove-Item -Recurse -Force }" || exit /b 1
-)
-
-if not exist "%UPD%" (
-  echo Missing updater script: %UPD%
-  exit /b 1
 )
 
 if exist "%TMP%" rmdir /s /q "%TMP%"
@@ -44,9 +38,6 @@ if %RC% GEQ 8 (
   exit /b 1
 )
 
-copy /y "%UPD%" "%OUT%\update_windows.bat" >nul || exit /b 1
-copy /y "%UPD%" "%CD%\dist\update_windows.bat" >nul || exit /b 1
-
 set "INS=%ROOT%\Update\aether_windows_installer.bat"
 if exist "%INS%" (
   copy /y "%INS%" "%OUT%\aether_windows_installer.bat" >nul || exit /b 1
@@ -54,7 +45,7 @@ if exist "%INS%" (
 
 powershell -NoProfile -Command "& { [IO.File]::WriteAllText((Join-Path $env:OUT '.aether_web_version'), $env:VERSION) }" || exit /b 1
 
-powershell -NoProfile -Command "& { $crlf=[char]13+[char]10; $txt=@('Aether Web (Windows x64)','', 'Quick start', '1) Extract this ZIP and copy the folder aether-windows-x64 to a local path, for example: C:\Aether-Web', '2) In that folder, double click Aether.vbs', '', 'Offline update', '- Run update_windows.bat to check and install newer versions from:', '  https://aether.aiphys.cn/download') -join $crlf; Set-Content -Path (Join-Path $env:OUT 'README_FIRST.txt') -Value ($txt + $crlf) -Encoding ascii }" || exit /b 1
+powershell -NoProfile -Command "& { $crlf=[char]13+[char]10; $txt=@('Aether Web (Windows x64)','', 'Quick start', '1) Extract this ZIP and copy the folder aether-windows-x64 to a local path, for example: C:\Aether-Web', '2) In that folder, double click Aether.vbs', '', 'Updates', '- Use Aether''s in-app update flow to download and install newer versions.') -join $crlf; Set-Content -Path (Join-Path $env:OUT 'README_FIRST.txt') -Value ($txt + $crlf) -Encoding ascii }" || exit /b 1
 
 set "ZIP=%CD%\dist\aether-windows-x64.zip"
 if exist "%ZIP%" del /f /q "%ZIP%"
@@ -69,6 +60,5 @@ rmdir /s /q "%TMP%" >nul 2>nul
 
 echo Done
 echo Asset: %ZIP%
-echo Updater: %CD%\dist\update_windows.bat
 echo YML:   %YML%
-echo Note:  ZIP includes folder %PKG%
+echo Note:  ZIP includes folder %PKG% and aether_windows_installer.bat


### PR DESCRIPTION
### Issue for this PR

Closes #259

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Removes `update_*` scripts from the initial web release artifacts and GitHub release uploads for macOS, Linux, and Windows.

The web update flow still works because the packaged `aether_*_installer.*` scripts remain in place and continue to fetch versioned update scripts from the download service at runtime.

This also updates the related release and versioning docs so they match the current distribution behavior.

### How did you verify your code works?

- Ran `bun install` to restore the missing `@larksuiteoapi/node-sdk` dependency in the workspace
- Ran `bun typecheck` in `packages/opencode`
- Ran the repository pre-push `bun turbo typecheck` successfully during `git push`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
