### PR TITLE
fix: unify web release version markers

### DIFF
--- a/Update/release-and-upload-mac-web.sh
+++ b/Update/release-and-upload-mac-web.sh
@@ -49,7 +49,8 @@ mkdir -p "$pkg"
 cp -R "$src"/. "$pkg"/
 
 # Write version file
-printf "%s\n" "$ver" > "$pkg/.aether_version"
+rm -f "$pkg/.aether_version"
+printf "%s\n" "$ver" > "$pkg/.aether_web_version"
 
 ins="$root/Update/aether_darwin_installer.command"
 if [ -f "$ins" ]; then

--- a/packing_scripts/release-linux-web.sh
+++ b/packing_scripts/release-linux-web.sh
@@ -40,6 +40,7 @@ if [ -f "$ins" ]; then
   cp "$ins" "$out/aether_linux_installer.sh"
   chmod +x "$out/aether_linux_installer.sh"
 fi
+rm -f "$out/.aether_version"
 printf "%s\n" "$ver" >"$out/.aether_web_version"
 
 if [ -f "$out/aether" ]; then

--- a/packing_scripts/release-mac-web.sh
+++ b/packing_scripts/release-mac-web.sh
@@ -42,7 +42,8 @@ if [ -f "$ins" ]; then
   chmod +x "$out/aether_darwin_installer.command"
 fi
 
-printf "%s\n" "$ver" >"$out/.aether_version"
+rm -f "$out/.aether_version"
+printf "%s\n" "$ver" >"$out/.aether_web_version"
 
 if [ -f "$out/aether" ]; then
   chmod +x "$out/aether"

--- a/packing_scripts/release-windows-web.bat
+++ b/packing_scripts/release-windows-web.bat
@@ -43,6 +43,7 @@ if exist "%INS%" (
   copy /y "%INS%" "%OUT%\aether_windows_installer.bat" >nul || exit /b 1
 )
 
+if exist "%OUT%\.aether_version" del /f /q "%OUT%\.aether_version" >nul 2>nul
 powershell -NoProfile -Command "& { [IO.File]::WriteAllText((Join-Path $env:OUT '.aether_web_version'), $env:VERSION) }" || exit /b 1
 
 powershell -NoProfile -Command "& { $crlf=[char]13+[char]10; $txt=@('Aether Web (Windows x64)','', 'Quick start', '1) Extract this ZIP and copy the folder aether-windows-x64 to a local path, for example: C:\Aether-Web', '2) In that folder, double click Aether.vbs', '', 'Updates', '- Use Aether''s in-app update flow to download and install newer versions.') -join $crlf; Set-Content -Path (Join-Path $env:OUT 'README_FIRST.txt') -Value ($txt + $crlf) -Encoding ascii }" || exit /b 1


### PR DESCRIPTION
### Issue for this PR

Closes #294

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes the Web CD packaging scripts so all three platforms use the same version marker file, `.aether_web_version`.

The macOS Web packaging scripts were writing `.aether_version`, while Linux and Windows used `.aether_web_version`. The runtime only reads `.aether_web_version`, so the macOS package could fall back to the embedded binary version instead of the intended packaged release version. This PR changes the macOS scripts to write `.aether_web_version` and adds cleanup for stale `.aether_version` files in the macOS, Linux, and Windows Web packaging scripts so old markers do not leak into packaged artifacts.

### How did you verify your code works?

Ran:
- `bash -n packing_scripts/release-mac-web.sh`
- `bash -n packing_scripts/release-linux-web.sh`
- `bash -n Update/release-and-upload-mac-web.sh`

Also verified by searching the repo that no CD path still writes `.aether_version`; remaining references only remove stale `.aether_version` files before writing `.aether_web_version`.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
