### PR TITLE
Improve dock UX and Feishu command consistency

### DIFF
--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -803,6 +803,8 @@ export const dict = {
   "session.review.noVcs.createGit.action": "إنشاء مستودع Git",
   "session.todo.progress": "تم إكمال {{done}} من {{total}} مهام",
   "session.question.progress": "{{current}} من {{total}} أسئلة",
+  "session.question.collapse": "طي",
+  "session.question.expand": "توسيع",
   "session.header.open.finder": "Finder",
   "session.header.open.fileExplorer": "مستكشف الملفات",
   "session.header.open.fileManager": "مدير الملفات",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -813,6 +813,8 @@ export const dict = {
   "session.review.noVcs.createGit.action": "Criar repositório Git",
   "session.todo.progress": "{{done}} de {{total}} tarefas concluídas",
   "session.question.progress": "{{current}} de {{total}} perguntas",
+  "session.question.collapse": "Recolher",
+  "session.question.expand": "Expandir",
   "session.header.open.finder": "Finder",
   "session.header.open.fileExplorer": "Explorador de Arquivos",
   "session.header.open.fileManager": "Gerenciador de Arquivos",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -889,6 +889,8 @@ export const dict = {
   "session.review.noVcs.createGit.action": "Kreiraj Git repozitorij",
   "session.todo.progress": "{{done}} od {{total}} zadataka završeno",
   "session.question.progress": "{{current}} od {{total}} pitanja",
+  "session.question.collapse": "Sažmi",
+  "session.question.expand": "Proširi",
   "session.header.open.finder": "Finder",
   "session.header.open.fileExplorer": "File Explorer",
   "session.header.open.fileManager": "File Manager",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -883,6 +883,8 @@ export const dict = {
   "session.review.noVcs.createGit.action": "Opret Git-repository",
   "session.todo.progress": "{{done}} af {{total}} opgaver fuldført",
   "session.question.progress": "{{current}} af {{total}} spørgsmål",
+  "session.question.collapse": "Skjul",
+  "session.question.expand": "Udvid",
   "session.header.open.finder": "Finder",
   "session.header.open.fileExplorer": "Stifinder",
   "session.header.open.fileManager": "Filhåndtering",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -824,6 +824,8 @@ export const dict = {
   "session.review.noVcs.createGit.action": "Git-Repository erstellen",
   "session.todo.progress": "{{done}} von {{total}} Aufgaben erledigt",
   "session.question.progress": "{{current}} von {{total}} Fragen",
+  "session.question.collapse": "Einklappen",
+  "session.question.expand": "Ausklappen",
   "session.header.open.finder": "Finder",
   "session.header.open.fileExplorer": "Datei-Explorer",
   "session.header.open.fileManager": "Dateimanager",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -600,6 +600,8 @@ export const dict = {
   "session.todo.expand": "Expand",
   "session.todo.progress": "{{done}} of {{total}} todos completed",
   "session.question.progress": "{{current}} of {{total}} questions",
+  "session.question.collapse": "Collapse",
+  "session.question.expand": "Expand",
   "session.followupDock.summary.one": "{{count}} queued message",
   "session.followupDock.summary.other": "{{count}} queued messages",
   "session.followupDock.sendNow": "Send now",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -896,6 +896,8 @@ export const dict = {
   "session.review.noVcs.createGit.action": "Crear repositorio Git",
   "session.todo.progress": "{{done}} de {{total}} tareas completadas",
   "session.question.progress": "{{current}} de {{total}} preguntas",
+  "session.question.collapse": "Contraer",
+  "session.question.expand": "Expandir",
   "session.header.open.finder": "Finder",
   "session.header.open.fileExplorer": "Explorador de archivos",
   "session.header.open.fileManager": "Gestor de archivos",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -822,6 +822,8 @@ export const dict = {
   "session.review.noVcs.createGit.action": "Créer un dépôt Git",
   "session.todo.progress": "{{done}} tâches sur {{total}} terminées",
   "session.question.progress": "{{current}} questions sur {{total}}",
+  "session.question.collapse": "Réduire",
+  "session.question.expand": "Développer",
   "session.header.open.finder": "Finder",
   "session.header.open.fileExplorer": "Explorateur de fichiers",
   "session.header.open.fileManager": "Gestionnaire de fichiers",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -808,6 +808,8 @@ export const dict = {
   "session.review.noVcs.createGit.action": "Git リポジトリを作成",
   "session.todo.progress": "{{done}} 個中 {{total}} 個の Todo が完了",
   "session.question.progress": "{{total}} 問中 {{current}} 問",
+  "session.question.collapse": "折りたたむ",
+  "session.question.expand": "展開",
   "session.header.open.finder": "Finder",
   "session.header.open.fileExplorer": "エクスプローラー",
   "session.header.open.fileManager": "ファイルマネージャー",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -807,6 +807,8 @@ export const dict = {
   "session.review.noVcs.createGit.action": "Git 저장소 생성",
   "session.todo.progress": "{{total}}개의 할 일 중 {{done}}개 완료",
   "session.question.progress": "{{total}}개의 질문 중 {{current}}개",
+  "session.question.collapse": "접기",
+  "session.question.expand": "펼치기",
   "session.header.open.finder": "Finder",
   "session.header.open.fileExplorer": "파일 탐색기",
   "session.header.open.fileManager": "파일 관리자",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -889,6 +889,8 @@ export const dict = {
   "session.review.noVcs.createGit.action": "Opprett Git-depot",
   "session.todo.progress": "{{done}} av {{total}} oppgaver fullført",
   "session.question.progress": "{{current}} av {{total}} spørsmål",
+  "session.question.collapse": "Skjul",
+  "session.question.expand": "Utvid",
   "session.header.open.finder": "Finder",
   "session.header.open.fileExplorer": "Filutforsker",
   "session.header.open.fileManager": "Filbehandler",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -810,6 +810,8 @@ export const dict = {
   "session.review.noVcs.createGit.action": "Utwórz repozytorium Git",
   "session.todo.progress": "Ukończono {{done}} z {{total}} zadań",
   "session.question.progress": "{{current}} z {{total}} pytań",
+  "session.question.collapse": "Zwiń",
+  "session.question.expand": "Rozwiń",
   "session.header.open.finder": "Finder",
   "session.header.open.fileExplorer": "Eksplorator plików",
   "session.header.open.fileManager": "Menedżer plików",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -892,6 +892,8 @@ export const dict = {
   "session.review.noVcs.createGit.action": "Создать репозиторий Git",
   "session.todo.progress": "Выполнено {{done}} из {{total}} задач",
   "session.question.progress": "{{current}} из {{total}} вопросов",
+  "session.question.collapse": "Свернуть",
+  "session.question.expand": "Развернуть",
   "session.header.open.finder": "Finder",
   "session.header.open.fileExplorer": "Проводник",
   "session.header.open.fileManager": "Файловый менеджер",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -879,6 +879,8 @@ export const dict = {
   "session.review.noVcs.createGit.action": "สร้าง Git repository",
   "session.todo.progress": "เสร็จสิ้น {{done}} จาก {{total}} รายการ",
   "session.question.progress": "{{current}} จาก {{total}} คำถาม",
+  "session.question.collapse": "ย่อ",
+  "session.question.expand": "ขยาย",
   "session.header.open.finder": "Finder",
   "session.header.open.fileExplorer": "File Explorer",
   "session.header.open.fileManager": "File Manager",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -898,6 +898,8 @@ export const dict = {
   "session.review.noVcs.createGit.action": "Git deposu oluştur",
   "session.todo.progress": "{{total}} görevin {{done}} tanesi tamamlandı",
   "session.question.progress": "{{total}} sorunun {{current}} tanesi",
+  "session.question.collapse": "Daralt",
+  "session.question.expand": "Genişlet",
   "session.header.open.finder": "Finder",
   "session.header.open.fileExplorer": "Dosya Gezgini",
   "session.header.open.fileManager": "Dosya Yöneticisi",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -939,6 +939,8 @@ export const dict = {
   "session.review.noVcs.createGit.action": "创建 Git 仓库",
   "session.todo.progress": "已完成 {{done}} 个任务（共 {{total}} 个）",
   "session.question.progress": "{{current}}/{{total}} 个问题",
+  "session.question.collapse": "收起",
+  "session.question.expand": "展开",
   "session.header.open.finder": "访达",
   "session.header.open.fileExplorer": "文件资源管理器",
   "session.header.open.fileManager": "文件管理器",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -872,6 +872,8 @@ export const dict = {
   "session.review.noVcs.createGit.action": "建立 Git 儲存庫",
   "session.todo.progress": "已完成 {{done}} 個待辦事項（共 {{total}} 個）",
   "session.question.progress": "{{current}}/{{total}} 個問題",
+  "session.question.collapse": "收合",
+  "session.question.expand": "展開",
   "session.header.open.finder": "Finder",
   "session.header.open.fileExplorer": "檔案總管",
   "session.header.open.fileManager": "檔案管理員",

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -142,7 +142,12 @@ export function SessionComposerRegion(props: {
         <Show when={props.state.questionRequest()} keyed>
           {(request) => (
             <div>
-              <SessionQuestionDock request={request} onSubmit={props.onResponseSubmit} />
+              <SessionQuestionDock
+                request={request}
+                onSubmit={props.onResponseSubmit}
+                collapseLabel={language.t("session.question.collapse")}
+                expandLabel={language.t("session.question.expand")}
+              />
             </div>
           )}
         </Show>
@@ -262,7 +267,9 @@ export function SessionComposerRegion(props: {
                         class="shrink-0 rounded-md px-1 py-0.5 text-12-medium text-text-weak transition hover:bg-surface-hover hover:text-text-strong"
                         onClick={() => readingMode?.setPendingQuestion(null)}
                         aria-label={language.t("common.clear")}
-                      >x</button>
+                      >
+                        x
+                      </button>
                     </div>
                   </div>
                 )}
@@ -285,4 +292,3 @@ export function SessionComposerRegion(props: {
     </div>
   )
 }
-

--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -4,6 +4,7 @@ import { useMutation } from "@tanstack/solid-query"
 import { Button } from "@opencode-ai/ui/button"
 import { DockPrompt } from "@opencode-ai/ui/dock-prompt"
 import { Icon } from "@opencode-ai/ui/icon"
+import { IconButton } from "@opencode-ai/ui/icon-button"
 import { showToast } from "@opencode-ai/ui/toast"
 import type { QuestionAnswer, QuestionRequest } from "@opencode-ai/sdk/v2"
 import { useLanguage } from "@/context/language"
@@ -13,10 +14,23 @@ const min = 240
 
 const cache = new Map<
   string,
-  { tab: number; answers: QuestionAnswer[]; custom: string[]; customOn: boolean[]; size?: number; base?: number }
+  {
+    tab: number
+    answers: QuestionAnswer[]
+    custom: string[]
+    customOn: boolean[]
+    collapsed?: boolean
+    size?: number
+    base?: number
+  }
 >()
 
-export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit: () => void }> = (props) => {
+export const SessionQuestionDock: Component<{
+  request: QuestionRequest
+  onSubmit: () => void
+  collapseLabel: string
+  expandLabel: string
+}> = (props) => {
   const sdk = useSDK()
   const language = useLanguage()
 
@@ -29,6 +43,7 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
     answers: cached?.answers ?? ([] as QuestionAnswer[]),
     custom: cached?.custom ?? ([] as string[]),
     customOn: cached?.customOn ?? ([] as boolean[]),
+    collapsed: cached?.collapsed ?? false,
     editing: false,
     base: cached?.base,
     size: cached?.size,
@@ -50,6 +65,19 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
   })
 
   const last = createMemo(() => store.tab >= total() - 1)
+
+  const toggleCollapse = () => setStore("collapsed", (v) => !v)
+
+  const preview = createMemo(() => question()?.question ?? "")
+
+  createEffect(() => {
+    if (!root) return
+    if (store.collapsed) {
+      root.setAttribute("data-collapsed", "true")
+    } else {
+      root.removeAttribute("data-collapsed")
+    }
+  })
 
   const customUpdate = (value: string, selected: boolean = on()) => {
     const prev = input().trim()
@@ -104,7 +132,7 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
 
   const paint = () => {
     if (!root) return
-    if (store.size === undefined || store.base === undefined) {
+    if (store.collapsed || store.size === undefined || store.base === undefined) {
       root.style.removeProperty("--question-prompt-height")
       root.style.removeProperty("--question-prompt-offset")
       return
@@ -116,6 +144,7 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
 
   const drag = (e: PointerEvent) => {
     if (sending()) return
+    if (store.collapsed) return
     if (!(e.currentTarget instanceof HTMLDivElement)) return
 
     e.preventDefault()
@@ -190,6 +219,7 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
       answers: store.answers.map((a) => (a ? [...a] : [])),
       custom: store.custom.map((s) => s ?? ""),
       customOn: store.customOn.map((b) => b ?? false),
+      collapsed: store.collapsed,
       base: store.base,
       size: store.size,
     })
@@ -333,19 +363,38 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
   return (
     <DockPrompt
       kind="question"
-      ref={(el) => (root = el)}
+      ref={(el) => {
+        root = el
+      }}
       overlay={
-        <div
-          data-slot="question-resize"
-          role="separator"
-          aria-orientation="horizontal"
-          aria-label="Resize"
-          onPointerDown={drag}
-        />
+        <Show when={!store.collapsed}>
+          <div
+            data-slot="question-resize"
+            role="separator"
+            aria-orientation="horizontal"
+            aria-label="Resize"
+            onPointerDown={drag}
+          />
+        </Show>
       }
       header={
-        <>
+        <div
+          data-slot="question-header-toggle"
+          role="button"
+          tabIndex={0}
+          onClick={toggleCollapse}
+          onKeyDown={(event) => {
+            if (event.key !== "Enter" && event.key !== " ") return
+            event.preventDefault()
+            toggleCollapse()
+          }}
+        >
           <div data-slot="question-header-title">{summary()}</div>
+          <Show when={store.collapsed && preview()}>
+            <span data-slot="question-header-preview" class="min-w-0 flex-1 truncate">
+              {preview()}
+            </span>
+          </Show>
           <div data-slot="question-progress">
             <For each={questions()}>
               {(_, i) => (
@@ -358,82 +407,147 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
                     (store.customOn[i()] === true && (store.custom[i()] ?? "").trim().length > 0)
                   }
                   disabled={sending()}
-                  onClick={() => jump(i())}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    jump(i())
+                  }}
                   aria-label={`${language.t("ui.tool.questions")} ${i() + 1}`}
                 />
               )}
             </For>
           </div>
-        </>
+          <IconButton
+            data-slot="question-collapse-button"
+            data-collapsed={store.collapsed ? "true" : "false"}
+            icon="chevron-down"
+            size="normal"
+            variant="ghost"
+            style={{ transform: `rotate(${store.collapsed ? 180 : 0}deg)` }}
+            onMouseDown={(event) => {
+              event.preventDefault()
+              event.stopPropagation()
+            }}
+            onClick={(event) => {
+              event.stopPropagation()
+              toggleCollapse()
+            }}
+            aria-label={store.collapsed ? props.expandLabel : props.collapseLabel}
+          />
+        </div>
       }
       footer={
-        <>
-          <Button variant="ghost" size="large" disabled={sending()} onClick={reject}>
-            {language.t("ui.common.dismiss")}
-          </Button>
-          <div data-slot="question-footer-actions">
-            <Show when={store.tab > 0}>
-              <Button variant="secondary" size="large" disabled={sending()} onClick={back}>
-                {language.t("ui.common.back")}
-              </Button>
-            </Show>
-            <Button variant={last() ? "primary" : "secondary"} size="large" disabled={sending()} onClick={next}>
-              {last() ? language.t("ui.common.submit") : language.t("ui.common.next")}
+        <Show when={!store.collapsed}>
+          <>
+            <Button variant="ghost" size="large" disabled={sending()} onClick={reject}>
+              {language.t("ui.common.dismiss")}
             </Button>
-          </div>
-        </>
+            <div data-slot="question-footer-actions">
+              <Show when={store.tab > 0}>
+                <Button variant="secondary" size="large" disabled={sending()} onClick={back}>
+                  {language.t("ui.common.back")}
+                </Button>
+              </Show>
+              <Button variant={last() ? "primary" : "secondary"} size="large" disabled={sending()} onClick={next}>
+                {last() ? language.t("ui.common.submit") : language.t("ui.common.next")}
+              </Button>
+            </div>
+          </>
+        </Show>
       }
     >
-      <div data-slot="question-text">{question()?.question}</div>
-      <Show when={multi()} fallback={<div data-slot="question-hint">{language.t("ui.question.singleHint")}</div>}>
-        <div data-slot="question-hint">{language.t("ui.question.multiHint")}</div>
-      </Show>
-      <div data-slot="question-options">
-        <For each={options()}>
-          {(opt, i) => {
-            const picked = () => store.answers[store.tab]?.includes(opt.label) ?? false
-            return (
+      <Show when={!store.collapsed}>
+        <div data-slot="question-text">{question()?.question}</div>
+        <Show when={multi()} fallback={<div data-slot="question-hint">{language.t("ui.question.singleHint")}</div>}>
+          <div data-slot="question-hint">{language.t("ui.question.multiHint")}</div>
+        </Show>
+        <div data-slot="question-options">
+          <For each={options()}>
+            {(opt, i) => {
+              const picked = () => store.answers[store.tab]?.includes(opt.label) ?? false
+              return (
+                <button
+                  data-slot="question-option"
+                  data-picked={picked()}
+                  role={multi() ? "checkbox" : "radio"}
+                  aria-checked={picked()}
+                  disabled={sending()}
+                  onClick={() => selectOption(i())}
+                >
+                  <span data-slot="question-option-check" aria-hidden="true">
+                    <span
+                      data-slot="question-option-box"
+                      data-type={multi() ? "checkbox" : "radio"}
+                      data-picked={picked()}
+                    >
+                      <Show when={multi()} fallback={<span data-slot="question-option-radio-dot" />}>
+                        <Icon name="check-small" size="small" />
+                      </Show>
+                    </span>
+                  </span>
+                  <span data-slot="question-option-main">
+                    <span data-slot="option-label">{opt.label}</span>
+                    <Show when={opt.description}>
+                      <span data-slot="option-description">{opt.description}</span>
+                    </Show>
+                  </span>
+                </button>
+              )
+            }}
+          </For>
+
+          <Show
+            when={store.editing}
+            fallback={
               <button
                 data-slot="question-option"
-                data-picked={picked()}
+                data-custom="true"
+                data-picked={on()}
                 role={multi() ? "checkbox" : "radio"}
-                aria-checked={picked()}
+                aria-checked={on()}
                 disabled={sending()}
-                onClick={() => selectOption(i())}
+                onClick={customOpen}
               >
-                <span data-slot="question-option-check" aria-hidden="true">
-                  <span
-                    data-slot="question-option-box"
-                    data-type={multi() ? "checkbox" : "radio"}
-                    data-picked={picked()}
-                  >
+                <span
+                  data-slot="question-option-check"
+                  aria-hidden="true"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    customToggle()
+                  }}
+                >
+                  <span data-slot="question-option-box" data-type={multi() ? "checkbox" : "radio"} data-picked={on()}>
                     <Show when={multi()} fallback={<span data-slot="question-option-radio-dot" />}>
                       <Icon name="check-small" size="small" />
                     </Show>
                   </span>
                 </span>
                 <span data-slot="question-option-main">
-                  <span data-slot="option-label">{opt.label}</span>
-                  <Show when={opt.description}>
-                    <span data-slot="option-description">{opt.description}</span>
-                  </Show>
+                  <span data-slot="option-label">{language.t("ui.messagePart.option.typeOwnAnswer")}</span>
+                  <span data-slot="option-description">{input() || language.t("ui.question.custom.placeholder")}</span>
                 </span>
               </button>
-            )
-          }}
-        </For>
-
-        <Show
-          when={store.editing}
-          fallback={
-            <button
+            }
+          >
+            <form
               data-slot="question-option"
               data-custom="true"
               data-picked={on()}
               role={multi() ? "checkbox" : "radio"}
               aria-checked={on()}
-              disabled={sending()}
-              onClick={customOpen}
+              onMouseDown={(e) => {
+                if (sending()) {
+                  e.preventDefault()
+                  return
+                }
+                if (e.target instanceof HTMLTextAreaElement) return
+                const input = e.currentTarget.querySelector('[data-slot="question-custom-input"]')
+                if (input instanceof HTMLTextAreaElement) input.focus()
+              }}
+              onSubmit={(e) => {
+                e.preventDefault()
+                commitCustom()
+              }}
             >
               <span
                 data-slot="question-option-check"
@@ -452,81 +566,40 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
               </span>
               <span data-slot="question-option-main">
                 <span data-slot="option-label">{language.t("ui.messagePart.option.typeOwnAnswer")}</span>
-                <span data-slot="option-description">{input() || language.t("ui.question.custom.placeholder")}</span>
-              </span>
-            </button>
-          }
-        >
-          <form
-            data-slot="question-option"
-            data-custom="true"
-            data-picked={on()}
-            role={multi() ? "checkbox" : "radio"}
-            aria-checked={on()}
-            onMouseDown={(e) => {
-              if (sending()) {
-                e.preventDefault()
-                return
-              }
-              if (e.target instanceof HTMLTextAreaElement) return
-              const input = e.currentTarget.querySelector('[data-slot="question-custom-input"]')
-              if (input instanceof HTMLTextAreaElement) input.focus()
-            }}
-            onSubmit={(e) => {
-              e.preventDefault()
-              commitCustom()
-            }}
-          >
-            <span
-              data-slot="question-option-check"
-              aria-hidden="true"
-              onClick={(e) => {
-                e.preventDefault()
-                e.stopPropagation()
-                customToggle()
-              }}
-            >
-              <span data-slot="question-option-box" data-type={multi() ? "checkbox" : "radio"} data-picked={on()}>
-                <Show when={multi()} fallback={<span data-slot="question-option-radio-dot" />}>
-                  <Icon name="check-small" size="small" />
-                </Show>
-              </span>
-            </span>
-            <span data-slot="question-option-main">
-              <span data-slot="option-label">{language.t("ui.messagePart.option.typeOwnAnswer")}</span>
-              <textarea
-                ref={(el) =>
-                  setTimeout(() => {
-                    el.focus()
-                    el.style.height = "0px"
-                    el.style.height = `${el.scrollHeight}px`
-                  }, 0)
-                }
-                data-slot="question-custom-input"
-                placeholder={language.t("ui.question.custom.placeholder")}
-                value={input()}
-                rows={1}
-                disabled={sending()}
-                onKeyDown={(e) => {
-                  if (e.key === "Escape") {
-                    e.preventDefault()
-                    setStore("editing", false)
-                    return
+                <textarea
+                  ref={(el) =>
+                    setTimeout(() => {
+                      el.focus()
+                      el.style.height = "0px"
+                      el.style.height = `${el.scrollHeight}px`
+                    }, 0)
                   }
-                  if (e.key !== "Enter" || e.shiftKey) return
-                  e.preventDefault()
-                  commitCustom()
-                }}
-                onInput={(e) => {
-                  customUpdate(e.currentTarget.value)
-                  e.currentTarget.style.height = "0px"
-                  e.currentTarget.style.height = `${e.currentTarget.scrollHeight}px`
-                }}
-              />
-            </span>
-          </form>
-        </Show>
-      </div>
+                  data-slot="question-custom-input"
+                  placeholder={language.t("ui.question.custom.placeholder")}
+                  value={input()}
+                  rows={1}
+                  disabled={sending()}
+                  onKeyDown={(e) => {
+                    if (e.key === "Escape") {
+                      e.preventDefault()
+                      setStore("editing", false)
+                      return
+                    }
+                    if (e.key !== "Enter" || e.shiftKey) return
+                    e.preventDefault()
+                    commitCustom()
+                  }}
+                  onInput={(e) => {
+                    customUpdate(e.currentTarget.value)
+                    e.currentTarget.style.height = "0px"
+                    e.currentTarget.style.height = `${e.currentTarget.scrollHeight}px`
+                  }}
+                />
+              </span>
+            </form>
+          </Show>
+        </div>
+      </Show>
     </DockPrompt>
   )
 }

--- a/packages/app/src/pages/session/composer/session-todo-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-todo-dock.tsx
@@ -221,16 +221,13 @@ export function SessionTodoDock(props: {
 function TodoList(props: { todos: Todo[]; open: boolean }) {
   const [store, setStore] = createStore({
     stuck: false,
-    scrolling: false,
   })
   let scrollRef!: HTMLDivElement
-  let timer: number | undefined
 
   const inProgress = createMemo(() => props.todos.findIndex((todo) => todo.status === "in_progress"))
 
   const ensure = () => {
     if (!props.open) return
-    if (store.scrolling) return
     if (!scrollRef || scrollRef.offsetParent === null) return
 
     const el = scrollRef.querySelector("[data-in-progress]")
@@ -261,11 +258,6 @@ function TodoList(props: { todos: Todo[]; open: boolean }) {
     }),
   )
 
-  onCleanup(() => {
-    if (!timer) return
-    window.clearTimeout(timer)
-  })
-
   return (
     <div class="relative">
       <div
@@ -274,13 +266,6 @@ function TodoList(props: { todos: Todo[]; open: boolean }) {
         style={{ "overflow-anchor": "none" }}
         onScroll={(e) => {
           setStore("stuck", e.currentTarget.scrollTop > 0)
-          setStore("scrolling", true)
-          if (timer) window.clearTimeout(timer)
-          timer = window.setTimeout(() => {
-            setStore("scrolling", false)
-            if (inProgress() < 0) return
-            requestAnimationFrame(ensure)
-          }, 250)
         }}
       >
         <Index each={props.todos}>

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -335,6 +335,14 @@ class FeishuManagerImpl {
     return `${ctx.projectName}  ·  ${ctx.sessionTitle}  ·  ${mode}  ·  ${ctx.modelStr}\n————————\n`
   }
 
+  private async replyCmd(messageId: string, chatId: string, body: string): Promise<void> {
+    if (!body.trim()) {
+      await this.replyText(messageId, body)
+      return
+    }
+    await this.replyText(messageId, this.commandHeader(await this.commandCtx(chatId)) + body)
+  }
+
   private async setPref(chatId: string, patch: Record<string, any>): Promise<void> {
     const ctx = await this.commandCtx(chatId)
     await Instance.provide({
@@ -1140,8 +1148,7 @@ class FeishuManagerImpl {
     })
     this._chatSessions[chatId] = session.id
     await this.saveSessionMap()
-    const ctx = await this.commandCtx(chatId)
-    await this.replyText(messageId, this.commandHeader(ctx) + `✅ 已开启新对话\n💬 ${session.title}`)
+    await this.replyCmd(messageId, chatId, `✅ 已开启新对话\n💬 ${session.title}`)
   }
 
   /**
@@ -1157,12 +1164,12 @@ class FeishuManagerImpl {
     }
 
     if (args.length === 0) {
-      await this.replyText(messageId, this.commandHeader(ctx) + this.formatModelList(ctx, false))
+      await this.replyCmd(messageId, chatId, this.formatModelList(ctx, false))
       return
     }
 
     if (args[0] === "list") {
-      await this.replyText(messageId, this.commandHeader(ctx) + this.formatModelList(ctx, true))
+      await this.replyCmd(messageId, chatId, this.formatModelList(ctx, true))
       return
     }
 
@@ -1172,10 +1179,10 @@ class FeishuManagerImpl {
       await this.setPref(chatId, {
         model: { providerID: ProviderID.make(entry.providerID), modelID: ModelID.make(entry.modelID) },
       })
-      await this.replyText(
+      await this.replyCmd(
         messageId,
-        this.commandHeader(ctx) +
-          `✅ 已切换模型：${entry.providerID}/${entry.modelID}\n（仅对当前对话生效，/new 后将重置）`,
+        chatId,
+        `✅ 已切换模型：${entry.providerID}/${entry.modelID}\n（仅对当前对话生效，/new 后将重置）`,
       )
       return
     }
@@ -1185,31 +1192,22 @@ class FeishuManagerImpl {
       const [providerID, modelID] = arg.split("/", 2)
       const found = this._modelList.find((e) => e.providerID === providerID && e.modelID === modelID)
       if (!found) {
-        await this.replyText(
-          messageId,
-          this.commandHeader(ctx) + `❌ 未找到模型：${arg}\n请先发送 /model 查看可用模型。`,
-        )
+        await this.replyCmd(messageId, chatId, `❌ 未找到模型：${arg}\n请先发送 /model 查看可用模型。`)
         return
       }
       await this.setPref(chatId, { model: { providerID: ProviderID.make(providerID), modelID: ModelID.make(modelID) } })
-      await this.replyText(
-        messageId,
-        this.commandHeader(ctx) + `✅ 已切换模型：${arg}\n（仅对当前对话生效，/new 后将重置）`,
-      )
+      await this.replyCmd(messageId, chatId, `✅ 已切换模型：${arg}\n（仅对当前对话生效，/new 后将重置）`)
       return
     }
 
-    await this.replyText(messageId, this.commandHeader(ctx) + "❌ 无效参数，请输入编号、list 或 provider/model 格式。")
+    await this.replyCmd(messageId, chatId, "❌ 无效参数，请输入编号、list 或 provider/model 格式。")
   }
 
   private formatModelList(ctx: Awaited<ReturnType<typeof this.commandCtx>>, full: boolean): string {
     const prefModel = ctx.pref?.model
     const current = prefModel ?? this._connectedModel
-    const currentStr = current ? `${current.providerID}/${current.modelID}` : "（全局默认）"
 
     const lines: string[] = []
-    lines.push(`🤖 当前：${currentStr}`)
-    lines.push("")
     lines.push("📦 可用模型：")
 
     const byProvider = new Map<string, ModelEntry[]>()
@@ -1246,7 +1244,7 @@ class FeishuManagerImpl {
     const ctx = await this.commandCtx(chatId)
     const model = this.resolveModel(chatId)
     if (!model) {
-      await this.replyText(messageId, this.commandHeader(ctx) + "❌ 压缩当前会话前，请先使用 /model 选择模型。")
+      await this.replyCmd(messageId, chatId, "❌ 压缩当前会话前，请先使用 /model 选择模型。")
       return
     }
     await Instance.provide({
@@ -1270,7 +1268,7 @@ class FeishuManagerImpl {
         await SessionPrompt.loop({ sessionID: SessionID.make(ctx.sessionId) })
       },
     })
-    await this.replyText(messageId, this.commandHeader(ctx) + "✅ 已开始压缩当前会话上下文，请稍后查看结果。")
+    await this.replyCmd(messageId, chatId, "✅ 已开始压缩当前会话上下文，请稍后查看结果。")
   }
 
   /**
@@ -1290,26 +1288,23 @@ class FeishuManagerImpl {
         },
       })
     } catch {
-      await this.replyText(messageId, this.commandHeader(ctx) + "❌ 无法获取模式列表，请检查 Aether 服务是否正常。")
+      await this.replyCmd(messageId, chatId, "❌ 无法获取模式列表，请检查 Aether 服务是否正常。")
       return
     }
     const visible = agents.filter((a) => !a.hidden)
     const names = visible.map((a) => a.name)
     if (!arg) {
       const sample = names.slice(0, 10).join("、") || "（暂无可用模式）"
-      await this.replyText(messageId, this.commandHeader(ctx) + `🧠 当前模式：${current}\n可用模式：${sample}`)
+      await this.replyCmd(messageId, chatId, `🧠 可用模式：${sample}`)
       return
     }
     if (!names.includes(arg)) {
       const sample = names.slice(0, 10).join("、") || "（暂无可用模式）"
-      await this.replyText(messageId, this.commandHeader(ctx) + `❌ 未找到模式：${arg}\n可用模式：${sample}`)
+      await this.replyCmd(messageId, chatId, `❌ 未找到模式：${arg}\n可用模式：${sample}`)
       return
     }
     await this.setPref(chatId, { agent: arg })
-    await this.replyText(
-      messageId,
-      this.commandHeader(ctx) + `✅ 已切换模式：${arg}\n（仅对当前对话生效，/new 后将重置）`,
-    )
+    await this.replyCmd(messageId, chatId, `✅ 已切换模式：${arg}\n（仅对当前对话生效，/new 后将重置）`)
   }
 
   /**
@@ -1321,11 +1316,11 @@ class FeishuManagerImpl {
     const auto = ctx.pref?.autoAccept ?? false
     if (!arg) {
       const mode = auto ? "自动批准" : "手动审批"
-      await this.replyText(messageId, this.commandHeader(ctx) + `🔐 当前审批模式：${mode}\n可用模式：auto、ask`)
+      await this.replyCmd(messageId, chatId, `🔐 当前审批模式：${mode}\n可用模式：auto、ask`)
       return
     }
     if (arg !== "auto" && arg !== "ask") {
-      await this.replyText(messageId, this.commandHeader(ctx) + "❌ 仅支持 /approval auto 或 /approval ask")
+      await this.replyCmd(messageId, chatId, "❌ 仅支持 /approval auto 或 /approval ask")
       return
     }
     await this.setPref(chatId, { autoAccept: arg === "auto" })
@@ -1337,15 +1332,12 @@ class FeishuManagerImpl {
           directory: ctx.dir,
           fn: () => Permission.reply({ requestID: pending.id, reply: "always" }),
         })
-        await this.replyText(
-          messageId,
-          this.commandHeader(ctx) + "✅ 已开启自动接受权限，并已自动批准当前挂起的授权请求",
-        )
+        await this.replyCmd(messageId, chatId, "✅ 已开启自动接受权限，并已自动批准当前挂起的授权请求")
       } else {
-        await this.replyText(messageId, this.commandHeader(ctx) + "✅ 已开启自动接受权限\n（后续权限请求将自动批准）")
+        await this.replyCmd(messageId, chatId, "✅ 已开启自动接受权限\n（后续权限请求将自动批准）")
       }
     } else {
-      await this.replyText(messageId, this.commandHeader(ctx) + "✅ 已停止自动接受权限\n（后续权限请求将需要你确认）")
+      await this.replyCmd(messageId, chatId, "✅ 已停止自动接受权限\n（后续权限请求将需要你确认）")
     }
   }
 
@@ -1357,14 +1349,11 @@ class FeishuManagerImpl {
     const ctx = await this.commandCtx(chatId)
     const current = ctx.pref?.variant || "（默认）"
     if (!arg) {
-      await this.replyText(messageId, this.commandHeader(ctx) + `🔀 当前变体：${current}`)
+      await this.replyCmd(messageId, chatId, `🔀 当前变体：${current}`)
       return
     }
     await this.setPref(chatId, { variant: arg })
-    await this.replyText(
-      messageId,
-      this.commandHeader(ctx) + `✅ 已切换变体：${arg}\n（仅对当前对话生效，/new 后将重置）`,
-    )
+    await this.replyCmd(messageId, chatId, `✅ 已切换变体：${arg}\n（仅对当前对话生效，/new 后将重置）`)
   }
 
   /**
@@ -1376,7 +1365,7 @@ class FeishuManagerImpl {
   private async cmdProject(messageId: string, chatId: string, arg: string): Promise<void> {
     const allProjects = this.getProjects()
     if (allProjects.length === 0) {
-      await this.replyText(messageId, "❌ 无法获取项目列表，请检查 Aether 是否正常运行。")
+      await this.replyCmd(messageId, chatId, "❌ 无法获取项目列表，请检查 Aether 是否正常运行。")
       return
     }
 
@@ -1388,7 +1377,7 @@ class FeishuManagerImpl {
       const delArg = arg.slice(5).trim()
       const idx = parseInt(delArg, 10) - 1
       if (isNaN(idx) || idx < 0 || idx >= allProjects.length) {
-        await this.replyText(messageId, `❌ 用法：/project hide n（n 为 1~${allProjects.length}）`)
+        await this.replyCmd(messageId, chatId, `❌ 用法：/project hide n（n 为 1~${allProjects.length}）`)
         return
       }
       const target = allProjects[idx]
@@ -1396,14 +1385,13 @@ class FeishuManagerImpl {
       this._hiddenDirs[directory] = Date.now()
       await this.saveHiddenDirs()
       const name = this.projectName(target)
-      await this.replyText(messageId, `✅ 已隐藏：${name}\n（在桌面端或消息端重新使用后自动恢复）`)
+      await this.replyCmd(messageId, chatId, `✅ 已隐藏：${name}\n（在桌面端或消息端重新使用后自动恢复）`)
       return
     }
 
     // /project list — all projects including hidden
     if (arg === "list") {
-      const currentItem = allProjects.find((p) => this.projectDir(p) === currentDir) ?? allProjects[0]
-      const lines = [`📂 当前项目：${this.clip(this.projectName(currentItem), 24)}`, "", "📂 项目列表：", ""]
+      const lines = ["📂 项目列表：", ""]
       for (let i = 0; i < allProjects.length; i++) {
         const item = allProjects[i]
         const directory = this.projectDir(item)
@@ -1412,7 +1400,7 @@ class FeishuManagerImpl {
         lines.push(`${i + 1}. ${this.projectName(item)}${tag}${mark}`)
         lines.push(`   ${directory}`)
       }
-      await this.replyText(messageId, lines.join("\n"))
+      await this.replyCmd(messageId, chatId, lines.join("\n"))
       return
     }
 
@@ -1420,7 +1408,7 @@ class FeishuManagerImpl {
     if (arg) {
       const idx = parseInt(arg, 10) - 1
       if (isNaN(idx) || idx < 0 || idx >= allProjects.length) {
-        await this.replyText(messageId, `❌ 请输入 1~${allProjects.length} 之间的编号。`)
+        await this.replyCmd(messageId, chatId, `❌ 请输入 1~${allProjects.length} 之间的编号。`)
         return
       }
       const chosen = allProjects[idx]
@@ -1466,7 +1454,7 @@ class FeishuManagerImpl {
       const name = this.projectName(chosen)
       const note = created ? "已创建新会话" : `已进入该项目最新会话：${sessionTitle}`
       console.log("[feishu] /project switched:", chatId, "->", newDir)
-      await this.replyText(messageId, `✅ 已切换到：${name}\n   ${newDir}\n（${note}）`)
+      await this.replyCmd(messageId, chatId, `✅ 已切换到：${name}\n   ${newDir}\n（${note}）`)
       return
     }
 
@@ -1474,12 +1462,11 @@ class FeishuManagerImpl {
     if (visibleProjects.length === 0) {
       const hint =
         Object.keys(this._hiddenDirs).length > 0 ? `（有 ${Object.keys(this._hiddenDirs).length} 个项目已隐藏）` : ""
-      await this.replyText(messageId, `❌ 未找到任何项目。${hint}`)
+      await this.replyCmd(messageId, chatId, `❌ 未找到任何项目。${hint}`)
       return
     }
 
-    const currentItem2 = allProjects.find((p) => this.projectDir(p) === currentDir) ?? allProjects[0]
-    const lines = [`📂 当前项目：${this.clip(this.projectName(currentItem2), 24)}`, "", "📂 项目列表：", ""]
+    const lines = ["📂 项目列表：", ""]
     let count = 0
     for (let i = 0; i < allProjects.length && count < 10; i++) {
       const item = allProjects[i]
@@ -1495,7 +1482,7 @@ class FeishuManagerImpl {
     if (Object.keys(this._hiddenDirs).length > 0) {
       lines.push(`ℹ️ 已隐藏 ${Object.keys(this._hiddenDirs).length} 个项目（重新使用后自动恢复）`)
     }
-    await this.replyText(messageId, lines.join("\n"))
+    await this.replyCmd(messageId, chatId, lines.join("\n"))
   }
 
   private formatSessionTime(timestamp: number): string {
@@ -1521,9 +1508,7 @@ class FeishuManagerImpl {
     const currentId = this._chatSessions[chatId]
 
     if (arg === "list") {
-      const currentItem = items.find((i) => i.id === currentId)
-      const currentTitle = currentItem?.title ?? currentId?.slice(0, 8) ?? "无"
-      const lines = [`🗂 当前会话：${currentTitle}`, "", "🗂 会话列表：", ""]
+      const lines = ["🗂 会话列表：", ""]
       for (let i = 0; i < items.length; i++) {
         const item = items[i]
         const tag = item.id === currentId ? " ◀" : ""
@@ -1531,15 +1516,16 @@ class FeishuManagerImpl {
         lines.push(`   ${this.formatSessionTime(item.time.updated)}`)
       }
       if (!items.length) lines.push("（当前项目下还没有任何会话）")
-      await this.replyText(messageId, lines.join("\n"))
+      await this.replyCmd(messageId, chatId, lines.join("\n"))
       return
     }
 
     if (arg) {
       const idx = parseInt(arg, 10) - 1
       if (isNaN(idx) || idx < 0 || idx >= items.length) {
-        await this.replyText(
+        await this.replyCmd(
           messageId,
+          chatId,
           items.length ? `❌ 请输入 1~${items.length} 之间的数字。` : "❌ 当前项目下还没有任何会话。",
         )
         return
@@ -1547,8 +1533,9 @@ class FeishuManagerImpl {
       const chosen = items[idx]
       this._chatSessions[chatId] = chosen.id
       void this.clearRuntime(chatId)
-      await this.replyText(
+      await this.replyCmd(
         messageId,
+        chatId,
         `✅ 已切换到会话：${chosen.title}\n   更新时间：${this.formatSessionTime(chosen.time.updated)}`,
       )
       return
@@ -1561,12 +1548,11 @@ class FeishuManagerImpl {
         fn: () => Session.create({ title: `飞书对话 ${chatId.slice(-6)}` }),
       })
       this._chatSessions[chatId] = session.id
-      await this.replyText(messageId, "📂 当前项目下还没有任何会话，已自动创建一个新会话并切换。")
+      await this.replyCmd(messageId, chatId, "📂 当前项目下还没有任何会话，已自动创建一个新会话并切换。")
       return
     }
 
-    const currentItem = items.find((i) => i.id === currentId) ?? items[0]
-    const lines = [`🗂 当前会话：${currentItem.title}`, "", "🗂 会话列表：", ""]
+    const lines = ["🗂 会话列表：", ""]
     for (let i = 0; i < Math.min(items.length, 10); i++) {
       const item = items[i]
       const tag = item.id === currentId ? " ◀" : ""
@@ -1575,7 +1561,7 @@ class FeishuManagerImpl {
     }
     lines.push("")
     lines.push("💡 /s n 切换会话 | /s l 查看全部")
-    await this.replyText(messageId, lines.join("\n"))
+    await this.replyCmd(messageId, chatId, lines.join("\n"))
   }
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, writeFile, rm, stat } from "fs/promises"
-import { join, basename } from "path"
+import { isAbsolute, join, basename } from "path"
 import { homedir } from "os"
 import { existsSync } from "fs"
 import z from "zod"
@@ -790,7 +790,8 @@ class FeishuManagerImpl {
 
           let promptText = text
           if (this.detectFileSendIntent(text)) {
-            promptText += `\n\n[系统提示：用户需要通过飞书接收文件附件，请在回复中包含该文件的完整绝对路径（格式如 /home/user/file.md），系统将自动将其作为附件发送给用户]`
+            promptText +=
+              "\n\n[系统提示：用户需要通过飞书接收文件附件，请在回复中包含该文件在当前系统上的完整绝对路径。Windows 示例：E:\\\\work\\\\demo\\\\file.md；macOS/Linux 示例：/Users/demo/file.md 或 /home/demo/file.md。系统将自动把该路径对应的文件作为附件发送给用户。]"
           }
           const intent = this.detectSummaryIntent(text)
           if (intent.isSummary) {
@@ -997,8 +998,26 @@ class FeishuManagerImpl {
 
   /** Extract existing absolute file paths mentioned in text (e.g. in AI response). */
   private extractFilePathsFromText(text: string): string[] {
-    const matches = text.match(/`?(\/[^\s`'"(){}<>]+\.[a-zA-Z0-9]+)`?/g) ?? []
-    return [...new Set(matches.map((m) => m.replace(/^`|`$/g, "").trim()).filter((p) => existsSync(p)))]
+    const files = [
+      ...this.extractPathTokens(text, /`([^`]+)`/g),
+      ...this.extractPathTokens(text, /([A-Za-z]:\\[^\s'"(){}<>]+|\/(?:[^\s`'"(){}<>]+\/?)+)/g),
+    ]
+    return [...new Set(files.filter((p) => this.isFilePath(p)))]
+  }
+
+  private extractPathTokens(text: string, pattern: RegExp): string[] {
+    const items: string[] = []
+    for (const match of text.matchAll(pattern)) {
+      const raw = (match[1] ?? match[0] ?? "").trim()
+      const file = raw.replace(/^[`'\"]+|[`'\",.;:!?]+$/g, "").trim()
+      if (file) items.push(file)
+    }
+    return items
+  }
+
+  private isFilePath(path: string): boolean {
+    if (!isAbsolute(path)) return false
+    return existsSync(path)
   }
 
   /** Map file extension to Feishu file_type. */

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -829,6 +829,18 @@
   transform: translateY(var(--question-prompt-offset, 0px));
   margin-bottom: var(--question-prompt-offset, 0px);
 
+  &[data-collapsed="true"] {
+    height: auto !important;
+    max-height: none !important;
+    transform: none !important;
+    margin-bottom: 0 !important;
+
+    [data-slot="question-content"],
+    [data-slot="question-footer"] {
+      display: none;
+    }
+  }
+
   [data-slot="question-resize"] {
     position: absolute;
     inset-inline: 12px;
@@ -860,12 +872,12 @@
     padding: 8px 8px 0;
   }
 
-  [data-slot="question-header"] {
+  [data-slot="question-header-toggle"] {
     display: flex;
     align-items: center;
-    justify-content: space-between;
     gap: 12px;
     padding: 0 10px;
+    cursor: pointer;
   }
 
   [data-slot="question-header-title"] {
@@ -1143,6 +1155,18 @@
     display: flex;
     align-items: center;
     gap: 8px;
+  }
+
+  [data-slot="question-header-preview"] {
+    font-family: var(--font-family-sans);
+    font-size: 14px;
+    font-weight: var(--font-weight-regular);
+    line-height: var(--line-height-large);
+    color: var(--text-base);
+  }
+
+  [data-slot="question-collapse-button"] {
+    margin-left: auto;
   }
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #296

### Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR contains four scoped commits that improve session composer behavior and make Feishu command handling more consistent, while excluding the earlier PDF-to-Markdown / Markdown translation removal work.

On the UI side, it adds collapse/expand support to the question dock so it matches the todo dock interaction model, and it fixes the todo dock scroll reset issue so longer lists stay stable during updates. Together, these changes make the composer area easier to use in longer sessions.

On the Feishu side, it fixes cross-platform file path handling and refactors command replies to use a shared header format aligned with WeChat output. That improves portability across operating systems and makes command responses easier to scan.

Included commits:
- 45dcde314 fix: support cross-platform Feishu file paths
- c76ba0706 fix: stop todo dock scroll reset
- 4fb7e65fd feat: add collapse/expand to question dock, matching todo dock behavior
- 4e168a19b refactor: unify Feishu command headers

### How did you verify your code works?

- Reviewed the reduced branch diff to confirm the PR excludes the PDF-to-Markdown / Markdown translation removal commit.
- Ran bun run typecheck in packages/app successfully.
- Pushed the updated branch successfully through the repository pre-push hook; bun turbo typecheck passed.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._