### PR TITLE
fix: find bundled default skills from binary directory on Mac

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1362,10 +1362,20 @@ export namespace Config {
   })
   export type DefaultSkill = z.infer<typeof DefaultSkill>
 
-  // Search upward from process.cwd() for .opencode/skills, calculated once at startup.
+  // Search for .opencode/skills, calculated once at startup.
   // This ensures the source skills dir is always the server's own project regardless of
   // which project the user is currently viewing.
+  // Priority: binary directory first (for packaged Mac/Win releases where skills are
+  // bundled next to the binary), then upward from process.cwd() (for dev/CLI usage).
   function findServerSkillsDirSync(): string | undefined {
+    // Check next to the binary first (handles compiled single-binary releases)
+    const binaryDir = path.dirname(process.execPath)
+    const binaryCandidate = path.join(binaryDir, ".opencode", "skills")
+    try {
+      if (statSync(binaryCandidate).isDirectory()) return binaryCandidate
+    } catch {}
+
+    // Fall back to searching upward from process.cwd() (dev environment)
     let dir = process.cwd()
     while (true) {
       const candidate = path.join(dir, ".opencode", "skills")


### PR DESCRIPTION
### Issue for this PR

Closes #281

### Type of change

- [x] Bug fix

### What does this PR do?

`findServerSkillsDirSync()` in `config.ts` used to search upward only from `process.cwd()`. On Mac, the launcher script (`Aether.command`) sets the binary path but does not `cd` into it, so `process.cwd()` is the user's home directory — which has no `.opencode/skills`. The function returned `undefined`, causing `listDefaultSkills()` to always return an empty array.

The fix adds a check of `path.dirname(process.execPath)` (the directory containing the binary) before falling back to the `process.cwd()` upward search. The build script already copies skills to `dist/{name}/bin/.opencode/skills` next to the binary, so this resolves correctly in packaged releases. In dev environments, `process.execPath` points to the `bun` runtime binary, which has no `.opencode/skills` beside it, so the fallback path is taken as before — no regression.

`paths.ts` already used `process.execPath` for config directory resolution; this change makes skills discovery consistent with that pattern.

### How did you verify your code works?

- Traced through the `Aether.command` launcher to confirm `process.cwd()` is not set to the binary directory.
- Confirmed the build script places skills at `dist/{name}/bin/.opencode/skills` (next to `process.execPath`).
- Verified `paths.ts` uses the same `path.dirname(process.execPath)` approach for config discovery, confirming the pattern is correct.
- Confirmed dev environment fallback is unaffected: `bun` binary directory has no `.opencode/skills`, so the `statSync` catch fires and the cwd upward search proceeds as before.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR