### PR TITLE
feat: improve feishu and chat bridge session flow

### DIFF
--- a/Aether-wechat-bridge/aether_wechat_agent.py
+++ b/Aether-wechat-bridge/aether_wechat_agent.py
@@ -152,26 +152,58 @@ def output_qrcode_base64(qrcode_url: str) -> str:
 
 HELP_TEXT = """📋 可用命令：
 
-/new          开启全新对话（无当前会话上下文）
-/stop         停止当前会话中的执行
-/compact      压缩当前会话上下文
-/model        查看可用 LLM 模型（每个 provider 最多显示前 5 个）
-/model list   查看所有可用 LLM 模型
-/model n      切换到编号 n 的模型（按全量模型编号）
-/agent        查看当前会话模式
-/agent <name> 切换到指定模式（如 build、plan、docs）
-/variant      查看当前变体
-/variant <name> 切换到指定变体
-/approval     查看当前审批模式
-/approval <name> 切换审批模式（如 auto、ask）
-/project      查看最近项目
-/project list 查看全部项目
-/project n    切换到编号 n 的项目
-/project hide n  隐藏项目（在桌面端或微信端重新使用后自动恢复）
-/session      查看当前项目下的最近会话
-/session list 查看当前项目下全部会话
-/session n    切换到当前项目下编号 n 的会话
-/help         显示此帮助信息"""
+/n, /new      开启新对话
+/stop         停止当前执行
+/c, /compact  压缩当前上下文
+
+/m, /model    查看可用模型
+/m l          查看全部模型
+/m n          切换编号模型
+
+/a, /agent    查看当前模式
+/a <name>     切换指定模式
+
+/p, /project  查看最近项目
+/p l          查看全部项目
+/p n          切换编号项目
+
+/s, /session  查看最近会话
+/s l          查看全部会话
+/s n          切换编号会话
+
+/h, /help     显示帮助信息
+/help list    显示全部命令"""
+
+HELP_LIST_TEXT = """📋 全部命令：
+
+/n, /new           开启新对话
+/stop              停止当前执行
+/c, /compact       压缩当前上下文
+
+/m, /model         查看可用模型
+/m l, /model list  查看全部模型
+/m n, /model n     切换编号模型
+
+/a, /agent         查看当前模式
+/a <name>          切换指定模式
+
+/p, /project       查看最近项目
+/p l, /project list 查看全部项目
+/p n, /project n   切换编号项目
+/project hide n    隐藏指定项目
+
+/s, /session       查看最近会话
+/s l, /session list 查看全部会话
+/s n, /session n   切换编号会话
+
+/approval          查看审批模式
+/approval <name>   切换审批模式
+
+/variant           查看当前变体
+/variant <name>    切换指定变体
+
+/h, /help          显示帮助信息
+/help list         显示全部命令"""
 
 _HIDDEN_FILE: Path = (
     Path(SESSION_FILE).parent / "hidden_projects.json"
@@ -552,11 +584,11 @@ class AetherAgent(Agent):
         parts = stripped.split(maxsplit=1)
         cmd = parts[0].lower()
         arg = parts[1].strip() if len(parts) > 1 else ""
-        if cmd == "/help":
-            return HELP_TEXT
+        if cmd in {"/h", "/help"}:
+            return HELP_LIST_TEXT if arg == "list" else HELP_TEXT
         if cmd == "/stop":
             return await self._cmd_stop(conv_id)
-        if cmd == "/new":
+        if cmd in {"/n", "/new"}:
             old = self._sessions.pop(conv_id, None)
             self._session_list.pop(conv_id, None)
             self._clear_runtime(conv_id)
@@ -567,9 +599,11 @@ class AetherAgent(Agent):
                 logger.info(f"[/new] 清除会话 {old[:8]}... for {conv_id}")
             logger.info(f"[/new] 为 {conv_id} 创建新会话 {session_id[:8]}...")
             return "✅ 已开启新对话，上下文已清空。"
-        if cmd == "/compact":
+        if cmd in {"/c", "/compact"}:
             return await self._cmd_compact(conv_id)
-        if cmd == "/model":
+        if cmd in {"/m", "/model"}:
+            if arg == "l":
+                arg = "list"
             if not arg:
                 return await self._cmd_list_models(conv_id)
             if arg == "list":
@@ -578,15 +612,21 @@ class AetherAgent(Agent):
             if arg.isdigit():
                 return self._cmd_set_model_by_index(conv_id, int(arg))
             return self._cmd_set_model(conv_id, arg)
-        if cmd == "/agent":
+        if cmd in {"/a", "/agent"}:
             return await self._cmd_agent(conv_id, arg)
         if cmd == "/variant":
             return await self._cmd_variant(conv_id, arg)
         if cmd == "/approval":
             return await self._cmd_approval(conv_id, arg)
-        if cmd == "/project":
+        if cmd in {"/p", "/project"}:
+            if arg == "l":
+                arg = "list"
+            elif arg.startswith("h "):
+                arg = f"hide {arg[2:].strip()}"
             return await self._cmd_project(conv_id, arg)
-        if cmd == "/session":
+        if cmd in {"/s", "/session"}:
+            if arg == "l":
+                arg = "list"
             return await self._cmd_session(conv_id, arg)
         return f"❓ 未知命令：{cmd}，发送 /help 查看可用命令。"
 

--- a/Aether-wechat-bridge/aether_wechat_agent.py
+++ b/Aether-wechat-bridge/aether_wechat_agent.py
@@ -574,7 +574,7 @@ class AetherAgent(Agent):
             lines.append(f"{i}. {title}{tag}")
             lines.append(f"   {updated}")
         lines.append("")
-        lines.append("💡 /session n 切换会话 | /session list 查看全部")
+        lines.append("💡 /s n 切换会话 | /s l 查看全部")
         return chr(10).join(lines)
 
     async def _handle_slash_command(self, conv_id: str, text: str):
@@ -628,7 +628,7 @@ class AetherAgent(Agent):
             if arg == "l":
                 arg = "list"
             return await self._cmd_session(conv_id, arg)
-        return f"❓ 未知命令：{cmd}，发送 /help 查看可用命令。"
+        return f"❓ 未知命令：{cmd}\n发送 /help 查看常用命令，/help list 查看全部命令。"
 
     async def _cmd_list_models(self, conv_id: str, full: bool = False) -> str:
         try:
@@ -676,13 +676,13 @@ class AetherAgent(Agent):
                 lines.append(f"  {num}. {pid}/{model_id}{tag}")
             if not full and len(sorted_ids) > len(visible):
                 lines.append(
-                    f"  ... 还有 {len(sorted_ids) - len(visible)} 个，发送 /model list 查看全部"
+                    f"  ... 还有 {len(sorted_ids) - len(visible)} 个，发送 /m l 查看全部"
                 )
         self._model_list = model_list
         if len(lines) <= 5:
             lines.append("（暂无已配置的模型，请先在 Aether 中连接 provider）")
         lines.append("")
-        lines.append("💡 /model n 切换模型 | /model list 查看全部")
+        lines.append("💡 /m n 切换模型 | /m l 查看全部")
         return chr(10).join(lines)
 
     async def _cmd_agent(self, conv_id: str, arg: str) -> str:
@@ -726,7 +726,7 @@ class AetherAgent(Agent):
         auto = (pref or {}).get("autoAccept")
         if not arg:
             mode = "自动批准" if auto else "手动审批"
-            return f"🔐 当前审批模式：{mode}\n💡 /approval auto 自动批准 | /approval ask 手动审批"
+            return f"🔐 当前审批模式：{mode}\n可用模式：auto、ask"
         if arg not in {"auto", "ask"}:
             return "❌ 仅支持 /approval auto 或 /approval ask"
         if session_id:
@@ -820,7 +820,7 @@ class AetherAgent(Agent):
             self._hidden_dirs[directory] = int(datetime.now().timestamp() * 1000)
             self._save_hidden_dirs()
             name = self._project_name(target)
-            return f"✅ 已隐藏：{name}\n（在桌面端或微信端重新使用后自动恢复）"
+            return f"✅ 已隐藏：{name}\n（在桌面端或消息端重新使用后自动恢复）"
 
         if arg == "list":
             lines = ["📂 项目列表：", ""]
@@ -875,9 +875,7 @@ class AetherAgent(Agent):
             lines.append(f"{idx}. {self._project_name(item)}{tag}")
             lines.append(f"   {directory}")
         lines.append("")
-        lines.append(
-            "💡 /project n 切换 | /project list 查看全部 | /project hide n 隐藏"
-        )
+        lines.append("💡 /p n 切换 | /p l 查看全部")
         if self._hidden_dirs:
             lines.append(
                 f"ℹ️ 已隐藏 {len(self._hidden_dirs)} 个项目（重新使用后自动恢复）"

--- a/Aether-wechat-bridge/aether_wechat_agent.py
+++ b/Aether-wechat-bridge/aether_wechat_agent.py
@@ -239,6 +239,12 @@ class AetherAgent(Agent):
         except Exception as e:
             logger.warning(f"加载隐藏项目失败: {e}")
         try:
+            all_projects = await self._get_projects()
+            visible = [
+                p for p in all_projects if self._project_dir(p) not in self._hidden_dirs
+            ]
+            if visible:
+                self.directory = self._project_dir(visible[0])
             session_id, created = await self._ensure_session(self.directory)
             logger.info(
                 f"默认会话: {session_id[:8]}... dir={self.directory} created={created}"

--- a/Aether-wechat-bridge/aether_wechat_agent.py
+++ b/Aether-wechat-bridge/aether_wechat_agent.py
@@ -176,34 +176,57 @@ HELP_TEXT = """📋 可用命令：
 
 HELP_LIST_TEXT = """📋 全部命令：
 
-/n, /new           开启新对话
-/stop              停止当前执行
-/c, /compact       压缩当前上下文
+/n, /new
+  开启新对话，清空当前会话上下文
 
-/m, /model         查看可用模型
-/m l, /model list  查看全部模型
-/m n, /model n     切换编号模型
+/stop
+  停止当前执行中的任务
 
-/a, /agent         查看当前模式
-/a <name>          切换指定模式
+/c, /compact
+  压缩当前会话上下文
 
-/p, /project       查看最近项目
-/p l, /project list 查看全部项目
-/p n, /project n   切换编号项目
-/project hide n    隐藏指定项目
+/m, /model
+  查看可用模型
+/m l, /model list
+  查看全部模型（l = list）
+/m n, /model n
+  切换到编号 n 的模型（n 为全量模型编号）
 
-/s, /session       查看最近会话
-/s l, /session list 查看全部会话
-/s n, /session n   切换编号会话
+/a, /agent
+  查看当前模式
+/a <name>, /agent <name>
+  切换模式（如 build、plan、docs）
 
-/approval          查看审批模式
-/approval <name>   切换审批模式
+/p, /project
+  查看最近项目
+/p l, /project list
+  查看全部项目（l = list）
+/p n, /project n
+  切换到编号 n 的项目
+/project hide n
+  隐藏编号 n 的项目，重新在桌面端或消息端使用后自动恢复
 
-/variant           查看当前变体
-/variant <name>    切换指定变体
+/s, /session
+  查看最近会话
+/s l, /session list
+  查看当前项目下全部会话（l = list）
+/s n, /session n
+  切换到当前项目下编号 n 的会话
 
-/h, /help          显示帮助信息
-/help list         显示全部命令"""
+/approval
+  查看审批模式
+/approval <name>
+  切换审批模式（name 可选：auto、ask）
+
+/variant
+  查看当前变体
+/variant <name>
+  切换到指定变体（name 为变体名）
+
+/h, /help
+  显示常用命令
+/help list
+  显示全部命令"""
 
 _HIDDEN_FILE: Path = (
     Path(SESSION_FILE).parent / "hidden_projects.json"

--- a/Aether-wechat-bridge/aether_wechat_agent.py
+++ b/Aether-wechat-bridge/aether_wechat_agent.py
@@ -446,9 +446,8 @@ class AetherAgent(Agent):
             {"x-opencode-directory": quote(directory, safe="")} if directory else {}
         )
         body = {k: v for k, v in kwargs.items() if v is not None}
-        body["source"] = "wechat"
         try:
-            resp = await self._client.put(
+            resp = await self._client.patch(
                 f"{self.base_url}/session/{session_id}/preference",
                 json=body,
                 headers=headers,
@@ -476,7 +475,7 @@ class AetherAgent(Agent):
         session_id = self._sessions.get(conv_id)
         if session_id:
             pref = await self._get_preference(session_id, directory)
-            if (pref or {}).get("approval") != "auto":
+            if not (pref or {}).get("autoAccept"):
                 return False
         else:
             return False
@@ -684,13 +683,16 @@ class AetherAgent(Agent):
         session_id = self._sessions.get(conv_id)
         directory = self._conv_dirs.get(conv_id) or self.directory
         pref = await self._get_preference(session_id, directory) if session_id else None
-        current = (pref or {}).get("approval") or "ask"
+        auto = (pref or {}).get("autoAccept")
         if not arg:
-            return f"🔐 当前审批模式：{current}\n可用模式：auto、ask"
+            mode = "自动批准" if auto else "手动审批"
+            return f"🔐 当前审批模式：{mode}\n💡 /approval auto 自动批准 | /approval ask 手动审批"
         if arg not in {"auto", "ask"}:
             return "❌ 仅支持 /approval auto 或 /approval ask"
         if session_id:
-            await self._set_preference(session_id, directory, approval=arg)
+            await self._set_preference(
+                session_id, directory, autoAccept=(arg == "auto")
+            )
         logger.info(f"[/approval] {conv_id} -> {arg}")
         if arg == "auto" and conv_id in self._pending_permissions:
             await self._handle_permission_reply(conv_id, "2")

--- a/docs/feishu-architecture.md
+++ b/docs/feishu-architecture.md
@@ -5,6 +5,7 @@
 Aether 通过飞书官方 SDK 的 **WebSocket 长连接模式**，在本地与飞书服务器建立实时通信。用户在飞书中给机器人发消息，Aether 本地接收并调用 AI 处理后，通过飞书 API 回复。
 
 核心特点：
+
 - **无需公网地址**：本地主动连接飞书服务器，不需要 webhook 或云端部署
 - **内置实现**：TypeScript 原生集成，非子进程方案
 - **体验一致**：与微信连接的使用流程完全对齐
@@ -82,37 +83,37 @@ idle ──▶ starting ──▶ connected
   └───── error ◀───────────┘
 ```
 
-| 状态 | 含义 |
-|------|------|
-| `idle` | 未连接，等待用户操作 |
-| `starting` | 正在建立 WebSocket 连接 |
-| `connected` | 连接成功，正常接收消息 |
-| `error` | 连接失败或运行时错误 |
+| 状态        | 含义                    |
+| ----------- | ----------------------- |
+| `idle`      | 未连接，等待用户操作    |
+| `starting`  | 正在建立 WebSocket 连接 |
+| `connected` | 连接成功，正常接收消息  |
+| `error`     | 连接失败或运行时错误    |
 
 #### 关键方法
 
-| 方法 | 职责 |
-|------|------|
-| `start(config?, model?)` | 入口。加载或接收配置和模型，触发连接 |
-| `_doStart(config, model)` | 实际连接逻辑：创建 SDK 客户端、注册事件、启动 WebSocket、设置连接模型 |
-| `handleMessage(data)` | 接收飞书消息 → 过滤 @mention → 映射会话 → 解析模型 → 调用 AI → 回复 |
-| `handleCommand(text)` | 分发 `/new`、`/model`、`/help` 等斜杠命令 |
-| `cmdNew(messageId, chatId)` | 清除会话映射和本聊天的模型 override，立即新建会话 |
-| `cmdModel(messageId, chatId, args)` | 无参数列出模型，有参数切换本聊天的模型 |
-| `cmdProject(messageId, chatId, arg)` | 查看/切换/隐藏项目，完整对齐微信端逻辑 |
-| `buildModelList()` | 调用 `Provider.list()` 展平成编号列表，供 `/model` 使用 |
-| `resolveModel(chatId)` | 三级模型解析：per-chat override → 连接快照 → undefined |
-| `getProjects()` | 调用 `Project.recentList()` 并过滤根目录，与微信端 `GET /project/recent` 数据一致 |
-| `replyText(messageId, text)` | 通过飞书 REST API 回复文本消息 |
-| `replyFile(messageId, filePath)` | 用 native fetch 上传本地文件并以附件形式回复 |
-| `getTenantAccessToken()` | 用 native fetch 获取 tenant_access_token（绕过 SDK axios） |
-| `detectFileSendIntent(text)` | 检测用户是否在索要文件（含"发给我/源文件/原文件"等词） |
-| `extractReadFiles(msg)` | 从 AI 响应的 ToolPart 中提取被读取的文件路径 |
-| `extractFilePathsFromText(text)` | 从文本中用正则提取存在于磁盘的绝对路径 |
-| `detectSummaryIntent(text)` | 检测用户是否在请求群聊总结，返回时间范围和条数 |
-| `fetchChatHistory(chatId, opts)` | 调用飞书 message.list API 拉取群聊历史并格式化 |
-| `stop()` | 断开 WebSocket，清理客户端和所有模型状态 |
-| `clearSession()` | 删除本地配置和会话映射文件 |
+| 方法                                 | 职责                                                                              |
+| ------------------------------------ | --------------------------------------------------------------------------------- |
+| `start(config?, model?)`             | 入口。加载或接收配置和模型，触发连接                                              |
+| `_doStart(config, model)`            | 实际连接逻辑：创建 SDK 客户端、注册事件、启动 WebSocket、设置连接模型             |
+| `handleMessage(data)`                | 接收飞书消息 → 过滤 @mention → 映射会话 → 解析模型 → 调用 AI → 回复               |
+| `handleCommand(text)`                | 分发 `/new`、`/model`、`/help` 等斜杠命令                                         |
+| `cmdNew(messageId, chatId)`          | 清除会话映射和本聊天的模型 override，立即新建会话                                 |
+| `cmdModel(messageId, chatId, args)`  | 无参数列出模型，有参数切换本聊天的模型                                            |
+| `cmdProject(messageId, chatId, arg)` | 查看/切换/隐藏项目，完整对齐微信端逻辑                                            |
+| `buildModelList()`                   | 调用 `Provider.list()` 展平成编号列表，供 `/model` 使用                           |
+| `resolveModel(chatId)`               | 三级模型解析：per-chat override → 连接快照 → undefined                            |
+| `getProjects()`                      | 调用 `Project.recentList()` 并过滤根目录，与微信端 `GET /project/recent` 数据一致 |
+| `replyText(messageId, text)`         | 通过飞书 REST API 回复文本消息                                                    |
+| `replyFile(messageId, filePath)`     | 用 native fetch 上传本地文件并以附件形式回复                                      |
+| `getTenantAccessToken()`             | 用 native fetch 获取 tenant_access_token（绕过 SDK axios）                        |
+| `detectFileSendIntent(text)`         | 检测用户是否在索要文件（含"发给我/源文件/原文件"等词）                            |
+| `extractReadFiles(msg)`              | 从 AI 响应的 ToolPart 中提取被读取的文件路径                                      |
+| `extractFilePathsFromText(text)`     | 从文本中用正则提取存在于磁盘的绝对路径                                            |
+| `detectSummaryIntent(text)`          | 检测用户是否在请求群聊总结，返回时间范围和条数                                    |
+| `fetchChatHistory(chatId, opts)`     | 调用飞书 message.list API 拉取群聊历史并格式化                                    |
+| `stop()`                             | 断开 WebSocket，清理客户端和所有模型状态                                          |
+| `clearSession()`                     | 删除本地配置和会话映射文件                                                        |
 
 #### AsyncLocalStorage 上下文绑定
 
@@ -162,14 +163,15 @@ private async _doStart(config: FeishuConfig, model: ModelRef | null): Promise<vo
 
 #### 数据持久化
 
-| 文件 | 内容 |
-|------|------|
-| `config.json` | App ID 和 App Secret |
-| `sessions.json` | 飞书聊天 → Aether 会话 ID 映射 |
-| `hidden_projects.json` | 隐藏项目目录 → 隐藏时间戳 |
+| 文件                   | 内容                                                      |
+| ---------------------- | --------------------------------------------------------- |
+| `config.json`          | App ID 和 App Secret                                      |
+| `sessions.json`        | 飞书聊天 → Aether 会话 ID 映射                            |
+| `hidden_projects.json` | 隐藏项目目录 → 隐藏时间戳                                 |
 | `default_project.json` | 默认项目目录（`/project default n` 设置，重连后自动生效） |
 
 存储路径按平台：
+
 - Windows: `%APPDATA%\opencode\feishu\`
 - macOS: `~/Library/Application Support/opencode/feishu/`
 - Linux: `~/.local/share/opencode/feishu/`
@@ -178,13 +180,13 @@ private async _doStart(config: FeishuConfig, model: ModelRef | null): Promise<vo
 
 通过 Hono 框架注册在 `/feishu` 路径下。
 
-| 方法 | 路径 | 说明 |
-|------|------|------|
-| POST | `/feishu/start` | 启动连接。body 可选传 `appId`/`appSecret` 和 `model`，否则用已保存配置 |
-| POST | `/feishu/stop` | 断开连接 |
-| GET | `/feishu/status` | 返回 `{ status, appId, hasConfig, error }` |
-| GET | `/feishu/events` | SSE 事件流，推送状态变更和心跳 |
-| DELETE | `/feishu/session` | 清除本地配置和会话数据 |
+| 方法   | 路径              | 说明                                                                   |
+| ------ | ----------------- | ---------------------------------------------------------------------- |
+| POST   | `/feishu/start`   | 启动连接。body 可选传 `appId`/`appSecret` 和 `model`，否则用已保存配置 |
+| POST   | `/feishu/stop`    | 断开连接                                                               |
+| GET    | `/feishu/status`  | 返回 `{ status, appId, hasConfig, error }`                             |
+| GET    | `/feishu/events`  | SSE 事件流，推送状态变更和心跳                                         |
+| DELETE | `/feishu/session` | 清除本地配置和会话数据                                                 |
 
 #### SSE 事件流
 
@@ -199,6 +201,7 @@ private async _doStart(config: FeishuConfig, model: ModelRef | null): Promise<vo
 ```
 
 事件格式：
+
 ```json
 data: {"type": "feishu.connected", "properties": {"appId": "cli_xxx"}}
 data: {"type": "feishu.status", "properties": {"status": "starting", "message": "正在连接飞书..."}}
@@ -211,13 +214,13 @@ SolidJS 对话框组件，提供完整的连接管理界面。
 
 #### UI 状态
 
-| 状态 | 显示内容 |
-|------|---------|
-| `idle` | 飞书图标 + "连接飞书"按钮（有配置时）或"配置飞书应用"按钮 |
-| `config` | App ID / App Secret 输入表单 |
-| `loading` | 旋转动画 + 状态文字 |
-| `connected` | 绿色勾 + 已连接信息 + "断开连接"/"切换应用"按钮 |
-| `error` | 红色警告 + 错误信息 + "重试"按钮 |
+| 状态        | 显示内容                                                  |
+| ----------- | --------------------------------------------------------- |
+| `idle`      | 飞书图标 + "连接飞书"按钮（有配置时）或"配置飞书应用"按钮 |
+| `config`    | App ID / App Secret 输入表单                              |
+| `loading`   | 旋转动画 + 状态文字                                       |
+| `connected` | 绿色勾 + 已连接信息 + "断开连接"/"切换应用"按钮           |
+| `error`     | 红色警告 + 错误信息 + "重试"按钮                          |
 
 #### 事件处理时序
 
@@ -241,6 +244,7 @@ export const [feishuStatus, setFeishuStatus] = createSignal<FeishuStatus>("idle"
 ```
 
 在 `prompt-input.tsx` 中用于工具栏按钮的状态指示颜色：
+
 - 蓝色 = connected
 - 黄色闪烁 = loading
 - 红色 = error
@@ -324,23 +328,23 @@ replyFile(messageId, filePath)
 
 ### 命令
 
-| 命令 | 行为 |
-|------|------|
-| `/project` | 显示前 10 个非隐藏项目，当前项目标 `◀`，默认项目标 `[默认]` |
-| `/project list` | 显示全部项目，隐藏项目标 `[已隐藏]`，默认项目标 `[默认]` |
-| `/project n` | 切换到第 n 个项目，自动复用/新建该项目的会话 |
-| `/project hide n` | 隐藏第 n 个项目；该项目有新活动后自动恢复 |
-| `/project default n` | 设置第 n 个项目为默认项目，持久化到磁盘，重连后自动进入 |
+| 命令                 | 行为                                                         |
+| -------------------- | ------------------------------------------------------------ |
+| `/project`           | 显示前 10 个非隐藏项目，当前项目标 `◀`，默认项目标 `[默认]` |
+| `/project list`      | 显示全部项目，隐藏项目标 `[已隐藏]`，默认项目标 `[默认]`     |
+| `/project n`         | 切换到第 n 个项目，自动复用/新建该项目的会话                 |
+| `/project hide n`    | 隐藏第 n 个项目；该项目有新活动后自动恢复                    |
+| `/project default n` | 设置第 n 个项目为默认项目，持久化到磁盘，重连后自动进入      |
 
 ## 会话切换
 
 ### 命令
 
-| 命令 | 行为 |
-|------|------|
-| `/session` | 显示当前项目前 10 个会话，当前会话标 `◀` |
-| `/session list` | 显示全部会话 |
-| `/session n` | 切换到第 n 个会话 |
+| 命令            | 行为                                      |
+| --------------- | ----------------------------------------- |
+| `/session`      | 显示当前项目前 10 个会话，当前会话标 `◀` |
+| `/session list` | 显示全部会话                              |
+| `/session n`    | 切换到第 n 个会话                         |
 
 ### 设计
 
@@ -382,11 +386,11 @@ await Instance.provide({
 
 ### 状态字段
 
-| 字段 | 类型 | 生命周期 |
-|------|------|---------|
-| `_chatDirs` | `Record<chatId, directory>` | `/project n` 设置，`stop()` 时清除 |
-| `_hiddenDirs` | `Record<directory, timestamp>` | `/project hide n` 设置，持久化，重连保留 |
-| `_defaultDir` | `string \| null` | `/project default n` 设置，持久化到 `default_project.json`，重连保留 |
+| 字段          | 类型                           | 生命周期                                                             |
+| ------------- | ------------------------------ | -------------------------------------------------------------------- |
+| `_chatDirs`   | `Record<chatId, directory>`    | `/project n` 设置，`stop()` 时清除                                   |
+| `_hiddenDirs` | `Record<directory, timestamp>` | `/project hide n` 设置，持久化，重连保留                             |
+| `_defaultDir` | `string \| null`               | `/project default n` 设置，持久化到 `default_project.json`，重连保留 |
 
 ### 三级解析（`resolveModel(chatId)`）
 
@@ -400,11 +404,11 @@ undefined → SessionPrompt 内部默认逻辑
 
 ### 状态字段
 
-| 字段 | 类型 | 生命周期 |
-|------|------|---------|
-| `_connectedModel` | `{ providerID, modelID } \| null` | 连接时由前端传入，`stop()` 时清除 |
-| `_modelOverrides` | `Record<chatId, ModelRef>` | `/model n` 设置，`/new` 或 `stop()` 清除 |
-| `_modelList` | `ModelEntry[]` | 连接时预构建，`stop()` 时清除 |
+| 字段              | 类型                              | 生命周期                                 |
+| ----------------- | --------------------------------- | ---------------------------------------- |
+| `_connectedModel` | `{ providerID, modelID } \| null` | 连接时由前端传入，`stop()` 时清除        |
+| `_modelOverrides` | `Record<chatId, ModelRef>`        | `/model n` 设置，`/new` 或 `stop()` 清除 |
+| `_modelList`      | `ModelEntry[]`                    | 连接时预构建，`stop()` 时清除            |
 
 ### 连接时传递模型
 
@@ -438,60 +442,63 @@ undefined → SessionPrompt 内部默认逻辑
 
 ## 依赖
 
-| 包 | 版本 | 用途 |
-|----|------|------|
+| 包                        | 版本   | 用途                                            |
+| ------------------------- | ------ | ----------------------------------------------- |
 | `@larksuiteoapi/node-sdk` | 1.60.0 | 飞书官方 SDK：WSClient、EventDispatcher、Client |
 
 SDK 使用方式：
+
 - `lark.WSClient` — WebSocket 长连接客户端
 - `lark.EventDispatcher` — 事件注册和分发
 - `lark.Client` — REST API 客户端（发送回复消息、拉取消息历史）
 - `lark.LoggerLevel.debug` — 调试日志级别
 
 `lark.Client` 调用的 API：
+
 - `larkClient.im.message.reply()` — 回复文本消息
 - `larkClient.im.message.list()` — 拉取群聊消息历史（总结功能，需 `im:message.group_msg` 权限）
 
 native `fetch` 直接调用的飞书 REST API（绕过 SDK axios，解决 Bun 兼容性问题）：
+
 - `POST /open-apis/auth/v3/tenant_access_token/internal` — 获取 tenant access token
 - `POST /open-apis/im/v1/files` — 上传文件资源，获取 file_key（需 `im:resource` 权限）
 - `POST /open-apis/im/v1/messages/{messageId}/reply` — 以附件形式回复消息
 
 ## 与微信连接的架构对比
 
-| 维度 | 微信 | 飞书 |
-|------|------|------|
-| 连接方式 | Python 子进程 + 客户端长连接 | TypeScript 内置 + WebSocket 长连接 |
-| SDK | Python wechatferry | Node.js @larksuiteoapi/node-sdk |
-| 认证 | 扫二维码 | App ID + App Secret |
-| 消息桥接 | 子进程 stdout/HTTP 通信 | 进程内直接调用 Session API |
-| 上下文处理 | HTTP API 自带中间件上下文 | Instance.bind() 手动绑定上下文 |
-| 需要公网 | 否 | 否 |
-| 首次配置 | 扫码 | 飞书开放平台创建应用 |
-| 模型传递 | 环境变量 `AETHER_MODEL` | POST body `model` 字段 |
+| 维度       | 微信                         | 飞书                               |
+| ---------- | ---------------------------- | ---------------------------------- |
+| 连接方式   | Python 子进程 + 客户端长连接 | TypeScript 内置 + WebSocket 长连接 |
+| SDK        | Python wechatferry           | Node.js @larksuiteoapi/node-sdk    |
+| 认证       | 扫二维码                     | App ID + App Secret                |
+| 消息桥接   | 子进程 stdout/HTTP 通信      | 进程内直接调用 Session API         |
+| 上下文处理 | HTTP API 自带中间件上下文    | Instance.bind() 手动绑定上下文     |
+| 需要公网   | 否                           | 否                                 |
+| 首次配置   | 扫码                         | 飞书开放平台创建应用               |
+| 模型传递   | 环境变量 `AETHER_MODEL`      | POST body `model` 字段             |
 
 ## 已知限制
 
 1. **接收仅支持文本消息**：接收图片、文件等消息类型暂不处理；发送侧已支持文本和文件附件
-2. **无自动重连**：WebSocket 断开后需手动重新连接
+2. **自动重连存在等待窗口**：断网或连接异常后会自动重连，采用指数退避并在 5 分钟后封顶；网络恢复后最长可能还需等待一个退避周期
 3. **单实例**：FeishuManager 是全局单例，不支持同时连接多个飞书应用
 4. **群聊限制**：群聊中仅响应 @机器人 的消息，未 @则忽略；@mention 占位符会自动过滤
 
 ## 变更记录
 
-| 日期 | 修改内容 | 原因 |
-|------|---------|------|
-| 2026-04-06 11:39 | 事件回调从 `await` 改为 `void`（非阻塞） | 飞书服务器在回调未及时返回时会重发消息，导致用户收到重复回复 |
-| 2026-04-06 11:39 | `handleMessage` 的 catch 中增加 `replyText` 错误反馈 | 报错时飞书用户无任何提示，现在会收到错误信息 |
-| 2026-04-06 16:05 | 首次发消息优先复用最近会话，而非总是新建 | 飞书每条消息都新建会话，web 端体验混乱 |
-| 2026-04-06 16:25 | 每条 AI 回复顶部追加项目和会话标题（`📁 项目名\n💬 会话名\n───`） | 用户无法感知当前处于哪个项目/会话 |
-| 2026-04-06 17:09 | `/new` 改为立即创建新会话（`Session.create`），不再等到下一条消息才新建 | web 端侧边栏需实时出现新会话，旧实现只清除映射延迟到下条消息才生效 |
-| 2026-04-06 18:54 | 新增模型选择逻辑：连接时前端传模型 + per-chat override + `/model` 命令 | 飞书端应沿用 web UI 当前选中的模型，连接后 web UI 切换模型不应影响飞书端 |
-| 2026-04-06 19:17 | `/model` 列表格式改为按 provider 分组，参考微信端风格 | 原格式不直观，统一两端体验 |
-| 2026-04-06 19:17 | 新增 `/project` 命令：查看/切换/隐藏项目，数据源与微信端一致 | 多项目场景下需在飞书端切换工作目录；切换后消息自动在对应项目上下文中执行 |
-| 2026-04-06 19:17 | 取消隐藏改为双机制：飞书消息直接判断 + GlobalBus 监听 web 端活动 | `time.activity` 只在项目初始化时更新，不反映 session 消息，原方案对活跃项目无效 |
-| 2026-04-07 | 新增 `/session` 命令：查看/切换会话，数据源与微信端一致；`_chatSessions` 存储 per-chat 当前会话 | 微信端支持多会话切换，飞书端功能对齐 |
-| 2026-04-07 | 群聊中仅响应 @机器人 的消息，检查 `chat_type` 和 `mentions` 字段 | 之前群聊中所有消息都会触发回复，@一次后机器人对所有消息都回复 |
-| 2026-04-08 16:28 | 新增群聊总结功能：`detectSummaryIntent()` 关键词检测 + `fetchChatHistory()` 拉取历史注入 prompt | 用户可直接用自然语言（如"帮我总结今天的群聊"）触发，无需斜杠命令；需开启 `im:message.group_msg` 权限 |
-| 2026-04-08 16:28 | 新增文件发送功能：AI 回复后自动提取 `PatchPart` 中的变更文件，通过 `larkClient.im.file.create()` 上传并回复到飞书 | 用户在飞书请求 AI 生成/修改文件后，可直接在聊天中收到文件附件 |
-| 2026-04-08 17:54 | 新增 `/project default n` 命令：设置默认项目，持久化到 `default_project.json`，重连后自动生效；`effectiveDir` 改为三级回退 `_chatDirs ?? _defaultDir ?? Instance.directory` | 用户每次重连都需手动切换项目，体验繁琐 |
+| 日期             | 修改内容                                                                                                                                                                    | 原因                                                                                                 |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| 2026-04-06 11:39 | 事件回调从 `await` 改为 `void`（非阻塞）                                                                                                                                    | 飞书服务器在回调未及时返回时会重发消息，导致用户收到重复回复                                         |
+| 2026-04-06 11:39 | `handleMessage` 的 catch 中增加 `replyText` 错误反馈                                                                                                                        | 报错时飞书用户无任何提示，现在会收到错误信息                                                         |
+| 2026-04-06 16:05 | 首次发消息优先复用最近会话，而非总是新建                                                                                                                                    | 飞书每条消息都新建会话，web 端体验混乱                                                               |
+| 2026-04-06 16:25 | 每条 AI 回复顶部追加项目和会话标题（`📁 项目名\n💬 会话名\n───`）                                                                                                           | 用户无法感知当前处于哪个项目/会话                                                                    |
+| 2026-04-06 17:09 | `/new` 改为立即创建新会话（`Session.create`），不再等到下一条消息才新建                                                                                                     | web 端侧边栏需实时出现新会话，旧实现只清除映射延迟到下条消息才生效                                   |
+| 2026-04-06 18:54 | 新增模型选择逻辑：连接时前端传模型 + per-chat override + `/model` 命令                                                                                                      | 飞书端应沿用 web UI 当前选中的模型，连接后 web UI 切换模型不应影响飞书端                             |
+| 2026-04-06 19:17 | `/model` 列表格式改为按 provider 分组，参考微信端风格                                                                                                                       | 原格式不直观，统一两端体验                                                                           |
+| 2026-04-06 19:17 | 新增 `/project` 命令：查看/切换/隐藏项目，数据源与微信端一致                                                                                                                | 多项目场景下需在飞书端切换工作目录；切换后消息自动在对应项目上下文中执行                             |
+| 2026-04-06 19:17 | 取消隐藏改为双机制：飞书消息直接判断 + GlobalBus 监听 web 端活动                                                                                                            | `time.activity` 只在项目初始化时更新，不反映 session 消息，原方案对活跃项目无效                      |
+| 2026-04-07       | 新增 `/session` 命令：查看/切换会话，数据源与微信端一致；`_chatSessions` 存储 per-chat 当前会话                                                                             | 微信端支持多会话切换，飞书端功能对齐                                                                 |
+| 2026-04-07       | 群聊中仅响应 @机器人 的消息，检查 `chat_type` 和 `mentions` 字段                                                                                                            | 之前群聊中所有消息都会触发回复，@一次后机器人对所有消息都回复                                        |
+| 2026-04-08 16:28 | 新增群聊总结功能：`detectSummaryIntent()` 关键词检测 + `fetchChatHistory()` 拉取历史注入 prompt                                                                             | 用户可直接用自然语言（如"帮我总结今天的群聊"）触发，无需斜杠命令；需开启 `im:message.group_msg` 权限 |
+| 2026-04-08 16:28 | 新增文件发送功能：AI 回复后自动提取 `PatchPart` 中的变更文件，通过 `larkClient.im.file.create()` 上传并回复到飞书                                                           | 用户在飞书请求 AI 生成/修改文件后，可直接在聊天中收到文件附件                                        |
+| 2026-04-08 17:54 | 新增 `/project default n` 命令：设置默认项目，持久化到 `default_project.json`，重连后自动生效；`effectiveDir` 改为三级回退 `_chatDirs ?? _defaultDir ?? Instance.directory` | 用户每次重连都需手动切换项目，体验繁琐                                                               |

--- a/docs/feishu-refactor-plan.md
+++ b/docs/feishu-refactor-plan.md
@@ -1,0 +1,440 @@
+# 飞书端重构操作计划
+
+## 目标
+
+按以下既定方案重构飞书端消息处理流程，不新增额外产品逻辑：
+
+1. 用户输入后，如果是 `/help`，直接在飞书侧返回结果并结束当次会话，不进入后端。
+2. 判断用户输入是否属于非 `/stop` 和 `/compact` 的 slash 命令。若是，则直接执行，并结束当次会话；执行过程中自动查看当前 `session id` 和 `session preference`。
+3. 否则，查看当前 session 状态，分为：
+   - A：空闲
+   - B：等待用户授权或者回答问题
+   - C：正常执行任务
+
+   对输入 `/stop`：
+   - A：提示"没有任务在执行"
+   - B、C：停止这个正在运行的 session
+
+   对其它输入：
+   - A：正常执行用户输入
+   - B：返回 session 状态，并提示用户输入什么内容来授权或回答（参考微信端方案）
+   - C：提示当前 session 正在生成回复（具体文案参考微信端）
+
+---
+
+## 现状确认
+
+当前飞书逻辑主要集中在 `packages/opencode/src/feishu/manager.ts`。
+
+已确认的现状：
+
+- `/help` 已在飞书侧直接处理，位于 `packages/opencode/src/feishu/manager.ts:875`
+- 所有 slash 命令统一在 `handleCommand()` 中分发，位于 `packages/opencode/src/feishu/manager.ts:851`
+- 普通文本当前优先按以下顺序处理：
+  1. pending question
+  2. pending permission
+  3. busy 检查
+  4. 创建/复用 session
+  5. `syncPending()`
+  6. `SessionPrompt.prompt()`
+- 当前"忙碌中"提示文案为：
+  `当前会话正在生成回复，请等待结束后再发送；\n如需停止请输入 /stop`
+  位于 `packages/opencode/src/feishu/manager.ts:535`
+- 当前 `/stop` 逻辑会同时把 pending question / pending permission 也视为可停止状态，位于 `packages/opencode/src/feishu/manager.ts:1007`
+- 当前 B 状态依赖运行时内存：
+  - `_pendingQuestions`
+  - `_pendingPermissions`
+- 当前也有从 session 同步待处理交互的逻辑 `syncPending()`，位于 `packages/opencode/src/feishu/manager.ts:1373`
+
+---
+
+## 重构原则
+
+本次只按给定方案调整，不做额外能力扩展：
+
+- 不改飞书 route 层，仍由 `packages/opencode/src/server/routes/feishu.ts` 调用 `FeishuManager`
+- 不改已有 slash 命令集合和命令语义
+- 不改 Session/Question/Permission 基础模型
+- 不新增新的后端 API
+- 不把 `/help`、非 `/stop` `/compact` 的 slash 命令转入主对话 prompt 流程
+
+---
+
+## 具体改造步骤
+
+### 1. 在飞书侧抽象统一的 session 状态判定
+
+在 `packages/opencode/src/feishu/manager.ts` 内新增一个专用状态判定方法，例如：
+
+- 输入：`chatId`
+- 输出：
+  - `state: "idle" | "waiting" | "running"`
+  - `sessionId`
+  - `dir`
+  - `pref`
+  - 可选的 `question` / `permission`
+
+该方法内部严格按以下顺序判定：
+
+1. 先定位当前 session
+   - 复用现有 `currentSession(chatId, true/false)`、`effectiveDir(chatId)`、`SessionPreference.get()`
+   - 这里应优先使用"已有 session"；不要为了状态查询无条件新建 session
+2. 判断是否存在待回答问题
+   - 先看内存中的 `_pendingQuestions[chatId]`
+   - 若没有，再调用 `Question.list()` 按 `sessionId` 查找
+3. 判断是否存在待授权请求
+   - 先看内存中的 `_pendingPermissions[chatId]`
+   - 若没有，再调用 `Permission.list()` 按 `sessionId` 查找
+4. 判断 session 是否 busy
+   - 使用现有 `SessionStatus.get(SessionID.make(sessionId))`
+5. 最终归类：
+   - 有 question 或 permission => `waiting`
+   - 否则 busy => `running`
+   - 否则 => `idle`
+
+注意：
+
+- 若当前 chat 尚无 session，则直接判定为 `idle`
+- 判定方法内部不要发送消息，只返回状态数据
+
+---
+
+### 2. 重写 `handleMessage()` 的顶层分流顺序
+
+调整 `packages/opencode/src/feishu/manager.ts:447` 附近的主流程，改为严格对应方案的顺序：
+
+#### 2.1 先处理 `/help`
+
+保留现有 `/help` 飞书侧直返逻辑，但将其提升为最优先判断：
+
+- 用户输入文本后
+- 如果 `text === "/help"` 或命令首项为 `/help`
+- 直接调用现有帮助回复逻辑
+- 立即 `return`
+- 不进入状态判定
+- 不进入主 prompt 流程
+
+#### 2.2 再处理"非 `/stop` 和 `/compact` 的 slash 命令"
+
+若输入以 `/` 开头，且命令不是 `/stop`、`/compact`：
+
+- 直接执行 `handleCommand()`
+- 执行中沿用现有 `commandCtx()` 自动查看当前 `session id` 和 `session preference`
+- 命令执行完成后立即 `return`
+- 不进入下面的 A/B/C 状态判断
+
+这里实际包含：
+
+- `/new`
+- `/model`
+- `/agent`
+- `/approval`
+- `/variant`
+- `/project`
+- `/session`
+- 以及未来仍走 `handleCommand()` 的其它非 `/stop` `/compact` slash 命令
+
+#### 2.3 对 `/stop`、`/compact` 和普通文本统一进入状态分流
+
+此时再调用"步骤 1"的统一状态判定方法，得到 A/B/C：
+
+- A = `idle`
+- B = `waiting`
+- C = `running`
+
+---
+
+### 3. 严格实现 `/stop` 的 A/B/C 规则
+
+在 `handleMessage()` 中针对 `/stop` 单独分支，不再直接沿用现有 `cmdStop()` 的全部语义。
+
+#### 3.1 状态 A：空闲
+
+返回固定语义：
+
+- "没有任务在执行"
+
+对应处理：
+
+- 不调用 `SessionPrompt.cancel()`
+- 不清理 pending runtime
+- 直接回复并结束
+
+#### 3.2 状态 B：等待用户授权或者回答问题
+
+停止这个正在运行的 session。
+
+执行动作：
+
+- 若 session 存在，调用 `SessionPrompt.cancel(SessionID.make(sessionId))`
+- 清理当前 chat 的 `_pendingQuestions`、`_pendingPermissions`
+- 返回停止成功文案
+
+原因：
+
+- 方案明确要求 B、C 都停止正在运行的 session
+- 即使 B 主要表现为等待交互，仍按方案视为可停止
+
+#### 3.3 状态 C：正常执行任务
+
+沿用停止执行逻辑：
+
+- 调用 `SessionPrompt.cancel(SessionID.make(sessionId))`
+- 清理当前 chat 的 pending runtime
+- 返回停止成功文案
+
+#### 3.4 `cmdStop()` 的处理方式
+
+为避免双套语义冲突，建议：
+
+- 保留 `cmdStop()` 供内部复用，但改造成"接收外部已判定的状态并执行"
+- 或者不再让 `handleMessage()` 对 `/stop` 走 `handleCommand()`，而是在 `handleMessage()` 里直接实现 `/stop` 的 A/B/C 逻辑
+
+推荐后者，因为更符合本次方案"先判状态，再按状态处理 `/stop`"。
+
+---
+
+### 4. 严格实现"其它输入"的 A/B/C 规则
+
+这里的"其它输入"包括：
+
+- 普通文本
+- `/compact`
+
+因为根据你的方案，第 2 步已把"非 `/stop`、`/compact` 的 slash 命令"提前直接执行掉，所以剩下的 slash 只有 `/stop` 和 `/compact`。
+
+#### 4.1 状态 A：空闲
+
+正常执行用户输入：
+
+- 普通文本：进入现有主 prompt 流程
+- `/compact`：执行现有 `cmdCompact()` 逻辑
+
+这里要注意：
+
+- 只有在状态 A 下，普通文本才允许继续进入 `SessionPrompt.prompt()`
+- 只有在状态 A 下，`/compact` 才允许执行
+
+#### 4.2 状态 B：等待用户授权或者回答问题
+
+不再像当前实现那样把用户文本直接当作回答并提交。
+
+而是改为：
+
+- 返回当前 session 状态
+- 明确提示用户当前正在等待"授权"还是"回答问题"
+- 明确告诉用户应该输入什么内容
+
+具体要求：
+
+- 若是 pending question：
+  - 返回 `formatQuestionRequest()` 对应内容，或在其前补一行状态说明
+- 若是 pending permission：
+  - 返回 `formatPermissionRequest()` 对应内容，或在其前补一行状态说明
+- 文案形式参考微信端方案，但实现层面先复用飞书已有的两个 formatter：
+  - `formatQuestionRequest()`
+  - `formatPermissionRequest()`
+
+这一步的核心变化是：
+
+- B 状态下"其它输入"不直接消费为答案
+- 而是先提示用户该如何回答/授权
+
+#### 4.3 状态 C：正常执行任务
+
+返回"当前 session 正在生成回复"的提示，不执行用户输入。
+
+文案要求：
+
+- 具体文案参考微信端
+- 若暂时未找到微信端对应文本，先与现有飞书文案保持一致，再在实施时替换为微信端同款
+
+当前飞书现有可对齐文案为：
+
+`当前会话正在生成回复，请等待结束后再发送；如需停止请输入 /stop`
+
+---
+
+### 5. 调整"B 状态自动消费输入"的旧逻辑
+
+当前 `handleMessage()` 中以下逻辑需要迁移或收口：
+
+- `packages/opencode/src/feishu/manager.ts:500`
+- `packages/opencode/src/feishu/manager.ts:508`
+
+即：
+
+- 当前 chat 有 pending question 时，直接把文本作为回答
+- 当前 chat 有 pending permission 时，直接把文本作为授权回复
+
+这与本次方案中"其它输入在 B 状态下先返回提示，不直接提交"冲突，因此必须修改。
+
+建议改法：
+
+- 将"自动把文本作为回答/授权"的逻辑从主入口移除
+- 改成只在明确满足"这是对问题/授权的回复"的专门路径下调用
+- 如果本次方案不要求保留自动回复能力，则主入口不再自动消费
+
+按你当前给定方案，建议严格执行：
+
+- 主入口不自动提交 B 状态输入
+- 只返回状态提示和输入指引
+
+---
+
+### 6. 重新梳理 `/compact` 的入口位置
+
+当前 `/compact` 由 `handleCommand()` 直接执行。
+
+根据你的方案，应调整为：
+
+- `/compact` 不属于"直接执行并结束"的那一类
+- `/compact` 要先参与 A/B/C 状态判定
+- 仅当状态 A 时才执行 `cmdCompact()`
+- 状态 B 时返回"等待授权/回答"的状态提示
+- 状态 C 时返回"正在生成回复"的提示
+
+因此需要把 `/compact` 从"通用 slash 直执行分支"中排除。
+
+---
+
+### 7. 保留并复用现有上下文能力
+
+以下现有能力保持不变，只做调用时机调整：
+
+- `commandCtx(chatId)`  
+  用于自动查看当前 `session id`、`session preference`、项目名、会话名、模式、模型
+- `currentSession(chatId, create?)`
+- `effectiveDir(chatId)`
+- `formatQuestionRequest()`
+- `formatPermissionRequest()`
+- `clearRuntime(chatId)`
+- `cmdCompact()`
+
+这样可以保证：
+
+- 非 `/stop` `/compact` slash 命令仍能自动读取 session 上下文
+- B 状态提示继续复用当前已存在的飞书格式化文案
+
+---
+
+## 建议的代码落点
+
+### 主要修改文件
+
+- `packages/opencode/src/feishu/manager.ts`
+
+### 重点修改函数
+
+- `handleMessage()`
+- `handleCommand()`  
+  仅调整其调用入口，不必大改命令内部实现
+- `cmdStop()`  
+  视实现方式决定是否保留/瘦身
+- 新增统一状态判定方法
+- 视需要新增：
+  - B 状态回复方法
+  - C 状态回复方法
+
+---
+
+## 推荐实施顺序
+
+1. 新增统一 session 状态判定方法
+2. 重构 `handleMessage()` 顶层分流顺序
+3. 将 `/help` 提升为最高优先级直返
+4. 将"非 `/stop` `/compact` 的 slash 命令"提前直执行并返回
+5. 将 `/stop` 改为按 A/B/C 处理
+6. 将 `/compact` 改为先判状态再决定是否执行
+7. 删除或迁移"B 状态自动消费输入"的旧逻辑
+8. 统一检查 B/C 状态回复文案是否符合微信端方案
+
+---
+
+## 验收清单
+
+### `/help`
+
+- 输入 `/help`
+- 飞书直接返回帮助内容
+- 不进入 session prompt
+- 不创建新 session
+- 不触发 Question / Permission / SessionStatus 判断
+
+### 非 `/stop` `/compact` slash 命令
+
+- 输入 `/model`、`/agent`、`/project`、`/session` 等
+- 直接执行命令
+- 自动读取当前 session id / session preference
+- 不进入主 prompt 流程
+
+### `/stop`
+
+- 状态 A：返回"没有任务在执行"
+- 状态 B：停止 session，并返回停止成功
+- 状态 C：停止 session，并返回停止成功
+
+### `/compact`
+
+- 状态 A：正常执行压缩
+- 状态 B：不执行压缩，返回等待授权/回答提示
+- 状态 C：不执行压缩，返回"正在生成回复"提示
+
+### 普通文本
+
+- 状态 A：正常进入 prompt
+- 状态 B：只返回等待授权/回答提示，不直接当作回答提交
+- 状态 C：只返回"正在生成回复"提示，不进入 prompt
+
+---
+
+## 风险点
+
+### 1. `currentSession(chatId, true)` 的副作用
+
+现有 `commandCtx()` 会在缺少 session 时自动创建 session。  
+做状态判定时不能无条件复用这个行为，否则"仅查询状态"也会新建 session。
+
+处理要求：
+
+- 状态判定时优先使用不创建 session 的查询方式
+- 只有真正进入 A 状态执行用户输入时，才允许按现有逻辑创建 session
+
+### 2. B 状态来源有两套
+
+当前 B 状态既可能来自：
+
+- 内存中的 `_pendingQuestions` / `_pendingPermissions`
+- 存储层中的 `Question.list()` / `Permission.list()`
+
+处理要求：
+
+- 统一状态判定时两者都要覆盖
+- 以内存优先，存储兜底
+
+### 3. `/stop` 在 B 状态是否一定存在可 cancel 的 prompt
+
+有可能 session 当前并不 busy，只是停在等待授权/提问。  
+但方案要求 B、C 都停止 session，因此实现上应允许：
+
+- 即使 `SessionStatus` 不是 `busy`
+- 仍清理 pending 状态
+- 并尝试调用 cancel 或至少保证当前交互被终止
+
+---
+
+## 与当前实现的差异总结
+
+当前实现：
+
+- B 状态下，普通文本会直接被当作回答/授权输入
+- `/compact` 直接执行，不参与 A/B/C 分流
+- `/stop` 逻辑混合了 busy 与 pending 判断，但不是按你要求的 A/B/C 入口组织
+
+目标实现：
+
+- `/help` 飞书侧直返并结束
+- 非 `/stop` `/compact` slash 命令直接执行并结束
+- `/stop`、`/compact`、普通文本统一先判 A/B/C
+- B 状态下只提示，不自动消费用户输入
+- C 状态下统一返回"正在生成回复"的提示

--- a/packages/app/src/components/dialog-feishu.tsx
+++ b/packages/app/src/components/dialog-feishu.tsx
@@ -10,7 +10,7 @@ import { useServer } from "@/context/server"
 import { setFeishuStatus } from "@/context/feishu"
 import { useLocal } from "@/context/local"
 
-type FeishuStatus = "idle" | "loading" | "config" | "connected" | "error"
+type FeishuStatus = "idle" | "loading" | "config" | "connected" | "reconnecting" | "error"
 
 interface FeishuEvent {
   type: string
@@ -49,6 +49,25 @@ export const DialogFeishu: Component = () => {
   }
 
   let abort: AbortController | null = null
+  let retry: ReturnType<typeof setTimeout> | null = null
+
+  const clearRetry = () => {
+    if (!retry) return
+    clearTimeout(retry)
+    retry = null
+  }
+
+  const scheduleRetry = () => {
+    if (retry || !hasConfig()) return
+    retry = setTimeout(() => {
+      retry = null
+      if (status() === "connected" || status() === "loading") return
+      updateStatus("reconnecting")
+      setLoadingMsg("飞书事件流已断开，正在重连...")
+      connectSSE()
+      void fetchStatus()
+    }, 3_000)
+  }
 
   const fetchStatus = async () => {
     try {
@@ -56,8 +75,11 @@ export const DialogFeishu: Component = () => {
       const data = await response.json()
       setHasConfig(data.hasConfig)
       if (data.status === "connected" && data.appId) {
+        clearRetry()
         updateStatus("connected")
         setConnectedAppId(data.appId)
+      } else if (data.status === "reconnecting") {
+        updateStatus("reconnecting")
       } else if (data.error) {
         setError(data.error)
         updateStatus("error")
@@ -113,6 +135,7 @@ export const DialogFeishu: Component = () => {
   }
 
   const stopBridge = async () => {
+    clearRetry()
     if (abort) {
       abort.abort()
       abort = null
@@ -122,6 +145,7 @@ export const DialogFeishu: Component = () => {
   }
 
   const logout = async () => {
+    clearRetry()
     if (abort) {
       abort.abort()
       abort = null
@@ -147,7 +171,10 @@ export const DialogFeishu: Component = () => {
           headers: { ...authHeaders(), Accept: "text/event-stream" },
           signal: abort!.signal,
         })
-        if (!response.ok || !response.body) return
+        if (!response.ok || !response.body) {
+          scheduleRetry()
+          return
+        }
 
         const reader = response.body.getReader()
         const decoder = new TextDecoder()
@@ -167,8 +194,12 @@ export const DialogFeishu: Component = () => {
             try {
               const event: FeishuEvent = JSON.parse(raw)
               if (event.type === "feishu.connected" && event.properties.appId) {
+                clearRetry()
                 setConnectedAppId(event.properties.appId)
                 updateStatus("connected")
+              } else if (event.type === "feishu.reconnecting") {
+                updateStatus("reconnecting")
+                setLoadingMsg("飞书连接中断，正在自动重连...")
               } else if (event.type === "feishu.error") {
                 setError({
                   code: event.properties.code || "unknown",
@@ -179,11 +210,15 @@ export const DialogFeishu: Component = () => {
                 const s = event.properties.status === "starting" ? "loading" : event.properties.status
                 updateStatus(s)
                 if (event.properties.message) setLoadingMsg(event.properties.message)
+                if (s === "connected") clearRetry()
               }
             } catch {}
           }
         }
-      } catch {}
+        scheduleRetry()
+      } catch {
+        scheduleRetry()
+      }
     })()
   }
 
@@ -196,6 +231,7 @@ export const DialogFeishu: Component = () => {
       abort.abort()
       abort = null
     }
+    clearRetry()
   })
 
   return (
@@ -391,6 +427,18 @@ export const DialogFeishu: Component = () => {
             <div class="flex flex-col items-center gap-4">
               <div class="size-12 animate-spin rounded-full border-2 border-icon-weak border-t-icon-base" />
               <p class="text-14-regular text-text-base">{loadingMsg()}</p>
+            </div>
+          </Match>
+
+          <Match when={status() === "reconnecting"}>
+            <div class="flex flex-col items-center gap-4">
+              <div class="size-16 rounded-full bg-surface-warning flex items-center justify-center">
+                <Icon name="arrow-right" size="large" class="text-icon-warning-base animate-spin" />
+              </div>
+              <div class="flex flex-col items-center gap-1">
+                <p class="text-16-medium text-text-strong">正在重连飞书</p>
+                <p class="text-14-regular text-text-weak text-center max-w-xs">{loadingMsg()}</p>
+              </div>
             </div>
           </Match>
 

--- a/packages/app/src/context/feishu.ts
+++ b/packages/app/src/context/feishu.ts
@@ -1,5 +1,5 @@
 import { createSignal } from "solid-js"
 
-export type FeishuStatus = "idle" | "loading" | "connected" | "error"
+export type FeishuStatus = "idle" | "loading" | "connected" | "reconnecting" | "error"
 
 export const [feishuStatus, setFeishuStatus] = createSignal<FeishuStatus>("idle")

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -186,6 +186,7 @@ export function createChildStoreManager(input: {
             limit: 5,
             message: {},
             part: {},
+            preference: {},
           })
           children[directory] = child
           disposers.set(directory, dispose)

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -11,7 +11,7 @@ import type {
   SessionStatus,
   Todo,
 } from "@opencode-ai/sdk/v2/client"
-import type { State, VcsCache } from "./types"
+import type { SessionPreference, State, VcsCache } from "./types"
 import { trimSessions } from "./session-trim"
 import { dropSessionCaches } from "./session-cache"
 
@@ -354,6 +354,11 @@ export function applyDirectoryEvent(input: {
     }
     case "lsp.updated": {
       input.loadLsp()
+      break
+    }
+    case "session.preference.updated": {
+      const props = event.properties as { sessionID: string; preference: SessionPreference }
+      input.setStore("preference", props.sessionID, reconcile(props.preference))
       break
     }
   }

--- a/packages/app/src/context/global-sync/types.ts
+++ b/packages/app/src/context/global-sync/types.ts
@@ -31,6 +31,14 @@ export type ProjectMeta = {
   }
 }
 
+export type SessionPreference = {
+  sessionID: string
+  agent?: string
+  model?: { providerID: string; modelID: string }
+  variant?: string
+  autoAccept?: boolean
+}
+
 export type State = {
   status: "loading" | "partial" | "complete"
   agent: Agent[]
@@ -69,6 +77,9 @@ export type State = {
   }
   part: {
     [messageID: string]: Part[]
+  }
+  preference: {
+    [sessionID: string]: SessionPreference
   }
 }
 

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -18,7 +18,7 @@ type State = {
   agent?: string
   model?: ModelKey
   variant?: string | null
-  approval?: "auto" | "ask"
+  autoAccept?: boolean
 }
 
 type Saved = {
@@ -254,7 +254,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         agent: agent.current()?.name,
         model: model ? { providerID: model.provider.id, modelID: model.id } : undefined,
         variant: selected(),
-        approval: scope()?.approval,
+        autoAccept: scope()?.autoAccept,
       } satisfies State
     }
 
@@ -275,12 +275,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
     const syncPreferenceToServer = (session: string, state: State) => {
       if (!sdk.client.session.preference) return
-      const body: Record<string, unknown> = { source: "desktop" }
+      const body: Record<string, unknown> = {}
       if (state.agent) body.agent = state.agent
       if (state.model) body.model = state.model
       if (state.variant != null) body.variant = state.variant
-      if (state.approval) body.approval = state.approval
-      sdk.client.session.preference.set({ sessionID: session, ...body }).catch(() => {})
+      if (state.autoAccept !== undefined) body.autoAccept = state.autoAccept
+      sdk.client.session.preference.update({ sessionID: session, ...body }).catch(() => {})
     }
 
     createEffect(() => {
@@ -303,7 +303,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           if (serverPref.agent) state.agent = serverPref.agent
           if (serverPref.model) state.model = serverPref.model
           if (serverPref.variant) state.variant = serverPref.variant
-          if (serverPref.approval) state.approval = serverPref.approval as "auto" | "ask"
+          if (serverPref.autoAccept !== undefined) state.autoAccept = serverPref.autoAccept
           if (Object.keys(state).length > 0) {
             setSaved("session", session, state)
           }
@@ -313,18 +313,24 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
     createEffect(() => {
       const unsub = sdk.event.listen((e) => {
-        const event = e.details as { type: string; properties?: { sessionID?: string; info?: State } }
-        if (event.type !== "session.preference.changed") return
+        const event = e.details as {
+          type: string
+          properties?: {
+            sessionID?: string
+            preference?: { agent?: string; model?: ModelKey; variant?: string; autoAccept?: boolean }
+          }
+        }
+        if (event.type !== "session.preference.updated") return
         const session = id()
         if (!session) return
         if (!event.properties || event.properties.sessionID !== session) return
-        const pref = event.properties.info
+        const pref = event.properties.preference
         if (!pref) return
         const state: State = {}
         if (pref.agent) state.agent = pref.agent
         if (pref.model) state.model = pref.model
         if (pref.variant) state.variant = pref.variant
-        if (pref.approval) state.approval = pref.approval
+        if (pref.autoAccept !== undefined) state.autoAccept = pref.autoAccept
         if (Object.keys(state).length > 0) {
           setSaved("session", session, { ...(saved.session[session] ?? {}), ...state })
         }

--- a/packages/app/src/context/permission-auto-respond.test.ts
+++ b/packages/app/src/context/permission-auto-respond.test.ts
@@ -81,6 +81,30 @@ describe("autoRespondsPermission", () => {
 
     expect(autoRespondsPermission(autoAccept, sessions, permission("root"), directory)).toBe(false)
   })
+
+  test("prefers preference.autoAccept over local autoAccept when preference is set", () => {
+    const sessions = [session({ id: "root" })]
+    const autoAccept = { root: true }
+    const preference = { root: { autoAccept: false } }
+
+    expect(autoRespondsPermission(autoAccept, sessions, permission("root"), "/tmp/project", preference)).toBe(false)
+  })
+
+  test("falls back to local autoAccept when preference.autoAccept is undefined", () => {
+    const sessions = [session({ id: "root" })]
+    const autoAccept = { root: true }
+    const preference = { root: {} }
+
+    expect(autoRespondsPermission(autoAccept, sessions, permission("root"), "/tmp/project", preference)).toBe(true)
+  })
+
+  test("inherits preference.autoAccept from parent session", () => {
+    const sessions = [session({ id: "root" }), session({ id: "child", parentID: "root" })]
+    const autoAccept = {}
+    const preference = { root: { autoAccept: true } }
+
+    expect(autoRespondsPermission(autoAccept, sessions, permission("child"), "/tmp/project", preference)).toBe(true)
+  })
 })
 
 describe("isDirectoryAutoAccepting", () => {

--- a/packages/app/src/context/permission-auto-respond.ts
+++ b/packages/app/src/context/permission-auto-respond.ts
@@ -43,8 +43,16 @@ export function autoRespondsPermission(
   session: { id: string; parentID?: string }[],
   permission: { sessionID: string },
   directory?: string,
+  preference?: Record<string, { autoAccept?: boolean }>,
 ) {
-  const value = sessionLineage(session, permission.sessionID)
+  const lineage = sessionLineage(session, permission.sessionID)
+  if (preference) {
+    const prefValue = lineage
+      .map((id) => preference[id]?.autoAccept)
+      .find((item): item is boolean => item !== undefined)
+    if (prefValue !== undefined) return prefValue
+  }
+  const value = lineage
     .map((id) => accepted(autoAccept, id, directory))
     .find((item): item is boolean => item !== undefined)
   return value ?? false

--- a/packages/app/src/context/permission.tsx
+++ b/packages/app/src/context/permission.tsx
@@ -13,6 +13,7 @@ import {
   isDirectoryAutoAccepting,
   autoRespondsPermission,
 } from "./permission-auto-respond"
+import type { SessionPreference } from "./global-sync/types"
 
 type PermissionRespondFn = (input: {
   sessionID: string
@@ -42,31 +43,6 @@ function hasPermissionPromptRules(permission: unknown) {
 
   const config = permission as Record<string, unknown>
   return Object.values(config).some(isNonAllowRule)
-}
-
-function allowAll(permission: unknown) {
-  if (permission === undefined) return undefined
-  if (typeof permission === "string") return permission === "allow"
-  if (!Array.isArray(permission)) return false
-  return permission.some((rule) => {
-    if (!rule || typeof rule !== "object" || Array.isArray(rule)) return false
-    const item = rule as Record<string, unknown>
-    return item.permission === "*" && item.pattern === "*" && item.action === "allow"
-  })
-}
-
-function sessionAccepts(session: { id: string; parentID?: string; permission?: unknown }[], sessionID: string) {
-  const map = new Map(session.map((item) => [item.id, item]))
-  const seen = new Set<string>()
-  let current: string | undefined = sessionID
-
-  while (current && !seen.has(current)) {
-    seen.add(current)
-    const item = map.get(current)
-    const value = allowAll(item?.permission)
-    if (value !== undefined) return value
-    current = item?.parentID
-  }
 }
 
 export const { use: usePermission, provider: PermissionProvider } = createSimpleContext({
@@ -106,7 +82,6 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
       }),
     )
 
-    // When config has permission: "allow", auto-enable directory-level auto-accept
     createEffect(() => {
       if (!ready()) return
       const directory = decode64(params.dir)
@@ -124,6 +99,12 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
         }
       }
     })
+
+    const current = () => {
+      const directory = decode64(params.dir)
+      if (!directory) return { session: [], preference: {} } as const
+      return globalSync.child(directory, { bootstrap: false })[0]
+    }
 
     const MAX_RESPONDED = 1000
     const RESPONDED_TTL_MS = 60 * 60 * 1000
@@ -164,10 +145,8 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
     }
 
     function isAutoAccepting(sessionID: string, directory?: string) {
-      const session = directory ? globalSync.child(directory, { bootstrap: false })[0].session : []
-      const value = sessionAccepts(session, sessionID)
-      if (value !== undefined) return value
-      return autoRespondsPermission(store.autoAccept, session, { sessionID }, directory)
+      const child = directory ? globalSync.child(directory, { bootstrap: false })[0] : current()
+      return autoRespondsPermission(store.autoAccept, [...child.session], { sessionID }, directory, child.preference)
     }
 
     function isAutoAcceptingDirectory(directory: string) {
@@ -175,10 +154,8 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
     }
 
     function shouldAutoRespond(permission: PermissionRequest, directory?: string) {
-      const session = directory ? globalSync.child(directory, { bootstrap: false })[0].session : []
-      const value = sessionAccepts(session, permission.sessionID)
-      if (value !== undefined) return value
-      return autoRespondsPermission(store.autoAccept, session, permission, directory)
+      const child = directory ? globalSync.child(directory, { bootstrap: false })[0] : current()
+      return autoRespondsPermission(store.autoAccept, [...child.session], permission, directory, child.preference)
     }
 
     function bumpEnableVersion(sessionID: string, directory?: string) {
@@ -188,10 +165,10 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
       return next
     }
 
-    function writeApproval(sessionID: string, directory: string, approval: "auto" | "ask") {
+    function writeAutoAccept(sessionID: string, directory: string, autoAccept: boolean) {
       return globalSDK
         .createClient({ directory, throwOnError: true })
-        .session.preference.set({ sessionID, approval, source: "desktop" })
+        .session.preference.update({ sessionID, autoAccept })
     }
 
     const unsubscribe = globalSDK.event.listen((e) => {
@@ -245,7 +222,7 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
         }),
       )
 
-      writeApproval(sessionID, directory, "auto").catch(() => undefined)
+      writeAutoAccept(sessionID, directory, true).catch(() => undefined)
 
       globalSDK.client.permission
         .list({ directory })
@@ -273,7 +250,7 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
       )
 
       if (directory) {
-        writeApproval(sessionID, directory, "ask").catch(() => undefined)
+        writeAutoAccept(sessionID, directory, false).catch(() => undefined)
       }
     }
 

--- a/packages/app/src/utils/server.ts
+++ b/packages/app/src/utils/server.ts
@@ -65,21 +65,20 @@ export type AppClient = Base & {
         agent?: string
         model?: { providerID: string; modelID: string }
         variant?: string
-        approval?: string
+        autoAccept?: boolean
       } | null>
-      set(input: {
+      update(input: {
         sessionID: string
         agent?: string
         model?: { providerID: string; modelID: string }
         variant?: string
-        approval?: string
-        source?: string
+        autoAccept?: boolean
       }): Req<{
         sessionID: string
         agent?: string
         model?: { providerID: string; modelID: string }
         variant?: string
-        approval?: string
+        autoAccept?: boolean
       } | null>
     }
   }
@@ -112,10 +111,10 @@ export function addPreferenceMethods(client: AppClient, baseUrl: string, auth?: 
       const data = await resp.json()
       return { data }
     },
-    async set(input) {
+    async update(input) {
       const { sessionID, ...body } = input
       const resp = await fetch(`${baseUrl}/session/${sessionID}/preference`, {
-        method: "PUT",
+        method: "PATCH",
         headers,
         body: JSON.stringify(body),
       })

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -29,7 +29,6 @@ const FEISHU_DATA_DIR =
 const CONFIG_FILE = join(FEISHU_DATA_DIR, "config.json")
 const SESSION_MAP_FILE = join(FEISHU_DATA_DIR, "sessions.json")
 const HIDDEN_DIRS_FILE = join(FEISHU_DATA_DIR, "hidden_projects.json")
-const DEFAULT_PROJECT_FILE = join(FEISHU_DATA_DIR, "default_project.json")
 
 export type FeishuStatus = "idle" | "starting" | "connected" | "error"
 
@@ -110,8 +109,8 @@ class FeishuManagerImpl {
   private _chatSessions: Record<string, string> = {}
   // Hidden project directories: directory -> timestamp when hidden. Persisted to disk.
   private _hiddenDirs: Record<string, number> = {}
-  // Default project directory applied to all chats on connect. Persisted to disk.
-  private _defaultDir: string | null = null
+  // Initial directory computed from first visible project on connect.
+  private _initialDir: string = ""
   // GlobalBus listener for detecting web UI activity on hidden projects.
   private _globalBusListener: ((event: { directory?: string; payload: any }) => void) | null = null
   // ─────────────────────────────────────────────────────────────────────────
@@ -254,7 +253,7 @@ class FeishuManagerImpl {
   private async currentSession(chatId: string, create?: boolean): Promise<string | undefined> {
     const pinned = this._chatSessions[chatId]
     if (pinned) return pinned
-    const dir = this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory
+    const dir = this._chatDirs[chatId] ?? (this._initialDir || Instance.directory)
     const recent = await Instance.provide({
       directory: dir,
       fn: () => [...Session.list({ directory: dir, roots: true, limit: 1 })],
@@ -302,8 +301,6 @@ class FeishuManagerImpl {
     await this.saveConfig(cfg)
     this.sessionMap = await this.loadSessionMap()
     this._hiddenDirs = await this.loadHiddenDirs()
-    this._defaultDir = await this.loadDefaultDir()
-
     void this._doStart(cfg, model ?? null)
     return { success: true }
   }
@@ -365,6 +362,27 @@ class FeishuManagerImpl {
       }
       this.status = "connected"
       Bus.publish(FeishuEvent.Connected, { appId: config.appId })
+
+      // Compute initial directory from first visible project
+      const allProjects = this.getProjects()
+      const visibleProjects = allProjects.filter((p) => !(this.projectDir(p) in this._hiddenDirs))
+      this._initialDir = visibleProjects.length > 0 ? this.projectDir(visibleProjects[0]) : Instance.directory
+
+      // Preheat a session in the initial directory
+      try {
+        await Instance.provide({
+          directory: this._initialDir,
+          fn: async () => {
+            const recent = [...Session.list({ directory: this._initialDir, roots: true, limit: 1 })]
+            if (recent.length === 0) {
+              await Session.create({ title: `飞书对话 startup` })
+            }
+          },
+        })
+        console.log("[feishu] preheated session in:", this._initialDir)
+      } catch (e) {
+        console.log("[feishu] failed to preheat session:", e)
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       this._error = { code: "start_failed", message }
@@ -426,7 +444,7 @@ class FeishuManagerImpl {
       }
 
       // Effective directory for this chat (may differ from connect-time Instance.directory)
-      const effectiveDir = this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory
+      const effectiveDir = this._chatDirs[chatId] ?? (this._initialDir || Instance.directory)
 
       // Feishu message to a hidden project → unhide immediately
       if (effectiveDir in this._hiddenDirs) {
@@ -504,12 +522,29 @@ class FeishuManagerImpl {
 
           const responseText = this.extractResponseText(msg)
           if (responseText) {
-            const projectName = effectiveDir.split("/").at(-1) ?? effectiveDir
+            const projectItem = this.getProjects().find(
+              (p) => this.normDir(this.projectDir(p)) === this.normDir(effectiveDir),
+            )
+            const projectName = this.clip(
+              projectItem
+                ? this.projectName(projectItem)
+                : (effectiveDir.replace(/\\/g, "/").replace(/\/+$/, "").split("/").at(-1) ?? effectiveDir),
+              24,
+            )
             const sessionInfo = [...Session.list({ directory: effectiveDir, roots: true, limit: 100 })].find(
               (s) => s.id === sessionId,
             )
-            const sessionTitle = sessionInfo?.title ?? sessionId.slice(0, 8)
-            const header = `📁 ${projectName}\n💬 ${sessionTitle}\n${"─".repeat(20)}\n`
+            const label = this.clip(sessionInfo?.title ?? sessionId.slice(0, 8), 24)
+            const pref = SessionPreference.get(sessionId)
+            const modeName = pref?.agent ?? "build"
+            const mode = modeName.charAt(0).toUpperCase() + modeName.slice(1)
+            const model = this.resolveModel(chatId)
+            const modelStr = model
+              ? `${model.providerID}/${model.modelID}`
+              : this._connectedModel
+                ? `${this._connectedModel.providerID}/${this._connectedModel.modelID}`
+                : "—"
+            const header = `${projectName}  ·  ${label}  ·  ${mode}  ·  ${modelStr}\n————————\n`
 
             console.log("[feishu] replying:", responseText.slice(0, 100))
             await this.replyText(messageId, header + responseText)
@@ -742,7 +777,7 @@ class FeishuManagerImpl {
     } else if (command === "/help") {
       await this.replyText(
         messageId,
-        "📋 可用命令：\n\n/new             开启全新对话（无当前会话上下文）\n/stop            停止当前会话中的执行\n/compact         压缩当前会话上下文\n/model           查看可用 LLM 模型（每个 provider 最多显示前 5 个）\n/model list      查看所有可用 LLM 模型\n/model n         切换到编号 n 的模型（按全量模型编号）\n/agent           查看当前会话模式\n/agent <name>    切换到指定模式（如 build、plan、docs）\n/approval        查看当前审批模式\n/approval <name> 切换审批模式（如 auto、ask）\n/variant         查看当前变体\n/variant <name>  切换到指定变体\n/project         查看最近项目\n/project list    查看全部项目\n/project n       切换到编号 n 的项目\n/project hide n  隐藏项目（在桌面端或飞书端重新使用后自动恢复）\n/project default n  设置编号 n 的项目为默认（重连后自动进入）\n/session         查看当前项目下的最近会话\n/session list    查看当前项目下全部会话\n/session n       切换到当前项目下编号 n 的会话\n/help            显示此帮助信息",
+        "📋 可用命令：\n\n/new             开启全新对话（无当前会话上下文）\n/stop            停止当前会话中的执行\n/compact         压缩当前会话上下文\n/model           查看可用 LLM 模型（每个 provider 最多显示前 5 个）\n/model list      查看所有可用 LLM 模型\n/model n         切换到编号 n 的模型（按全量模型编号）\n/agent           查看当前会话模式\n/agent <name>    切换到指定模式（如 build、plan、docs）\n/approval        查看当前审批模式\n/approval <name> 切换审批模式（如 auto、ask）\n/variant         查看当前变体\n/variant <name>  切换到指定变体\n/project         查看最近项目\n/project list    查看全部项目\n/project n       切换到编号 n 的项目\n/project hide n  隐藏项目（在桌面端或飞书端重新使用后自动恢复）\n/session         查看当前项目下的最近会话\n/session list    查看当前项目下全部会话\n/session n       切换到当前项目下编号 n 的会话\n/help            显示此帮助信息",
       )
     } else {
       await this.replyText(messageId, `未知命令: ${command}\n发送 /help 查看可用命令。`)
@@ -756,7 +791,7 @@ class FeishuManagerImpl {
     }
     delete this._chatSessions[chatId]
 
-    const effectiveDir = this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory
+    const effectiveDir = this._chatDirs[chatId] ?? (this._initialDir || Instance.directory)
     const session = await Instance.provide({
       directory: effectiveDir,
       fn: () => Session.create({ title: `飞书对话 ${chatId.slice(-6)}` }),
@@ -793,7 +828,7 @@ class FeishuManagerImpl {
       const sessionId = this._chatSessions[chatId]
       if (sessionId) {
         await Instance.provide({
-          directory: this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory,
+          directory: this._chatDirs[chatId] ?? (this._initialDir || Instance.directory),
           fn: () =>
             SessionPreference.set({
               sessionID: SessionID.make(sessionId),
@@ -820,7 +855,7 @@ class FeishuManagerImpl {
       const sessionId = this._chatSessions[chatId]
       if (sessionId) {
         await Instance.provide({
-          directory: this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory,
+          directory: this._chatDirs[chatId] ?? (this._initialDir || Instance.directory),
           fn: () =>
             SessionPreference.set({
               sessionID: SessionID.make(sessionId),
@@ -883,7 +918,7 @@ class FeishuManagerImpl {
       await this.replyText(messageId, "当前没有可停止的会话。")
       return
     }
-    const effectiveDir = this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory
+    const effectiveDir = this._chatDirs[chatId] ?? (this._initialDir || Instance.directory)
     const busy = await Instance.provide({
       directory: effectiveDir,
       fn: () => SessionStatus.get(SessionID.make(sessionId)),
@@ -903,7 +938,7 @@ class FeishuManagerImpl {
 
   /** /compact — compress the current session context */
   private async cmdCompact(messageId: string, chatId: string): Promise<void> {
-    const effectiveDir = this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory
+    const effectiveDir = this._chatDirs[chatId] ?? (this._initialDir || Instance.directory)
     let sessionId = this._chatSessions[chatId]
     if (!sessionId) {
       const session = await Instance.provide({
@@ -971,7 +1006,7 @@ class FeishuManagerImpl {
     }
     if (sessionId) {
       await Instance.provide({
-        directory: this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory,
+        directory: this._chatDirs[chatId] ?? (this._initialDir || Instance.directory),
         fn: () =>
           SessionPreference.set({
             sessionID: SessionID.make(sessionId),
@@ -1001,7 +1036,7 @@ class FeishuManagerImpl {
     }
     if (sessionId) {
       await Instance.provide({
-        directory: this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory,
+        directory: this._chatDirs[chatId] ?? (this._initialDir || Instance.directory),
         fn: () =>
           SessionPreference.set({
             sessionID: SessionID.make(sessionId),
@@ -1030,7 +1065,7 @@ class FeishuManagerImpl {
     }
     if (sessionId) {
       await Instance.provide({
-        directory: this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory,
+        directory: this._chatDirs[chatId] ?? (this._initialDir || Instance.directory),
         fn: () =>
           SessionPreference.set({
             sessionID: SessionID.make(sessionId),
@@ -1060,25 +1095,7 @@ class FeishuManagerImpl {
     await this.autoUnhide()
 
     const visibleProjects = allProjects.filter((p) => !(this.projectDir(p) in this._hiddenDirs))
-    const currentDir = this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory
-
-    // /project default <n>
-    if (arg.startsWith("default ")) {
-      const idxArg = arg.slice(8).trim()
-      const idx = parseInt(idxArg, 10) - 1
-      if (isNaN(idx) || idx < 0 || idx >= allProjects.length) {
-        await this.replyText(messageId, `❌ 用法：/project default n（n 为 1~${allProjects.length}）`)
-        return
-      }
-      const target = allProjects[idx]
-      this._defaultDir = this.projectDir(target)
-      await this.saveDefaultDir(this._defaultDir)
-      await this.replyText(
-        messageId,
-        `✅ 已设置默认项目：${this.projectName(target)}\n   ${this._defaultDir}\n（断开重连后自动进入此项目）`,
-      )
-      return
-    }
+    const currentDir = this._chatDirs[chatId] ?? (this._initialDir || Instance.directory)
 
     // /project hide <n>
     if (arg.startsWith("hide ")) {
@@ -1106,8 +1123,7 @@ class FeishuManagerImpl {
         const directory = this.projectDir(item)
         const tag = directory === currentDir ? " ◀" : ""
         const mark = directory in this._hiddenDirs ? " [已隐藏]" : ""
-        const def = directory === this._defaultDir ? " [默认]" : ""
-        lines.push(`${i + 1}. ${this.projectName(item)}${tag}${def}${mark}`)
+        lines.push(`${i + 1}. ${this.projectName(item)}${tag}${mark}`)
         lines.push(`   ${directory}`)
       }
       await this.replyText(messageId, lines.join("\n"))
@@ -1183,8 +1199,7 @@ class FeishuManagerImpl {
       const directory = this.projectDir(item)
       if (directory in this._hiddenDirs) continue
       const tag = directory === currentDir ? " ◀" : ""
-      const def = directory === this._defaultDir ? " [默认]" : ""
-      lines.push(`${i + 1}. ${this.projectName(item)}${tag}${def}`)
+      lines.push(`${i + 1}. ${this.projectName(item)}${tag}`)
       lines.push(`   ${directory}`)
       count++
     }
@@ -1207,7 +1222,7 @@ class FeishuManagerImpl {
    * /session <n>      — switch to session n
    */
   private async cmdSession(messageId: string, chatId: string, arg: string): Promise<void> {
-    const effectiveDir = this._chatDirs[chatId] ?? this._defaultDir ?? Instance.directory
+    const effectiveDir = this._chatDirs[chatId] ?? (this._initialDir || Instance.directory)
     let items: Session.Info[] = []
     await Instance.provide({
       directory: effectiveDir,
@@ -1311,6 +1326,7 @@ class FeishuManagerImpl {
     this._modelList = []
     this._chatDirs = {}
     this._chatSessions = {}
+    this._initialDir = ""
     // _hiddenDirs intentionally kept (persisted, survives reconnect)
     this.status = "idle"
   }
@@ -1369,21 +1385,6 @@ class FeishuManagerImpl {
   private async saveHiddenDirs(): Promise<void> {
     await mkdir(FEISHU_DATA_DIR, { recursive: true })
     await writeFile(HIDDEN_DIRS_FILE, JSON.stringify(this._hiddenDirs, null, 2))
-  }
-
-  private async loadDefaultDir(): Promise<string | null> {
-    try {
-      if (existsSync(DEFAULT_PROJECT_FILE)) {
-        const data = await readFile(DEFAULT_PROJECT_FILE, "utf-8")
-        return JSON.parse(data)?.directory ?? null
-      }
-    } catch {}
-    return null
-  }
-
-  private async saveDefaultDir(directory: string): Promise<void> {
-    await mkdir(FEISHU_DATA_DIR, { recursive: true })
-    await writeFile(DEFAULT_PROJECT_FILE, JSON.stringify({ directory }, null, 2))
   }
 
   async loadSession(): Promise<FeishuSession | null> {

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -45,6 +45,12 @@ export interface FeishuSession {
   createdAt: number
 }
 
+const HELP_TEXT =
+  "📋 可用命令：\n\n/n, /new      开启新对话\n/stop         停止当前执行\n/c, /compact  压缩当前上下文\n\n/m, /model    查看可用模型\n/m l          查看全部模型\n/m n          切换编号模型\n\n/a, /agent    查看当前模式\n/a <name>     切换指定模式\n\n/p, /project  查看最近项目\n/p l          查看全部项目\n/p n          切换编号项目\n\n/s, /session  查看最近会话\n/s l          查看全部会话\n/s n          切换编号会话\n\n/h, /help     显示帮助信息\n/help list    显示全部命令"
+
+const HELP_LIST_TEXT =
+  "📋 全部命令：\n\n/n, /new           开启新对话\n/stop              停止当前执行\n/c, /compact       压缩当前上下文\n\n/m, /model         查看可用模型\n/m l, /model list  查看全部模型\n/m n, /model n     切换编号模型\n\n/a, /agent         查看当前模式\n/a <name>          切换指定模式\n\n/p, /project       查看最近项目\n/p l, /project list 查看全部项目\n/p n, /project n   切换编号项目\n/project hide n    隐藏指定项目\n\n/s, /session       查看最近会话\n/s l, /session list 查看全部会话\n/s n, /session n   切换编号会话\n\n/approval          查看审批模式\n/approval <name>   切换审批模式\n\n/variant           查看当前变体\n/variant <name>    切换指定变体\n\n/h, /help          显示帮助信息\n/help list         显示全部命令"
+
 export const FeishuEvent = {
   StatusChanged: BusEvent.define(
     "feishu.status",
@@ -647,19 +653,17 @@ class FeishuManagerImpl {
       console.log("[feishu] text:", text)
 
       const isSlash = text.startsWith("/")
+      const parts = isSlash ? text.trim().split(/\s+/) : []
       const cmd = isSlash ? text.trim().split(/\s+/)[0].toLowerCase() : ""
 
-      if (cmd === "/help") {
-        await this.replyText(
-          messageId,
-          "📋 可用命令：\n\n/new             开启全新对话（无当前会话上下文）\n/stop            停止当前会话中的执行\n/compact         压缩当前会话上下文\n/model           查看可用 LLM 模型（每个 provider 最多显示前 5 个）\n/model list      查看所有可用 LLM 模型\n/model n         切换到编号 n 的模型（按全量模型编号）\n/agent           查看当前会话模式\n/agent <name>    切换到指定模式（如 build、plan、docs）\n/approval        查看当前审批模式\n/approval <name> 切换审批模式（如 auto、ask）\n/variant         查看当前变体\n/variant <name>  切换到指定变体\n/project         查看最近项目\n/project list    查看全部项目\n/project n       切换到编号 n 的项目\n/project hide n  隐藏项目（在桌面端或飞书端重新使用后自动恢复）\n/session         查看当前项目下的最近会话\n/session list    查看当前项目下全部会话\n/session n       切换到当前项目下编号 n 的会话\n/help            显示此帮助信息",
-        )
+      if (cmd === "/h" || cmd === "/help") {
+        await this.replyText(messageId, parts[1]?.toLowerCase() === "list" ? HELP_LIST_TEXT : HELP_TEXT)
         return
       }
 
       await this.autoUnhide()
 
-      if (isSlash && cmd !== "/stop" && cmd !== "/compact") {
+      if (isSlash && cmd !== "/stop" && cmd !== "/compact" && cmd !== "/c") {
         await this.handleCommand(text, messageId, chatId)
         return
       }
@@ -700,7 +704,7 @@ class FeishuManagerImpl {
         return
       }
 
-      if (cmd === "/compact") {
+      if (cmd === "/c" || cmd === "/compact") {
         const pendingQ = this._pendingQuestions[chatId]
         if (pendingQ) {
           await this.replyText(messageId, this.formatQuestionRequest(pendingQ))
@@ -1079,25 +1083,25 @@ class FeishuManagerImpl {
     const rest = parts.slice(1).join(" ")
 
     try {
-      if (command === "/new") {
+      if (command === "/n" || command === "/new") {
         await this.cmdNew(messageId, chatId)
-      } else if (command === "/model") {
-        await this.cmdModel(messageId, chatId, parts.slice(1))
-      } else if (command === "/agent") {
+      } else if (command === "/m" || command === "/model") {
+        const args = parts.slice(1)
+        if (args[0] === "l") args[0] = "list"
+        await this.cmdModel(messageId, chatId, args)
+      } else if (command === "/a" || command === "/agent") {
         await this.cmdAgent(messageId, chatId, rest)
       } else if (command === "/approval") {
         await this.cmdApproval(messageId, chatId, rest)
       } else if (command === "/variant") {
         await this.cmdVariant(messageId, chatId, rest)
-      } else if (command === "/project") {
-        await this.cmdProject(messageId, chatId, rest)
-      } else if (command === "/session") {
-        await this.cmdSession(messageId, chatId, rest)
-      } else if (command === "/help") {
-        await this.replyText(
-          messageId,
-          "📋 可用命令：\n\n/new             开启全新对话（无当前会话上下文）\n/stop            停止当前会话中的执行\n/compact         压缩当前会话上下文\n/model           查看可用 LLM 模型（每个 provider 最多显示前 5 个）\n/model list      查看所有可用 LLM 模型\n/model n         切换到编号 n 的模型（按全量模型编号）\n/agent           查看当前会话模式\n/agent <name>    切换到指定模式（如 build、plan、docs）\n/approval        查看当前审批模式\n/approval <name> 切换审批模式（如 auto、ask）\n/variant         查看当前变体\n/variant <name>  切换到指定变体\n/project         查看最近项目\n/project list    查看全部项目\n/project n       切换到编号 n 的项目\n/project hide n  隐藏项目（在桌面端或飞书端重新使用后自动恢复）\n/session         查看当前项目下的最近会话\n/session list    查看当前项目下全部会话\n/session n       切换到当前项目下编号 n 的会话\n/help            显示此帮助信息",
-        )
+      } else if (command === "/p" || command === "/project") {
+        const arg = rest === "l" ? "list" : rest.startsWith("h ") ? `hide ${rest.slice(2).trim()}` : rest
+        await this.cmdProject(messageId, chatId, arg)
+      } else if (command === "/s" || command === "/session") {
+        await this.cmdSession(messageId, chatId, rest === "l" ? "list" : rest)
+      } else if (command === "/h" || command === "/help") {
+        await this.replyText(messageId, rest.toLowerCase() === "list" ? HELP_LIST_TEXT : HELP_TEXT)
       } else {
         await this.replyText(messageId, `未知命令: ${command}\n发送 /help 查看可用命令。`)
       }

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -333,7 +333,7 @@ class FeishuManagerImpl {
     const ctx = await this.commandCtx(chatId)
     await Instance.provide({
       directory: ctx.dir,
-      fn: () => SessionPreference.set({ sessionID: SessionID.make(ctx.sessionId), source: "feishu", ...patch }),
+      fn: () => SessionPreference.update({ sessionID: SessionID.make(ctx.sessionId), ...patch }),
     })
   }
 
@@ -810,7 +810,7 @@ class FeishuManagerImpl {
           }
 
           const pref = sessionId ? SessionPreference.get(sessionId) : undefined
-          if (pref?.approval === "auto") {
+          if (pref?.autoAccept) {
             const session = await Session.get(SessionID.make(sessionId))
             if (!session.permission?.some((r) => r.permission === "*" && r.action === "allow")) {
               await Session.setPermission({
@@ -1301,16 +1301,17 @@ class FeishuManagerImpl {
    */
   private async cmdApproval(messageId: string, chatId: string, arg: string): Promise<void> {
     const ctx = await this.commandCtx(chatId)
-    const current = ctx.pref?.approval || "ask"
+    const auto = ctx.pref?.autoAccept ?? false
     if (!arg) {
-      await this.replyText(messageId, this.commandHeader(ctx) + `🔐 当前审批模式：${current}\n可用模式：auto、ask`)
+      const mode = auto ? "auto" : "ask"
+      await this.replyText(messageId, this.commandHeader(ctx) + `🔐 当前审批模式：${mode}\n可用模式：auto、ask`)
       return
     }
     if (arg !== "auto" && arg !== "ask") {
       await this.replyText(messageId, this.commandHeader(ctx) + "❌ 仅支持 /approval auto 或 /approval ask")
       return
     }
-    await this.setPref(chatId, { approval: arg })
+    await this.setPref(chatId, { autoAccept: arg === "auto" })
     if (arg === "auto") {
       const pending = this._pendingPermissions[chatId]
       if (pending) {

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -32,7 +32,7 @@ const CONFIG_FILE = join(FEISHU_DATA_DIR, "config.json")
 const SESSION_MAP_FILE = join(FEISHU_DATA_DIR, "sessions.json")
 const HIDDEN_DIRS_FILE = join(FEISHU_DATA_DIR, "hidden_projects.json")
 
-export type FeishuStatus = "idle" | "starting" | "connected" | "error"
+export type FeishuStatus = "idle" | "starting" | "connected" | "reconnecting" | "error"
 
 export interface FeishuConfig {
   appId: string
@@ -49,7 +49,7 @@ export const FeishuEvent = {
   StatusChanged: BusEvent.define(
     "feishu.status",
     z.object({
-      status: z.enum(["idle", "starting", "connected", "error"]),
+      status: z.enum(["idle", "starting", "connected", "reconnecting", "error"]),
       message: z.string().optional(),
     }),
   ),
@@ -64,6 +64,13 @@ export const FeishuEvent = {
     z.object({
       code: z.string(),
       message: z.string(),
+    }),
+  ),
+  Reconnecting: BusEvent.define(
+    "feishu.reconnecting",
+    z.object({
+      attempt: z.number(),
+      delay: z.number(),
     }),
   ),
 }
@@ -124,7 +131,19 @@ class FeishuManagerImpl {
   // ── Pending interaction state ─────────────────────────────────────────────
   private _pendingQuestions: Record<string, Question.Request> = {}
   private _pendingPermissions: Record<string, Permission.Request> = {}
+  private _queues = new Map<string, Promise<void>>()
+  private _heartbeat: ReturnType<typeof setInterval> | null = null
+  private _heartbeatFails = 0
+  private _reconnect: ReturnType<typeof setTimeout> | null = null
+  private _reconnectCount = 0
+  private _manualStop = false
+  private _lastConfig: FeishuConfig | null = null
+  private _starting = false
   // ─────────────────────────────────────────────────────────────────────────
+
+  private static readonly HEARTBEAT_MS = 30_000
+  private static readonly HEARTBEAT_FAILS = 3
+  private static readonly RECONNECT_MAX = 10
 
   get status() {
     return this._status
@@ -351,7 +370,7 @@ class FeishuManagerImpl {
     status?: string
     appId?: string
   }> {
-    if (this.wsClient || this._status === "starting" || this._status === "connected") {
+    if (this.wsClient || this._starting || ["starting", "connected", "reconnecting"].includes(this._status)) {
       return { success: false, message: "Feishu bridge is already running" }
     }
 
@@ -365,6 +384,8 @@ class FeishuManagerImpl {
 
     this.status = "starting"
     this._error = null
+    this._manualStop = false
+    this._lastConfig = cfg
 
     await this.saveConfig(cfg)
     this.sessionMap = await this.loadSessionMap()
@@ -374,13 +395,14 @@ class FeishuManagerImpl {
   }
 
   private async _doStart(config: FeishuConfig, model: ModelRef | null): Promise<void> {
+    this._starting = true
     try {
       this.statusMsg("starting", "正在连接飞书...")
       console.log("[feishu] _doStart called")
 
       const boundHandleMessage = (data: any) => {
         console.log("[feishu] >>> event received!")
-        void this.handleMessage(data)
+        void this.enqueueMessage(data)
       }
 
       this._appId = config.appId
@@ -401,12 +423,14 @@ class FeishuManagerImpl {
         appSecret: config.appSecret,
         loggerLevel: lark.LoggerLevel.debug,
       })
+      this.bindLifecycle(this.wsClient)
 
       console.log("[feishu] calling wsClient.start()...")
       await this.wsClient.start({ eventDispatcher })
       console.log("[feishu] wsClient.start() resolved")
 
       this._connectedModel = model
+      this._reconnectCount = 0
       console.log("[feishu] connected model:", this._connectedModel)
 
       this._modelList = await this.buildModelList()
@@ -428,6 +452,7 @@ class FeishuManagerImpl {
         appId: config.appId,
         createdAt: Date.now(),
       }
+      this.startHeartbeat()
       this.status = "connected"
       Bus.publish(FeishuEvent.Connected, { appId: config.appId })
 
@@ -441,7 +466,142 @@ class FeishuManagerImpl {
       this._error = { code: "start_failed", message }
       this.status = "error"
       Bus.publish(FeishuEvent.Error, this._error)
+      if (!this._manualStop) this.scheduleReconnect(message)
+    } finally {
+      this._starting = false
     }
+  }
+
+  private bindLifecycle(client: any): void {
+    const on = client?.on?.bind(client)
+    if (typeof on === "function") {
+      on("close", () => this.onDisconnect("ws_close"))
+      on("error", (err: unknown) => this.onDisconnect(err instanceof Error ? err.message : "ws_error"))
+    }
+
+    const bind = () => {
+      const ws = client?.ws
+      if (!ws || ws.__aetherBound) return
+      ws.__aetherBound = true
+      const close = ws.addEventListener?.bind(ws)
+      if (typeof close === "function") {
+        close("close", () => this.onDisconnect("socket_close"))
+        close("error", () => this.onDisconnect("socket_error"))
+        return
+      }
+      const add = ws.on?.bind(ws)
+      if (typeof add === "function") {
+        add("close", () => this.onDisconnect("socket_close"))
+        add("error", () => this.onDisconnect("socket_error"))
+      }
+    }
+
+    bind()
+
+    const connect = client?.connect?.bind(client)
+    if (typeof connect !== "function") return
+    client.connect = async (...args: any[]) => {
+      const result = await connect(...args)
+      bind()
+      return result
+    }
+  }
+
+  private onDisconnect(reason: string): void {
+    if (this._manualStop) return
+    if (this._status === "idle" || this._status === "error") return
+    console.warn("[feishu] disconnect detected:", reason)
+    this.stopHeartbeat()
+    this.scheduleReconnect(reason)
+  }
+
+  private scheduleReconnect(reason: string): void {
+    if (this._manualStop || !this._lastConfig) return
+    if (this._reconnect || this._status === "reconnecting") return
+    if (this._reconnectCount >= FeishuManagerImpl.RECONNECT_MAX) {
+      this._error = { code: "reconnect_failed", message: "飞书连接多次重试失败，请手动重新连接。" }
+      this.status = "error"
+      Bus.publish(FeishuEvent.Error, this._error)
+      return
+    }
+    const attempt = this._reconnectCount + 1
+    const delay = Math.min(2_000 * 2 ** this._reconnectCount, 30_000)
+    this._reconnectCount = attempt
+    this.statusMsg("reconnecting", `飞书连接已断开，正在重连（第 ${attempt} 次）...`)
+    Bus.publish(FeishuEvent.Reconnecting, { attempt, delay })
+    this._reconnect = setTimeout(() => {
+      this._reconnect = null
+      void this.restartAfterDisconnect(reason)
+    }, delay)
+  }
+
+  private async restartAfterDisconnect(reason: string): Promise<void> {
+    if (this._manualStop || !this._lastConfig) return
+    console.log("[feishu] reconnecting after:", reason)
+    await this.cleanupConnection(false)
+    await this._doStart(this._lastConfig, this._connectedModel)
+  }
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat()
+    this._heartbeatFails = 0
+    this._heartbeat = setInterval(() => {
+      void this.checkHeartbeat()
+    }, FeishuManagerImpl.HEARTBEAT_MS)
+  }
+
+  private stopHeartbeat(): void {
+    if (!this._heartbeat) return
+    clearInterval(this._heartbeat)
+    this._heartbeat = null
+  }
+
+  private async checkHeartbeat(): Promise<void> {
+    if (this._manualStop || this._status !== "connected") return
+    try {
+      await this.getTenantAccessToken()
+      this._heartbeatFails = 0
+    } catch (err) {
+      this._heartbeatFails += 1
+      console.warn("[feishu] heartbeat failed:", this._heartbeatFails, err)
+      if (this._heartbeatFails < FeishuManagerImpl.HEARTBEAT_FAILS) return
+      this.onDisconnect("heartbeat_failed")
+    }
+  }
+
+  private async cleanupConnection(reset = true): Promise<void> {
+    this.stopHeartbeat()
+    if (this._reconnect) {
+      clearTimeout(this._reconnect)
+      this._reconnect = null
+    }
+    if (this._globalBusListener) {
+      GlobalBus.off("event", this._globalBusListener)
+      this._globalBusListener = null
+    }
+    if (this.wsClient) {
+      const prev = this._manualStop
+      this._manualStop = true
+      try {
+        if (typeof this.wsClient.close === "function") {
+          await this.wsClient.close()
+        }
+      } catch {}
+      this._manualStop = prev
+      this.wsClient = null
+    }
+    this.larkClient = null
+    this._session = null
+    this._modelList = []
+    this._pendingQuestions = {}
+    this._pendingPermissions = {}
+    this._queues.clear()
+    if (!reset) return
+    this._connectedModel = null
+    this._chatDirs = {}
+    this._chatSessions = {}
+    this._initialDir = ""
+    this.status = "idle"
   }
 
   private async handleMessage(data: any): Promise<void> {
@@ -724,6 +884,20 @@ class FeishuManagerImpl {
         console.error("[feishu] failed to send error reply:", e2)
       }
     }
+  }
+
+  private enqueueMessage(data: any): Promise<void> {
+    const chatId = data?.message?.chat_id
+    if (!chatId) return this.handleMessage(data)
+    const prev = this._queues.get(chatId) ?? Promise.resolve()
+    const next = prev
+      .catch(() => {})
+      .then(() => this.handleMessage(data))
+      .finally(() => {
+        if (this._queues.get(chatId) === next) this._queues.delete(chatId)
+      })
+    this._queues.set(chatId, next)
+    return next
   }
 
   /** Detect if the user is asking for a chat summary and extract time range. */
@@ -1441,29 +1615,10 @@ class FeishuManagerImpl {
   }
 
   async stop(): Promise<void> {
-    if (this._globalBusListener) {
-      GlobalBus.off("event", this._globalBusListener)
-      this._globalBusListener = null
-    }
-    if (this.wsClient) {
-      try {
-        if (typeof this.wsClient.stop === "function") {
-          this.wsClient.stop()
-        }
-      } catch {}
-      this.wsClient = null
-      this.larkClient = null
-    }
-    this._session = null
-    this._connectedModel = null
-    this._modelList = []
-    this._chatDirs = {}
-    this._chatSessions = {}
-    this._initialDir = ""
-    this._pendingQuestions = {}
-    this._pendingPermissions = {}
+    this._manualStop = true
+    this._reconnectCount = 0
+    await this.cleanupConnection()
     // _hiddenDirs intentionally kept (persisted, survives reconnect)
-    this.status = "idle"
   }
 
   async clearSession(): Promise<void> {

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -1103,7 +1103,7 @@ class FeishuManagerImpl {
       } else if (command === "/h" || command === "/help") {
         await this.replyText(messageId, rest.toLowerCase() === "list" ? HELP_LIST_TEXT : HELP_TEXT)
       } else {
-        await this.replyText(messageId, `未知命令: ${command}\n发送 /help 查看可用命令。`)
+        await this.replyText(messageId, `❓ 未知命令：${command}\n发送 /help 查看常用命令，/help list 查看全部命令。`)
       }
     } catch (err) {
       console.error("[feishu] handleCommand error:", err)
@@ -1186,7 +1186,7 @@ class FeishuManagerImpl {
       return
     }
 
-    await this.replyText(messageId, this.commandHeader(ctx) + "无效参数，请输入编号、list 或 provider/model 格式。")
+    await this.replyText(messageId, this.commandHeader(ctx) + "❌ 无效参数，请输入编号、list 或 provider/model 格式。")
   }
 
   private formatModelList(ctx: Awaited<ReturnType<typeof this.commandCtx>>, full: boolean): string {
@@ -1215,7 +1215,7 @@ class FeishuManagerImpl {
         lines.push(`  ${entry.index}. ${entry.providerID}/${entry.modelID}${def}`)
       }
       if (!full && entries.length > visible.length) {
-        lines.push(`  ... 还有 ${entries.length - visible.length} 个，发送 /model list 查看全部`)
+        lines.push(`  ... 还有 ${entries.length - visible.length} 个，发送 /m l 查看全部`)
       }
     }
 
@@ -1224,7 +1224,7 @@ class FeishuManagerImpl {
     }
 
     lines.push("")
-    lines.push("💡 /model n 切换模型 | /model list 查看全部")
+    lines.push("💡 /m n 切换模型 | /m l 查看全部")
     return lines.join("\n")
   }
 
@@ -1307,7 +1307,7 @@ class FeishuManagerImpl {
     const ctx = await this.commandCtx(chatId)
     const auto = ctx.pref?.autoAccept ?? false
     if (!arg) {
-      const mode = auto ? "auto" : "ask"
+      const mode = auto ? "自动批准" : "手动审批"
       await this.replyText(messageId, this.commandHeader(ctx) + `🔐 当前审批模式：${mode}\n可用模式：auto、ask`)
       return
     }
@@ -1383,7 +1383,7 @@ class FeishuManagerImpl {
       this._hiddenDirs[directory] = Date.now()
       await this.saveHiddenDirs()
       const name = this.projectName(target)
-      await this.replyText(messageId, `✅ 已隐藏：${name}\n（在桌面端或飞书端重新使用后自动恢复）`)
+      await this.replyText(messageId, `✅ 已隐藏：${name}\n（在桌面端或消息端重新使用后自动恢复）`)
       return
     }
 
@@ -1478,7 +1478,7 @@ class FeishuManagerImpl {
       count++
     }
     lines.push("")
-    lines.push("💡 /project n 切换 | /project list 查看全部 | /project hide n 隐藏")
+    lines.push("💡 /p n 切换 | /p l 查看全部")
     if (Object.keys(this._hiddenDirs).length > 0) {
       lines.push(`ℹ️ 已隐藏 ${Object.keys(this._hiddenDirs).length} 个项目（重新使用后自动恢复）`)
     }
@@ -1561,7 +1561,7 @@ class FeishuManagerImpl {
       lines.push(`   ${this.formatSessionTime(item.time.updated)}`)
     }
     lines.push("")
-    lines.push("💡 /session n 切换会话 | /session list 查看全部")
+    lines.push("💡 /s n 切换会话 | /s l 查看全部")
     await this.replyText(messageId, lines.join("\n"))
   }
 

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -454,16 +454,12 @@ class FeishuManagerImpl {
         return
       }
 
-      // Check for hidden projects with new activity (web UI or prior Feishu messages)
-      await this.autoUnhide()
-
       const chatId = message.chat_id
       const messageId = message.message_id
       const rootId = message.root_id || message.parent_id || messageId
-      const chatType = message.chat_type // "p2p" or "group"
+      const chatType = message.chat_type
       console.log("[feishu] message:", { chatId, messageId, type: message.message_type, chatType })
 
-      // In group chats, only respond when the bot is @mentioned
       if (chatType === "group") {
         const mentions = message.mentions
         if (!mentions || !Array.isArray(mentions) || mentions.length === 0) {
@@ -486,61 +482,127 @@ class FeishuManagerImpl {
         return
       }
 
-      // Strip @mention tags (group chat)
       text = text.replace(/@_\w+\s*/g, "").trim()
       if (!text) return
       console.log("[feishu] text:", text)
 
-      // Handle slash commands
-      if (text.startsWith("/")) {
+      const isSlash = text.startsWith("/")
+      const cmd = isSlash ? text.trim().split(/\s+/)[0].toLowerCase() : ""
+
+      if (cmd === "/help") {
+        await this.replyText(
+          messageId,
+          "📋 可用命令：\n\n/new             开启全新对话（无当前会话上下文）\n/stop            停止当前会话中的执行\n/compact         压缩当前会话上下文\n/model           查看可用 LLM 模型（每个 provider 最多显示前 5 个）\n/model list      查看所有可用 LLM 模型\n/model n         切换到编号 n 的模型（按全量模型编号）\n/agent           查看当前会话模式\n/agent <name>    切换到指定模式（如 build、plan、docs）\n/approval        查看当前审批模式\n/approval <name> 切换审批模式（如 auto、ask）\n/variant         查看当前变体\n/variant <name>  切换到指定变体\n/project         查看最近项目\n/project list    查看全部项目\n/project n       切换到编号 n 的项目\n/project hide n  隐藏项目（在桌面端或飞书端重新使用后自动恢复）\n/session         查看当前项目下的最近会话\n/session list    查看当前项目下全部会话\n/session n       切换到当前项目下编号 n 的会话\n/help            显示此帮助信息",
+        )
+        return
+      }
+
+      await this.autoUnhide()
+
+      if (isSlash && cmd !== "/stop" && cmd !== "/compact") {
         await this.handleCommand(text, messageId, chatId)
         return
       }
 
-      // If this chat has a pending question, treat the text as an answer
-      const pendingQ = this._pendingQuestions[chatId]
-      if (pendingQ) {
-        delete this._pendingQuestions[chatId]
-        await this.handleQuestionReply(messageId, chatId, pendingQ, text)
-        return
-      }
-
-      // If this chat has a pending permission, treat the text as a permission reply
-      const pendingP = this._pendingPermissions[chatId]
-      if (pendingP) {
-        delete this._pendingPermissions[chatId]
-        await this.handlePermissionReply(messageId, chatId, pendingP, text)
-        return
-      }
-
-      // Effective directory for this chat (may differ from connect-time Instance.directory)
       const effectiveDir = this.effectiveDir(chatId)
 
-      // Feishu message to a hidden project → unhide immediately
       if (effectiveDir in this._hiddenDirs) {
         delete this._hiddenDirs[effectiveDir]
         console.log("[feishu] auto-unhide via Feishu message:", effectiveDir)
         void this.saveHiddenDirs()
       }
 
-      // Busy check (before entering main Instance.provide)
-      const currentSid = this._chatSessions[chatId]
-      if (currentSid) {
-        try {
+      if (cmd === "/stop") {
+        const hasPending = chatId in this._pendingQuestions || chatId in this._pendingPermissions
+        const currentSid = this._chatSessions[chatId]
+        if (!currentSid) {
+          await this.replyText(messageId, "没有任务在执行")
+          return
+        }
+        const busy = await Instance.provide({
+          directory: effectiveDir,
+          fn: () => SessionStatus.get(SessionID.make(currentSid)),
+        }).catch(() => ({ type: "idle" as const }))
+        if (busy.type !== "busy" && !hasPending) {
+          await this.replyText(messageId, "没有任务在执行")
+          return
+        }
+        if (busy.type === "busy") {
+          try {
+            await Instance.provide({
+              directory: effectiveDir,
+              fn: () => SessionPrompt.cancel(SessionID.make(currentSid)),
+            })
+          } catch {}
+        }
+        await this.clearRuntime(chatId)
+        await this.replyText(messageId, "✅ 已停止当前执行。")
+        return
+      }
+
+      if (cmd === "/compact") {
+        const pendingQ = this._pendingQuestions[chatId]
+        if (pendingQ) {
+          await this.replyText(messageId, this.formatQuestionRequest(pendingQ))
+          return
+        }
+        const pendingP = this._pendingPermissions[chatId]
+        if (pendingP) {
+          await this.replyText(messageId, this.formatPermissionRequest(pendingP))
+          return
+        }
+        const currentSid = this._chatSessions[chatId]
+        if (currentSid) {
           const busy = await Instance.provide({
             directory: effectiveDir,
             fn: () => SessionStatus.get(SessionID.make(currentSid)),
-          })
+          }).catch(() => null)
           if (busy?.type === "busy") {
-            await this.replyText(messageId, "当前会话正在生成回复，请等待结束后再发送；\n如需停止请输入 /stop")
+            await this.replyText(
+              messageId,
+              "当前会话正在生成回复，请等待当前对话结束后再发送；如需立即开始新问题，请先 /new 或切换 /session n。如需停止本会话请输入 /stop",
+            )
             return
           }
-        } catch {
-          // SessionStatus.get may fail if instance not booted yet; skip check
+        }
+        if (!(chatId in this._chatSessions)) {
+          await this.replyText(messageId, "没有任务在执行")
+          return
+        }
+        try {
+          await this.cmdCompact(messageId, chatId)
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err)
+          await this.replyText(messageId, `命令执行出错: ${msg}`)
+        }
+        return
+      }
+
+      const pendingQ = this._pendingQuestions[chatId]
+      if (pendingQ) {
+        await this.replyText(messageId, this.formatQuestionRequest(pendingQ))
+        return
+      }
+      const pendingP = this._pendingPermissions[chatId]
+      if (pendingP) {
+        await this.replyText(messageId, this.formatPermissionRequest(pendingP))
+        return
+      }
+      const currentSid = this._chatSessions[chatId]
+      if (currentSid) {
+        const busy = await Instance.provide({
+          directory: effectiveDir,
+          fn: () => SessionStatus.get(SessionID.make(currentSid)),
+        }).catch(() => null)
+        if (busy?.type === "busy") {
+          await this.replyText(
+            messageId,
+            "当前会话正在生成回复，请等待当前对话结束后再发送；如需立即开始新问题，请先 /new 或切换 /session n。如需停止本会话请输入 /stop",
+          )
+          return
         }
       }
 
-      // Run session lookup and AI prompt in the effective directory's Instance context
       await Instance.provide({
         directory: effectiveDir,
         fn: async () => {
@@ -565,18 +627,9 @@ class FeishuManagerImpl {
             await this.saveSessionMap()
           }
 
-          // Sync pending: check if session has unanswered questions or permissions
-          try {
-            const synced = await this.syncPending(messageId, chatId, sessionId, effectiveDir)
-            if (synced) return
-          } catch (e) {
-            console.log("[feishu] syncPending error, continuing:", e)
-          }
-
           const model = this.resolveModel(chatId)
           console.log("[feishu] using model:", model ?? "(default)")
 
-          // Detect summarization intent and inject chat history into prompt
           let promptText = text
           if (this.detectFileSendIntent(text)) {
             promptText += `\n\n[系统提示：用户需要通过飞书接收文件附件，请在回复中包含该文件的完整绝对路径（格式如 /home/user/file.md），系统将自动将其作为附件发送给用户]`
@@ -645,8 +698,6 @@ class FeishuManagerImpl {
             console.log("[feishu] no text in response")
           }
 
-          // If user explicitly asked for a file, send files that were read this turn
-          // or extract file paths mentioned in the AI response text
           if (this.detectFileSendIntent(text)) {
             let filesToSend = this.extractReadFiles(msg)
             if (filesToSend.length === 0 && responseText) {
@@ -856,10 +907,6 @@ class FeishuManagerImpl {
     try {
       if (command === "/new") {
         await this.cmdNew(messageId, chatId)
-      } else if (command === "/stop") {
-        await this.cmdStop(messageId, chatId)
-      } else if (command === "/compact") {
-        await this.cmdCompact(messageId, chatId)
       } else if (command === "/model") {
         await this.cmdModel(messageId, chatId, parts.slice(1))
       } else if (command === "/agent") {
@@ -1003,30 +1050,6 @@ class FeishuManagerImpl {
     return lines.join("\n")
   }
 
-  /** /stop — abort the active prompt in the current session */
-  private async cmdStop(messageId: string, chatId: string): Promise<void> {
-    const ctx = await this.commandCtx(chatId)
-    const hasPending = chatId in this._pendingQuestions || chatId in this._pendingPermissions
-    const busy = await Instance.provide({
-      directory: ctx.dir,
-      fn: () => SessionStatus.get(SessionID.make(ctx.sessionId)),
-    })
-    if (busy.type !== "busy" && !hasPending) {
-      await this.replyText(messageId, this.commandHeader(ctx) + "当前没有正在执行的任务。")
-      return
-    }
-    if (busy.type === "busy") {
-      await Instance.provide({
-        directory: ctx.dir,
-        fn: async () => {
-          SessionPrompt.cancel(SessionID.make(ctx.sessionId))
-        },
-      })
-    }
-    await this.clearRuntime(chatId)
-    await this.replyText(messageId, this.commandHeader(ctx) + "✅ 已停止当前执行。")
-  }
-
   /** /compact — compress the current session context */
   private async cmdCompact(messageId: string, chatId: string): Promise<void> {
     const ctx = await this.commandCtx(chatId)
@@ -1164,10 +1187,6 @@ class FeishuManagerImpl {
       await this.replyText(messageId, "❌ 无法获取项目列表，请检查 Aether 是否正常运行。")
       return
     }
-
-    // autoUnhide already ran at message entry; run again here to catch
-    // activity created by the current message batch before /project was typed
-    await this.autoUnhide()
 
     const visibleProjects = allProjects.filter((p) => !(this.projectDir(p) in this._hiddenDirs))
     const currentDir = this.effectiveDir(chatId)
@@ -1369,34 +1388,6 @@ class FeishuManagerImpl {
 
   // ─────────────────────────────────────────────────────────────────────────
 
-  /** Check for pending questions/permissions on a session; return true if handled */
-  private async syncPending(messageId: string, chatId: string, sessionId: string, dir: string): Promise<boolean> {
-    const sid = SessionID.make(sessionId)
-    const questions = await Question.list()
-    const q = questions.find((r) => r.sessionID === sid)
-    if (q) {
-      this._pendingQuestions[chatId] = q
-      await this.replyText(messageId, this.formatQuestionRequest(q))
-      return true
-    }
-
-    const permissions = await Permission.list()
-    const p = permissions.find((r) => r.sessionID === sid)
-    if (p) {
-      const pref = SessionPreference.get(sessionId)
-      if (pref?.approval === "auto") {
-        await Permission.reply({ requestID: p.id, reply: "always" })
-        delete this._pendingPermissions[chatId]
-        console.log("[feishu] auto-approved pending permission:", p.id)
-        return false
-      }
-      this._pendingPermissions[chatId] = p
-      await this.replyText(messageId, this.formatPermissionRequest(p))
-      return true
-    }
-    return false
-  }
-
   private formatQuestionRequest(q: Question.Request): string {
     const parts = ["🤔 Agent 需要您回答：", ""]
     for (let i = 0; i < q.questions.length; i++) {
@@ -1432,48 +1423,6 @@ class FeishuManagerImpl {
     parts.push("3. 拒绝（本次不允许执行）")
     parts.push("如需开始新问题，请先 /new 或切换 /session n。")
     return parts.join("\n")
-  }
-
-  private async handleQuestionReply(
-    messageId: string,
-    chatId: string,
-    q: Question.Request,
-    text: string,
-  ): Promise<void> {
-    const answers: string[][] = []
-    for (const info of q.questions) {
-      const idx = parseInt(text, 10)
-      if (!isNaN(idx) && idx >= 1 && idx <= (info.options?.length ?? 0)) {
-        answers.push([info.options![idx - 1].label])
-      } else {
-        answers.push([text])
-      }
-    }
-    await Question.reply({ requestID: q.id, answers })
-    await this.replyText(messageId, "✅ 已提交回答，请等待当前对话继续处理。")
-  }
-
-  private async handlePermissionReply(
-    messageId: string,
-    chatId: string,
-    p: Permission.Request,
-    text: string,
-  ): Promise<void> {
-    const idx = parseInt(text.trim(), 10)
-    const replyMap: Record<number, Permission.Reply> = { 1: "once", 2: "always", 3: "reject" }
-    const reply = replyMap[idx]
-    if (!reply) {
-      this._pendingPermissions[chatId] = p
-      await this.replyText(messageId, "未识别，请回复数字编号。\n\n" + this.formatPermissionRequest(p))
-      return
-    }
-    await Permission.reply({ requestID: p.id, reply })
-    const labels: Record<string, string> = {
-      once: "已收到授权：允许一次，请等待当前对话继续处理。",
-      always: "已收到授权：始终允许，请等待当前对话继续处理。",
-      reject: "已提交拒绝，请等待当前对话继续处理。",
-    }
-    await this.replyText(messageId, labels[reply])
   }
 
   private async replyText(messageId: string, text: string): Promise<void> {

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -19,6 +19,8 @@ import { ProviderID } from "@/provider/schema"
 import { ModelID } from "@/provider/schema"
 import { Agent } from "@/agent/agent"
 import { SessionPreference } from "@/session/preference"
+import { Question } from "@/question"
+import { Permission } from "@/permission"
 
 const FEISHU_DATA_DIR =
   process.platform === "darwin"
@@ -117,6 +119,11 @@ class FeishuManagerImpl {
 
   // ── Agent & approval state ────────────────────────────────────────────────
   // (Moved to SessionPreference)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  // ── Pending interaction state ─────────────────────────────────────────────
+  private _pendingQuestions: Record<string, Question.Request> = {}
+  private _pendingPermissions: Record<string, Permission.Request> = {}
   // ─────────────────────────────────────────────────────────────────────────
 
   get status() {
@@ -250,10 +257,71 @@ class FeishuManagerImpl {
     }
   }
 
+  private effectiveDir(chatId: string): string {
+    return this._chatDirs[chatId] ?? (this._initialDir || Instance.directory)
+  }
+
+  private async clearRuntime(chatId: string): Promise<void> {
+    delete this._pendingQuestions[chatId]
+    delete this._pendingPermissions[chatId]
+  }
+
+  private async commandCtx(chatId: string): Promise<{
+    dir: string
+    sessionId: string
+    pref: ReturnType<typeof SessionPreference.get>
+    projectName: string
+    sessionTitle: string
+    modeName: string
+    modelStr: string
+  }> {
+    const dir = this.effectiveDir(chatId)
+    const sessionId = await this.currentSession(chatId, true)
+    if (!sessionId) throw new Error("no session for chat: " + chatId)
+    const pref = SessionPreference.get(sessionId)
+    const projectItem = this.getProjects().find((p) => this.normDir(this.projectDir(p)) === this.normDir(dir))
+    const projectName = this.clip(
+      projectItem
+        ? this.projectName(projectItem)
+        : (dir.replace(/\\/g, "/").replace(/\/+$/, "").split("/").at(-1) ?? dir),
+      24,
+    )
+    let sessionTitle = sessionId.slice(0, 8)
+    try {
+      const info = await Instance.provide({
+        directory: dir,
+        fn: () => [...Session.list({ directory: dir, roots: true, limit: 100 })].find((s) => s.id === sessionId),
+      })
+      if (info?.title) sessionTitle = info.title
+    } catch {}
+    sessionTitle = this.clip(sessionTitle, 24)
+    const modeName = pref?.agent ?? "build"
+    const model = this.resolveModel(chatId)
+    const modelStr = model
+      ? `${model.providerID}/${model.modelID}`
+      : this._connectedModel
+        ? `${this._connectedModel.providerID}/${this._connectedModel.modelID}`
+        : "—"
+    return { dir, sessionId, pref, projectName, sessionTitle, modeName, modelStr }
+  }
+
+  private commandHeader(ctx: Awaited<ReturnType<typeof this.commandCtx>>): string {
+    const mode = ctx.modeName.charAt(0).toUpperCase() + ctx.modeName.slice(1)
+    return `${ctx.projectName}  ·  ${ctx.sessionTitle}  ·  ${mode}  ·  ${ctx.modelStr}\n————————\n`
+  }
+
+  private async setPref(chatId: string, patch: Record<string, any>): Promise<void> {
+    const ctx = await this.commandCtx(chatId)
+    await Instance.provide({
+      directory: ctx.dir,
+      fn: () => SessionPreference.set({ sessionID: SessionID.make(ctx.sessionId), source: "feishu", ...patch }),
+    })
+  }
+
   private async currentSession(chatId: string, create?: boolean): Promise<string | undefined> {
     const pinned = this._chatSessions[chatId]
     if (pinned) return pinned
-    const dir = this._chatDirs[chatId] ?? (this._initialDir || Instance.directory)
+    const dir = this.effectiveDir(chatId)
     const recent = await Instance.provide({
       directory: dir,
       fn: () => [...Session.list({ directory: dir, roots: true, limit: 1 })],
@@ -310,10 +378,10 @@ class FeishuManagerImpl {
       this.statusMsg("starting", "正在连接飞书...")
       console.log("[feishu] _doStart called")
 
-      const boundHandleMessage = Instance.bind((data: any) => {
+      const boundHandleMessage = (data: any) => {
         console.log("[feishu] >>> event received!")
         void this.handleMessage(data)
-      })
+      }
 
       this._appId = config.appId
       this._appSecret = config.appSecret
@@ -367,22 +435,7 @@ class FeishuManagerImpl {
       const allProjects = this.getProjects()
       const visibleProjects = allProjects.filter((p) => !(this.projectDir(p) in this._hiddenDirs))
       this._initialDir = visibleProjects.length > 0 ? this.projectDir(visibleProjects[0]) : Instance.directory
-
-      // Preheat a session in the initial directory
-      try {
-        await Instance.provide({
-          directory: this._initialDir,
-          fn: async () => {
-            const recent = [...Session.list({ directory: this._initialDir, roots: true, limit: 1 })]
-            if (recent.length === 0) {
-              await Session.create({ title: `飞书对话 startup` })
-            }
-          },
-        })
-        console.log("[feishu] preheated session in:", this._initialDir)
-      } catch (e) {
-        console.log("[feishu] failed to preheat session:", e)
-      }
+      console.log("[feishu] initial dir:", this._initialDir)
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       this._error = { code: "start_failed", message }
@@ -393,6 +446,7 @@ class FeishuManagerImpl {
 
   private async handleMessage(data: any): Promise<void> {
     try {
+      console.log("[feishu] handleMessage invoked")
       console.log("[feishu] received event:", JSON.stringify(data).slice(0, 500))
       const message = data?.message
       if (!message) {
@@ -443,8 +497,24 @@ class FeishuManagerImpl {
         return
       }
 
+      // If this chat has a pending question, treat the text as an answer
+      const pendingQ = this._pendingQuestions[chatId]
+      if (pendingQ) {
+        delete this._pendingQuestions[chatId]
+        await this.handleQuestionReply(messageId, chatId, pendingQ, text)
+        return
+      }
+
+      // If this chat has a pending permission, treat the text as a permission reply
+      const pendingP = this._pendingPermissions[chatId]
+      if (pendingP) {
+        delete this._pendingPermissions[chatId]
+        await this.handlePermissionReply(messageId, chatId, pendingP, text)
+        return
+      }
+
       // Effective directory for this chat (may differ from connect-time Instance.directory)
-      const effectiveDir = this._chatDirs[chatId] ?? (this._initialDir || Instance.directory)
+      const effectiveDir = this.effectiveDir(chatId)
 
       // Feishu message to a hidden project → unhide immediately
       if (effectiveDir in this._hiddenDirs) {
@@ -453,16 +523,31 @@ class FeishuManagerImpl {
         void this.saveHiddenDirs()
       }
 
+      // Busy check (before entering main Instance.provide)
+      const currentSid = this._chatSessions[chatId]
+      if (currentSid) {
+        try {
+          const busy = await Instance.provide({
+            directory: effectiveDir,
+            fn: () => SessionStatus.get(SessionID.make(currentSid)),
+          })
+          if (busy?.type === "busy") {
+            await this.replyText(messageId, "当前会话正在生成回复，请等待结束后再发送；\n如需停止请输入 /stop")
+            return
+          }
+        } catch {
+          // SessionStatus.get may fail if instance not booted yet; skip check
+        }
+      }
+
       // Run session lookup and AI prompt in the effective directory's Instance context
       await Instance.provide({
         directory: effectiveDir,
         fn: async () => {
           const sessionKey = `${chatId}:${rootId}`
-          // Pinned session (/session n) takes priority over thread-based mapping
           let sessionId = this._chatSessions[chatId] ?? this.sessionMap[sessionKey]
 
           if (!sessionId) {
-            // Reuse most recent session in this directory, or create one
             const recent = [...Session.list({ directory: effectiveDir, roots: true, limit: 1 })]
             if (recent.length > 0) {
               sessionId = recent[0].id
@@ -478,6 +563,14 @@ class FeishuManagerImpl {
             this._chatSessions[chatId] = sessionId
             this.sessionMap[sessionKey] = sessionId
             await this.saveSessionMap()
+          }
+
+          // Sync pending: check if session has unanswered questions or permissions
+          try {
+            const synced = await this.syncPending(messageId, chatId, sessionId, effectiveDir)
+            if (synced) return
+          } catch (e) {
+            console.log("[feishu] syncPending error, continuing:", e)
           }
 
           const model = this.resolveModel(chatId)
@@ -570,10 +663,14 @@ class FeishuManagerImpl {
       })
     } catch (err) {
       console.error("[feishu] handleMessage error:", err)
-      const messageId = data?.message?.message_id
-      if (messageId) {
-        const errMsg = err instanceof Error ? err.message : String(err)
-        await this.replyText(messageId, `处理消息时出错: ${errMsg}`).catch(() => {})
+      try {
+        const messageId = data?.message?.message_id
+        if (messageId) {
+          const errMsg = err instanceof Error ? err.message : String(err)
+          await this.replyText(messageId, `处理消息时出错: ${errMsg}`)
+        }
+      } catch (e2) {
+        console.error("[feishu] failed to send error reply:", e2)
       }
     }
   }
@@ -756,31 +853,37 @@ class FeishuManagerImpl {
     const command = parts[0].toLowerCase()
     const rest = parts.slice(1).join(" ")
 
-    if (command === "/new") {
-      await this.cmdNew(messageId, chatId)
-    } else if (command === "/stop") {
-      await this.cmdStop(messageId, chatId)
-    } else if (command === "/compact") {
-      await this.cmdCompact(messageId, chatId)
-    } else if (command === "/model") {
-      await this.cmdModel(messageId, chatId, parts.slice(1))
-    } else if (command === "/agent") {
-      await this.cmdAgent(messageId, chatId, rest)
-    } else if (command === "/approval") {
-      await this.cmdApproval(messageId, chatId, rest)
-    } else if (command === "/variant") {
-      await this.cmdVariant(messageId, chatId, rest)
-    } else if (command === "/project") {
-      await this.cmdProject(messageId, chatId, rest)
-    } else if (command === "/session") {
-      await this.cmdSession(messageId, chatId, rest)
-    } else if (command === "/help") {
-      await this.replyText(
-        messageId,
-        "📋 可用命令：\n\n/new             开启全新对话（无当前会话上下文）\n/stop            停止当前会话中的执行\n/compact         压缩当前会话上下文\n/model           查看可用 LLM 模型（每个 provider 最多显示前 5 个）\n/model list      查看所有可用 LLM 模型\n/model n         切换到编号 n 的模型（按全量模型编号）\n/agent           查看当前会话模式\n/agent <name>    切换到指定模式（如 build、plan、docs）\n/approval        查看当前审批模式\n/approval <name> 切换审批模式（如 auto、ask）\n/variant         查看当前变体\n/variant <name>  切换到指定变体\n/project         查看最近项目\n/project list    查看全部项目\n/project n       切换到编号 n 的项目\n/project hide n  隐藏项目（在桌面端或飞书端重新使用后自动恢复）\n/session         查看当前项目下的最近会话\n/session list    查看当前项目下全部会话\n/session n       切换到当前项目下编号 n 的会话\n/help            显示此帮助信息",
-      )
-    } else {
-      await this.replyText(messageId, `未知命令: ${command}\n发送 /help 查看可用命令。`)
+    try {
+      if (command === "/new") {
+        await this.cmdNew(messageId, chatId)
+      } else if (command === "/stop") {
+        await this.cmdStop(messageId, chatId)
+      } else if (command === "/compact") {
+        await this.cmdCompact(messageId, chatId)
+      } else if (command === "/model") {
+        await this.cmdModel(messageId, chatId, parts.slice(1))
+      } else if (command === "/agent") {
+        await this.cmdAgent(messageId, chatId, rest)
+      } else if (command === "/approval") {
+        await this.cmdApproval(messageId, chatId, rest)
+      } else if (command === "/variant") {
+        await this.cmdVariant(messageId, chatId, rest)
+      } else if (command === "/project") {
+        await this.cmdProject(messageId, chatId, rest)
+      } else if (command === "/session") {
+        await this.cmdSession(messageId, chatId, rest)
+      } else if (command === "/help") {
+        await this.replyText(
+          messageId,
+          "📋 可用命令：\n\n/new             开启全新对话（无当前会话上下文）\n/stop            停止当前会话中的执行\n/compact         压缩当前会话上下文\n/model           查看可用 LLM 模型（每个 provider 最多显示前 5 个）\n/model list      查看所有可用 LLM 模型\n/model n         切换到编号 n 的模型（按全量模型编号）\n/agent           查看当前会话模式\n/agent <name>    切换到指定模式（如 build、plan、docs）\n/approval        查看当前审批模式\n/approval <name> 切换审批模式（如 auto、ask）\n/variant         查看当前变体\n/variant <name>  切换到指定变体\n/project         查看最近项目\n/project list    查看全部项目\n/project n       切换到编号 n 的项目\n/project hide n  隐藏项目（在桌面端或飞书端重新使用后自动恢复）\n/session         查看当前项目下的最近会话\n/session list    查看当前项目下全部会话\n/session n       切换到当前项目下编号 n 的会话\n/help            显示此帮助信息",
+        )
+      } else {
+        await this.replyText(messageId, `未知命令: ${command}\n发送 /help 查看可用命令。`)
+      }
+    } catch (err) {
+      console.error("[feishu] handleCommand error:", err)
+      const errMsg = err instanceof Error ? err.message : String(err)
+      await this.replyText(messageId, `命令执行出错: ${errMsg}`).catch(() => {})
     }
   }
 
@@ -790,15 +893,17 @@ class FeishuManagerImpl {
       if (key.startsWith(`${chatId}:`)) delete this.sessionMap[key]
     }
     delete this._chatSessions[chatId]
+    void this.clearRuntime(chatId)
 
-    const effectiveDir = this._chatDirs[chatId] ?? (this._initialDir || Instance.directory)
+    const dir = this.effectiveDir(chatId)
     const session = await Instance.provide({
-      directory: effectiveDir,
+      directory: dir,
       fn: () => Session.create({ title: `飞书对话 ${chatId.slice(-6)}` }),
     })
     this._chatSessions[chatId] = session.id
     await this.saveSessionMap()
-    await this.replyText(messageId, `✅ 已开启新对话\n💬 ${session.title}`)
+    const ctx = await this.commandCtx(chatId)
+    await this.replyText(messageId, this.commandHeader(ctx) + `✅ 已开启新对话\n💬 ${session.title}`)
   }
 
   /**
@@ -808,38 +913,31 @@ class FeishuManagerImpl {
    * /model <provider/model> — set per-chat model override by name
    */
   private async cmdModel(messageId: string, chatId: string, args: string[]): Promise<void> {
+    const ctx = await this.commandCtx(chatId)
     if (this._modelList.length === 0) {
       this._modelList = await this.buildModelList()
     }
 
     if (args.length === 0) {
-      await this.replyText(messageId, this.formatModelList(chatId, false))
+      await this.replyText(messageId, this.commandHeader(ctx) + this.formatModelList(ctx, false))
       return
     }
 
     if (args[0] === "list") {
-      await this.replyText(messageId, this.formatModelList(chatId, true))
+      await this.replyText(messageId, this.commandHeader(ctx) + this.formatModelList(ctx, true))
       return
     }
 
     const n = parseInt(args[0], 10)
     if (!isNaN(n) && n >= 1 && n <= this._modelList.length) {
       const entry = this._modelList[n - 1]
-      const sessionId = this._chatSessions[chatId]
-      if (sessionId) {
-        await Instance.provide({
-          directory: this._chatDirs[chatId] ?? (this._initialDir || Instance.directory),
-          fn: () =>
-            SessionPreference.set({
-              sessionID: SessionID.make(sessionId),
-              model: { providerID: ProviderID.make(entry.providerID), modelID: ModelID.make(entry.modelID) },
-              source: "feishu",
-            }),
-        })
-      }
+      await this.setPref(chatId, {
+        model: { providerID: ProviderID.make(entry.providerID), modelID: ModelID.make(entry.modelID) },
+      })
       await this.replyText(
         messageId,
-        `✅ 已切换模型：${entry.providerID}/${entry.modelID}\n（仅对当前对话生效，/new 后将重置）`,
+        this.commandHeader(ctx) +
+          `✅ 已切换模型：${entry.providerID}/${entry.modelID}\n（仅对当前对话生效，/new 后将重置）`,
       )
       return
     }
@@ -849,31 +947,25 @@ class FeishuManagerImpl {
       const [providerID, modelID] = arg.split("/", 2)
       const found = this._modelList.find((e) => e.providerID === providerID && e.modelID === modelID)
       if (!found) {
-        await this.replyText(messageId, `❌ 未找到模型：${arg}\n请先发送 /model 查看可用模型。`)
+        await this.replyText(
+          messageId,
+          this.commandHeader(ctx) + `❌ 未找到模型：${arg}\n请先发送 /model 查看可用模型。`,
+        )
         return
       }
-      const sessionId = this._chatSessions[chatId]
-      if (sessionId) {
-        await Instance.provide({
-          directory: this._chatDirs[chatId] ?? (this._initialDir || Instance.directory),
-          fn: () =>
-            SessionPreference.set({
-              sessionID: SessionID.make(sessionId),
-              model: { providerID: ProviderID.make(providerID), modelID: ModelID.make(modelID) },
-              source: "feishu",
-            }),
-        })
-      }
-      await this.replyText(messageId, `✅ 已切换模型：${arg}\n（仅对当前对话生效，/new 后将重置）`)
+      await this.setPref(chatId, { model: { providerID: ProviderID.make(providerID), modelID: ModelID.make(modelID) } })
+      await this.replyText(
+        messageId,
+        this.commandHeader(ctx) + `✅ 已切换模型：${arg}\n（仅对当前对话生效，/new 后将重置）`,
+      )
       return
     }
 
-    await this.replyText(messageId, `无效参数，请输入编号、list 或 provider/model 格式。`)
+    await this.replyText(messageId, this.commandHeader(ctx) + "无效参数，请输入编号、list 或 provider/model 格式。")
   }
 
-  private formatModelList(chatId: string, full: boolean): string {
-    const sessionId = this._chatSessions[chatId]
-    const prefModel = sessionId ? SessionPreference.get(sessionId)?.model : undefined
+  private formatModelList(ctx: Awaited<ReturnType<typeof this.commandCtx>>, full: boolean): string {
+    const prefModel = ctx.pref?.model
     const current = prefModel ?? this._connectedModel
     const currentStr = current ? `${current.providerID}/${current.modelID}` : "（全局默认）"
 
@@ -913,50 +1005,40 @@ class FeishuManagerImpl {
 
   /** /stop — abort the active prompt in the current session */
   private async cmdStop(messageId: string, chatId: string): Promise<void> {
-    const sessionId = this._chatSessions[chatId]
-    if (!sessionId) {
-      await this.replyText(messageId, "当前没有可停止的会话。")
-      return
-    }
-    const effectiveDir = this._chatDirs[chatId] ?? (this._initialDir || Instance.directory)
+    const ctx = await this.commandCtx(chatId)
+    const hasPending = chatId in this._pendingQuestions || chatId in this._pendingPermissions
     const busy = await Instance.provide({
-      directory: effectiveDir,
-      fn: () => SessionStatus.get(SessionID.make(sessionId)),
+      directory: ctx.dir,
+      fn: () => SessionStatus.get(SessionID.make(ctx.sessionId)),
     })
-    if (busy.type !== "busy") {
-      await this.replyText(messageId, "当前没有正在执行的任务。")
+    if (busy.type !== "busy" && !hasPending) {
+      await this.replyText(messageId, this.commandHeader(ctx) + "当前没有正在执行的任务。")
       return
     }
-    await Instance.provide({
-      directory: effectiveDir,
-      fn: async () => {
-        SessionPrompt.cancel(SessionID.make(sessionId))
-      },
-    })
-    await this.replyText(messageId, "✅ 已停止当前执行。")
+    if (busy.type === "busy") {
+      await Instance.provide({
+        directory: ctx.dir,
+        fn: async () => {
+          SessionPrompt.cancel(SessionID.make(ctx.sessionId))
+        },
+      })
+    }
+    await this.clearRuntime(chatId)
+    await this.replyText(messageId, this.commandHeader(ctx) + "✅ 已停止当前执行。")
   }
 
   /** /compact — compress the current session context */
   private async cmdCompact(messageId: string, chatId: string): Promise<void> {
-    const effectiveDir = this._chatDirs[chatId] ?? (this._initialDir || Instance.directory)
-    let sessionId = this._chatSessions[chatId]
-    if (!sessionId) {
-      const session = await Instance.provide({
-        directory: effectiveDir,
-        fn: () => Session.create({ title: `飞书对话 ${chatId.slice(-6)}` }),
-      })
-      sessionId = session.id
-      this._chatSessions[chatId] = sessionId
-    }
+    const ctx = await this.commandCtx(chatId)
     const model = this.resolveModel(chatId)
     if (!model) {
-      await this.replyText(messageId, "❌ 压缩当前会话前，请先使用 /model 选择模型。")
+      await this.replyText(messageId, this.commandHeader(ctx) + "❌ 压缩当前会话前，请先使用 /model 选择模型。")
       return
     }
     await Instance.provide({
-      directory: effectiveDir,
+      directory: ctx.dir,
       fn: async () => {
-        const msgs = await Session.messages({ sessionID: SessionID.make(sessionId) })
+        const msgs = await Session.messages({ sessionID: SessionID.make(ctx.sessionId) })
         let currentAgent = await Agent.defaultAgent()
         for (let i = msgs.length - 1; i >= 0; i--) {
           const info = msgs[i].info
@@ -966,15 +1048,15 @@ class FeishuManagerImpl {
           }
         }
         await SessionCompaction.create({
-          sessionID: SessionID.make(sessionId),
-          agent: (sessionId ? SessionPreference.get(sessionId)?.agent : undefined) ?? currentAgent,
+          sessionID: SessionID.make(ctx.sessionId),
+          agent: ctx.pref?.agent ?? currentAgent,
           model,
           auto: false,
         })
-        await SessionPrompt.loop({ sessionID: SessionID.make(sessionId) })
+        await SessionPrompt.loop({ sessionID: SessionID.make(ctx.sessionId) })
       },
     })
-    await this.replyText(messageId, "✅ 已开始压缩当前会话上下文，请稍后查看结果。")
+    await this.replyText(messageId, this.commandHeader(ctx) + "✅ 已开始压缩当前会话上下文，请稍后查看结果。")
   }
 
   /**
@@ -982,40 +1064,38 @@ class FeishuManagerImpl {
    * /agent <name> — switch to named agent (e.g. build, plan, docs)
    */
   private async cmdAgent(messageId: string, chatId: string, arg: string): Promise<void> {
+    const ctx = await this.commandCtx(chatId)
     let agents: { name: string; hidden?: boolean }[] = []
+    let current: string = "build"
     try {
-      agents = await Agent.list()
+      await Instance.provide({
+        directory: ctx.dir,
+        fn: async () => {
+          agents = await Agent.list()
+          current = ctx.pref?.agent || (await Agent.defaultAgent())
+        },
+      })
     } catch {
-      await this.replyText(messageId, "❌ 无法获取模式列表，请检查 Aether 服务是否正常。")
+      await this.replyText(messageId, this.commandHeader(ctx) + "❌ 无法获取模式列表，请检查 Aether 服务是否正常。")
       return
     }
     const visible = agents.filter((a) => !a.hidden)
     const names = visible.map((a) => a.name)
-    const sessionId = this._chatSessions[chatId]
-    const prefAgent = sessionId ? SessionPreference.get(sessionId)?.agent : undefined
-    const current = prefAgent || (await Agent.defaultAgent())
     if (!arg) {
       const sample = names.slice(0, 10).join("、") || "（暂无可用模式）"
-      await this.replyText(messageId, `🧠 当前模式：${current}\n可用模式：${sample}`)
+      await this.replyText(messageId, this.commandHeader(ctx) + `🧠 当前模式：${current}\n可用模式：${sample}`)
       return
     }
     if (!names.includes(arg)) {
       const sample = names.slice(0, 10).join("、") || "（暂无可用模式）"
-      await this.replyText(messageId, `❌ 未找到模式：${arg}\n可用模式：${sample}`)
+      await this.replyText(messageId, this.commandHeader(ctx) + `❌ 未找到模式：${arg}\n可用模式：${sample}`)
       return
     }
-    if (sessionId) {
-      await Instance.provide({
-        directory: this._chatDirs[chatId] ?? (this._initialDir || Instance.directory),
-        fn: () =>
-          SessionPreference.set({
-            sessionID: SessionID.make(sessionId),
-            agent: arg,
-            source: "feishu",
-          }),
-      })
-    }
-    await this.replyText(messageId, `✅ 已切换模式：${arg}\n（仅对当前对话生效，/new 后将重置）`)
+    await this.setPref(chatId, { agent: arg })
+    await this.replyText(
+      messageId,
+      this.commandHeader(ctx) + `✅ 已切换模式：${arg}\n（仅对当前对话生效，/new 后将重置）`,
+    )
   }
 
   /**
@@ -1023,32 +1103,34 @@ class FeishuManagerImpl {
    * /approval <name> — switch approval mode (auto, ask)
    */
   private async cmdApproval(messageId: string, chatId: string, arg: string): Promise<void> {
-    const sessionId = await this.currentSession(chatId, !!arg)
-    const prefApproval = sessionId ? SessionPreference.get(sessionId)?.approval : undefined
-    const current = prefApproval || "ask"
+    const ctx = await this.commandCtx(chatId)
+    const current = ctx.pref?.approval || "ask"
     if (!arg) {
-      await this.replyText(messageId, `🔐 当前审批模式：${current}\n可用模式：auto、ask`)
+      await this.replyText(messageId, this.commandHeader(ctx) + `🔐 当前审批模式：${current}\n可用模式：auto、ask`)
       return
     }
     if (arg !== "auto" && arg !== "ask") {
-      await this.replyText(messageId, "❌ 仅支持 /approval auto 或 /approval ask")
+      await this.replyText(messageId, this.commandHeader(ctx) + "❌ 仅支持 /approval auto 或 /approval ask")
       return
     }
-    if (sessionId) {
-      await Instance.provide({
-        directory: this._chatDirs[chatId] ?? (this._initialDir || Instance.directory),
-        fn: () =>
-          SessionPreference.set({
-            sessionID: SessionID.make(sessionId),
-            approval: arg,
-            source: "feishu",
-          }),
-      })
-    }
+    await this.setPref(chatId, { approval: arg })
     if (arg === "auto") {
-      await this.replyText(messageId, "✅ 已开启自动接受权限\n（后续权限请求将自动批准）")
+      const pending = this._pendingPermissions[chatId]
+      if (pending) {
+        delete this._pendingPermissions[chatId]
+        await Instance.provide({
+          directory: ctx.dir,
+          fn: () => Permission.reply({ requestID: pending.id, reply: "always" }),
+        })
+        await this.replyText(
+          messageId,
+          this.commandHeader(ctx) + "✅ 已开启自动接受权限，并已自动批准当前挂起的授权请求",
+        )
+      } else {
+        await this.replyText(messageId, this.commandHeader(ctx) + "✅ 已开启自动接受权限\n（后续权限请求将自动批准）")
+      }
     } else {
-      await this.replyText(messageId, "✅ 已停止自动接受权限\n（后续权限请求将需要你确认）")
+      await this.replyText(messageId, this.commandHeader(ctx) + "✅ 已停止自动接受权限\n（后续权限请求将需要你确认）")
     }
   }
 
@@ -1057,24 +1139,17 @@ class FeishuManagerImpl {
    * /variant <name> — switch to named variant
    */
   private async cmdVariant(messageId: string, chatId: string, arg: string): Promise<void> {
-    const sessionId = this._chatSessions[chatId]
-    const prefVariant = sessionId ? SessionPreference.get(sessionId)?.variant : undefined
+    const ctx = await this.commandCtx(chatId)
+    const current = ctx.pref?.variant || "（默认）"
     if (!arg) {
-      await this.replyText(messageId, `🔀 当前变体：${prefVariant || "（默认）"}`)
+      await this.replyText(messageId, this.commandHeader(ctx) + `🔀 当前变体：${current}`)
       return
     }
-    if (sessionId) {
-      await Instance.provide({
-        directory: this._chatDirs[chatId] ?? (this._initialDir || Instance.directory),
-        fn: () =>
-          SessionPreference.set({
-            sessionID: SessionID.make(sessionId),
-            variant: arg,
-            source: "feishu",
-          }),
-      })
-    }
-    await this.replyText(messageId, `✅ 已切换变体：${arg}\n（仅对当前对话生效，/new 后将重置）`)
+    await this.setPref(chatId, { variant: arg })
+    await this.replyText(
+      messageId,
+      this.commandHeader(ctx) + `✅ 已切换变体：${arg}\n（仅对当前对话生效，/new 后将重置）`,
+    )
   }
 
   /**
@@ -1095,7 +1170,7 @@ class FeishuManagerImpl {
     await this.autoUnhide()
 
     const visibleProjects = allProjects.filter((p) => !(this.projectDir(p) in this._hiddenDirs))
-    const currentDir = this._chatDirs[chatId] ?? (this._initialDir || Instance.directory)
+    const currentDir = this.effectiveDir(chatId)
 
     // /project hide <n>
     if (arg.startsWith("hide ")) {
@@ -1145,6 +1220,7 @@ class FeishuManagerImpl {
         if (key.startsWith(`${chatId}:`)) delete this.sessionMap[key]
       }
       this._chatDirs[chatId] = newDir
+      void this.clearRuntime(chatId)
 
       // Auto-unhide if it was hidden
       if (newDir in this._hiddenDirs) {
@@ -1222,7 +1298,7 @@ class FeishuManagerImpl {
    * /session <n>      — switch to session n
    */
   private async cmdSession(messageId: string, chatId: string, arg: string): Promise<void> {
-    const effectiveDir = this._chatDirs[chatId] ?? (this._initialDir || Instance.directory)
+    const effectiveDir = this.effectiveDir(chatId)
     let items: Session.Info[] = []
     await Instance.provide({
       directory: effectiveDir,
@@ -1259,6 +1335,7 @@ class FeishuManagerImpl {
       }
       const chosen = items[idx]
       this._chatSessions[chatId] = chosen.id
+      void this.clearRuntime(chatId)
       await this.replyText(
         messageId,
         `✅ 已切换到会话：${chosen.title}\n   更新时间：${this.formatSessionTime(chosen.time.updated)}`,
@@ -1291,6 +1368,113 @@ class FeishuManagerImpl {
   }
 
   // ─────────────────────────────────────────────────────────────────────────
+
+  /** Check for pending questions/permissions on a session; return true if handled */
+  private async syncPending(messageId: string, chatId: string, sessionId: string, dir: string): Promise<boolean> {
+    const sid = SessionID.make(sessionId)
+    const questions = await Question.list()
+    const q = questions.find((r) => r.sessionID === sid)
+    if (q) {
+      this._pendingQuestions[chatId] = q
+      await this.replyText(messageId, this.formatQuestionRequest(q))
+      return true
+    }
+
+    const permissions = await Permission.list()
+    const p = permissions.find((r) => r.sessionID === sid)
+    if (p) {
+      const pref = SessionPreference.get(sessionId)
+      if (pref?.approval === "auto") {
+        await Permission.reply({ requestID: p.id, reply: "always" })
+        delete this._pendingPermissions[chatId]
+        console.log("[feishu] auto-approved pending permission:", p.id)
+        return false
+      }
+      this._pendingPermissions[chatId] = p
+      await this.replyText(messageId, this.formatPermissionRequest(p))
+      return true
+    }
+    return false
+  }
+
+  private formatQuestionRequest(q: Question.Request): string {
+    const parts = ["🤔 Agent 需要您回答：", ""]
+    for (let i = 0; i < q.questions.length; i++) {
+      const info = q.questions[i]
+      if (q.questions.length > 1) parts.push(`【问题 ${i + 1}】${info.question}`)
+      else parts.push(info.question)
+      if (info.options?.length) {
+        parts.push("可选答案：")
+        for (let j = 0; j < info.options.length; j++) {
+          const opt = info.options[j]
+          const suffix = opt.description ? `：${opt.description}` : ""
+          parts.push(`  ${j + 1}. ${opt.label}${suffix}`)
+        }
+      }
+    }
+    parts.push("")
+    parts.push("请直接回复答案（可输入数字编号；若题目允许自定义，也可直接输入文本）。")
+    parts.push("如需开始新问题，请先 /new 或切换 /session n。")
+    return parts.join("\n")
+  }
+
+  private formatPermissionRequest(p: Permission.Request): string {
+    const parts = ["🔐 当前操作需要你的授权：", ""]
+    parts.push(`权限：${p.permission}`)
+    if (p.patterns?.length) {
+      parts.push("范围：")
+      for (const item of p.patterns) parts.push(`  - ${item}`)
+    }
+    parts.push("")
+    parts.push("请直接回复：")
+    parts.push("1. 允许一次（仅这次）")
+    parts.push("2. 始终允许（后续同类操作自动通过）")
+    parts.push("3. 拒绝（本次不允许执行）")
+    parts.push("如需开始新问题，请先 /new 或切换 /session n。")
+    return parts.join("\n")
+  }
+
+  private async handleQuestionReply(
+    messageId: string,
+    chatId: string,
+    q: Question.Request,
+    text: string,
+  ): Promise<void> {
+    const answers: string[][] = []
+    for (const info of q.questions) {
+      const idx = parseInt(text, 10)
+      if (!isNaN(idx) && idx >= 1 && idx <= (info.options?.length ?? 0)) {
+        answers.push([info.options![idx - 1].label])
+      } else {
+        answers.push([text])
+      }
+    }
+    await Question.reply({ requestID: q.id, answers })
+    await this.replyText(messageId, "✅ 已提交回答，请等待当前对话继续处理。")
+  }
+
+  private async handlePermissionReply(
+    messageId: string,
+    chatId: string,
+    p: Permission.Request,
+    text: string,
+  ): Promise<void> {
+    const idx = parseInt(text.trim(), 10)
+    const replyMap: Record<number, Permission.Reply> = { 1: "once", 2: "always", 3: "reject" }
+    const reply = replyMap[idx]
+    if (!reply) {
+      this._pendingPermissions[chatId] = p
+      await this.replyText(messageId, "未识别，请回复数字编号。\n\n" + this.formatPermissionRequest(p))
+      return
+    }
+    await Permission.reply({ requestID: p.id, reply })
+    const labels: Record<string, string> = {
+      once: "已收到授权：允许一次，请等待当前对话继续处理。",
+      always: "已收到授权：始终允许，请等待当前对话继续处理。",
+      reject: "已提交拒绝，请等待当前对话继续处理。",
+    }
+    await this.replyText(messageId, labels[reply])
+  }
 
   private async replyText(messageId: string, text: string): Promise<void> {
     if (!this.larkClient) return
@@ -1327,6 +1511,8 @@ class FeishuManagerImpl {
     this._chatDirs = {}
     this._chatSessions = {}
     this._initialDir = ""
+    this._pendingQuestions = {}
+    this._pendingPermissions = {}
     // _hiddenDirs intentionally kept (persisted, survives reconnect)
     this.status = "idle"
   }

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -49,7 +49,7 @@ const HELP_TEXT =
   "📋 可用命令：\n\n/n, /new      开启新对话\n/stop         停止当前执行\n/c, /compact  压缩当前上下文\n\n/m, /model    查看可用模型\n/m l          查看全部模型\n/m n          切换编号模型\n\n/a, /agent    查看当前模式\n/a <name>     切换指定模式\n\n/p, /project  查看最近项目\n/p l          查看全部项目\n/p n          切换编号项目\n\n/s, /session  查看最近会话\n/s l          查看全部会话\n/s n          切换编号会话\n\n/h, /help     显示帮助信息\n/help list    显示全部命令"
 
 const HELP_LIST_TEXT =
-  "📋 全部命令：\n\n/n, /new           开启新对话\n/stop              停止当前执行\n/c, /compact       压缩当前上下文\n\n/m, /model         查看可用模型\n/m l, /model list  查看全部模型\n/m n, /model n     切换编号模型\n\n/a, /agent         查看当前模式\n/a <name>          切换指定模式\n\n/p, /project       查看最近项目\n/p l, /project list 查看全部项目\n/p n, /project n   切换编号项目\n/project hide n    隐藏指定项目\n\n/s, /session       查看最近会话\n/s l, /session list 查看全部会话\n/s n, /session n   切换编号会话\n\n/approval          查看审批模式\n/approval <name>   切换审批模式\n\n/variant           查看当前变体\n/variant <name>    切换指定变体\n\n/h, /help          显示帮助信息\n/help list         显示全部命令"
+  "📋 全部命令：\n\n/n, /new\n  开启新对话，清空当前会话上下文\n\n/stop\n  停止当前执行中的任务\n\n/c, /compact\n  压缩当前会话上下文\n\n/m, /model\n  查看可用模型\n/m l, /model list\n  查看全部模型（l = list）\n/m n, /model n\n  切换到编号 n 的模型（n 为全量模型编号）\n\n/a, /agent\n  查看当前模式\n/a <name>, /agent <name>\n  切换模式（如 build、plan、docs）\n\n/p, /project\n  查看最近项目\n/p l, /project list\n  查看全部项目（l = list）\n/p n, /project n\n  切换到编号 n 的项目\n/project hide n\n  隐藏编号 n 的项目，重新在桌面端或消息端使用后自动恢复\n\n/s, /session\n  查看最近会话\n/s l, /session list\n  查看当前项目下全部会话（l = list）\n/s n, /session n\n  切换到当前项目下编号 n 的会话\n\n/approval\n  查看审批模式\n/approval <name>\n  切换审批模式（name 可选：auto、ask）\n\n/variant\n  查看当前变体\n/variant <name>\n  切换到指定变体（name 为变体名）\n\n/h, /help\n  显示常用命令\n/help list\n  显示全部命令"
 
 export const FeishuEvent = {
   StatusChanged: BusEvent.define(
@@ -149,7 +149,7 @@ class FeishuManagerImpl {
 
   private static readonly HEARTBEAT_MS = 30_000
   private static readonly HEARTBEAT_FAILS = 3
-  private static readonly RECONNECT_MAX = 10
+  private static readonly RECONNECT_MAX_MS = 300_000
 
   get status() {
     return this._status
@@ -524,14 +524,8 @@ class FeishuManagerImpl {
   private scheduleReconnect(reason: string): void {
     if (this._manualStop || !this._lastConfig) return
     if (this._reconnect || this._status === "reconnecting") return
-    if (this._reconnectCount >= FeishuManagerImpl.RECONNECT_MAX) {
-      this._error = { code: "reconnect_failed", message: "飞书连接多次重试失败，请手动重新连接。" }
-      this.status = "error"
-      Bus.publish(FeishuEvent.Error, this._error)
-      return
-    }
     const attempt = this._reconnectCount + 1
-    const delay = Math.min(2_000 * 2 ** this._reconnectCount, 30_000)
+    const delay = Math.min(2_000 * 2 ** this._reconnectCount, FeishuManagerImpl.RECONNECT_MAX_MS)
     this._reconnectCount = attempt
     this.statusMsg("reconnecting", `飞书连接已断开，正在重连（第 ${attempt} 次）...`)
     Bus.publish(FeishuEvent.Reconnecting, { attempt, delay })

--- a/packages/opencode/src/server/routes/feishu.ts
+++ b/packages/opencode/src/server/routes/feishu.ts
@@ -36,8 +36,7 @@ export const FeishuRoutes = lazy(() =>
       }),
       async (c) => {
         const body = await c.req.json().catch(() => ({}))
-        const config =
-          body?.appId && body?.appSecret ? { appId: body.appId, appSecret: body.appSecret } : undefined
+        const config = body?.appId && body?.appSecret ? { appId: body.appId, appSecret: body.appSecret } : undefined
         const model =
           body?.model?.providerID && body?.model?.modelID
             ? { providerID: body.model.providerID as string, modelID: body.model.modelID as string }
@@ -81,7 +80,7 @@ export const FeishuRoutes = lazy(() =>
               "application/json": {
                 schema: resolver(
                   z.object({
-                    status: z.enum(["idle", "starting", "connected", "error"]),
+                    status: z.enum(["idle", "starting", "connected", "reconnecting", "error"]),
                     appId: z.string().nullable(),
                     hasConfig: z.boolean(),
                     error: z

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -1059,12 +1059,12 @@ export const SessionRoutes = lazy(() =>
         return c.json(pref ?? null)
       },
     )
-    .put(
+    .patch(
       "/:sessionID/preference",
       describeRoute({
-        summary: "Set session preference",
-        description: "Set preference for a session. Stored in memory and broadcast via SSE.",
-        operationId: "session.preference.set",
+        summary: "Update session preference",
+        description: "Patch preference for a session. Stored in memory and broadcast via SSE.",
+        operationId: "session.preference.update",
         responses: {
           200: {
             description: "Preference updated",
@@ -1094,18 +1094,16 @@ export const SessionRoutes = lazy(() =>
             })
             .optional(),
           variant: z.string().optional(),
-          approval: z.enum(["auto", "ask"]).optional(),
-          source: z.string().optional(),
+          autoAccept: z.boolean().optional(),
         }),
       ),
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
         const body = c.req.valid("json")
-        await SessionPreference.set({
+        const pref = await SessionPreference.update({
           sessionID,
           ...body,
         })
-        const pref = SessionPreference.get(sessionID)
         return c.json(pref ?? null)
       },
     ),

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -269,7 +269,7 @@ export namespace Session {
         error: MessageV2.Assistant.shape.error,
       }),
     ),
-    PreferenceChanged: SessionPreference.PreferenceChanged,
+    PreferenceUpdated: SessionPreference.PreferenceUpdated,
   }
 
   export const create = fn(
@@ -309,7 +309,7 @@ export namespace Session {
       const pref = SessionPreference.get(input.sessionID)
       if (pref) {
         const { sessionID: _, ...prefData } = pref
-        await SessionPreference.set({ sessionID: session.id, ...prefData, source: "desktop" })
+        await SessionPreference.update({ sessionID: session.id, ...prefData })
       }
       const msgs = await messages({ sessionID: input.sessionID })
       const idMap = new Map<string, MessageID>()

--- a/packages/opencode/src/session/preference.ts
+++ b/packages/opencode/src/session/preference.ts
@@ -20,16 +20,31 @@ export namespace SessionPreference {
       })
       .optional(),
     variant: z.string().optional(),
-    approval: z.enum(["auto", "ask"]).optional(),
+    autoAccept: z.boolean().optional(),
   })
 
   export type Info = z.output<typeof Info>
 
-  export const PreferenceChanged = BusEvent.define(
-    "session.preference.changed",
+  export const Patch = z.object({
+    sessionID: SessionID.zod,
+    agent: z.string().optional(),
+    model: z
+      .object({
+        providerID: ProviderID.zod,
+        modelID: ModelID.zod,
+      })
+      .optional(),
+    variant: z.string().optional(),
+    autoAccept: z.boolean().optional(),
+  })
+
+  export type Patch = z.output<typeof Patch>
+
+  export const PreferenceUpdated = BusEvent.define(
+    "session.preference.updated",
     z.object({
       sessionID: SessionID.zod,
-      info: Info,
+      preference: Info,
     }),
   )
 
@@ -37,34 +52,36 @@ export namespace SessionPreference {
     return store.get(sessionID)
   }
 
-  export async function set(input: SessionPreference.Info & { source?: string }): Promise<void> {
-    const { source, ...data } = input
-    const prev = store.get(data.sessionID)
-    const merged: SessionPreference.Info = {
-      ...prev,
-      ...data,
+  export async function update(patch: Patch): Promise<Info> {
+    const prev = store.get(patch.sessionID)
+    const merged: Info = {
+      sessionID: patch.sessionID,
+      agent: patch.agent ?? prev?.agent,
+      model: patch.model ?? prev?.model,
+      variant: patch.variant ?? prev?.variant,
+      autoAccept: patch.autoAccept ?? prev?.autoAccept,
     }
-    store.set(data.sessionID, merged)
-    log.info("set", { sessionID: data.sessionID, source })
+    store.set(patch.sessionID, merged)
+    log.info("update", { sessionID: patch.sessionID })
 
-    if (source !== "desktop") {
-      Bus.publish(PreferenceChanged, { sessionID: data.sessionID, info: merged })
-    }
+    Bus.publish(PreferenceUpdated, { sessionID: patch.sessionID, preference: merged })
 
-    if (data.approval !== undefined && data.approval !== prev?.approval) {
+    if (patch.autoAccept !== undefined && patch.autoAccept !== prev?.autoAccept) {
       const { Session } = await import(".")
-      if (data.approval === "auto") {
+      if (patch.autoAccept) {
         await Session.setPermission({
-          sessionID: data.sessionID,
+          sessionID: patch.sessionID,
           permission: [{ permission: "*", pattern: "*", action: "allow" }],
         })
-      } else if (data.approval === "ask") {
+      } else {
         await Session.setPermission({
-          sessionID: data.sessionID,
+          sessionID: patch.sessionID,
           permission: [],
         })
       }
     }
+
+    return merged
   }
 
   export function remove(sessionID: string): void {


### PR DESCRIPTION
### Issue for this PR

Closes #286

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This PR improves the Feishu and chat bridge experience across the current commit stack. It stabilizes reconnect and message handling, restructures the Feishu handler around state-based dispatch, unifies /approval behavior across desktop, WeChat, and Feishu with the shared autoAccept preference, aligns command feedback and session defaults, and adds clearer shorthand/help guidance for remote command usage.

### How did you verify your code works?

I pushed the branch successfully, which triggered the repository typecheck workflow during push. I also reviewed the full branch diff and commit stack. I did not include the unrelated uncommitted bun.lock change.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR