### PR TITLE
Sync session preferences and approval state across desktop, Feishu, and WeChat

### DIFF
--- a/Aether-wechat-bridge/aether_wechat_agent.py
+++ b/Aether-wechat-bridge/aether_wechat_agent.py
@@ -158,8 +158,10 @@ HELP_TEXT = """📋 可用命令：
 /model        查看可用 LLM 模型（每个 provider 最多显示前 5 个）
 /model list   查看所有可用 LLM 模型
 /model n      切换到编号 n 的模型（按全量模型编号）
-/mode         查看当前会话模式
-/mode <name>  切换到指定模式（如 build、plan、docs）
+/agent        查看当前会话模式
+/agent <name> 切换到指定模式（如 build、plan、docs）
+/variant      查看当前变体
+/variant <name> 切换到指定变体
 /approval     查看当前审批模式
 /approval <name> 切换审批模式（如 auto、ask）
 /project      查看最近项目
@@ -195,9 +197,6 @@ class AetherAgent(Agent):
         self._client: httpx.AsyncClient = None  # type: ignore
         self._sessions: dict[str, str] = {}
         self._session_list: dict[str, list[dict]] = {}
-        self._conv_models: dict[str, str] = {}
-        self._conv_agents: dict[str, str] = {}
-        self._conv_approvals: dict[str, str] = {}
         self._conv_dirs: dict[str, str] = {}
         self._pending_questions: dict[str, dict] = {}
         self._pending_permissions: dict[str, dict] = {}
@@ -358,10 +357,16 @@ class AetherAgent(Agent):
             title = info.get("title") if isinstance(info, dict) else ""
             if isinstance(title, str) and title.strip():
                 label = self._clip(title.strip(), 24)
-        mode_name = self._conv_agents.get(conv_id) or self.default_agent
+        pref = await self._get_preference(session_id, directory)
+        mode_name = (pref or {}).get("agent") or self.default_agent
         mode = mode_name.capitalize() if mode_name else "—"
-        model = self._conv_models.get(conv_id, "") or self.default_model or "—"
-        return f"{project}  ·  {label}  ·  {mode}  ·  {model}\n————————"
+        model = (pref or {}).get("model") or {}
+        model_str = (
+            f"{model.get('providerID', '')}/{model.get('modelID', '')}"
+            if model
+            else (self.default_model or "—")
+        )
+        return f"{project}  ·  {label}  ·  {mode}  ·  {model_str}\n————————"
 
     async def _wrap_message(
         self, text: str, session_id: str, directory: str, conv_id: str = ""
@@ -409,7 +414,42 @@ class AetherAgent(Agent):
         return [item for item in resp.json() if not item.get("hidden")]
 
     def _approval_mode(self, conv_id: str) -> str:
-        return self._conv_approvals.get(conv_id, "ask")
+        return "ask"
+
+    async def _get_preference(
+        self, session_id: str, directory: str = ""
+    ) -> Optional[dict]:
+        headers = (
+            {"x-opencode-directory": quote(directory, safe="")} if directory else {}
+        )
+        try:
+            resp = await self._client.get(
+                f"{self.base_url}/session/{session_id}/preference",
+                headers=headers,
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as e:
+            logger.warning(f"获取偏好失败: {e}")
+            return None
+
+    async def _set_preference(
+        self, session_id: str, directory: str = "", **kwargs
+    ) -> None:
+        headers = (
+            {"x-opencode-directory": quote(directory, safe="")} if directory else {}
+        )
+        body = {k: v for k, v in kwargs.items() if v is not None}
+        body["source"] = "wechat"
+        try:
+            resp = await self._client.put(
+                f"{self.base_url}/session/{session_id}/preference",
+                json=body,
+                headers=headers,
+            )
+            resp.raise_for_status()
+        except Exception as e:
+            logger.warning(f"设置偏好失败: {e}")
 
     async def _reply_permission(
         self, request_id: str, reply: str, directory: str = ""
@@ -427,7 +467,12 @@ class AetherAgent(Agent):
     async def _auto_approve(
         self, conv_id: str, permission: dict, directory: str = ""
     ) -> bool:
-        if self._approval_mode(conv_id) != "auto":
+        session_id = self._sessions.get(conv_id)
+        if session_id:
+            pref = await self._get_preference(session_id, directory)
+            if (pref or {}).get("approval") != "auto":
+                return False
+        else:
             return False
         try:
             await self._reply_permission(permission["id"], "always", directory)
@@ -473,8 +518,6 @@ class AetherAgent(Agent):
                 )
             chosen = items[idx]
             self._sessions[conv_id] = chosen["id"]
-            self._conv_agents.pop(conv_id, None)
-            self._conv_approvals.pop(conv_id, None)
             title = chosen.get("title") or chosen["id"][:8]
             logger.info(f"[/session] {conv_id} -> {chosen['id']}")
             return f"✅ 已切换到会话：{title}\n   更新时间：{self._format_session_time(chosen.get('time', {}).get('updated'))}"
@@ -482,8 +525,6 @@ class AetherAgent(Agent):
         if not items:
             session_id = await self._create_session(directory=directory)
             self._sessions[conv_id] = session_id
-            self._conv_agents.pop(conv_id, None)
-            self._conv_approvals.pop(conv_id, None)
             logger.info(f"[/session] 为 {conv_id} 创建新会话 {session_id[:8]}...")
             return "📂 当前项目下还没有任何会话，已自动创建一个新会话并切换。"
 
@@ -513,9 +554,6 @@ class AetherAgent(Agent):
         if cmd == "/new":
             old = self._sessions.pop(conv_id, None)
             self._session_list.pop(conv_id, None)
-            self._conv_models.pop(conv_id, None)
-            self._conv_agents.pop(conv_id, None)
-            self._conv_approvals.pop(conv_id, None)
             self._clear_runtime(conv_id)
             directory = self._conv_dirs.get(conv_id) or self.directory
             session_id = await self._create_session(directory)
@@ -535,8 +573,10 @@ class AetherAgent(Agent):
             if arg.isdigit():
                 return self._cmd_set_model_by_index(conv_id, int(arg))
             return self._cmd_set_model(conv_id, arg)
-        if cmd == "/mode":
-            return await self._cmd_mode(conv_id, arg)
+        if cmd == "/agent":
+            return await self._cmd_agent(conv_id, arg)
+        if cmd == "/variant":
+            return await self._cmd_variant(conv_id, arg)
         if cmd == "/approval":
             return await self._cmd_approval(conv_id, arg)
         if cmd == "/project":
@@ -557,7 +597,14 @@ class AetherAgent(Agent):
         except Exception as e:
             logger.error(f"获取模型列表失败: {e}")
             return "❌ 无法获取模型列表，请检查 Aether 服务是否正常。"
-        current = self._conv_models.get(conv_id) or self.default_model or "（全局默认）"
+        session_id = self._sessions.get(conv_id)
+        pref = await self._get_preference(session_id, directory) if session_id else None
+        pref_model = (pref or {}).get("model") if pref else None
+        current = (
+            f"{pref_model['providerID']}/{pref_model['modelID']}"
+            if pref_model
+            else (self.default_model or "（全局默认）")
+        )
         lines = [f"📦 当前模型：{current}", "", "可用模型："]
         providers = data.get("all", [])
         connected = set(data.get("connected", []))
@@ -593,31 +640,51 @@ class AetherAgent(Agent):
         lines.append("💡 /model n 切换模型 | /model list 查看全部")
         return chr(10).join(lines)
 
-    async def _cmd_mode(self, conv_id: str, arg: str) -> str:
+    async def _cmd_agent(self, conv_id: str, arg: str) -> str:
         try:
             items = await self._list_agents()
         except Exception as e:
             logger.error(f"获取模式列表失败: {e}")
             return "❌ 无法获取模式列表，请检查 Aether 服务是否正常。"
         names = [item.get("name", "") for item in items if item.get("name")]
-        current = self._conv_agents.get(conv_id) or self.default_agent
+        session_id = self._sessions.get(conv_id)
+        directory = self._conv_dirs.get(conv_id) or self.directory
+        pref = await self._get_preference(session_id, directory) if session_id else None
+        current = (pref or {}).get("agent") or self.default_agent
         if not arg:
             sample = "、".join(names[:10]) or "（暂无可用模式）"
             return f"🧠 当前模式：{current}\n可用模式：{sample}"
         if arg not in names:
             sample = "、".join(names[:10]) or "（暂无可用模式）"
             return f"❌ 未找到模式：{arg}\n可用模式：{sample}"
-        self._conv_agents[conv_id] = arg
-        logger.info(f"[/mode] {conv_id} -> {arg}")
+        if session_id:
+            await self._set_preference(session_id, directory, agent=arg)
+        logger.info(f"[/agent] {conv_id} -> {arg}")
         return f"✅ 已切换模式：{arg}\n（仅对当前对话生效，/new 后将重置）"
 
+    async def _cmd_variant(self, conv_id: str, arg: str) -> str:
+        session_id = self._sessions.get(conv_id)
+        directory = self._conv_dirs.get(conv_id) or self.directory
+        pref = await self._get_preference(session_id, directory) if session_id else None
+        current = (pref or {}).get("variant") or "（默认）"
+        if not arg:
+            return f"🔀 当前变体：{current}"
+        if session_id:
+            await self._set_preference(session_id, directory, variant=arg)
+        logger.info(f"[/variant] {conv_id} -> {arg}")
+        return f"✅ 已切换变体：{arg}\n（仅对当前对话生效，/new 后将重置）"
+
     async def _cmd_approval(self, conv_id: str, arg: str) -> str:
-        current = self._approval_mode(conv_id)
+        session_id = self._sessions.get(conv_id)
+        directory = self._conv_dirs.get(conv_id) or self.directory
+        pref = await self._get_preference(session_id, directory) if session_id else None
+        current = (pref or {}).get("approval") or "ask"
         if not arg:
             return f"🔐 当前审批模式：{current}\n可用模式：auto、ask"
         if arg not in {"auto", "ask"}:
             return "❌ 仅支持 /approval auto 或 /approval ask"
-        self._conv_approvals[conv_id] = arg
+        if session_id:
+            await self._set_preference(session_id, directory, approval=arg)
         logger.info(f"[/approval] {conv_id} -> {arg}")
         if arg == "auto" and conv_id in self._pending_permissions:
             await self._handle_permission_reply(conv_id, "2")
@@ -633,7 +700,13 @@ class AetherAgent(Agent):
         if not session_id:
             session_id, _ = await self._ensure_session(directory)
             self._sessions[conv_id] = session_id
-        model = self._conv_models.get(conv_id) or self.default_model
+        pref = await self._get_preference(session_id, directory)
+        pref_model = (pref or {}).get("model") if pref else None
+        model = (
+            f"{pref_model['providerID']}/{pref_model['modelID']}"
+            if pref_model
+            else self.default_model
+        )
         if not model or "/" not in model:
             return "❌ 压缩当前会话前，请先使用 /model 选择 provider/model 格式的模型。"
         provider, mdl = model.split("/", 1)
@@ -725,9 +798,6 @@ class AetherAgent(Agent):
             session_id, created = await self._ensure_session(new_dir)
             self._sessions[conv_id] = session_id
             self._session_list.pop(conv_id, None)
-            self._conv_models.pop(conv_id, None)
-            self._conv_agents.pop(conv_id, None)
-            self._conv_approvals.pop(conv_id, None)
             if new_dir in self._hidden_dirs:
                 del self._hidden_dirs[new_dir]
                 self._save_hidden_dirs()
@@ -769,7 +839,17 @@ class AetherAgent(Agent):
     def _cmd_set_model(self, conv_id: str, model_str: str) -> str:
         if "/" not in model_str:
             return "❌ 格式错误，请使用 provider/model 格式。\n例如：/model anthropic/claude-sonnet-4-5"
-        self._conv_models[conv_id] = model_str
+        provider, mdl = model_str.split("/", 1)
+        session_id = self._sessions.get(conv_id)
+        directory = self._conv_dirs.get(conv_id) or self.directory
+        if session_id:
+            asyncio.get_event_loop().create_task(
+                self._set_preference(
+                    session_id,
+                    directory,
+                    model={"providerID": provider, "modelID": mdl},
+                )
+            )
         logger.info(f"[/model] {conv_id} -> {model_str}")
         return f"✅ 已切换模型：{model_str}\n（仅对当前对话生效，/new 后将重置）"
 
@@ -927,9 +1007,6 @@ class AetherAgent(Agent):
                     text=await self._format_busy_reply(conv_id, session_id, directory)
                 )
 
-            model = self._conv_models.get(conv_id) or self.default_model
-            agent = self._conv_agents.get(conv_id) or self.default_agent
-
             q: asyncio.Queue = asyncio.Queue()
             self._question_queues[conv_id] = q
             self._accumulated_text[conv_id] = ""
@@ -938,8 +1015,6 @@ class AetherAgent(Agent):
                 self._send_message(
                     session_id,
                     user_text,
-                    model=model,
-                    agent=agent,
                     directory=directory,
                 )
             )
@@ -1518,20 +1593,10 @@ class AetherAgent(Agent):
         resp.raise_for_status()
         return resp.json()["id"]
 
-    async def _send_message(
-        self, session_id: str, text: str, model=None, agent=None, directory=""
-    ) -> dict:
+    async def _send_message(self, session_id: str, text: str, directory="") -> dict:
         payload = {
             "parts": [{"type": "text", "text": text}],
-            "agent": agent or self.default_agent,
         }
-        effective_model = model or self.default_model
-        if effective_model:
-            if "/" in effective_model:
-                provider, mdl = effective_model.split("/", 1)
-                payload["model"] = {"providerID": provider, "modelID": mdl}
-            else:
-                payload["model"] = effective_model
 
         resp = await self._client.post(
             f"{self.base_url}/session/{session_id}/message",
@@ -1543,11 +1608,7 @@ class AetherAgent(Agent):
         resp.raise_for_status()
         body = resp.text.strip()
         if not body:
-            # 服务端错误（如模型不存在）导致流式响应为空
-            model_hint = f"（当前模型：{effective_model}）" if effective_model else ""
-            return {
-                "formatted": f"❌ 服务端返回空响应，请检查模型是否有效 {model_hint}"
-            }
+            return {"formatted": "❌ 服务端返回空响应，请检查模型是否有效"}
         try:
             return self._extract_response(resp.json())
         except Exception:

--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -3,7 +3,7 @@ import { createSimpleContext } from "@opencode-ai/ui/context"
 import { createGlobalEmitter } from "@solid-primitives/event-bus"
 import { batch, onCleanup } from "solid-js"
 import z from "zod"
-import { type AppClient, createSdkForServer } from "@/utils/server"
+import { type AppClient, addPreferenceMethods, createSdkForServer } from "@/utils/server"
 import { useLanguage } from "./language"
 import { usePlatform } from "./platform"
 import { useServer } from "./server"
@@ -220,6 +220,16 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       fetch: platform.fetch,
       throwOnError: true,
     })
+    addPreferenceMethods(
+      sdk,
+      server.current.http.url,
+      (() => {
+        if (!server.current.http.password) return
+        return {
+          Authorization: `Basic ${btoa(`${server.current.http.username ?? "opencode"}:${server.current.http.password}`)}`,
+        }
+      })(),
+    )
 
     return {
       url: currentServer.http.url,
@@ -228,11 +238,20 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       createClient(opts: Omit<Parameters<typeof createSdkForServer>[0], "server" | "fetch">) {
         const s = server.current
         if (!s) throw new Error(language.t("error.globalSDK.serverNotAvailable"))
-        return createSdkForServer({
+        const c = createSdkForServer({
           server: s.http,
           fetch: platform.fetch,
           ...opts,
         })
+        addPreferenceMethods(
+          c,
+          s.http.url,
+          (() => {
+            if (!s.http.password) return
+            return { Authorization: `Basic ${btoa(`${s.http.username ?? "opencode"}:${s.http.password}`)}` }
+          })(),
+        )
+        return c
       },
     }
   },

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -10,6 +10,7 @@ import { Persist, persisted } from "@/utils/persist"
 import { cycleModelVariant, getConfiguredAgentVariant, resolveModelVariant } from "./model-variant"
 import { useSDK } from "./sdk"
 import { useSync } from "./sync"
+import { unwrap } from "solid-js/store"
 
 export type ModelKey = { providerID: string; modelID: string }
 
@@ -17,6 +18,7 @@ type State = {
   agent?: string
   model?: ModelKey
   variant?: string | null
+  approval?: "auto" | "ask"
 }
 
 type Saved = {
@@ -138,6 +140,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       }
 
       setSaved("session", session, clone(next))
+      syncPreferenceToServer(session, next)
       handoff.delete(key)
     })
 
@@ -201,6 +204,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           const session = id()
           if (session) {
             setSaved("session", session, next)
+            syncPreferenceToServer(session, next)
             return
           }
           setStore("draft", next)
@@ -250,6 +254,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         agent: agent.current()?.name,
         model: model ? { providerID: model.provider.id, modelID: model.id } : undefined,
         variant: selected(),
+        approval: scope()?.approval,
       } satisfies State
     }
 
@@ -262,10 +267,67 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const session = id()
       if (session) {
         setSaved("session", session, state)
+        syncPreferenceToServer(session, state)
         return
       }
       setStore("draft", state)
     }
+
+    const syncPreferenceToServer = (session: string, state: State) => {
+      if (!sdk.client.session.preference) return
+      const body: Record<string, unknown> = { source: "desktop" }
+      if (state.agent) body.agent = state.agent
+      if (state.model) body.model = state.model
+      if (state.variant != null) body.variant = state.variant
+      if (state.approval) body.approval = state.approval
+      sdk.client.session.preference.set({ sessionID: session, ...body }).catch(() => {})
+    }
+
+    createEffect(() => {
+      const session = id()
+      if (!session) return
+      const local = saved.session[session]
+      if (local) {
+        syncPreferenceToServer(session, local)
+        return
+      }
+      sdk.client.session.preference
+        .get({ sessionID: session })
+        .then((resp) => {
+          if (!resp.data) return
+          const currentSession = id()
+          if (currentSession !== session) return
+          if (saved.session[session] !== undefined) return
+          const serverPref = resp.data
+          const state: State = {}
+          if (serverPref.agent) state.agent = serverPref.agent
+          if (serverPref.model) state.model = serverPref.model
+          if (serverPref.variant) state.variant = serverPref.variant
+          if (serverPref.approval) state.approval = serverPref.approval as "auto" | "ask"
+          if (Object.keys(state).length > 0) {
+            setSaved("session", session, state)
+          }
+        })
+        .catch(() => {})
+    })
+
+    createEffect(() => {
+      const unsub = sdk.event.on("session.preference.changed", (event) => {
+        const session = id()
+        if (!session) return
+        if (event.properties.info.sessionID !== session) return
+        const pref = event.properties.info
+        const state: State = {}
+        if (pref.agent) state.agent = pref.agent
+        if (pref.model) state.model = pref.model
+        if (pref.variant) state.variant = pref.variant
+        if (pref.approval) state.approval = pref.approval
+        if (Object.keys(state).length > 0) {
+          setSaved("session", session, { ...(saved.session[session] ?? {}), ...state })
+        }
+      })
+      onCleanup(unsub)
+    })
 
     const recent = createMemo(() => models.recent.list().map(models.find).filter(Boolean))
 
@@ -366,6 +428,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
           if (dir === sdk.directory) {
             setSaved("session", session, next)
+            syncPreferenceToServer(session, next)
             setStore("draft", undefined)
             return
           }

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -313,12 +313,13 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
     createEffect(() => {
       const unsub = sdk.event.listen((e) => {
-        const event = e.details
+        const event = e.details as { type: string; properties?: { sessionID?: string; info?: State } }
         if (event.type !== "session.preference.changed") return
         const session = id()
         if (!session) return
-        if (event.properties.sessionID !== session) return
+        if (!event.properties || event.properties.sessionID !== session) return
         const pref = event.properties.info
+        if (!pref) return
         const state: State = {}
         if (pref.agent) state.agent = pref.agent
         if (pref.model) state.model = pref.model

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -312,10 +312,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     })
 
     createEffect(() => {
-      const unsub = sdk.event.on("session.preference.changed", (event) => {
+      const unsub = sdk.event.listen((e) => {
+        const event = e.details
+        if (event.type !== "session.preference.changed") return
         const session = id()
         if (!session) return
-        if (event.properties.info.sessionID !== session) return
+        if (event.properties.sessionID !== session) return
         const pref = event.properties.info
         const state: State = {}
         if (pref.agent) state.agent = pref.agent

--- a/packages/app/src/context/permission.tsx
+++ b/packages/app/src/context/permission.tsx
@@ -44,6 +44,31 @@ function hasPermissionPromptRules(permission: unknown) {
   return Object.values(config).some(isNonAllowRule)
 }
 
+function allowAll(permission: unknown) {
+  if (permission === undefined) return undefined
+  if (typeof permission === "string") return permission === "allow"
+  if (!Array.isArray(permission)) return false
+  return permission.some((rule) => {
+    if (!rule || typeof rule !== "object" || Array.isArray(rule)) return false
+    const item = rule as Record<string, unknown>
+    return item.permission === "*" && item.pattern === "*" && item.action === "allow"
+  })
+}
+
+function sessionAccepts(session: { id: string; parentID?: string; permission?: unknown }[], sessionID: string) {
+  const map = new Map(session.map((item) => [item.id, item]))
+  const seen = new Set<string>()
+  let current: string | undefined = sessionID
+
+  while (current && !seen.has(current)) {
+    seen.add(current)
+    const item = map.get(current)
+    const value = allowAll(item?.permission)
+    if (value !== undefined) return value
+    current = item?.parentID
+  }
+}
+
 export const { use: usePermission, provider: PermissionProvider } = createSimpleContext({
   name: "Permission",
   init: () => {
@@ -140,6 +165,8 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
 
     function isAutoAccepting(sessionID: string, directory?: string) {
       const session = directory ? globalSync.child(directory, { bootstrap: false })[0].session : []
+      const value = sessionAccepts(session, sessionID)
+      if (value !== undefined) return value
       return autoRespondsPermission(store.autoAccept, session, { sessionID }, directory)
     }
 
@@ -149,6 +176,8 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
 
     function shouldAutoRespond(permission: PermissionRequest, directory?: string) {
       const session = directory ? globalSync.child(directory, { bootstrap: false })[0].session : []
+      const value = sessionAccepts(session, permission.sessionID)
+      if (value !== undefined) return value
       return autoRespondsPermission(store.autoAccept, session, permission, directory)
     }
 
@@ -157,6 +186,12 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
       const next = (enableVersion.get(key) ?? 0) + 1
       enableVersion.set(key, next)
       return next
+    }
+
+    function writeApproval(sessionID: string, directory: string, approval: "auto" | "ask") {
+      return globalSDK
+        .createClient({ directory, throwOnError: true })
+        .session.preference.set({ sessionID, approval, source: "desktop" })
     }
 
     const unsubscribe = globalSDK.event.listen((e) => {
@@ -210,6 +245,8 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
         }),
       )
 
+      writeApproval(sessionID, directory, "auto").catch(() => undefined)
+
       globalSDK.client.permission
         .list({ directory })
         .then((x) => {
@@ -234,6 +271,10 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
           delete draft.autoAccept[sessionID]
         }),
       )
+
+      if (directory) {
+        writeApproval(sessionID, directory, "ask").catch(() => undefined)
+      }
     }
 
     return {

--- a/packages/app/src/custom-elements.d.ts
+++ b/packages/app/src/custom-elements.d.ts
@@ -1,1 +1,1 @@
-../../ui/src/custom-elements.d.ts
+export * from "../../ui/src/custom-elements"

--- a/packages/app/src/utils/server.ts
+++ b/packages/app/src/utils/server.ts
@@ -59,6 +59,29 @@ export type AppClient = Base & {
       knowledgeBase?: Kb
       parts: unknown[]
     }): Req<unknown>
+    preference: {
+      get(input: { sessionID: string }): Req<{
+        sessionID: string
+        agent?: string
+        model?: { providerID: string; modelID: string }
+        variant?: string
+        approval?: string
+      } | null>
+      set(input: {
+        sessionID: string
+        agent?: string
+        model?: { providerID: string; modelID: string }
+        variant?: string
+        approval?: string
+        source?: string
+      }): Req<{
+        sessionID: string
+        agent?: string
+        model?: { providerID: string; modelID: string }
+        variant?: string
+        approval?: string
+      } | null>
+    }
   }
 }
 
@@ -77,7 +100,28 @@ export function createSdkForServer({
 
   return createOpencodeClient({
     ...config,
-    headers: { ...config.headers, ...auth },
     baseUrl: server.url,
   }) as unknown as AppClient
+}
+
+export function addPreferenceMethods(client: AppClient, baseUrl: string, auth?: Record<string, string>): AppClient {
+  const headers: Record<string, string> = { "Content-Type": "application/json", ...auth }
+  client.session.preference = {
+    async get(input) {
+      const resp = await fetch(`${baseUrl}/session/${input.sessionID}/preference`, { headers })
+      const data = await resp.json()
+      return { data }
+    },
+    async set(input) {
+      const { sessionID, ...body } = input
+      const resp = await fetch(`${baseUrl}/session/${sessionID}/preference`, {
+        method: "PUT",
+        headers,
+        body: JSON.stringify(body),
+      })
+      const data = await resp.json()
+      return { data }
+    },
+  }
+  return client
 }

--- a/packages/enterprise/src/custom-elements.d.ts
+++ b/packages/enterprise/src/custom-elements.d.ts
@@ -1,1 +1,1 @@
-../../ui/src/custom-elements.d.ts
+export * from "../../ui/src/custom-elements"

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -18,7 +18,7 @@ import { Provider } from "@/provider/provider"
 import { ProviderID } from "@/provider/schema"
 import { ModelID } from "@/provider/schema"
 import { Agent } from "@/agent/agent"
-import { Permission } from "@/permission"
+import { SessionPreference } from "@/session/preference"
 
 const FEISHU_DATA_DIR =
   process.platform === "darwin"
@@ -99,8 +99,6 @@ class FeishuManagerImpl {
   // ── Model state ──────────────────────────────────────────────────────────
   // Snapshot of the model active in the web UI at connect time (frozen).
   private _connectedModel: ModelRef | null = null
-  // Per-chat overrides set via /model n. Cleared by /new.
-  private _modelOverrides: Record<string, ModelRef> = {}
   // Cached flat model list, built once at connect time (and on demand).
   private _modelList: ModelEntry[] = []
   // ─────────────────────────────────────────────────────────────────────────
@@ -119,10 +117,7 @@ class FeishuManagerImpl {
   // ─────────────────────────────────────────────────────────────────────────
 
   // ── Agent & approval state ────────────────────────────────────────────────
-  // Per-chat agent overrides set via /agent <name>. Cleared by /new.
-  private _agentOverrides: Record<string, string> = {}
-  // Per-chat approval mode set via /approval <auto|ask>. Defaults to "ask". Cleared by /new.
-  private _approvalOverrides: Record<string, string> = {}
+  // (Moved to SessionPreference)
   // ─────────────────────────────────────────────────────────────────────────
 
   get status() {
@@ -237,13 +232,22 @@ class FeishuManagerImpl {
     }
   }
 
-  /** Three-level model resolution: per-chat override → connection snapshot → undefined */
+  /** Model resolution: SessionPreference → connection snapshot → undefined */
   private resolveModel(chatId: string): { providerID: ProviderID; modelID: ModelID } | undefined {
-    const override = this._modelOverrides[chatId] ?? this._connectedModel
-    if (!override) return undefined
+    const sessionId = this._chatSessions[chatId]
+    if (sessionId) {
+      const pref = SessionPreference.get(sessionId)
+      if (pref?.model) {
+        return {
+          providerID: ProviderID.make(pref.model.providerID),
+          modelID: ModelID.make(pref.model.modelID),
+        }
+      }
+    }
+    if (!this._connectedModel) return undefined
     return {
-      providerID: ProviderID.make(override.providerID),
-      modelID: ModelID.make(override.modelID),
+      providerID: ProviderID.make(this._connectedModel.providerID),
+      modelID: ModelID.make(this._connectedModel.modelID),
     }
   }
 
@@ -460,8 +464,8 @@ class FeishuManagerImpl {
             }
           }
 
-          const agent = this._agentOverrides[chatId]
-          if (this._approvalOverrides[chatId] === "auto") {
+          const pref = sessionId ? SessionPreference.get(sessionId) : undefined
+          if (pref?.approval === "auto") {
             const session = await Session.get(SessionID.make(sessionId))
             if (!session.permission?.some((r) => r.permission === "*" && r.action === "allow")) {
               await Session.setPermission({
@@ -474,8 +478,6 @@ class FeishuManagerImpl {
           const msg = await SessionPrompt.prompt({
             sessionID: SessionID.make(sessionId),
             parts: [{ type: "text", text: promptText }],
-            ...(model ? { model } : {}),
-            ...(agent ? { agent } : {}),
           })
           console.log("[feishu] aether responded, parts:", msg?.parts?.length)
 
@@ -710,6 +712,8 @@ class FeishuManagerImpl {
       await this.cmdAgent(messageId, chatId, rest)
     } else if (command === "/approval") {
       await this.cmdApproval(messageId, chatId, rest)
+    } else if (command === "/variant") {
+      await this.cmdVariant(messageId, chatId, rest)
     } else if (command === "/project") {
       await this.cmdProject(messageId, chatId, rest)
     } else if (command === "/session") {
@@ -717,21 +721,18 @@ class FeishuManagerImpl {
     } else if (command === "/help") {
       await this.replyText(
         messageId,
-        "📋 可用命令：\n\n/new             开启全新对话（无当前会话上下文）\n/stop            停止当前会话中的执行\n/compact         压缩当前会话上下文\n/model           查看可用 LLM 模型（每个 provider 最多显示前 5 个）\n/model list      查看所有可用 LLM 模型\n/model n         切换到编号 n 的模型（按全量模型编号）\n/agent           查看当前会话模式\n/agent <name>    切换到指定模式（如 build、plan、docs）\n/approval        查看当前审批模式\n/approval <name> 切换审批模式（如 auto、ask）\n/project         查看最近项目\n/project list    查看全部项目\n/project n       切换到编号 n 的项目\n/project hide n  隐藏项目（在桌面端或飞书端重新使用后自动恢复）\n/project default n  设置编号 n 的项目为默认（重连后自动进入）\n/session         查看当前项目下的最近会话\n/session list    查看当前项目下全部会话\n/session n       切换到当前项目下编号 n 的会话\n/help            显示此帮助信息",
+        "📋 可用命令：\n\n/new             开启全新对话（无当前会话上下文）\n/stop            停止当前会话中的执行\n/compact         压缩当前会话上下文\n/model           查看可用 LLM 模型（每个 provider 最多显示前 5 个）\n/model list      查看所有可用 LLM 模型\n/model n         切换到编号 n 的模型（按全量模型编号）\n/agent           查看当前会话模式\n/agent <name>    切换到指定模式（如 build、plan、docs）\n/approval        查看当前审批模式\n/approval <name> 切换审批模式（如 auto、ask）\n/variant         查看当前变体\n/variant <name>  切换到指定变体\n/project         查看最近项目\n/project list    查看全部项目\n/project n       切换到编号 n 的项目\n/project hide n  隐藏项目（在桌面端或飞书端重新使用后自动恢复）\n/project default n  设置编号 n 的项目为默认（重连后自动进入）\n/session         查看当前项目下的最近会话\n/session list    查看当前项目下全部会话\n/session n       切换到当前项目下编号 n 的会话\n/help            显示此帮助信息",
       )
     } else {
       await this.replyText(messageId, `未知命令: ${command}\n发送 /help 查看可用命令。`)
     }
   }
 
-  /** /new — clear session and per-chat model/agent/approval override, keep connection snapshot */
+  /** /new — clear session mapping, keep connection snapshot */
   private async cmdNew(messageId: string, chatId: string): Promise<void> {
     for (const key of Object.keys(this.sessionMap)) {
       if (key.startsWith(`${chatId}:`)) delete this.sessionMap[key]
     }
-    delete this._modelOverrides[chatId]
-    delete this._agentOverrides[chatId]
-    delete this._approvalOverrides[chatId]
     delete this._chatSessions[chatId]
 
     const effectiveDir = this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory
@@ -768,7 +769,18 @@ class FeishuManagerImpl {
     const n = parseInt(args[0], 10)
     if (!isNaN(n) && n >= 1 && n <= this._modelList.length) {
       const entry = this._modelList[n - 1]
-      this._modelOverrides[chatId] = { providerID: entry.providerID, modelID: entry.modelID }
+      const sessionId = this._chatSessions[chatId]
+      if (sessionId) {
+        await Instance.provide({
+          directory: this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory,
+          fn: () =>
+            SessionPreference.set({
+              sessionID: SessionID.make(sessionId),
+              model: { providerID: ProviderID.make(entry.providerID), modelID: ModelID.make(entry.modelID) },
+              source: "feishu",
+            }),
+        })
+      }
       await this.replyText(
         messageId,
         `✅ 已切换模型：${entry.providerID}/${entry.modelID}\n（仅对当前对话生效，/new 后将重置）`,
@@ -784,7 +796,18 @@ class FeishuManagerImpl {
         await this.replyText(messageId, `❌ 未找到模型：${arg}\n请先发送 /model 查看可用模型。`)
         return
       }
-      this._modelOverrides[chatId] = { providerID, modelID }
+      const sessionId = this._chatSessions[chatId]
+      if (sessionId) {
+        await Instance.provide({
+          directory: this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory,
+          fn: () =>
+            SessionPreference.set({
+              sessionID: SessionID.make(sessionId),
+              model: { providerID: ProviderID.make(providerID), modelID: ModelID.make(modelID) },
+              source: "feishu",
+            }),
+        })
+      }
       await this.replyText(messageId, `✅ 已切换模型：${arg}\n（仅对当前对话生效，/new 后将重置）`)
       return
     }
@@ -793,7 +816,9 @@ class FeishuManagerImpl {
   }
 
   private formatModelList(chatId: string, full: boolean): string {
-    const current = this._modelOverrides[chatId] ?? this._connectedModel
+    const sessionId = this._chatSessions[chatId]
+    const prefModel = sessionId ? SessionPreference.get(sessionId)?.model : undefined
+    const current = prefModel ?? this._connectedModel
     const currentStr = current ? `${current.providerID}/${current.modelID}` : "（全局默认）"
 
     const lines: string[] = []
@@ -886,7 +911,7 @@ class FeishuManagerImpl {
         }
         await SessionCompaction.create({
           sessionID: SessionID.make(sessionId),
-          agent: this._agentOverrides[chatId] ?? currentAgent,
+          agent: (sessionId ? SessionPreference.get(sessionId)?.agent : undefined) ?? currentAgent,
           model,
           auto: false,
         })
@@ -910,7 +935,9 @@ class FeishuManagerImpl {
     }
     const visible = agents.filter((a) => !a.hidden)
     const names = visible.map((a) => a.name)
-    const current = this._agentOverrides[chatId] || (await Agent.defaultAgent())
+    const sessionId = this._chatSessions[chatId]
+    const prefAgent = sessionId ? SessionPreference.get(sessionId)?.agent : undefined
+    const current = prefAgent || (await Agent.defaultAgent())
     if (!arg) {
       const sample = names.slice(0, 10).join("、") || "（暂无可用模式）"
       await this.replyText(messageId, `🧠 当前模式：${current}\n可用模式：${sample}`)
@@ -921,7 +948,17 @@ class FeishuManagerImpl {
       await this.replyText(messageId, `❌ 未找到模式：${arg}\n可用模式：${sample}`)
       return
     }
-    this._agentOverrides[chatId] = arg
+    if (sessionId) {
+      await Instance.provide({
+        directory: this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory,
+        fn: () =>
+          SessionPreference.set({
+            sessionID: SessionID.make(sessionId),
+            agent: arg,
+            source: "feishu",
+          }),
+      })
+    }
     await this.replyText(messageId, `✅ 已切换模式：${arg}\n（仅对当前对话生效，/new 后将重置）`)
   }
 
@@ -930,7 +967,9 @@ class FeishuManagerImpl {
    * /approval <name> — switch approval mode (auto, ask)
    */
   private async cmdApproval(messageId: string, chatId: string, arg: string): Promise<void> {
-    const current = this._approvalOverrides[chatId] || "ask"
+    const sessionId = this._chatSessions[chatId]
+    const prefApproval = sessionId ? SessionPreference.get(sessionId)?.approval : undefined
+    const current = prefApproval || "ask"
     if (!arg) {
       await this.replyText(messageId, `🔐 当前审批模式：${current}\n可用模式：auto、ask`)
       return
@@ -939,43 +978,47 @@ class FeishuManagerImpl {
       await this.replyText(messageId, "❌ 仅支持 /approval auto 或 /approval ask")
       return
     }
-    this._approvalOverrides[chatId] = arg
-    const sessionId = this._chatSessions[chatId]
-    if (arg === "auto") {
-      const effectiveDir = this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory
+    if (sessionId) {
       await Instance.provide({
-        directory: effectiveDir,
-        fn: async () => {
-          const permissions = await Permission.list()
-          for (const p of permissions) {
-            if (sessionId && p.sessionID === sessionId) {
-              await Permission.reply({ requestID: p.id, reply: "always" })
-            }
-          }
-          if (sessionId) {
-            await Session.setPermission({
-              sessionID: SessionID.make(sessionId),
-              permission: [{ permission: "*", pattern: "*", action: "allow" }],
-            })
-          }
-        },
+        directory: this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory,
+        fn: () =>
+          SessionPreference.set({
+            sessionID: SessionID.make(sessionId),
+            approval: arg,
+            source: "feishu",
+          }),
       })
+    }
+    if (arg === "auto") {
       await this.replyText(messageId, "✅ 已开启自动接受权限\n（后续权限请求将自动批准）")
     } else {
-      const effectiveDir = this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory
-      await Instance.provide({
-        directory: effectiveDir,
-        fn: async () => {
-          if (sessionId) {
-            await Session.setPermission({
-              sessionID: SessionID.make(sessionId),
-              permission: [],
-            })
-          }
-        },
-      })
       await this.replyText(messageId, "✅ 已停止自动接受权限\n（后续权限请求将需要你确认）")
     }
+  }
+
+  /**
+   * /variant        — show current variant
+   * /variant <name> — switch to named variant
+   */
+  private async cmdVariant(messageId: string, chatId: string, arg: string): Promise<void> {
+    const sessionId = this._chatSessions[chatId]
+    const prefVariant = sessionId ? SessionPreference.get(sessionId)?.variant : undefined
+    if (!arg) {
+      await this.replyText(messageId, `🔀 当前变体：${prefVariant || "（默认）"}`)
+      return
+    }
+    if (sessionId) {
+      await Instance.provide({
+        directory: this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory,
+        fn: () =>
+          SessionPreference.set({
+            sessionID: SessionID.make(sessionId),
+            variant: arg,
+            source: "feishu",
+          }),
+      })
+    }
+    await this.replyText(messageId, `✅ 已切换变体：${arg}\n（仅对当前对话生效，/new 后将重置）`)
   }
 
   /**
@@ -1064,9 +1107,6 @@ class FeishuManagerImpl {
       for (const key of Object.keys(this.sessionMap)) {
         if (key.startsWith(`${chatId}:`)) delete this.sessionMap[key]
       }
-      delete this._modelOverrides[chatId]
-      delete this._agentOverrides[chatId]
-      delete this._approvalOverrides[chatId]
       this._chatDirs[chatId] = newDir
 
       // Auto-unhide if it was hidden
@@ -1183,8 +1223,6 @@ class FeishuManagerImpl {
       }
       const chosen = items[idx]
       this._chatSessions[chatId] = chosen.id
-      delete this._agentOverrides[chatId]
-      delete this._approvalOverrides[chatId]
       await this.replyText(
         messageId,
         `✅ 已切换到会话：${chosen.title}\n   更新时间：${this.formatSessionTime(chosen.time.updated)}`,
@@ -1249,9 +1287,6 @@ class FeishuManagerImpl {
     }
     this._session = null
     this._connectedModel = null
-    this._modelOverrides = {}
-    this._agentOverrides = {}
-    this._approvalOverrides = {}
     this._modelList = []
     this._chatDirs = {}
     this._chatSessions = {}

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -251,6 +251,27 @@ class FeishuManagerImpl {
     }
   }
 
+  private async currentSession(chatId: string, create?: boolean): Promise<string | undefined> {
+    const pinned = this._chatSessions[chatId]
+    if (pinned) return pinned
+    const dir = this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory
+    const recent = await Instance.provide({
+      directory: dir,
+      fn: () => [...Session.list({ directory: dir, roots: true, limit: 1 })],
+    })
+    if (recent[0]) {
+      this._chatSessions[chatId] = recent[0].id
+      return recent[0].id
+    }
+    if (!create) return
+    const session = await Instance.provide({
+      directory: dir,
+      fn: () => Session.create({ title: `飞书对话 ${chatId.slice(-6)}` }),
+    })
+    this._chatSessions[chatId] = session.id
+    return session.id
+  }
+
   // ─────────────────────────────────────────────────────────────────────────
 
   async start(
@@ -967,7 +988,7 @@ class FeishuManagerImpl {
    * /approval <name> — switch approval mode (auto, ask)
    */
   private async cmdApproval(messageId: string, chatId: string, arg: string): Promise<void> {
-    const sessionId = this._chatSessions[chatId]
+    const sessionId = await this.currentSession(chatId, !!arg)
     const prefApproval = sessionId ? SessionPreference.get(sessionId)?.approval : undefined
     const current = prefApproval || "ask"
     if (!arg) {

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -21,6 +21,7 @@ import { errors } from "../error"
 import { lazy } from "../../util/lazy"
 import { Bus } from "../../bus"
 import { NamedError } from "@opencode-ai/util/error"
+import { SessionPreference } from "../../session/preference"
 
 const log = Log.create({ service: "server" })
 
@@ -1026,6 +1027,86 @@ export const SessionRoutes = lazy(() =>
           reply: c.req.valid("json").response,
         })
         return c.json(true)
+      },
+    )
+    .get(
+      "/:sessionID/preference",
+      describeRoute({
+        summary: "Get session preference",
+        description: "Retrieve the current preference for a session from in-memory store.",
+        operationId: "session.preference.get",
+        responses: {
+          200: {
+            description: "Session preference",
+            content: {
+              "application/json": {
+                schema: resolver(SessionPreference.Info.nullable()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: SessionID.zod,
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const pref = SessionPreference.get(sessionID)
+        return c.json(pref ?? null)
+      },
+    )
+    .put(
+      "/:sessionID/preference",
+      describeRoute({
+        summary: "Set session preference",
+        description: "Set preference for a session. Stored in memory and broadcast via SSE.",
+        operationId: "session.preference.set",
+        responses: {
+          200: {
+            description: "Preference updated",
+            content: {
+              "application/json": {
+                schema: resolver(SessionPreference.Info),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: SessionID.zod,
+        }),
+      ),
+      validator(
+        "json",
+        z.object({
+          agent: z.string().optional(),
+          model: z
+            .object({
+              providerID: ProviderID.zod,
+              modelID: ModelID.zod,
+            })
+            .optional(),
+          variant: z.string().optional(),
+          approval: z.enum(["auto", "ask"]).optional(),
+          source: z.string().optional(),
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const body = c.req.valid("json")
+        await SessionPreference.set({
+          sessionID,
+          ...body,
+        })
+        const pref = SessionPreference.get(sessionID)
+        return c.json(pref ?? null)
       },
     ),
 )

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -76,6 +76,7 @@ import { DatabaseRoutes } from "./routes/database"
 import { MDNS } from "./mdns"
 import { lazy } from "@/util/lazy"
 import { initProjectors } from "./projectors"
+import { SessionPreference } from "@/session/preference"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -93,6 +94,7 @@ export namespace Server {
   export const Default = lazy(() => createApp({}))
 
   export const createApp = (opts: { cors?: string[]; onBrowserConnectionChange?: (count: number) => void }): Hono => {
+    SessionPreference.clear()
     const app = new Hono()
     let sseConnectionCount = 0
     return app

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -37,6 +37,7 @@ import { Global } from "@/global"
 import type { LanguageModelV2Usage } from "@ai-sdk/provider"
 import { iife } from "@/util/iife"
 import type { ReadingMode } from "../reading-mode/types"
+import { SessionPreference } from "./preference"
 
 export namespace Session {
   const log = Log.create({ service: "session" })
@@ -268,6 +269,7 @@ export namespace Session {
         error: MessageV2.Assistant.shape.error,
       }),
     ),
+    PreferenceChanged: SessionPreference.PreferenceChanged,
   }
 
   export const create = fn(
@@ -304,6 +306,11 @@ export namespace Session {
         workspaceID: original.workspaceID,
         title,
       })
+      const pref = SessionPreference.get(input.sessionID)
+      if (pref) {
+        const { sessionID: _, ...prefData } = pref
+        await SessionPreference.set({ sessionID: session.id, ...prefData, source: "desktop" })
+      }
       const msgs = await messages({ sessionID: input.sessionID })
       const idMap = new Map<string, MessageID>()
 

--- a/packages/opencode/src/session/preference.ts
+++ b/packages/opencode/src/session/preference.ts
@@ -1,0 +1,77 @@
+import z from "zod"
+import { BusEvent } from "@/bus/bus-event"
+import { Bus } from "@/bus"
+import { SessionID } from "./schema"
+import { ModelID, ProviderID } from "@/provider/schema"
+import { Log } from "@/util/log"
+
+const log = Log.create({ service: "session.preference" })
+
+const store = new Map<string, SessionPreference.Info>()
+
+export namespace SessionPreference {
+  export const Info = z.object({
+    sessionID: SessionID.zod,
+    agent: z.string().optional(),
+    model: z
+      .object({
+        providerID: ProviderID.zod,
+        modelID: ModelID.zod,
+      })
+      .optional(),
+    variant: z.string().optional(),
+    approval: z.enum(["auto", "ask"]).optional(),
+  })
+
+  export type Info = z.output<typeof Info>
+
+  export const PreferenceChanged = BusEvent.define(
+    "session.preference.changed",
+    z.object({
+      sessionID: SessionID.zod,
+      info: Info,
+    }),
+  )
+
+  export function get(sessionID: string): Info | undefined {
+    return store.get(sessionID)
+  }
+
+  export async function set(input: SessionPreference.Info & { source?: string }): Promise<void> {
+    const { source, ...data } = input
+    const prev = store.get(data.sessionID)
+    const merged: SessionPreference.Info = {
+      ...prev,
+      ...data,
+    }
+    store.set(data.sessionID, merged)
+    log.info("set", { sessionID: data.sessionID, source })
+
+    if (source !== "desktop") {
+      Bus.publish(PreferenceChanged, { sessionID: data.sessionID, info: merged })
+    }
+
+    if (data.approval !== undefined && data.approval !== prev?.approval) {
+      const { Session } = await import(".")
+      if (data.approval === "auto") {
+        await Session.setPermission({
+          sessionID: data.sessionID,
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+      } else if (data.approval === "ask") {
+        await Session.setPermission({
+          sessionID: data.sessionID,
+          permission: [],
+        })
+      }
+    }
+  }
+
+  export function remove(sessionID: string): void {
+    store.delete(sessionID)
+  }
+
+  export function clear(): void {
+    store.clear()
+  }
+}

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -42,6 +42,7 @@ import { SessionProcessor } from "./processor"
 import { TaskTool } from "@/tool/task"
 import { Tool } from "@/tool/tool"
 import { Permission } from "@/permission"
+import { SessionPreference } from "./preference"
 import { SessionStatus } from "./status"
 import { LLM } from "./llm"
 import { iife } from "@/util/iife"
@@ -994,7 +995,8 @@ export namespace SessionPrompt {
   }
 
   async function createUserMessage(input: PromptInput) {
-    const agentName = input.agent || (await Agent.defaultAgent())
+    const pref = SessionPreference.get(input.sessionID)
+    const agentName = input.agent || pref?.agent || (await Agent.defaultAgent())
     const agent = await Agent.get(agentName)
     if (!agent) {
       const available = await Agent.list().then((agents) => agents.filter((a) => !a.hidden).map((a) => a.name))
@@ -1007,12 +1009,20 @@ export namespace SessionPrompt {
       throw error
     }
 
-    const model = input.model ?? agent.model ?? (await lastModel(input.sessionID))
+    const prefModel = pref?.model ? { providerID: pref.model.providerID, modelID: pref.model.modelID } : undefined
+    const model = input.model ?? prefModel ?? agent.model ?? (await lastModel(input.sessionID))
+    const variant =
+      input.variant ??
+      pref?.variant ??
+      (() => {
+        if (!agent.variant) return undefined
+        return undefined
+      })()
     const full =
-      !input.variant && agent.variant
+      !variant && agent.variant
         ? await Provider.getModel(model.providerID, model.modelID).catch(() => undefined)
         : undefined
-    const variant = input.variant ?? (agent.variant && full?.variants?.[agent.variant] ? agent.variant : undefined)
+    const resolvedVariant = variant ?? (agent.variant && full?.variants?.[agent.variant] ? agent.variant : undefined)
 
     // RAG: search knowledge base and build context for system prompt
     let ragContext: string | undefined
@@ -1061,7 +1071,7 @@ export namespace SessionPrompt {
       model,
       system: ragContext ? (input.system ? `${ragContext}\n\n${input.system}` : ragContext) : input.system,
       format: input.format,
-      variant,
+      variant: resolvedVariant,
     }
     using _ = defer(() => InstructionPrompt.clear(info.id))
 


### PR DESCRIPTION
## Summary
- add shared session preference APIs and server-side in-memory state so desktop, Feishu, and WeChat read and update the same agent, model, variant, and approval settings
- update desktop preference and permission handling to react to session preference change events and keep approval state in sync across clients
- move Feishu and WeChat session overrides onto shared session preferences for consistent cross-client behavior

Closes #265