### PR TITLE
refactor: remove reading mode action from chat composer

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1451,21 +1451,6 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                   <Icon name="plus" class="size-4.5" />
                 </Button>
               </TooltipKeybind>
-              <Tooltip placement="top" value={language.t("prompt.action.readingMode")}>
-                <Button
-                  data-action="prompt-reading-mode"
-                  type="button"
-                  variant="ghost"
-                  class="size-8 p-0"
-                  style={buttons()}
-                  onClick={() => dialog.show(() => <DialogReadingMode />)}
-                  disabled={store.mode !== "normal"}
-                  tabIndex={store.mode === "normal" ? undefined : -1}
-                  aria-label={language.t("prompt.action.readingMode")}
-                >
-                  <Icon name="glasses" class="size-4.5" />
-                </Button>
-              </Tooltip>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Issue for this PR

Closes #290

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Removes the reading mode button from the chat composer toolbar in `packages/app/src/components/prompt-input.tsx`. This keeps the input area focused on standard chat actions and removes an extra button that is not needed in the default workflow.

### How did you verify your code works?

Pushed the clean branch and confirmed the repository typecheck completed successfully during push.

### Screenshots / recordings

Not applicable.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
