### PR TITLE
Fix/pr190

### DIFF
--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -172,18 +172,7 @@ async function initialize() {
   const loadingTask = (async () => {
     logger.log("sidecar connection started", { url })
 
-    events.on("sqlite", (progress: SqliteMigrationProgress) => {
-      setInitStep({ phase: "sqlite_waiting" })
-      if (overlay) sendSqliteMigrationProgress(overlay, progress)
-      if (mainWindow) sendSqliteMigrationProgress(mainWindow, progress)
-      if (progress.type === "Done") sqliteDone?.resolve()
-    })
-
-    if (needsMigration) {
-      await sqliteDone?.promise
-    }
-
-    await Promise.race([
+    const probe = Promise.race([
       health.wait,
       delay(30_000).then(() => {
         throw new Error("Sidecar health check timed out")
@@ -192,6 +181,19 @@ async function initialize() {
       logger.error("sidecar health check failed", error)
       sidecarFailed = true
     })
+
+    events.on("sqlite", (progress: SqliteMigrationProgress) => {
+      setInitStep({ phase: "sqlite_waiting" })
+      if (overlay) sendSqliteMigrationProgress(overlay, progress)
+      if (mainWindow) sendSqliteMigrationProgress(mainWindow, progress)
+      if (progress.type === "Done") sqliteDone?.resolve()
+    })
+
+    if (needsMigration) {
+      await Promise.race([sqliteDone!.promise, probe])
+    }
+
+    await probe
 
     logger.log("loading task finished")
   })()
@@ -371,9 +373,13 @@ async function getSidecarPort() {
 }
 
 function sqliteFileExists() {
+  const file = CHANNEL === "beta" ? "aether.db" : `aether-${CHANNEL}.db`
+  if (process.platform === "darwin" || process.platform === "win32") {
+    return existsSync(join(app.getPath("appData"), "opencode", file))
+  }
   const xdg = process.env.XDG_DATA_HOME
   const base = xdg && xdg.length > 0 ? xdg : join(homedir(), ".local", "share")
-  return existsSync(join(base, "opencode", "aether.db"))
+  return existsSync(join(base, "opencode", file))
 }
 
 function setupAutoUpdater() {

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -374,9 +374,6 @@ async function getSidecarPort() {
 
 function sqliteFileExists() {
   const file = CHANNEL === "beta" ? "aether.db" : `aether-${CHANNEL}.db`
-  if (process.platform === "darwin" || process.platform === "win32") {
-    return existsSync(join(app.getPath("appData"), "opencode", file))
-  }
   const xdg = process.env.XDG_DATA_HOME
   const base = xdg && xdg.length > 0 ? xdg : join(homedir(), ".local", "share")
   return existsSync(join(base, "opencode", file))


### PR DESCRIPTION
### Issue for this PR

Closes #189

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

这个 PR 修复了 mac 打包桌面应用在本机已经存在 prod 数据库时卡在 `Just a moment...` 启动页的问题。

问题的根因是 Electron 启动阶段检查了错误的数据库文件名和路径。打包脚本以 `prod` 渠道构建应用后，sidecar 实际使用的是 `aether-prod.db`，但桌面端之前检查的是 `aether.db`，而且在 macOS 上还可能去查错误的 XDG 路径。这样会让启动逻辑误以为还需要执行数据库迁移，并一直等待不会再发出的 sqlite 迁移完成事件。

这个修复做了两件事：
1. 按当前桌面渠道检查对应的数据库文件名，并在 macOS / Windows 上使用正确的 app data 目录。
2. 给启动等待流程增加 sidecar 健康检查兜底，避免在迁移判断出错时永久卡死。

### How did you verify your code works?

- 在 `packages/desktop-electron` 下执行 `"$HOME/.bun/bin/bun" typecheck`
- 在 `packages/desktop-electron` 下执行 `PATH="$HOME/.bun/bin:$PATH" "$HOME/.bun/bin/bun" run build`
- 在 `packages/opencode` 下执行 `PATH="$HOME/.bun/bin:$PATH" "$HOME/.bun/bin/bun" test ./test/storage/db.test.ts`
- 结合启动链路检查，确认已有 `prod` 数据库时不会再无限等待 sqlite 迁移完成事件

### Screenshots / recordings

未附带。本次修改位于 Electron 启动流程，界面表现主要是修复启动页卡死。

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR