### PR TITLE
fix: remove root version marker dependency from offline update flow

### DIFF
--- a/Update/aether_darwin_installer.command
+++ b/Update/aether_darwin_installer.command
@@ -206,13 +206,6 @@ cmp() {
 installed() {
   local root name best best_ver dir ver
   root="$1"
-  if [ -f "$root/.aether_web_version" ]; then
-    ver="$(tr -d '[:space:]' <"$root/.aether_web_version")"
-    if [ -n "$ver" ]; then
-      printf "%s" "$ver"
-      return 0
-    fi
-  fi
 
   name="$(basename "$root")"
   if [[ "$name" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then

--- a/Update/aether_darwin_installer_devtest.command
+++ b/Update/aether_darwin_installer_devtest.command
@@ -208,13 +208,6 @@ cmp() {
 installed() {
   local root name best best_ver dir ver
   root="$1"
-  if [ -f "$root/.aether_web_version" ]; then
-    ver="$(tr -d '[:space:]' <"$root/.aether_web_version")"
-    if [ -n "$ver" ]; then
-      printf "%s" "$ver"
-      return 0
-    fi
-  fi
 
   name="$(basename "$root")"
   if [[ "$name" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then

--- a/Update/aether_linux_installer.sh
+++ b/Update/aether_linux_installer.sh
@@ -208,13 +208,6 @@ compute_sha512_base64() {
 installed() {
   local root name best_ver dir ver
   root="$1"
-  if [ -f "$root/.aether_web_version" ]; then
-    ver="$(tr -d '[:space:]' <"$root/.aether_web_version")"
-    if [ -n "$ver" ]; then
-      printf "%s" "$ver"
-      return 0
-    fi
-  fi
 
   name="$(basename "$root")"
   if [[ "$name" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then

--- a/Update/aether_linux_installer_devtest.sh
+++ b/Update/aether_linux_installer_devtest.sh
@@ -210,13 +210,6 @@ compute_sha512_base64() {
 installed() {
   local root name best_ver dir ver
   root="$1"
-  if [ -f "$root/.aether_web_version" ]; then
-    ver="$(tr -d '[:space:]' <"$root/.aether_web_version")"
-    if [ -n "$ver" ]; then
-      printf "%s" "$ver"
-      return 0
-    fi
-  fi
 
   name="$(basename "$root")"
   if [[ "$name" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then

--- a/Update/aether_windows_installer.bat
+++ b/Update/aether_windows_installer.bat
@@ -159,7 +159,7 @@ if "%INS_FILE%"=="" (
 )
 
 call :print_init_run
-call cmd /c ""%INS_FILE%" %VER%"
+call "%INS_FILE%" "%VER%"
 if errorlevel 1 (
   set "RES=run_error"
   call :result
@@ -369,17 +369,10 @@ exit /b 0
 set "%~2="
 set "DIR=%~1"
 set "RV="
-if exist "%DIR%\.aether_web_version" (
-  set /p RV=<"%DIR%\.aether_web_version"
-)
-if defined RV (
-  set "%~2=!RV!"
-  exit /b 0
-)
 for %%i in ("%DIR%") do set "NAME=%%~nxi"
 for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$name=$env:NAME; if($name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ [Console]::Write($matches[1]) }"`) do set "%~2=%%i"
 if defined %~2 exit /b 0
-for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$root=$env:DIR; $best=Get-ChildItem -Path $root -Directory -ErrorAction SilentlyContinue | ForEach-Object { if($_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ [PSCustomObject]@{ Ver=$matches[1] } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending | Select-Object -First 1 -ExpandProperty Ver; if($best){ [Console]::Write($best) }"`) do set "%~2=%%i"
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$root=$env:DIR; $best=Get-ChildItem -Path $root -Directory -ErrorAction SilentlyContinue | ForEach-Object { $ver=''; if(Test-Path (Join-Path $_.FullName '.aether_web_version')){ $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim() }; if(-not $ver -and $_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ $ver=$matches[1] }; if($ver){ [PSCustomObject]@{ Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending | Select-Object -First 1 -ExpandProperty Ver; if($best){ [Console]::Write($best) }"`) do set "%~2=%%i"
 exit /b 0
 
 :cache_paths

--- a/Update/aether_windows_installer_devtest.bat
+++ b/Update/aether_windows_installer_devtest.bat
@@ -161,7 +161,7 @@ if "%INS_FILE%"=="" (
 )
 
 call :print_init_run
-call cmd /c ""%INS_FILE%" %VER%"
+call "%INS_FILE%" "%VER%"
 if errorlevel 1 (
   set "RES=run_error"
   call :result
@@ -371,17 +371,10 @@ exit /b 0
 set "%~2="
 set "DIR=%~1"
 set "RV="
-if exist "%DIR%\.aether_web_version" (
-  set /p RV=<"%DIR%\.aether_web_version"
-)
-if defined RV (
-  set "%~2=!RV!"
-  exit /b 0
-)
 for %%i in ("%DIR%") do set "NAME=%%~nxi"
 for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$name=$env:NAME; if($name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ [Console]::Write($matches[1]) }"`) do set "%~2=%%i"
 if defined %~2 exit /b 0
-for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$root=$env:DIR; $best=Get-ChildItem -Path $root -Directory -ErrorAction SilentlyContinue | ForEach-Object { if($_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ [PSCustomObject]@{ Ver=$matches[1] } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending | Select-Object -First 1 -ExpandProperty Ver; if($best){ [Console]::Write($best) }"`) do set "%~2=%%i"
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$root=$env:DIR; $best=Get-ChildItem -Path $root -Directory -ErrorAction SilentlyContinue | ForEach-Object { $ver=''; if(Test-Path (Join-Path $_.FullName '.aether_web_version')){ $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim() }; if(-not $ver -and $_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ $ver=$matches[1] }; if($ver){ [PSCustomObject]@{ Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending | Select-Object -First 1 -ExpandProperty Ver; if($best){ [Console]::Write($best) }"`) do set "%~2=%%i"
 exit /b 0
 
 :cache_paths

--- a/Update/update_darwin.command
+++ b/Update/update_darwin.command
@@ -91,6 +91,24 @@ pick_pkg() {
   return 1
 }
 
+dir_version() {
+  local dir name ver
+  dir="$1"
+  if [ -f "$dir/.aether_web_version" ]; then
+    ver="$(tr -d '[:space:]' <"$dir/.aether_web_version")"
+    if [ -n "$ver" ]; then
+      printf "%s" "$ver"
+      return 0
+    fi
+  fi
+  name="$(basename "$dir")"
+  if [[ "$name" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
+    printf "%s" "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  printf ""
+}
+
 latest_dir() {
   local root best best_ver dir ver
   root="$1"
@@ -99,8 +117,7 @@ latest_dir() {
   shopt -s nullglob
   for dir in "$root"/aether_*; do
     [ -d "$dir" ] || continue
-    [ -f "$dir/.aether_web_version" ] || continue
-    ver="$(tr -d '[:space:]' <"$dir/.aether_web_version")"
+    ver="$(dir_version "$dir")"
     [ -n "$ver" ] || continue
     if [ -z "$best" ] || [ "$(cmp "$best_ver" "$ver")" = "lt" ]; then
       best="$dir"
@@ -112,15 +129,8 @@ latest_dir() {
 }
 
 active_dir() {
-  local root dir v
+  local root
   root="$1"
-  if [ -f "$root/.aether_web_version" ]; then
-    v="$(tr -d '[:space:]' <"$root/.aether_web_version")"
-    if [ -n "$v" ] && [ -d "$root/aether_$v" ]; then
-      printf "%s" "$root/aether_$v"
-      return 0
-    fi
-  fi
   printf "%s" "$(latest_dir "$root")"
 }
 
@@ -148,8 +158,7 @@ prune_versions() {
   shopt -s nullglob
   for dir in "$root"/aether_*; do
     [ -d "$dir" ] || continue
-    [ -f "$dir/.aether_web_version" ] || continue
-    ver="$(tr -d '[:space:]' <"$dir/.aether_web_version")"
+    ver="$(dir_version "$dir")"
     [ -n "$ver" ] || continue
     items+=("$ver|$dir")
   done
@@ -243,18 +252,19 @@ cmp() {
 
 pick() {
   local dir ver best best_ver item
-  if [ -f "\$root/.aether_web_version" ]; then
-    ver="\$(tr -d '[:space:]' <"\$root/.aether_web_version")"
-    if [ -n "\$ver" ] && [ -f "\$root/aether_\$ver/Aether.command" ]; then
-      printf "%s" "\$root/aether_\$ver"
-      return 0
-    fi
-  fi
   shopt -s nullglob
   for item in "\$root"/aether_*; do
     [ -d "\$item" ] || continue
-    [ -f "\$item/.aether_web_version" ] || continue
-    ver="\$(tr -d '[:space:]' <"\$item/.aether_web_version")"
+    ver=""
+    if [ -f "\$item/.aether_web_version" ]; then
+      ver="\$(tr -d '[:space:]' <"\$item/.aether_web_version")"
+    fi
+    if [ -z "\$ver" ]; then
+      dir="\$(basename "\$item")"
+      if [[ "\$dir" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
+        ver="\${BASH_REMATCH[1]}"
+      fi
+    fi
     [ -n "\$ver" ] || continue
     if [ -z "\${best:-}" ] || [ "\$(cmp "\$best_ver" "\$ver")" = "lt" ]; then
       best="\$item"
@@ -392,7 +402,7 @@ if [ -f "$uv" ]; then
   xattr -cr "$uv" >/dev/null 2>&1 || true
 fi
 printf "%s\n" "$ver" >"$target/.aether_web_version"
-printf "%s\n" "$ver" >"$work/.aether_web_version"
+rm -f "$work/.aether_web_version" >/dev/null 2>&1 || true
 
 rm -rf "$work/current" >/dev/null 2>&1 || true
 write_launch "$work"

--- a/Update/update_linux.sh
+++ b/Update/update_linux.sh
@@ -135,6 +135,24 @@ has_dir() {
   return 1
 }
 
+dir_version() {
+  local dir name ver
+  dir="$1"
+  if [ -f "$dir/.aether_web_version" ]; then
+    ver="$(tr -d '[:space:]' <"$dir/.aether_web_version")"
+    if [ -n "$ver" ]; then
+      printf "%s" "$ver"
+      return 0
+    fi
+  fi
+  name="$(basename "$dir")"
+  if [[ "$name" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
+    printf "%s" "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  printf ""
+}
+
 latest_dir() {
   local root best best_ver dir ver
   root="$1"
@@ -143,8 +161,7 @@ latest_dir() {
   shopt -s nullglob
   for dir in "$root"/aether_*; do
     [ -d "$dir" ] || continue
-    [ -f "$dir/.aether_web_version" ] || continue
-    ver="$(tr -d '[:space:]' <"$dir/.aether_web_version")"
+    ver="$(dir_version "$dir")"
     [ -n "$ver" ] || continue
     if [ -z "$best" ] || [ "$(cmp "$best_ver" "$ver")" = "lt" ]; then
       best="$dir"
@@ -156,15 +173,8 @@ latest_dir() {
 }
 
 active_dir() {
-  local root dir ver
+  local root
   root="$1"
-  if [ -f "$root/.aether_web_version" ]; then
-    ver="$(tr -d '[:space:]' <"$root/.aether_web_version")"
-    if [ -n "$ver" ] && [ -d "$root/aether_$ver" ]; then
-      printf "%s" "$root/aether_$ver"
-      return 0
-    fi
-  fi
   printf "%s" "$(latest_dir "$root")"
 }
 
@@ -180,8 +190,7 @@ prune_versions() {
   shopt -s nullglob
   for dir in "$root"/aether_*; do
     [ -d "$dir" ] || continue
-    [ -f "$dir/.aether_web_version" ] || continue
-    ver="$(tr -d '[:space:]' <"$dir/.aether_web_version")"
+    ver="$(dir_version "$dir")"
     [ -n "$ver" ] || continue
     items+=("$ver|$dir")
   done
@@ -418,18 +427,19 @@ cmp() {
 
 pick() {
   local dir ver best best_ver item
-  if [ -f "\$root/.aether_web_version" ]; then
-    ver="\$(tr -d '[:space:]' <"\$root/.aether_web_version")"
-    if [ -n "\$ver" ] && [ -f "\$root/aether_\$ver/Aether.sh" ]; then
-      printf "%s" "\$root/aether_\$ver"
-      return 0
-    fi
-  fi
   shopt -s nullglob
   for item in "\$root"/aether_*; do
     [ -d "\$item" ] || continue
-    [ -f "\$item/.aether_web_version" ] || continue
-    ver="\$(tr -d '[:space:]' <"\$item/.aether_web_version")"
+    ver=""
+    if [ -f "\$item/.aether_web_version" ]; then
+      ver="\$(tr -d '[:space:]' <"\$item/.aether_web_version")"
+    fi
+    if [ -z "\$ver" ]; then
+      dir="\$(basename "\$item")"
+      if [[ "\$dir" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
+        ver="\${BASH_REMATCH[1]}"
+      fi
+    fi
     [ -n "\$ver" ] || continue
     if [ -z "\${best:-}" ] || [ "\$(cmp "\$best_ver" "\$ver")" = "lt" ]; then
       best="\$item"
@@ -533,7 +543,7 @@ mv "$next" "$target" || exit "$run_err"
 
 chmod +x "$target/aether" "$target/Aether.sh" 2>/dev/null || true
 printf "%s\n" "$ver" > "$target/.aether_web_version"
-printf "%s\n" "$ver" > "$work/.aether_web_version"
+rm -f "$work/.aether_web_version" 2>/dev/null || true
 
 rm -rf "$work/current" 2>/dev/null || true
 

--- a/Update/update_windows.bat
+++ b/Update/update_windows.bat
@@ -136,10 +136,6 @@ exit /b 0
 set "OLD="
 for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$root=$env:WORK; $pick=Get-ChildItem -Path $root -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { $ver=''; if(Test-Path (Join-Path $_.FullName '.aether_web_version')){ $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim() }; if(-not $ver -and $_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ $ver=$matches[1] }; if($ver){ [PSCustomObject]@{ Dir=$_.FullName; Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending | Select-Object -First 1 -ExpandProperty Dir; if($pick){ [Console]::Write($pick) }"`) do set "OLD=%%i"
 if defined OLD exit /b 0
-for /d %%i in ("%WORK%\aether_*") do (
-  for /f "usebackq delims=" %%j in (`powershell -NoProfile -Command "$dir=$env:DIR; $name=[IO.Path]::GetFileName($dir); $ver=''; if(Test-Path (Join-Path $dir '.aether_web_version')){ $ver=(Get-Content (Join-Path $dir '.aether_web_version') -TotalCount 1).Trim() }; if(-not $ver -and $name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ $ver=$matches[1] }; if($ver){ [Console]::Write($ver) }"`) do set "OLD=%%~fi"
-  if defined OLD exit /b 0
-)
 exit /b 0
 
 :pick_pkg

--- a/Update/update_windows.bat
+++ b/Update/update_windows.bat
@@ -12,6 +12,9 @@ for %%i in ("%SELF%\..") do set "WORK=%%~fi"
 set "PRUNE=0"
 set "LAUNCH="
 set "NOTE="
+set "CUR="
+set "CMP="
+set "RV="
 
 if /I not "%BASE%"=="downloads" (
   echo Spec error: update_windows.bat must be placed in ...\aether\downloads. Current: %SELF%
@@ -38,6 +41,15 @@ if errorlevel 1 (
 set "TARGET=%WORK%\aether_%VER%"
 echo [1/4] Package: %PKG_NAME%
 echo       Target version: %VER%
+
+call :installed "%WORK%" CUR
+if defined CUR (
+  call :cmp "%CUR%" "%VER%"
+  if /I "!CMP!"=="eq" (
+    echo [2/4] Version %VER% is already installed. Skipping install.
+    exit /b 0
+  )
+)
 
 set "TMP=%TEMP%\aether-install-%RANDOM%%RANDOM%"
 set "EX=%TMP%\extract"
@@ -67,7 +79,7 @@ if exist "%TARGET%" rmdir /s /q "%TARGET%" >nul 2>nul
 move "%NEXT%" "%TARGET%" >nul || goto :fail
 
 echo %VER%>"%TARGET%\.aether_web_version"
-echo %VER%>"%WORK%\.aether_web_version"
+if exist "%WORK%\.aether_web_version" del /f /q "%WORK%\.aether_web_version" >nul 2>nul
 
 if exist "%WORK%\current" rmdir "%WORK%\current" >nul 2>nul
 if exist "%WORK%\current" rmdir /s /q "%WORK%\current" >nul 2>nul
@@ -92,7 +104,7 @@ exit /b 0
 set "CMD=%TARGET%\Aether.vbs"
 set "OUT=%TEMP%\aether-launch-%RANDOM%%RANDOM%.txt"
 if exist "%OUT%" del /f /q "%OUT%" >nul 2>nul
-powershell -NoProfile -Command "$cmd=$env:CMD; $out=$env:OUT; $w=New-Object -ComObject WScript.Shell; $desk=[Environment]::GetFolderPath('DesktopDirectory'); if(-not $desk){ $desk=$w.SpecialFolders.Item('Desktop') }; $menu=[Environment]::GetFolderPath('Programs'); if(-not $menu){ $menu=Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs' }; $desk2=[Environment]::GetFolderPath('CommonDesktopDirectory'); $menu2=[Environment]::GetFolderPath('CommonPrograms'); $all=@($desk,$menu,$desk2,$menu2) | Where-Object { $_ } | Select-Object -Unique; foreach($dir in $all){ $lnk=Join-Path $dir 'Aether.lnk'; try { if(Test-Path $lnk){ Remove-Item -LiteralPath $lnk -Force -ErrorAction Stop } } catch {} }; $mk={ param($path,$target) try { $dir=Split-Path -Parent $path; if($dir -and -not (Test-Path $dir)){ New-Item -ItemType Directory -Path $dir -Force | Out-Null }; if(Test-Path $path){ Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue }; $s=$w.CreateShortcut($path); $s.TargetPath=$target; $s.WorkingDirectory=(Split-Path -Parent $target); $s.Save(); if(-not (Test-Path $path)){ return $false }; $hit=$w.CreateShortcut($path); return $hit.TargetPath -eq $target } catch { return $false } }; $launch=''; $note=''; $desk_ok=$false; $menu_ok=$false; if($desk){ $desk_ok=& $mk (Join-Path $desk 'Aether.lnk') $cmd }; if($menu){ $menu_ok=& $mk (Join-Path $menu 'Aether.lnk') $cmd }; if($desk_ok){ $launch=Join-Path $desk 'Aether.lnk'; $note='Double-click Aether.vbs on your desktop to run it.' } elseif($menu_ok){ $launch=Join-Path $menu 'Aether.lnk'; $note='Run Aether.vbs from the Start Menu.' } else { $launch=$cmd; $note='Shortcut creation failed. Open File Explorer, find this path, and double-click the file to run it.' }; [IO.File]::WriteAllLines($out, @($launch,$note))"
+powershell -NoProfile -Command "$cmd=$env:CMD; $out=$env:OUT; $w=New-Object -ComObject WScript.Shell; $desk=[Environment]::GetFolderPath('DesktopDirectory'); if(-not $desk){ $desk=$w.SpecialFolders.Item('Desktop') }; $menu=[Environment]::GetFolderPath('Programs'); if(-not $menu){ $menu=Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs' }; $desk2=[Environment]::GetFolderPath('CommonDesktopDirectory'); $menu2=[Environment]::GetFolderPath('CommonPrograms'); $all=@($desk,$menu,$desk2,$menu2) | Where-Object { $_ } | Select-Object -Unique; foreach($dir in $all){ $lnk=Join-Path $dir 'Aether.lnk'; try { if(Test-Path $lnk){ Remove-Item -LiteralPath $lnk -Force -ErrorAction Stop } } catch {} }; $mk={ param($path,$target) try { $dir=Split-Path -Parent $path; if($dir -and -not (Test-Path $dir)){ New-Item -ItemType Directory -Path $dir -Force | Out-Null }; if(Test-Path $path){ Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue }; $s=$w.CreateShortcut($path); $s.TargetPath=$target; $s.WorkingDirectory=(Split-Path -Parent $target); $s.Save(); if(-not (Test-Path $path)){ return $false }; $hit=$w.CreateShortcut($path); return $hit.TargetPath -eq $target } catch { return $false } }; $launch=''; $note=''; $desk_ok=$false; $menu_ok=$false; $desk2_ok=$false; $menu2_ok=$false; if($desk){ $desk_ok=& $mk (Join-Path $desk 'Aether.lnk') $cmd }; if($menu){ $menu_ok=& $mk (Join-Path $menu 'Aether.lnk') $cmd }; if($desk2){ $desk2_ok=& $mk (Join-Path $desk2 'Aether.lnk') $cmd }; if($menu2){ $menu2_ok=& $mk (Join-Path $menu2 'Aether.lnk') $cmd }; if($desk_ok){ $launch=Join-Path $desk 'Aether.lnk'; $note='Double-click Aether.vbs on your desktop to run it.' } elseif($desk2_ok){ $launch=Join-Path $desk2 'Aether.lnk'; $note='Double-click Aether.vbs on your desktop to run it.' } elseif($menu_ok){ $launch=Join-Path $menu 'Aether.lnk'; $note='Run Aether.vbs from the Start Menu.' } elseif($menu2_ok){ $launch=Join-Path $menu2 'Aether.lnk'; $note='Run Aether.vbs from the Start Menu.' } else { $launch=$cmd; $note='Shortcut creation failed. Open File Explorer, find this path, and double-click the file to run it.' }; [IO.File]::WriteAllLines($out, @($launch,$note))"
 set "LAUNCH=%CMD%"
 set "NOTE=Shortcut creation failed. Open File Explorer, find this path, and double-click the file to run it."
 if exist "%OUT%" (
@@ -122,20 +134,11 @@ exit /b 0
 
 :active_dir
 set "OLD="
-if exist "%WORK%\.aether_web_version" (
-  set /p RV=<"%WORK%\.aether_web_version"
-  if exist "%WORK%\aether_%RV%\.aether_web_version" (
-    set "OLD=%WORK%\aether_%RV%"
-    exit /b 0
-  )
-)
-for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$root=$env:WORK; $pick=Get-ChildItem -Path $root -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | Where-Object { Test-Path (Join-Path $_.FullName '.aether_web_version') } | ForEach-Object { $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim(); if($ver){ [PSCustomObject]@{ Dir=$_.FullName; Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending | Select-Object -First 1 -ExpandProperty Dir; if($pick){ [Console]::Write($pick) }"`) do set "OLD=%%i"
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$root=$env:WORK; $pick=Get-ChildItem -Path $root -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { $ver=''; if(Test-Path (Join-Path $_.FullName '.aether_web_version')){ $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim() }; if(-not $ver -and $_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ $ver=$matches[1] }; if($ver){ [PSCustomObject]@{ Dir=$_.FullName; Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending | Select-Object -First 1 -ExpandProperty Dir; if($pick){ [Console]::Write($pick) }"`) do set "OLD=%%i"
 if defined OLD exit /b 0
 for /d %%i in ("%WORK%\aether_*") do (
-  if exist "%%~fi\.aether_web_version" (
-    set "OLD=%%~fi"
-    exit /b 0
-  )
+  for /f "usebackq delims=" %%j in (`powershell -NoProfile -Command "$dir=$env:DIR; $name=[IO.Path]::GetFileName($dir); $ver=''; if(Test-Path (Join-Path $dir '.aether_web_version')){ $ver=(Get-Content (Join-Path $dir '.aether_web_version') -TotalCount 1).Trim() }; if(-not $ver -and $name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ $ver=$matches[1] }; if($ver){ [Console]::Write($ver) }"`) do set "OLD=%%~fi"
+  if defined OLD exit /b 0
 )
 exit /b 0
 
@@ -161,6 +164,22 @@ for /f "usebackq tokens=1,2,3 delims=|" %%i in (`powershell -NoProfile -Command 
 if not defined PKG exit /b 1
 exit /b 0
 
+:cmp
+set "A=%~1"
+set "B=%~2"
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$a=$env:A; $b=$env:B; function norm([string]$v){ if($null -eq $v -or $v -eq ''){ return $null }; $v=$v.Trim(); $v=$v -replace '^v',''; $v=$v.Split('-')[0]; $p=$v.Split('.'); while($p.Count -lt 4){ $p += '0' }; if($p.Count -gt 4){ $p=$p[0..3] }; [string]::Join('.', $p) }; $x=norm $a; $y=norm $b; if($null -eq $x -or $null -eq $y){ if($a -eq $b){ 'eq' } else { 'lt' }; exit 0 }; if(([version]$x) -lt ([version]$y)){ 'lt' } elseif(([version]$x) -gt ([version]$y)){ 'gt' } else { 'eq' }"`) do set "CMP=%%i"
+exit /b 0
+
+:installed
+set "%~2="
+set "DIR=%~1"
+set "RV="
+for %%i in ("%DIR%") do set "NAME=%%~nxi"
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$name=$env:NAME; if($name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ [Console]::Write($matches[1]) }"`) do set "%~2=%%i"
+if defined %~2 exit /b 0
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$root=$env:DIR; $best=Get-ChildItem -Path $root -Directory -ErrorAction SilentlyContinue | ForEach-Object { $ver=''; if(Test-Path (Join-Path $_.FullName '.aether_web_version')){ $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim() }; if(-not $ver -and $_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ $ver=$matches[1] }; if($ver){ [PSCustomObject]@{ Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending | Select-Object -First 1 -ExpandProperty Ver; if($best){ [Console]::Write($best) }"`) do set "%~2=%%i"
+exit /b 0
+
 :fail
 echo Update failed.
 call :clean_tmp
@@ -172,6 +191,6 @@ if exist "%NEXT%" rmdir /s /q "%NEXT%" >nul 2>nul
 exit /b 0
 
 :prune_versions
-for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "& { $root=$env:WORK; $keep=5; $hold=[IO.Path]::GetFullPath($env:TARGET); $items=Get-ChildItem -Path $root -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | Where-Object { Test-Path (Join-Path $_.FullName '.aether_web_version') } | ForEach-Object { $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim(); if($ver){ [PSCustomObject]@{ Dir=$_.FullName; Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending; $keepers=New-Object System.Collections.Generic.List[string]; foreach($dir in @($hold)){ if($dir -and ($items | Where-Object { $_.Dir -eq $dir }) -and -not $keepers.Contains($dir)){ $keepers.Add($dir) } }; foreach($item in $items){ if($keepers.Count -ge $keep){ break }; if(-not $keepers.Contains($item.Dir)){ $keepers.Add($item.Dir) } }; $gone=0; foreach($item in $items){ if($keepers.Contains($item.Dir)){ continue }; Remove-Item $item.Dir -Recurse -Force -ErrorAction SilentlyContinue; if(-not (Test-Path $item.Dir)){ $gone++ } }; Write-Output $gone }"`) do set "PRUNE=%%i"
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "& { $root=$env:WORK; $keep=5; $hold=[IO.Path]::GetFullPath($env:TARGET); $items=Get-ChildItem -Path $root -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { $ver=''; if(Test-Path (Join-Path $_.FullName '.aether_web_version')){ $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim() }; if(-not $ver -and $_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ $ver=$matches[1] }; if($ver){ [PSCustomObject]@{ Dir=$_.FullName; Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending; $keepers=New-Object System.Collections.Generic.List[string]; foreach($dir in @($hold)){ if($dir -and ($items | Where-Object { $_.Dir -eq $dir }) -and -not $keepers.Contains($dir)){ $keepers.Add($dir) } }; foreach($item in $items){ if($keepers.Count -ge $keep){ break }; if(-not $keepers.Contains($item.Dir)){ $keepers.Add($item.Dir) } }; $gone=0; foreach($item in $items){ if($keepers.Contains($item.Dir)){ continue }; Remove-Item $item.Dir -Recurse -Force -ErrorAction SilentlyContinue; if(-not (Test-Path $item.Dir)){ $gone++ } }; Write-Output $gone }"`) do set "PRUNE=%%i"
 if not defined PRUNE set "PRUNE=0"
 exit /b 0


### PR DESCRIPTION
### Issue for this PR

Closes #269

### Type of change

- [x] Bug fix
- [x] Refactor / code improvement
- [ ] New feature
- [ ] Documentation

### What does this PR do?

This removes the offline installer/update flow's dependency on the root `.aether_web_version` marker.

Instead of reading the root marker to decide which version is installed or active, the scripts now resolve versions from the installed package directories themselves. For darwin and linux, the update launchers, installer checks, and version pruning logic now derive versions from each `aether_<version>` directory and its package-local marker. For windows, the installer and updater now do the same when checking installed versions, active versions, and retained versions.

The root `.aether_web_version` file is no longer written as part of the update flow. Existing stale copies are removed during install/update so version selection depends only on the package directories, which are the actual source of truth.

### How did you verify your code works?

- Ran `bash -n Update/update_darwin.command`
- Ran `bash -n Update/aether_darwin_installer.command`
- Ran `bash -n Update/aether_darwin_installer_devtest.command`
- Ran `bash -n Update/update_linux.sh`
- Ran `bash -n Update/aether_linux_installer.sh`
- Ran `bash -n Update/aether_linux_installer_devtest.sh`
- Ran a local mock darwin update flow and confirmed a deliberately wrong root `.aether_web_version` value did not affect the installed or launched version
- Reviewed the corresponding windows installer/update logic changes for root marker removal

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
