### PR TITLE
ci: restore windows unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,37 @@ jobs:
       - name: Run app unit tests
         run: bun --cwd packages/app test:unit
 
+  # Restore Windows coverage using the same hosted runner family already used by publish.yml.
+  app-unit-windows:
+    name: app unit (windows)
+    runs-on: windows-2022
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Configure git identity
+        run: |
+          git config --global user.email "bot@opencode.ai"
+          git config --global user.name "opencode"
+
+      - name: Run app unit tests
+        run: bun --cwd packages/app test:unit
+
   # Second-layer CI: keep core package tests visible even while they are still failing.
   # This is intentional: these failures represent real product/test issues, not runner noise.
   opencode-unit:
@@ -66,11 +97,40 @@ jobs:
           OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: "true"
         run: bun test --timeout 30000
 
-  # Windows test jobs are intentionally not part of the current required CI baseline.
-  # The repository contains symlinks that fail during checkout on GitHub-hosted Windows
-  # runners with "Filename too long", so keeping them here as required jobs would only
-  # add infrastructure noise before tests even start.
-  #
-  # App E2E is also intentionally excluded from the current required CI baseline.
+  opencode-unit-windows:
+    name: opencode unit (windows)
+    runs-on: windows-2022
+    timeout-minutes: 20
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Configure git identity
+        run: |
+          git config --global user.email "bot@opencode.ai"
+          git config --global user.name "opencode"
+
+      - name: Run opencode unit tests
+        working-directory: packages/opencode
+        env:
+          OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: "true"
+        run: bun test --timeout 30000
+
+  # App E2E is intentionally excluded from the current required CI baseline.
   # The local E2E harness currently fails to acquire an ephemeral port in CI and needs
   # its own stabilization pass before it can serve as a trustworthy correctness gate.

--- a/docs/ci-guide.md
+++ b/docs/ci-guide.md
@@ -22,7 +22,7 @@
   - 仓库设置：
     - 必须启用 GitHub Actions
     - 因 job 需要 `checks: write`，`Settings -> Actions -> General -> Workflow permissions` 需要设为 `Read and write permissions`
-    - 如果组织限制了可用 action，需要放行 `actions/checkout@v4`、`oven-sh/setup-bun@v2`、`actions/cache@v4`
+    - 如果组织限制了可用 action，需要放行 `actions/checkout@v4`、`actions/setup-node@v4`、`oven-sh/setup-bun@v2`、`actions/cache@v4`
   - Repository variables：无
   - Repository secrets：无自定义项；使用系统自带 `GITHUB_TOKEN`
   - 可选但常见的仓库配置：
@@ -41,18 +41,29 @@
     - 配置 git 身份
     - 执行 `bun --cwd packages/app test:unit`
     - 该命令实际会跑 `packages/app` 下的 `bun test --preload ./happydom.ts ./src`
+  - `app-unit-windows`
+    - 运行在 GitHub Hosted `windows-2022`
+    - 先调用 `actions/setup-node@v4` 固定 Node `24`，再调用 `.github/actions/setup-bun`
+    - 配置 git 身份
+    - 执行 `bun --cwd packages/app test:unit`
   - `opencode-unit`
     - checkout 仓库
     - 调用 `.github/actions/setup-bun`
     - 在 `packages/opencode` 下设置 `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER=true`
     - 执行 `bun test --timeout 30000`
     - 这条 job 设置了 `20` 分钟超时
+  - `opencode-unit-windows`
+    - 运行在 GitHub Hosted `windows-2022`
+    - 先调用 `actions/setup-node@v4` 固定 Node `24`，再调用 `.github/actions/setup-bun`
+    - 配置 git 身份
+    - 在 `packages/opencode` 下设置 `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER=true`
+    - 执行 `bun test --timeout 30000`
+    - 同样设置了 `20` 分钟超时
 - 作用：
-  - 为 `packages/app` 和 `packages/opencode` 提供持续的单元测试校验
+  - 为 `packages/app` 和 `packages/opencode` 提供 Linux 与 Windows 两个平台的持续单元测试校验
   - 把较稳定的前端单测与核心包单测分开展示，便于区分问题来源
 - 备注：
   - workflow 注释明确说明：
-    - Windows 测试当前不纳入 required baseline，原因是仓库 symlink 在 GitHub Hosted Windows runner 上会遇到 checkout 阶段的 `Filename too long`
     - app E2E 当前也不纳入 required baseline，原因是 CI 中临时端口分配尚未稳定
 
 #### `typecheck.yml`

--- a/packages/opencode/src/storage/legacy-db.ts
+++ b/packages/opencode/src/storage/legacy-db.ts
@@ -1,6 +1,7 @@
 import { Database as Sqlite } from "bun:sqlite"
 import fs from "fs/promises"
 import path from "path"
+import { setTimeout as sleep } from "node:timers/promises"
 import z from "zod"
 import { Flag } from "@/flag/flag"
 import { Global } from "@/global"
@@ -61,6 +62,28 @@ async function versions(file: string) {
     }
   } catch {
     return {}
+  }
+}
+
+function lock(err: unknown) {
+  return typeof err === "object" && err !== null && "code" in err && ["EBUSY", "EPERM"].includes(String(err.code))
+}
+
+async function copy(src: string, dst: string) {
+  if (process.platform !== "win32") {
+    await fs.copyFile(src, dst)
+    return
+  }
+
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      await fs.copyFile(src, dst)
+      return
+    } catch (err) {
+      if (!lock(err) || attempt >= 9) throw err
+      Bun.gc(true)
+      await sleep(100)
+    }
   }
 }
 
@@ -156,7 +179,7 @@ export namespace LegacyDB {
     if (stat) return
     const file = await latest()
     if (!file) return
-    await fs.copyFile(file.path, target)
+    await copy(file.path, target)
     await Promise.all([copySidecar(file.path, target, "shm"), copySidecar(file.path, target, "wal")])
     return file.path
   }

--- a/packages/opencode/src/tool/path.test.ts
+++ b/packages/opencode/src/tool/path.test.ts
@@ -31,6 +31,8 @@ describe("resolveInput", () => {
   })
 
   test("resolves a relative path from the root", () => {
+    // path.resolve() uses Windows semantics on native Windows; skip this WSL-only test
+    if (process.platform === "win32") return
     expect(resolveInput("/home/st_97142/Aether", "docs/paper.pdf", "5.15.167.4-microsoft-standard-WSL2")).toBe(
       "/home/st_97142/Aether/docs/paper.pdf",
     )

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -2,7 +2,7 @@ import { chmod, mkdir, readFile, writeFile } from "fs/promises"
 import { createWriteStream, existsSync, statSync } from "fs"
 import { lookup } from "mime-types"
 import { realpathSync } from "fs"
-import { dirname, join, relative, resolve as pathResolve } from "path"
+import { dirname, isAbsolute, join, relative, resolve as pathResolve } from "path"
 import { Readable } from "stream"
 import { pipeline } from "stream/promises"
 import { Glob } from "./glob"
@@ -142,11 +142,16 @@ export namespace Filesystem {
   export function overlaps(a: string, b: string) {
     const relA = relative(a, b)
     const relB = relative(b, a)
+    if (process.platform === "win32" && (isAbsolute(relA) || isAbsolute(relB))) return false
     return !relA || !relA.startsWith("..") || !relB || !relB.startsWith("..")
   }
 
   export function contains(parent: string, child: string) {
-    return !relative(parent, child).startsWith("..")
+    const rel = relative(parent, child)
+    // On Windows, path.relative() returns an absolute path when paths are on
+    // different drives. Such paths are never contained within the parent.
+    if (process.platform === "win32" && isAbsolute(rel)) return false
+    return !rel.startsWith("..")
   }
 
   export async function findUp(target: string, start: string, stop?: string) {

--- a/packages/opencode/test/storage/legacy-db.test.ts
+++ b/packages/opencode/test/storage/legacy-db.test.ts
@@ -7,11 +7,23 @@ import { LegacyDB } from "../../src/storage/legacy-db"
 
 async function clean() {
   const rows = await fs.readdir(Global.Path.data, { withFileTypes: true }).catch(() => [])
-  await Promise.all(
-    rows
-      .filter((row) => row.isFile() && /^.*\.db(?:-shm|-wal)?$/i.test(row.name))
-      .map((row) => fs.rm(path.join(Global.Path.data, row.name), { force: true })),
-  )
+  const files = rows
+    .filter((row) => row.isFile() && /^.*\.db(?:-shm|-wal)?$/i.test(row.name))
+    .map((row) => path.join(Global.Path.data, row.name))
+  // Windows can keep SQLite WAL handles alive after db.close() until GC runs.
+  // Retry with forced GC to avoid flaky EBUSY (same pattern as test/preload.ts).
+  for (const file of files) {
+    for (let attempt = 0; attempt < 10; attempt++) {
+      try {
+        await fs.rm(file, { force: true })
+        break
+      } catch (e: any) {
+        if (e?.code !== "EBUSY" || attempt >= 9) throw e
+        Bun.gc(true)
+        await new Promise((r) => setTimeout(r, 100))
+      }
+    }
+  }
 }
 
 function create(file: string, rows: { id: string; title: string; version: string; time: number }[]) {


### PR DESCRIPTION
### Issue for this PR

Closes #272

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Restores Windows unit coverage in `.github/workflows/test.yml` without pulling in the upstream Blacksmith-based test workflow.

This PR adds GitHub Hosted `windows-2022` jobs for the existing app and opencode unit checks, keeps the current Linux jobs unchanged, and uses `actions/setup-node@v4` with Node 24 before the shared Bun setup to match the Windows CI stability fix used upstream.

After the first Windows CI run exposed opencode-specific failures, this branch also adds a follow-up Windows-only fix:
- tighten Windows cross-drive path checks in `Filesystem.contains()` and `Filesystem.overlaps()`
- skip a WSL-only `resolveInput()` test on native Windows
- harden legacy SQLite DB copying on Windows with retry-on-lock behavior
- deflake the LegacyDB cleanup test logic for Windows WAL/SHM handle release

It also updates `docs/ci-guide.md` so the workflow documentation matches the restored Windows coverage and no longer claims that Windows unit tests are excluded because of the old checkout-time path-length issue.

### How did you verify your code works?

- Ran `bun test:unit` in `packages/app` successfully
- Ran `bun test src/tool/path.test.ts` in `packages/opencode`
- Ran `bun test test/file/path-traversal.test.ts` in `packages/opencode`
- Ran `bun test test/storage/legacy-db.test.ts` in `packages/opencode`
- Pre-push `bun turbo typecheck` completed successfully
- Ran `git diff --check`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR