### PR TITLE
fix: restore staged app e2e ci baseline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,6 +174,107 @@ jobs:
           OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: "true"
         run: bun test --timeout 30000
 
-  # App E2E is intentionally excluded from the current required CI baseline.
-  # The local E2E harness currently fails to acquire an ephemeral port in CI and needs
-  # its own stabilization pass before it can serve as a trustworthy correctness gate.
+  # App E2E is restored as its own job so runner/setup issues stay isolated from unit jobs.
+  e2e:
+    name: app e2e (${{ matrix.settings.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - name: linux
+            host: ubuntu-latest
+          - name: windows
+            host: windows-2022
+    runs-on: ${{ matrix.settings.host }}
+    timeout-minutes: 35
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Read Playwright version
+        id: playwright-version
+        run: |
+          version=$(node -e 'console.log(require("./packages/app/package.json").devDependencies["@playwright/test"])')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.playwright-browsers
+          key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ steps.playwright-version.outputs.version }}-chromium
+
+      - name: Install Playwright system dependencies
+        if: runner.os == 'Linux'
+        working-directory: packages/app
+        run: bunx playwright install-deps chromium
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: packages/app
+        run: bunx playwright install chromium
+
+      - name: Run app e2e tests
+        working-directory: packages/app
+        run: |
+          specs=()
+          while IFS= read -r line; do
+            line="${line%%#*}"
+            line="${line#"${line%%[![:space:]]*}"}"
+            line="${line%"${line##*[![:space:]]}"}"
+            if [ -n "$line" ]; then
+              specs+=("$line")
+            fi
+          done < e2e/ci-specs.txt
+
+          bun test:e2e:local "${specs[@]}"
+        env:
+          CI: true
+          PLAYWRIGHT_JUNIT_OUTPUT: e2e/junit-${{ matrix.settings.name }}.xml
+
+      - name: Run app e2e serial specs
+        if: success()
+        working-directory: packages/app
+        run: |
+          specs=()
+          while IFS= read -r line; do
+            line="${line%%#*}"
+            line="${line#"${line%%[![:space:]]*}"}"
+            line="${line%"${line##*[![:space:]]}"}"
+            if [ -n "$line" ]; then
+              specs+=("$line")
+            fi
+          done < e2e/ci-specs-serial.txt
+
+          bun test:e2e:local --workers 1 "${specs[@]}"
+        env:
+          CI: true
+          PLAYWRIGHT_JUNIT_OUTPUT: e2e/junit-${{ matrix.settings.name }}-serial.xml
+
+      - name: Upload Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-${{ matrix.settings.name }}-${{ github.run_attempt }}
+          if-no-files-found: ignore
+          retention-days: 7
+          path: |
+            packages/app/e2e/junit-*.xml
+            packages/app/e2e/test-results
+            packages/app/e2e/playwright-report

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ tmp
 dist
 ts-dist
 .turbo
+.playwright-browsers/
 **/.serena
 .serena/
 /result

--- a/docs/ci-e2e-restoration-plan.md
+++ b/docs/ci-e2e-restoration-plan.md
@@ -1,0 +1,345 @@
+# CI E2E 恢复与迁移现状
+
+本文档只描述当前现状、已完成进度、验证矩阵、未决问题和下一步，不再按时间顺序记录每次试跑反馈。
+
+目标不是整包照搬 `upstream/dev` 的 E2E，而是在尊重当前 Aether 程序实现的前提下：
+
+- 先恢复 app E2E 进入 CI
+- 再逐步吸收 upstream 的 harness 和测试
+- 每次都区分 runner 问题、harness/mock LLM 问题、测试语义偏移、以及程序自身真实问题
+
+## 工作原则
+
+后续推进必须一直遵守：
+
+1. 任何修改只要可能影响现有单测，必须先停下说明，等待决断。
+2. 任何修改只要可能影响用户实际使用时的程序运行或行为，必须先停下说明，等待决断。
+3. 任何迁移、补充、修改具体测试时，只要测试与当前程序实现存在不同、偏移或冲突，必须先详细汇报，再等待决断。
+4. 测试迁移必须尊重当前程序的既定实现，不能为了贴合 upstream 测试而反向修改当前产品行为。
+
+## 当前结论
+
+### 1. CI E2E 基线已经恢复
+
+当前仓库已经重新具备在 CI 中运行 app E2E 的基础能力：
+
+- `.github/workflows/test.yml` 已恢复 app E2E job
+- app E2E CI 入口当前改为读取 `packages/app/e2e/ci-specs.txt` 与 `packages/app/e2e/ci-specs-serial.txt` 两份临时白名单
+- Playwright 浏览器缓存、Linux 依赖、JUnit 输出、artifact 上传已补回
+- `packages/app/script/e2e-local.ts` 已增加 `PLAYWRIGHT_BROWSERS_PATH` 兜底，默认落到仓库根 `.playwright-browsers`
+
+当前策略不是给失败 spec 逐条加 `skip`，而是：
+
+- 保留所有 spec 文件原样存在
+- 只让 CI 先运行当前已核验通过的白名单 spec
+- 其中大多数 spec 保留常规并发，只有少数并发敏感 spec 单独串行
+- 未修复的 spec 继续保留在仓库中，等待逐条修复后再放回白名单
+
+这个兜底不会改变当前 GitHub Actions 里已经显式设置 `PLAYWRIGHT_BROWSERS_PATH` 的行为，只是在未显式传入环境变量时避免 Playwright 去临时 sandbox 缓存目录找浏览器。
+
+### 2. upstream 的新 E2E 基建已部分吸收，但不能整包替换
+
+当前已经并行接入了 upstream 新 harness 的关键基础能力，包括：
+
+- `packages/app/e2e/backend.ts`
+- `packages/opencode/test/lib/llm-server.ts`
+- `packages/opencode/test/lib/effect.ts`
+- `packages/opencode/src/provider/provider.ts`
+- `packages/app/e2e/utils.ts`
+- `packages/app/e2e/fixtures.ts`
+- `packages/app/e2e/actions.ts`
+- `packages/app/src/testing/prompt.ts`
+- `packages/app/src/testing/model-selection.ts`
+- `packages/app/src/testing/terminal.ts`
+- `packages/app/src/context/local.tsx`
+- `packages/app/src/components/prompt-input/submit.ts`
+
+当前策略是并行接入，不是整体替换：
+
+- 旧 `withProject` / `sdk` / `gotoSession` 路径仍保留
+- 新 `project` / `assistant` / `llm` / `backend` harness 已可用
+- 当前已有 spec 不需要被一次性全部改写
+
+### 3. 不能直接整包迁入 upstream 当前 E2E
+
+原因不是“个别断言不同”，而是 upstream 的测试基建、测试探针和程序行为假设一起演进了。直接整包替换 `packages/app/e2e`，在当前 Aether 上会同时遇到：
+
+- fixture 体系不同
+- mock LLM 接线方式不同
+- prompt/model probe 能力不同
+- sidebar / workspace / session 区域的产品行为已与 upstream 假设分叉
+
+结论：
+
+- upstream 的 harness 可以逐步吸收
+- upstream 的 spec 不能默认逐文件照搬
+
+## 已完成工作
+
+### A. CI 与 runner 恢复
+
+已完成文件：
+
+- `.github/workflows/test.yml`
+- `docs/ci-guide.md`
+- `packages/app/playwright.config.ts`
+- `packages/app/script/e2e-local.ts`
+- `packages/app/.gitignore`
+- 根 `.gitignore`
+
+已验证事实：
+
+- 本地 CI 模式 smoke 可运行
+- `playwright-report`、`test-results`、JUnit 产物生成正常
+- `bun test:e2e:local` 已不再因为 Playwright 浏览器缓存路径落到临时 sandbox 而失败
+
+### B. harness 与 probe 基础设施接入
+
+已完成事项：
+
+- 新增 isolated backend 启动器
+- 新增 mock LLM server
+- 在 `provider.ts` 中加入 `OPENCODE_E2E_LLM_URL` 路径
+- 在 app 侧补齐 prompt/model/terminal probe
+- 在 `fixtures.ts` 中并行接入新 harness
+- 在 `actions.ts` 中加入兼容当前迁移所需的扩展
+
+已验证事实：
+
+- `packages/app` 下 `bun typecheck` 通过
+- `packages/opencode` 下 `bun typecheck` 通过
+- 受影响的现有单测仍通过：
+  - `packages/app/src/components/prompt-input/submit.test.ts`
+  - `packages/opencode/test/provider/provider.test.ts`
+
+### C. 已按当前实现调整的测试
+
+已完成并确认语义对齐的测试：
+
+- `packages/app/e2e/projects/workspace-new-session.spec.ts`
+
+当前对这条 spec 的准确定义是：
+
+- 点击某个 workspace 的 `New session`
+- 进入目标 workspace
+- 等待页面稳定到该 workspace 下的最终 session
+- 在最终稳定 session 中发送 prompt
+- 验证消息保存到该 workspace 下的最终 session
+
+这里已经确认当前程序实现不保证“点击后第一个瞬时出现的 `sessionID` 一直保持不变”，所以测试不再把这一点当作语义要求。
+
+### D. 已完成的低风险测试迁移
+
+以下 spec 已完成调整并实跑通过：
+
+- `packages/app/e2e/projects/projects-close.spec.ts`
+- `packages/app/e2e/terminal/terminal-reconnect.spec.ts`
+- `packages/app/e2e/terminal/terminal-tabs.spec.ts`
+- `packages/app/e2e/session/session-undo-redo.spec.ts`
+
+## 当前验证矩阵
+
+### 总量
+
+- `packages/app/e2e/**/*.spec.ts` 当前总计 `50` 条 spec
+
+### 当前已核验通过
+
+当前已实际核验通过 `37` 条 spec。
+
+通过 spec 列表：
+
+- `packages/app/e2e/app/home.spec.ts`
+- `packages/app/e2e/app/navigation.spec.ts`
+- `packages/app/e2e/app/palette.spec.ts`
+- `packages/app/e2e/app/server-default.spec.ts`
+- `packages/app/e2e/app/session.spec.ts`
+- `packages/app/e2e/commands/input-focus.spec.ts`
+- `packages/app/e2e/commands/panels.spec.ts`
+- `packages/app/e2e/commands/tab-close.spec.ts`
+- `packages/app/e2e/files/file-open.spec.ts`
+- `packages/app/e2e/files/file-tree.spec.ts`
+- `packages/app/e2e/files/file-viewer.spec.ts`
+- `packages/app/e2e/models/models-visibility.spec.ts`
+- `packages/app/e2e/projects/project-edit.spec.ts`
+- `packages/app/e2e/projects/projects-close.spec.ts`
+- `packages/app/e2e/projects/workspace-new-session.spec.ts`
+- `packages/app/e2e/projects/workspaces.spec.ts`
+- `packages/app/e2e/prompt/prompt-async.spec.ts`
+- `packages/app/e2e/prompt/prompt-history.spec.ts`
+- `packages/app/e2e/prompt/prompt-mention.spec.ts`
+- `packages/app/e2e/prompt/prompt-multiline.spec.ts`
+- `packages/app/e2e/prompt/prompt-shell.spec.ts`
+- `packages/app/e2e/prompt/prompt-slash-open.spec.ts`
+- `packages/app/e2e/prompt/prompt-slash-share.spec.ts`
+- `packages/app/e2e/prompt/prompt-slash-terminal.spec.ts`
+- `packages/app/e2e/prompt/prompt.spec.ts`
+- `packages/app/e2e/session/session-child-navigation.spec.ts`
+- `packages/app/e2e/session/session-undo-redo.spec.ts`
+- `packages/app/e2e/session/session.spec.ts`
+- `packages/app/e2e/settings/settings-models.spec.ts`
+- `packages/app/e2e/settings/settings.spec.ts`
+- `packages/app/e2e/sidebar/sidebar.spec.ts`
+- `packages/app/e2e/status/status-popover.spec.ts`
+- `packages/app/e2e/terminal/terminal-init.spec.ts`
+- `packages/app/e2e/terminal/terminal-reconnect.spec.ts`
+- `packages/app/e2e/terminal/terminal-tabs.spec.ts`
+- `packages/app/e2e/terminal/terminal.spec.ts`
+- `packages/app/e2e/thinking-level.spec.ts`
+
+### 当前仍未通过
+
+当前仍有 `13` 条 spec 在低并发复核下继续失败：
+
+- `packages/app/e2e/app/titlebar-history.spec.ts`
+- `packages/app/e2e/models/model-picker.spec.ts`
+- `packages/app/e2e/projects/projects-switch.spec.ts`
+- `packages/app/e2e/prompt/context.spec.ts`
+- `packages/app/e2e/prompt/prompt-drop-file-uri.spec.ts`
+- `packages/app/e2e/prompt/prompt-drop-file.spec.ts`
+- `packages/app/e2e/session/session-composer-dock.spec.ts`
+- `packages/app/e2e/session/session-model-persistence.spec.ts`
+- `packages/app/e2e/session/session-review.spec.ts`
+- `packages/app/e2e/settings/settings-keybinds.spec.ts`
+- `packages/app/e2e/settings/settings-providers.spec.ts`
+- `packages/app/e2e/sidebar/sidebar-popover-actions.spec.ts`
+- `packages/app/e2e/sidebar/sidebar-session-links.spec.ts`
+
+因此当前 CI 白名单与本地已核验通过 spec 一致，暂时只覆盖这 `37` 条。
+
+其中并发策略为：
+
+- 常规并发白名单：`31` 条 spec
+- 单独串行白名单：`6` 条 spec
+
+当前被单独串行的 spec 是：
+
+- `packages/app/e2e/files/file-viewer.spec.ts`
+- `packages/app/e2e/prompt/prompt-async.spec.ts`
+- `packages/app/e2e/prompt/prompt-history.spec.ts`
+- `packages/app/e2e/prompt/prompt.spec.ts`
+- `packages/app/e2e/terminal/terminal-init.spec.ts`
+- `packages/app/e2e/terminal/terminal-reconnect.spec.ts`
+
+它们被放入串行白名单的原因不是“当前确认只在串行才正确”，而是：
+
+- 在高并发首轮全量核验中失败
+- 在 `--workers 1` 低并发复核中转为通过
+- 或者在主并发白名单回归中表现为 flaky，但在独立低负载运行中稳定通过
+- 现阶段先按更保守方式纳入 CI，后续可继续验证是否能回到常规并发
+
+## 现有验证结果如何得出
+
+### 首轮全量核验
+
+对之前尚未逐条确认的 `43` 条 spec 做过一轮高并发全量运行：
+
+- 结果：`85 passed / 24 failed / 4 skipped`
+- spec 级结果：`26` 条 spec 通过，`17` 条 spec 失败
+- 运行条件：Playwright `43 workers`
+
+这轮结果不能直接用来判定产品真实问题，因为同时伴随：
+
+- `MaxListenersExceededWarning`
+- frontend 更新检查 socket 错误
+- 插件版本查询 / `bun info` 失败
+- `NotFoundError` / cleanup 噪音
+
+### 低并发复核
+
+随后对那 `17` 条首轮失败 spec 做了 `--workers 1` 串行复核：
+
+- 结果：`34 passed / 21 failed`
+- 有 `4` 条 spec 在低并发下转绿：
+  - `packages/app/e2e/files/file-viewer.spec.ts`
+  - `packages/app/e2e/prompt/prompt-async.spec.ts`
+  - `packages/app/e2e/prompt/prompt-history.spec.ts`
+  - `packages/app/e2e/prompt/prompt.spec.ts`
+
+因此当前可直接下的结论是：
+
+- 这 4 条更像首轮受到并发污染
+- 剩余 `13` 条不能再简单归因给高并发
+
+## 当前未决问题分桶
+
+### 1. 已确认的测试语义偏移
+
+当前已经明确确认一条需要先决策的语义偏移：
+
+- `packages/app/e2e/settings/settings-keybinds.spec.ts`
+  - 其中 `changing new session keybind works` 仍然假设触发 `new session` 后 URL 形如 `/session`
+  - 当前实际行为是直接进入 `/session/<id>`
+  - 这与 `workspace-new-session.spec.ts` 暴露出的当前实现特征一致
+
+按工作原则，这一项在继续改测试前必须先单独决策。
+
+### 2. 很可能不是纯 runner 问题
+
+以下失败在低并发下仍稳定存在，不能再简单归因给 runner：
+
+- `packages/app/e2e/app/titlebar-history.spec.ts`
+- `packages/app/e2e/models/model-picker.spec.ts`
+- `packages/app/e2e/projects/projects-switch.spec.ts`
+- `packages/app/e2e/prompt/context.spec.ts`
+- `packages/app/e2e/prompt/prompt-drop-file-uri.spec.ts`
+- `packages/app/e2e/prompt/prompt-drop-file.spec.ts`
+- `packages/app/e2e/session/session-model-persistence.spec.ts`
+- `packages/app/e2e/settings/settings-providers.spec.ts`
+- `packages/app/e2e/sidebar/sidebar-popover-actions.spec.ts`
+- `packages/app/e2e/sidebar/sidebar-session-links.spec.ts`
+
+这些项后续需要继续区分：
+
+- harness / mock LLM / probe 是否缺能力
+- 当前 UI 交互是否和测试假设不一致
+- 当前程序是否存在真实问题
+
+### 3. 局部 case 失败，不是整份 spec 全坏
+
+以下 spec 目前暴露的是局部失败，而不是整份 spec 全面失效：
+
+- `packages/app/e2e/session/session-composer-dock.spec.ts`
+  - 当前明确失败的 case 是拖拽 resize 高度断言未满足
+- `packages/app/e2e/session/session-review.spec.ts`
+  - 当前失败落在 `waitSessionIdle()` 不收敛，以及 review 布局相关断言
+
+这两条需要以“局部行为/交互问题”来查，不应简单按“整份 spec 不适配”处理。
+
+### 4. 当前优先级最高的待查项
+
+在仍失败的项里，当前优先级最高的是：
+
+- `packages/app/e2e/session/session-model-persistence.spec.ts`
+
+原因：
+
+- 它从一开始就是已知不稳定项
+- 低并发下仍失败
+- 它更接近“当前实现、probe、session 状态恢复语义”三者之间的真实分界点
+
+## 当前推荐推进顺序
+
+1. 保持“不整包替换 upstream spec”的策略不变。
+2. 对已确认语义偏移的 `settings-keybinds.spec.ts` 先单独决策，再决定是否改测试。
+3. 对非语义偏移项，优先单独评估 `session-model-persistence.spec.ts`。
+4. 继续把其余失败分成四类：runner、harness/mock、测试语义偏移、真实程序问题。
+5. 对 `sidebar`、`review`、`provider dialog`、`drag-resize` 这类问题，优先查局部交互和 probe，而不是先改产品行为。
+
+## 失败判断顺序
+
+后续每次遇到失败，都应按以下顺序判断：
+
+1. runner 是否正确拉起 backend / web / Playwright
+2. 测试是否仍然打到了真实 provider，而不是 mock LLM
+3. probe 是否把当前页面状态暴露给 E2E
+4. fixture/harness 是否与该 spec 所需能力匹配
+5. 如果以上都成立，再判断是否属于当前 Aether 的真实产品问题
+
+不要把以下问题混在一起：
+
+- CI / runner / 浏览器安装问题
+- `e2e-local.ts` 的 Playwright 浏览器缓存路径问题
+- harness 或 mock LLM 缺能力问题
+- 测试与当前实现不匹配问题
+- 当前程序自身真实问题

--- a/docs/ci-guide.md
+++ b/docs/ci-guide.md
@@ -16,7 +16,7 @@
 
 #### `test.yml`
 
-- 类型：CI / 单元测试
+- 类型：CI / 单元测试 + E2E 测试
 - 状态：活跃
 - 所需 GitHub 配置：
   - 仓库设置：
@@ -78,13 +78,33 @@
     - 在 `packages/opencode` 下设置 `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER=true`
     - 执行 `bun test --timeout 30000`
     - 同样设置了 `20` 分钟超时
+  - `e2e`
+    - 采用 Linux / Windows 矩阵，分别运行在 `ubuntu-latest` 与 `windows-2022`
+    - 先调用 `actions/setup-node@v4` 固定 Node `24`，再调用 `.github/actions/setup-bun`
+    - 读取 `packages/app/package.json` 中的 `@playwright/test` 版本，作为 Playwright 浏览器缓存 key 的一部分
+    - 缓存路径固定为仓库根 `.playwright-browsers`
+    - Linux 上额外执行 `bunx playwright install-deps chromium`
+    - 缓存未命中时执行 `bunx playwright install chromium`
+    - 通过 `packages/app/e2e/ci-specs.txt` 与 `packages/app/e2e/ci-specs-serial.txt` 两份临时白名单选择当前已核验通过的 spec
+    - 大多数已核验通过 spec 仍按 Playwright 的常规 CI 并发运行
+    - 只有少数已确认有并发敏感迹象的 spec 会通过 `bun test:e2e:local --workers 1 <spec...>` 单独串行运行
+    - 设置 `CI=true` 与 `PLAYWRIGHT_JUNIT_OUTPUT=e2e/junit-<os>.xml`
+    - 失败与成功都会上传 `packages/app/e2e/junit-*.xml`、`packages/app/e2e/test-results`、`packages/app/e2e/playwright-report`
+    - job 设置了 `35` 分钟超时
 - 作用：
   - 为 `packages/ui`、`packages/app` 和 `packages/opencode` 提供 Linux 与 Windows 两个平台的持续单元测试校验
   - 把 UI 组件测试、前端页面测试和核心包测试分开展示，便于定位问题来源
   - 让 app 包同时覆盖纯逻辑 Bun 测试和需要 Solid 编译/渲染环境的 Vitest 测试
+  - 为 `packages/app` 恢复独立的 E2E 校验入口，并把 runner / Playwright / 测试失败与 unit job 分离展示
 - 备注：
-  - workflow 注释明确说明：
-    - app E2E 当前也不纳入 required baseline，原因是 CI 中临时端口分配尚未稳定
+  - app E2E 已恢复到同一条 workflow 中，但仍作为独立 job 展示
+  - 当前 CI 不会直接执行全部 `50` 条 app E2E spec，而是先执行白名单中的 `37` 条已核验通过 spec
+  - 其中只有 `6` 条并发敏感 spec 单独串行，其余 `31` 条仍走常规并发
+  - 后续若出现失败，需要区分：
+    - runner / 浏览器安装问题
+    - 当前旧 E2E 套件自身问题
+    - 产品行为与测试假设不一致
+  - 这条 workflow 当前恢复的是“当前仓库已有 E2E 基线”，不是一次性整包同步 upstream 当前所有新 E2E
   - `packages/app/script/vitest.ts` 与 `packages/ui/script/vitest.ts` 都会优先查找标准 `node_modules/vitest/vitest.mjs`，找不到再回退到 `node_modules/.bun` 缓存目录；这是为了兼容 Bun 在不同平台上的依赖安装布局
   - `packages/app/src/test/setup.ts` 与 `packages/ui/src/test/setup.ts` 也使用相同的双路径查找策略加载 `@happy-dom/global-registrator`
   - `packages/app/tsconfig.json` 与 `packages/ui/tsconfig.json` 都显式排除了 `src/**/*.vitest.ts(x)` 和 `src/test`，避免 Vitest 类型污染主 typecheck 图

--- a/packages/app/.gitignore
+++ b/packages/app/.gitignore
@@ -1,3 +1,4 @@
 src/assets/theme.css
 e2e/test-results
 e2e/playwright-report
+e2e/junit-*.xml

--- a/packages/app/e2e/actions.ts
+++ b/packages/app/e2e/actions.ts
@@ -366,7 +366,7 @@ export async function seedProjects(page: Page, input: { directory: string; extra
   )
 }
 
-export async function createTestProject() {
+export async function createTestProject(input?: { serverUrl?: string }) {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-e2e-project-"))
   const id = `e2e-${path.basename(root)}`
 
@@ -375,13 +375,14 @@ export async function createTestProject() {
   execSync("git init", { cwd: root, stdio: "ignore" })
   await fs.writeFile(path.join(root, ".git", "opencode"), id)
   execSync("git config core.fsmonitor false", { cwd: root, stdio: "ignore" })
+  execSync("git config commit.gpgsign false", { cwd: root, stdio: "ignore" })
   execSync("git add -A", { cwd: root, stdio: "ignore" })
   execSync('git -c user.name="e2e" -c user.email="e2e@example.com" commit -m "init" --allow-empty', {
     cwd: root,
     stdio: "ignore",
   })
 
-  return resolveDirectory(root)
+  return resolveDirectory(root, input?.serverUrl)
 }
 
 export async function cleanupTestProject(directory: string) {
@@ -430,22 +431,22 @@ export async function waitSlug(page: Page, skip: string[] = []) {
   return next
 }
 
-export async function resolveSlug(slug: string) {
+export async function resolveSlug(slug: string, input?: { serverUrl?: string }) {
   const directory = base64Decode(slug)
   if (!directory) throw new Error(`Failed to decode workspace slug: ${slug}`)
-  const resolved = await resolveDirectory(directory)
+  const resolved = await resolveDirectory(directory, input?.serverUrl)
   return { directory: resolved, slug: base64Encode(resolved), raw: slug }
 }
 
-export async function waitDir(page: Page, directory: string) {
-  const target = await resolveDirectory(directory)
+export async function waitDir(page: Page, directory: string, input?: { serverUrl?: string }) {
+  const target = await resolveDirectory(directory, input?.serverUrl)
   await expect
     .poll(
       async () => {
         await assertHealthy(page, "waitDir")
         const slug = slugFromUrl(page.url())
         if (!slug) return ""
-        return resolveSlug(slug)
+        return resolveSlug(slug, input)
           .then((item) => item.directory)
           .catch(() => "")
       },
@@ -455,22 +456,33 @@ export async function waitDir(page: Page, directory: string) {
   return { directory: target, slug: base64Encode(target) }
 }
 
-export async function waitSession(page: Page, input: { directory: string; sessionID?: string }) {
-  const target = await resolveDirectory(input.directory)
+export async function waitSession(
+  page: Page,
+  input: {
+    directory: string
+    sessionID?: string
+    serverUrl?: string
+    allowAnySession?: boolean
+  },
+) {
+  const target = await resolveDirectory(input.directory, input.serverUrl)
   await expect
     .poll(
       async () => {
         await assertHealthy(page, "waitSession")
         const slug = slugFromUrl(page.url())
         if (!slug) return false
-        const resolved = await resolveSlug(slug).catch(() => undefined)
+        const resolved = await resolveSlug(slug, { serverUrl: input.serverUrl }).catch(() => undefined)
         if (!resolved || resolved.directory !== target) return false
-        if (input.sessionID && sessionIDFromUrl(page.url()) !== input.sessionID) return false
+        const current = sessionIDFromUrl(page.url())
+        if (input.sessionID && current !== input.sessionID) return false
+        if (!input.sessionID && !input.allowAnySession && current) return false
 
         const state = await probeSession(page)
         if (input.sessionID && (!state || state.sessionID !== input.sessionID)) return false
+        if (!input.sessionID && !input.allowAnySession && state?.sessionID) return false
         if (state?.dir) {
-          const dir = await resolveDirectory(state.dir).catch(() => state.dir ?? "")
+          const dir = await resolveDirectory(state.dir, input.serverUrl).catch(() => state.dir ?? "")
           if (dir !== target) return false
         }
 
@@ -486,9 +498,9 @@ export async function waitSession(page: Page, input: { directory: string; sessio
   return { directory: target, slug: base64Encode(target) }
 }
 
-export async function waitSessionSaved(directory: string, sessionID: string, timeout = 30_000) {
-  const sdk = createSdk(directory)
-  const target = await resolveDirectory(directory)
+export async function waitSessionSaved(directory: string, sessionID: string, timeout = 30_000, serverUrl?: string) {
+  const sdk = createSdk(directory, serverUrl)
+  const target = await resolveDirectory(directory, serverUrl)
 
   await expect
     .poll(
@@ -498,7 +510,7 @@ export async function waitSessionSaved(directory: string, sessionID: string, tim
           .then((x) => x.data)
           .catch(() => undefined)
         if (!data?.directory) return ""
-        return resolveDirectory(data.directory).catch(() => data.directory)
+        return resolveDirectory(data.directory, serverUrl).catch(() => data.directory)
       },
       { timeout },
     )
@@ -663,8 +675,9 @@ export async function cleanupSession(input: {
   sessionID: string
   directory?: string
   sdk?: ReturnType<typeof createSdk>
+  serverUrl?: string
 }) {
-  const sdk = input.sdk ?? (input.directory ? createSdk(input.directory) : undefined)
+  const sdk = input.sdk ?? (input.directory ? createSdk(input.directory, input.serverUrl) : undefined)
   if (!sdk) throw new Error("cleanupSession requires sdk or directory")
   await waitSessionIdle(sdk, input.sessionID, 5_000).catch(() => undefined)
   const current = await status(sdk, input.sessionID).catch(() => undefined)

--- a/packages/app/e2e/backend.ts
+++ b/packages/app/e2e/backend.ts
@@ -1,0 +1,141 @@
+import { spawn } from "node:child_process"
+import fs from "node:fs/promises"
+import net from "node:net"
+import os from "node:os"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+type Handle = {
+  url: string
+  stop: () => Promise<void>
+}
+
+function freePort() {
+  return new Promise<number>((resolve, reject) => {
+    const server = net.createServer()
+    server.once("error", reject)
+    server.listen(0, () => {
+      const address = server.address()
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("Failed to acquire a free port")))
+        return
+      }
+      server.close((err) => {
+        if (err) reject(err)
+        else resolve(address.port)
+      })
+    })
+  })
+}
+
+async function waitForHealth(url: string, probe = "/global/health") {
+  const end = Date.now() + 120_000
+  let last = ""
+  while (Date.now() < end) {
+    try {
+      const res = await fetch(`${url}${probe}`)
+      if (res.ok) return
+      last = `status ${res.status}`
+    } catch (err) {
+      last = err instanceof Error ? err.message : String(err)
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+  throw new Error(`Timed out waiting for backend health at ${url}${probe}${last ? ` (${last})` : ""}`)
+}
+
+function done(proc: ReturnType<typeof spawn>) {
+  return proc.exitCode !== null || proc.signalCode !== null
+}
+
+async function waitExit(proc: ReturnType<typeof spawn>, timeout = 10_000) {
+  if (done(proc)) return
+  await Promise.race([
+    new Promise<void>((resolve) => proc.once("exit", () => resolve())),
+    new Promise<void>((resolve) => setTimeout(resolve, timeout)),
+  ])
+}
+
+const cap = 100
+
+function trim(input: string[]) {
+  if (input.length > cap) input.splice(0, input.length - cap)
+}
+
+function tail(input: string[]) {
+  return input.slice(-40).join("")
+}
+
+export async function startBackend(label: string, input?: { llmUrl?: string }): Promise<Handle> {
+  const port = await freePort()
+  const sandbox = await fs.mkdtemp(path.join(os.tmpdir(), `opencode-e2e-${label}-`))
+  const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+  const repoDir = path.resolve(appDir, "../..")
+  const opencodeDir = path.join(repoDir, "packages", "opencode")
+  const env = {
+    ...process.env,
+    OPENCODE_DISABLE_LSP_DOWNLOAD: "true",
+    OPENCODE_DISABLE_DEFAULT_PLUGINS: "true",
+    OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: "true",
+    OPENCODE_TEST_HOME: path.join(sandbox, "home"),
+    XDG_DATA_HOME: path.join(sandbox, "share"),
+    XDG_CACHE_HOME: path.join(sandbox, "cache"),
+    XDG_CONFIG_HOME: path.join(sandbox, "config"),
+    XDG_STATE_HOME: path.join(sandbox, "state"),
+    OPENCODE_CLIENT: "app",
+    OPENCODE_STRICT_CONFIG_DEPS: "true",
+    OPENCODE_E2E_LLM_URL: input?.llmUrl,
+  } satisfies Record<string, string | undefined>
+  const out: string[] = []
+  const err: string[] = []
+  const proc = spawn(
+    "bun",
+    ["run", "--conditions=browser", "./src/index.ts", "serve", "--port", String(port), "--hostname", "127.0.0.1"],
+    {
+      cwd: opencodeDir,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  )
+  proc.stdout?.on("data", (chunk) => {
+    out.push(String(chunk))
+    trim(out)
+  })
+  proc.stderr?.on("data", (chunk) => {
+    err.push(String(chunk))
+    trim(err)
+  })
+
+  const url = `http://127.0.0.1:${port}`
+  try {
+    await waitForHealth(url)
+  } catch (error) {
+    proc.kill("SIGTERM")
+    await fs.rm(sandbox, { recursive: true, force: true }).catch(() => undefined)
+    throw new Error(
+      [
+        `Failed to start isolated e2e backend for ${label}`,
+        error instanceof Error ? error.message : String(error),
+        tail(out),
+        tail(err),
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    )
+  }
+
+  return {
+    url,
+    async stop() {
+      if (!done(proc)) {
+        proc.kill("SIGTERM")
+        await waitExit(proc)
+      }
+      if (!done(proc)) {
+        proc.kill("SIGKILL")
+        await waitExit(proc)
+      }
+      await fs.rm(sandbox, { recursive: true, force: true }).catch(() => undefined)
+    },
+  }
+}

--- a/packages/app/e2e/ci-specs-serial.txt
+++ b/packages/app/e2e/ci-specs-serial.txt
@@ -1,0 +1,9 @@
+# Temporary CI serial allowlist for specs that showed concurrency sensitivity
+# during local verification.
+
+e2e/files/file-viewer.spec.ts
+e2e/prompt/prompt-async.spec.ts
+e2e/prompt/prompt-history.spec.ts
+e2e/prompt/prompt.spec.ts
+e2e/terminal/terminal-init.spec.ts
+e2e/terminal/terminal-reconnect.spec.ts

--- a/packages/app/e2e/ci-specs.txt
+++ b/packages/app/e2e/ci-specs.txt
@@ -1,0 +1,34 @@
+# Temporary CI allowlist for app E2E.
+# These specs have been locally verified to pass on the current Aether implementation.
+
+e2e/app/home.spec.ts
+e2e/app/navigation.spec.ts
+e2e/app/palette.spec.ts
+e2e/app/server-default.spec.ts
+e2e/app/session.spec.ts
+e2e/commands/input-focus.spec.ts
+e2e/commands/panels.spec.ts
+e2e/commands/tab-close.spec.ts
+e2e/files/file-open.spec.ts
+e2e/files/file-tree.spec.ts
+e2e/models/models-visibility.spec.ts
+e2e/projects/project-edit.spec.ts
+e2e/projects/projects-close.spec.ts
+e2e/projects/workspace-new-session.spec.ts
+e2e/projects/workspaces.spec.ts
+e2e/prompt/prompt-mention.spec.ts
+e2e/prompt/prompt-multiline.spec.ts
+e2e/prompt/prompt-shell.spec.ts
+e2e/prompt/prompt-slash-open.spec.ts
+e2e/prompt/prompt-slash-share.spec.ts
+e2e/prompt/prompt-slash-terminal.spec.ts
+e2e/session/session-child-navigation.spec.ts
+e2e/session/session-undo-redo.spec.ts
+e2e/session/session.spec.ts
+e2e/settings/settings-models.spec.ts
+e2e/settings/settings.spec.ts
+e2e/sidebar/sidebar.spec.ts
+e2e/status/status-popover.spec.ts
+e2e/terminal/terminal-tabs.spec.ts
+e2e/terminal/terminal.spec.ts
+e2e/thinking-level.spec.ts

--- a/packages/app/e2e/fixtures.ts
+++ b/packages/app/e2e/fixtures.ts
@@ -1,5 +1,9 @@
 import { test as base, expect, type Page } from "@playwright/test"
+import { ManagedRuntime } from "effect"
 import type { E2EWindow } from "../src/testing/terminal"
+import type { Item, Usage } from "../../opencode/test/lib/llm-server"
+import { TestLLMServer } from "../../opencode/test/lib/llm-server"
+import { startBackend } from "./backend"
 import {
   healthPhase,
   cleanupSession,
@@ -10,10 +14,119 @@ import {
   sessionIDFromUrl,
   waitSlug,
   waitSession,
+  waitSessionIdle,
+  waitSessionSaved,
 } from "./actions"
-import { createSdk, dirSlug, getWorktree, sessionPath } from "./utils"
+import { promptSelector } from "./selectors"
+import { createSdk, dirSlug, getWorktree, serverUrl, sessionPath } from "./utils"
 
 export const settingsKey = "settings.v3"
+
+type LLMFixture = {
+  url: string
+  push: (...input: Parameters<TestLLMServer.Service["push"]>) => Promise<void>
+  pushMatch: (...input: Parameters<TestLLMServer.Service["pushMatch"]>) => Promise<void>
+  textMatch: (...input: Parameters<TestLLMServer.Service["textMatch"]>) => Promise<void>
+  toolMatch: (...input: Parameters<TestLLMServer.Service["toolMatch"]>) => Promise<void>
+  text: (value: string, opts?: { usage?: Usage }) => Promise<void>
+  tool: (name: string, input: unknown) => Promise<void>
+  toolHang: (name: string, input: unknown) => Promise<void>
+  reason: (value: string, opts?: { text?: string; usage?: Usage }) => Promise<void>
+  fail: (message?: unknown) => Promise<void>
+  error: (status: number, body: unknown) => Promise<void>
+  hang: () => Promise<void>
+  hold: (value: string, wait: PromiseLike<unknown>) => Promise<void>
+  hits: () => Promise<Array<{ url: URL; body: Record<string, unknown> }>>
+  calls: () => Promise<number>
+  wait: (count: number) => Promise<void>
+  inputs: () => Promise<Record<string, unknown>[]>
+  pending: () => Promise<number>
+  misses: () => Promise<Array<{ url: URL; body: Record<string, unknown> }>>
+}
+
+type LLMWorker = LLMFixture & {
+  reset: () => Promise<void>
+}
+
+type AssistantFixture = {
+  reply: LLMFixture["text"]
+  tool: LLMFixture["tool"]
+  toolHang: LLMFixture["toolHang"]
+  reason: LLMFixture["reason"]
+  fail: LLMFixture["fail"]
+  error: LLMFixture["error"]
+  hang: LLMFixture["hang"]
+  hold: LLMFixture["hold"]
+  calls: LLMFixture["calls"]
+  pending: LLMFixture["pending"]
+}
+
+const seedModel = (() => {
+  const [providerID = "opencode", modelID = "big-pickle"] = (
+    process.env.OPENCODE_E2E_MODEL ?? "opencode/big-pickle"
+  ).split("/")
+  return {
+    providerID: providerID || "opencode",
+    modelID: modelID || "big-pickle",
+  }
+})()
+
+function clean(value: string | null) {
+  return (value ?? "").replace(/\u200B/g, "").trim()
+}
+
+async function visit(page: Page, url: string) {
+  let err: unknown
+  for (const _ of [0, 1, 2]) {
+    try {
+      await page.goto(url)
+      return
+    } catch (cause) {
+      err = cause
+      if (!String(cause).includes("ERR_CONNECTION_REFUSED")) throw cause
+      await new Promise((resolve) => setTimeout(resolve, 300))
+    }
+  }
+  throw err
+}
+
+async function promptSend(page: Page) {
+  return page
+    .evaluate(() => {
+      const win = window as E2EWindow
+      const sent = win.__opencode_e2e?.prompt?.sent
+      return {
+        started: sent?.started ?? 0,
+        count: sent?.count ?? 0,
+        sessionID: sent?.sessionID,
+        directory: sent?.directory,
+      }
+    })
+    .catch(() => ({ started: 0, count: 0, sessionID: undefined, directory: undefined }))
+}
+
+type ProjectHandle = {
+  directory: string
+  slug: string
+  gotoSession: (sessionID?: string) => Promise<void>
+  trackSession: (sessionID: string, directory?: string) => void
+  trackDirectory: (directory: string) => void
+  sdk: ReturnType<typeof createSdk>
+}
+
+type ProjectOptions = {
+  extra?: string[]
+  model?: { providerID: string; modelID: string }
+  setup?: (directory: string) => Promise<void>
+  beforeGoto?: (project: { directory: string; sdk: ReturnType<typeof createSdk> }) => Promise<void>
+}
+
+type ProjectFixture = ProjectHandle & {
+  open: (options?: ProjectOptions) => Promise<void>
+  prompt: (text: string) => Promise<string>
+  user: (text: string) => Promise<string>
+  shell: (cmd: string) => Promise<string>
+}
 
 type TestFixtures = {
   sdk: ReturnType<typeof createSdk>
@@ -28,14 +141,111 @@ type TestFixtures = {
     }) => Promise<T>,
     options?: { extra?: string[] },
   ) => Promise<T>
+  llm: LLMFixture
+  assistant: AssistantFixture
+  project: ProjectFixture
 }
 
 type WorkerFixtures = {
+  _llm: LLMWorker
+  backend: {
+    url: string
+    sdk: (directory?: string) => ReturnType<typeof createSdk>
+  }
   directory: string
   slug: string
 }
 
 export const test = base.extend<TestFixtures, WorkerFixtures>({
+  _llm: [
+    async ({}, use) => {
+      const rt = ManagedRuntime.make(TestLLMServer.layer)
+      try {
+        const svc = await rt.runPromise(TestLLMServer.asEffect())
+        await use({
+          url: svc.url,
+          push: (...input) => rt.runPromise(svc.push(...input)),
+          pushMatch: (...input) => rt.runPromise(svc.pushMatch(...input)),
+          textMatch: (...input) => rt.runPromise(svc.textMatch(...input)),
+          toolMatch: (...input) => rt.runPromise(svc.toolMatch(...input)),
+          text: (value, opts) => rt.runPromise(svc.text(value, opts)),
+          tool: (name, input) => rt.runPromise(svc.tool(name, input)),
+          toolHang: (name, input) => rt.runPromise(svc.toolHang(name, input)),
+          reason: (value, opts) => rt.runPromise(svc.reason(value, opts)),
+          fail: (message) => rt.runPromise(svc.fail(message)),
+          error: (status, body) => rt.runPromise(svc.error(status, body)),
+          hang: () => rt.runPromise(svc.hang),
+          hold: (value, wait) => rt.runPromise(svc.hold(value, wait)),
+          reset: () => rt.runPromise(svc.reset),
+          hits: () => rt.runPromise(svc.hits),
+          calls: () => rt.runPromise(svc.calls),
+          wait: (count) => rt.runPromise(svc.wait(count)),
+          inputs: () => rt.runPromise(svc.inputs),
+          pending: () => rt.runPromise(svc.pending),
+          misses: () => rt.runPromise(svc.misses),
+        })
+      } finally {
+        await rt.dispose()
+      }
+    },
+    { scope: "worker" },
+  ],
+  backend: [
+    async ({ _llm }, use, workerInfo) => {
+      const handle = await startBackend(`w${workerInfo.workerIndex}`, { llmUrl: _llm.url })
+      try {
+        await use({
+          url: handle.url,
+          sdk: (directory?: string) => createSdk(directory, handle.url),
+        })
+      } finally {
+        await handle.stop()
+      }
+    },
+    { scope: "worker" },
+  ],
+  llm: async ({ _llm }, use) => {
+    await _llm.reset()
+    await use({
+      url: _llm.url,
+      push: _llm.push,
+      pushMatch: _llm.pushMatch,
+      textMatch: _llm.textMatch,
+      toolMatch: _llm.toolMatch,
+      text: _llm.text,
+      tool: _llm.tool,
+      toolHang: _llm.toolHang,
+      reason: _llm.reason,
+      fail: _llm.fail,
+      error: _llm.error,
+      hang: _llm.hang,
+      hold: _llm.hold,
+      hits: _llm.hits,
+      calls: _llm.calls,
+      wait: _llm.wait,
+      inputs: _llm.inputs,
+      pending: _llm.pending,
+      misses: _llm.misses,
+    })
+    const pending = await _llm.pending()
+    if (pending > 0) {
+      throw new Error(`TestLLMServer still has ${pending} queued response(s) after the test finished`)
+    }
+  },
+  assistant: async ({ llm }, use) => {
+    await use({
+      reply: llm.text,
+      tool: llm.tool,
+      toolHang: llm.toolHang,
+      reason: llm.reason,
+      fail: llm.fail,
+      error: llm.error,
+      hang: llm.hang,
+      hold: llm.hold,
+      calls: llm.calls,
+      pending: llm.pending,
+    })
+  },
   page: async ({ page }, use) => {
     let boundary: string | undefined
     setHealthPhase(page, "test")
@@ -121,34 +331,324 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
       }
     })
   },
+  project: async ({ page, llm, backend }, use) => {
+    const item = makeProject(page, llm, backend)
+    try {
+      await use(item.project)
+    } finally {
+      await item.cleanup()
+    }
+  },
 })
 
-async function seedStorage(page: Page, input: { directory: string; extra?: string[] }) {
-  await seedProjects(page, input)
-  await page.addInitScript(() => {
-    const win = window as E2EWindow
-    win.__opencode_e2e = {
-      ...win.__opencode_e2e,
-      model: {
-        enabled: true,
-      },
-      prompt: {
-        enabled: true,
-      },
-      terminal: {
-        enabled: true,
-        terminals: {},
-      },
+function makeProject(
+  page: Page,
+  llm: LLMFixture,
+  backend: { url: string; sdk: (directory?: string) => ReturnType<typeof createSdk> },
+) {
+  let state:
+    | {
+        directory: string
+        slug: string
+        sdk: ReturnType<typeof createSdk>
+        sessions: Map<string, string>
+        dirs: Set<string>
+      }
+    | undefined
+
+  const need = () => {
+    if (state) return state
+    throw new Error("project.open() must be called first")
+  }
+
+  const trackSession = (sessionID: string, directory?: string) => {
+    const cur = need()
+    cur.sessions.set(sessionID, directory ?? cur.directory)
+  }
+
+  const trackDirectory = (directory: string) => {
+    const cur = need()
+    if (directory !== cur.directory) cur.dirs.add(directory)
+  }
+
+  const gotoSession = async (sessionID?: string) => {
+    const cur = need()
+    await visit(page, sessionPath(cur.directory, sessionID))
+    await waitSession(page, {
+      directory: cur.directory,
+      sessionID,
+      serverUrl: backend.url,
+      allowAnySession: !sessionID,
+    })
+    const current = sessionIDFromUrl(page.url())
+    if (current) trackSession(current)
+  }
+
+  const open = async (options?: ProjectOptions) => {
+    if (state) return
+    const directory = await createTestProject({ serverUrl: backend.url })
+    const sdk = backend.sdk(directory)
+    await options?.setup?.(directory)
+    await seedStorage(page, {
+      directory,
+      extra: options?.extra,
+      model: options?.model,
+      serverUrl: backend.url,
+    })
+    state = {
+      directory,
+      slug: "",
+      sdk,
+      sessions: new Map(),
+      dirs: new Set(),
     }
-    localStorage.setItem(
-      "opencode.global.dat:model",
-      JSON.stringify({
-        recent: [{ providerID: "opencode", modelID: "big-pickle" }],
-        user: [],
-        variant: {},
-      }),
+    await options?.beforeGoto?.({ directory, sdk })
+    await gotoSession()
+    need().slug = await waitSlug(page)
+  }
+
+  const send = async (text: string, input: { noReply: boolean; shell: boolean }) => {
+    if (input.noReply) {
+      const cur = need()
+      const state = await page.evaluate(() => {
+        const model = (window as E2EWindow).__opencode_e2e?.model?.current
+        if (!model) return null
+        return {
+          dir: model.dir,
+          sessionID: model.sessionID,
+          agent: model.agent,
+          model: model.model ? { providerID: model.model.providerID, modelID: model.model.modelID } : undefined,
+          variant: model.variant ?? undefined,
+        }
+      })
+      const dir = state?.dir ?? cur.directory
+      const sdk = backend.sdk(dir)
+      const sessionID = state?.sessionID
+        ? state.sessionID
+        : await sdk.session.create({ directory: dir, title: "E2E Session" }).then((res) => {
+            if (!res.data?.id) throw new Error("Failed to create no-reply session")
+            return res.data.id
+          })
+      await sdk.session.prompt({
+        sessionID,
+        agent: state?.agent,
+        model: state?.model,
+        variant: state?.variant,
+        noReply: true,
+        parts: [{ type: "text", text }],
+      })
+      await visit(page, sessionPath(dir, sessionID))
+      const active = await waitSession(page, {
+        directory: dir,
+        sessionID,
+        serverUrl: backend.url,
+      })
+      trackSession(sessionID, active.directory)
+      await waitSessionSaved(active.directory, sessionID, 90_000, backend.url)
+      return sessionID
+    }
+
+    const prev = await promptSend(page)
+    if (!input.noReply && !input.shell && (await llm.pending()) === 0) {
+      await llm.text("ok")
+    }
+
+    const prompt = page.locator(promptSelector).first()
+    const submit = async () => {
+      await expect(prompt).toBeVisible()
+      await prompt.click()
+      if (input.shell) {
+        await page.keyboard.type("!")
+        await expect(prompt).toHaveAttribute("aria-label", /enter shell command/i)
+      }
+      await page.keyboard.type(text)
+      await expect.poll(async () => clean(await prompt.textContent())).toBe(text)
+      await page.keyboard.press("Enter")
+      const started = await expect
+        .poll(async () => (await promptSend(page)).started, { timeout: 5_000 })
+        .toBeGreaterThan(prev.started)
+        .then(() => true)
+        .catch(() => false)
+      if (started) return
+      const send = page.getByRole("button", { name: "Send" }).first()
+      const enabled = await send
+        .isEnabled()
+        .then((value) => value)
+        .catch(() => false)
+      if (enabled) {
+        await send.click()
+        return
+      }
+      await prompt.click()
+      await page.keyboard.press("Enter")
+      await expect.poll(async () => (await promptSend(page)).started, { timeout: 5_000 }).toBeGreaterThan(prev.started)
+    }
+
+    await submit()
+
+    let next: { sessionID: string; directory: string } | undefined
+    await expect
+      .poll(
+        async () => {
+          const sent = await promptSend(page)
+          if (sent.count <= prev.count) return ""
+          if (!sent.sessionID || !sent.directory) return ""
+          next = { sessionID: sent.sessionID, directory: sent.directory }
+          return sent.sessionID
+        },
+        { timeout: 90_000 },
+      )
+      .not.toBe("")
+
+    if (!next) throw new Error("Failed to observe prompt submission in e2e prompt probe")
+    const active = await waitSession(page, {
+      directory: next.directory,
+      sessionID: next.sessionID,
+      serverUrl: backend.url,
+    })
+    trackSession(next.sessionID, active.directory)
+    if (!input.shell) {
+      await waitSessionSaved(active.directory, next.sessionID, 90_000, backend.url)
+    }
+    await waitSessionIdle(backend.sdk(active.directory), next.sessionID, 90_000).catch(() => undefined)
+    return next.sessionID
+  }
+
+  const cleanup = async () => {
+    const cur = state
+    if (!cur) return
+    setHealthPhase(page, "cleanup")
+    await Promise.allSettled(
+      Array.from(cur.sessions, ([sessionID, directory]) =>
+        cleanupSession({ sessionID, directory, serverUrl: backend.url }),
+      ),
     )
-  })
+    await Promise.allSettled(Array.from(cur.dirs, (directory) => cleanupTestProject(directory)))
+    await cleanupTestProject(cur.directory)
+    state = undefined
+    setHealthPhase(page, "test")
+  }
+
+  return {
+    project: {
+      open,
+      prompt: (text: string) => send(text, { noReply: false, shell: false }),
+      user: (text: string) => send(text, { noReply: true, shell: false }),
+      shell: (cmd: string) => send(cmd, { noReply: false, shell: true }),
+      gotoSession,
+      trackSession,
+      trackDirectory,
+      get directory() {
+        return need().directory
+      },
+      get slug() {
+        return need().slug
+      },
+      get sdk() {
+        return need().sdk
+      },
+    },
+    cleanup,
+  }
+}
+
+async function seedStorage(
+  page: Page,
+  input: {
+    directory: string
+    extra?: string[]
+    model?: { providerID: string; modelID: string }
+    serverUrl?: string
+  },
+) {
+  if (!input.serverUrl) {
+    await seedProjects(page, { directory: input.directory, extra: input.extra })
+    await page.addInitScript((model: { providerID: string; modelID: string }) => {
+      const win = window as E2EWindow
+      win.__opencode_e2e = {
+        ...win.__opencode_e2e,
+        model: {
+          enabled: true,
+        },
+        prompt: {
+          enabled: true,
+        },
+        terminal: {
+          enabled: true,
+          terminals: {},
+        },
+      }
+      localStorage.setItem(
+        "opencode.global.dat:model",
+        JSON.stringify({
+          recent: [model],
+          user: [],
+          variant: {},
+        }),
+      )
+    }, input.model ?? seedModel)
+    return
+  }
+
+  const origin = input.serverUrl ?? serverUrl
+  await page.addInitScript(
+    (args: {
+      directory: string
+      serverUrl: string
+      extra: string[]
+      model: { providerID: string; modelID: string }
+    }) => {
+      const key = "opencode.global.dat:server"
+      const raw = localStorage.getItem(key)
+      const parsed = (() => {
+        if (!raw) return undefined
+        try {
+          return JSON.parse(raw) as unknown
+        } catch {
+          return undefined
+        }
+      })()
+
+      const store = parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {}
+      const list = Array.isArray(store.list) ? store.list : []
+      const lastProject = store.lastProject && typeof store.lastProject === "object" ? store.lastProject : {}
+      const projects = store.projects && typeof store.projects === "object" ? store.projects : {}
+      const next = { ...(projects as Record<string, unknown>) }
+      const nextList = list.includes(args.serverUrl) ? list : [args.serverUrl, ...list]
+
+      const add = (origin: string, directory: string) => {
+        const current = next[origin]
+        const items = Array.isArray(current) ? current : []
+        const existing = items.filter(
+          (project): project is { worktree: string; expanded?: boolean } =>
+            !!project &&
+            typeof project === "object" &&
+            "worktree" in project &&
+            typeof (project as { worktree?: unknown }).worktree === "string",
+        )
+        if (existing.some((project) => project.worktree === directory)) return
+        next[origin] = [{ worktree: directory, expanded: true }, ...existing]
+      }
+
+      for (const directory of [args.directory, ...args.extra]) {
+        add("local", directory)
+        add(args.serverUrl, directory)
+      }
+
+      localStorage.setItem(key, JSON.stringify({ list: nextList, projects: next, lastProject }))
+      localStorage.setItem("opencode.settings.dat:defaultServerUrl", args.serverUrl)
+
+      const win = window as E2EWindow
+      win.__opencode_e2e = {
+        ...win.__opencode_e2e,
+        model: { enabled: true },
+        prompt: { enabled: true },
+        terminal: { enabled: true, terminals: {} },
+      }
+      localStorage.setItem("opencode.global.dat:model", JSON.stringify({ recent: [args.model], user: [], variant: {} }))
+    },
+    { directory: input.directory, serverUrl: origin, extra: input.extra ?? [], model: input.model ?? seedModel },
+  )
 }
 
 export { expect }

--- a/packages/app/e2e/projects/workspace-new-session.spec.ts
+++ b/packages/app/e2e/projects/workspace-new-session.spec.ts
@@ -6,7 +6,6 @@ import {
   sessionIDFromUrl,
   setWorkspacesEnabled,
   waitDir,
-  waitSession,
   waitSessionSaved,
   waitSlug,
 } from "../actions"
@@ -19,6 +18,33 @@ function item(space: { slug: string; raw: string }) {
 
 function button(space: { slug: string; raw: string }) {
   return `${workspaceNewSessionSelector(space.slug)}, ${workspaceNewSessionSelector(space.raw)}`
+}
+
+async function waitStableSession(page: Page, timeout = 15_000) {
+  let prev = ""
+  let next = ""
+  await expect
+    .poll(
+      () => {
+        const current = sessionIDFromUrl(page.url()) ?? ""
+        if (!current) {
+          prev = ""
+          next = ""
+          return ""
+        }
+        if (current !== prev) {
+          prev = current
+          next = ""
+          return ""
+        }
+        next = current
+        return current
+      },
+      { timeout },
+    )
+    .not.toBe("")
+  if (!next) throw new Error(`Failed to observe a stable session id from url: ${page.url()}`)
+  return next
 }
 
 async function waitWorkspaceReady(page: Page, space: { slug: string; raw: string }) {
@@ -45,8 +71,9 @@ async function openWorkspaceNewSession(page: Page, space: { slug: string; raw: s
   await expect(next).toBeVisible()
   await next.click({ force: true })
 
-  await waitSession(page, { directory: space.directory })
-  await expect.poll(() => sessionIDFromUrl(page.url()) ?? "").toBe("")
+  await waitDir(page, space.directory)
+  await expect(page.locator(promptSelector).first()).toBeVisible({ timeout: 45_000 })
+  return waitStableSession(page)
 }
 
 async function createSessionFromWorkspace(
@@ -61,10 +88,7 @@ async function createSessionFromWorkspace(
   await prompt.fill(text)
   await page.keyboard.press("Enter")
 
-  await expect.poll(() => sessionIDFromUrl(page.url()) ?? "", { timeout: 15_000 }).not.toBe("")
-  const sessionID = sessionIDFromUrl(page.url())
-  if (!sessionID) throw new Error(`Failed to parse session id from url: ${page.url()}`)
-
+  const sessionID = await waitStableSession(page)
   await waitSessionSaved(space.directory, sessionID)
   await createSdk(space.directory)
     .session.abort({ sessionID })

--- a/packages/app/e2e/utils.ts
+++ b/packages/app/e2e/utils.ts
@@ -26,21 +26,21 @@ export const serverNamePattern = new RegExp(`(?:${serverNames.map(escape).join("
 export const modKey = process.platform === "darwin" ? "Meta" : "Control"
 export const terminalToggleKey = "Control+Backquote"
 
-export function createSdk(directory?: string) {
-  return createOpencodeClient({ baseUrl: serverUrl, directory, throwOnError: true })
+export function createSdk(directory?: string, baseUrl = serverUrl) {
+  return createOpencodeClient({ baseUrl, directory, throwOnError: true })
 }
 
-export async function resolveDirectory(directory: string) {
-  return createSdk(directory)
+export async function resolveDirectory(directory: string, baseUrl = serverUrl) {
+  return createSdk(directory, baseUrl)
     .path.get()
     .then((x) => x.data?.directory ?? directory)
 }
 
-export async function getWorktree() {
-  const sdk = createSdk()
+export async function getWorktree(baseUrl = serverUrl) {
+  const sdk = createSdk(undefined, baseUrl)
   const result = await sdk.path.get()
   const data = result.data
-  if (!data?.worktree) throw new Error(`Failed to resolve a worktree from ${serverUrl}/path`)
+  if (!data?.worktree) throw new Error(`Failed to resolve a worktree from ${baseUrl}/path`)
   return data.worktree
 }
 

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -7,6 +7,11 @@ const serverPort = process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"
 const command = `bun run dev -- --host 0.0.0.0 --port ${port}`
 const reuse = !process.env.CI
 const workers = Number(process.env.PLAYWRIGHT_WORKERS ?? (process.env.CI ? 5 : 0)) || undefined
+const reporter = [["html", { outputFolder: "e2e/playwright-report", open: "never" }], ["line"]] as const
+
+if (process.env.PLAYWRIGHT_JUNIT_OUTPUT) {
+  reporter.push(["junit", { outputFile: process.env.PLAYWRIGHT_JUNIT_OUTPUT }])
+}
 
 export default defineConfig({
   testDir: "./e2e",
@@ -19,7 +24,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers,
-  reporter: [["html", { outputFolder: "e2e/playwright-report", open: "never" }], ["line"]],
+  reporter,
   webServer: {
     command,
     url: baseURL,

--- a/packages/app/script/e2e-local.ts
+++ b/packages/app/script/e2e-local.ts
@@ -71,13 +71,14 @@ const serverEnv = {
   OPENCODE_E2E_PROJECT_DIR: repoDir,
   OPENCODE_E2E_SESSION_TITLE: "E2E Session",
   OPENCODE_E2E_MESSAGE: "Seeded for UI e2e",
-  OPENCODE_E2E_MODEL: "opencode/gpt-5-nano",
+  OPENCODE_E2E_MODEL: process.env.OPENCODE_E2E_MODEL ?? "opencode/gpt-5-nano",
   OPENCODE_CLIENT: "app",
   OPENCODE_STRICT_CONFIG_DEPS: "true",
 } satisfies Record<string, string>
 
 const runnerEnv = {
   ...serverEnv,
+  PLAYWRIGHT_BROWSERS_PATH: process.env.PLAYWRIGHT_BROWSERS_PATH ?? path.join(repoDir, ".playwright-browsers"),
   PLAYWRIGHT_SERVER_HOST: "127.0.0.1",
   PLAYWRIGHT_SERVER_PORT: String(serverPort),
   VITE_OPENCODE_SERVER_HOST: "127.0.0.1",
@@ -87,23 +88,51 @@ const runnerEnv = {
 
 let seed: ReturnType<typeof Bun.spawn> | undefined
 let runner: ReturnType<typeof Bun.spawn> | undefined
-let server: { stop: () => Promise<void> | void } | undefined
+let server: { stop: (close?: boolean) => Promise<void> | void } | undefined
 let inst: { Instance: { disposeAll: () => Promise<void> | void } } | undefined
 let cleaned = false
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function terminate(proc: ReturnType<typeof Bun.spawn> | undefined, label: string) {
+  if (!proc) return
+  if (proc.exitCode !== null) {
+    await proc.exited.catch(() => undefined)
+    return
+  }
+
+  proc.kill("SIGTERM")
+  const soft = await Promise.race([proc.exited.then(() => true).catch(() => true), sleep(5_000).then(() => false)])
+  if (soft) return
+
+  console.warn(`e2e-local cleanup timeout: ${label} ignored SIGTERM, escalating to SIGKILL`)
+  proc.kill("SIGKILL")
+  await Promise.race([proc.exited.catch(() => undefined), sleep(2_000)])
+}
+
+async function bound(job: Promise<unknown> | unknown, label: string, ms = 10_000) {
+  return await Promise.race([
+    Promise.resolve(job),
+    sleep(ms).then(() => {
+      console.warn(`e2e-local cleanup timeout: ${label} exceeded ${ms}ms`)
+    }),
+  ])
+}
 
 const cleanup = async () => {
   if (cleaned) return
   cleaned = true
 
-  if (seed && seed.exitCode === null) seed.kill("SIGTERM")
-  if (runner && runner.exitCode === null) runner.kill("SIGTERM")
+  await Promise.allSettled([terminate(runner, "runner"), terminate(seed, "seed")])
 
-  const jobs = [
-    inst?.Instance.disposeAll(),
-    server?.stop(),
-    keepSandbox ? undefined : fs.rm(sandbox, { recursive: true, force: true }),
-  ].filter(Boolean)
-  await Promise.allSettled(jobs)
+  await Promise.allSettled([
+    inst ? bound(inst.Instance.disposeAll(), "Instance.disposeAll()") : undefined,
+    server ? bound(server.stop(true), "server.stop(true)") : undefined,
+  ])
+
+  if (!keepSandbox) {
+    await bound(fs.rm(sandbox, { recursive: true, force: true }), "fs.rm(sandbox)")
+  }
 }
 
 const shutdown = (code: number, reason: string) => {
@@ -158,7 +187,7 @@ try {
 
     const servermod = await import("../../opencode/src/server/server")
     inst = await import("../../opencode/src/project/instance")
-    server = servermod.Server.listen({ port: serverPort, hostname: "127.0.0.1" })
+    server = await servermod.Server.listen({ port: serverPort, hostname: "127.0.0.1" })
     console.log(`opencode server listening on http://127.0.0.1:${serverPort}`)
 
     await waitForHealth(`http://127.0.0.1:${serverPort}/global/health`)

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -17,6 +17,7 @@ import { useSDK } from "@/context/sdk"
 import { useServer } from "@/context/server"
 import { useSync } from "@/context/sync"
 import { useKnowledge } from "@/context/knowledge"
+import { promptProbe } from "@/testing/prompt"
 import { Identifier } from "@/utils/id"
 import { Worktree as WorktreeState } from "@/utils/worktree"
 import { buildRequestParts, type DataAttachment } from "./build-request-parts"
@@ -443,6 +444,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
 
     input.addToHistory(currentPrompt, mode)
     input.resetHistoryNavigation()
+    promptProbe.start()
 
     const projectDirectory = sdk.directory
     const isNewSession = !params.id
@@ -567,6 +569,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       return
     }
 
+    promptProbe.submit({ sessionID: session.id, directory: sessionDirectory })
     input.onSubmit?.()
 
     if (mode === "shell") {

--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -530,6 +530,10 @@ export const Terminal = (props: TerminalProps) => {
           if (disposed) return
           tries = 0
           probe.connect()
+          queueMicrotask(() => {
+            if (disposed) return
+            probe.settle()
+          })
           local.onConnect?.()
           scheduleSize(t.cols, t.rows)
         }

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -462,10 +462,18 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     }
 
     if (modelEnabled()) {
+      const probe = Symbol("model-probe")
+
+      modelProbe.bind(probe, {
+        setAgent: agent.set,
+        setModel: model.set,
+        setVariant: model.variant.set,
+      })
+
       createEffect(() => {
         const agent = result.agent.current()
         const model = result.model.current()
-        modelProbe.set({
+        modelProbe.set(probe, {
           dir: sdk.directory,
           sessionID: id(),
           last: store.last,
@@ -483,10 +491,20 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           pick: scope(),
           base: undefined,
           current: store.current,
+          variants: result.model.variant.list(),
+          models: result.model
+            .list()
+            .filter((item) => result.model.visible({ providerID: item.provider.id, modelID: item.id }))
+            .map((item) => ({
+              providerID: item.provider.id,
+              modelID: item.id,
+              name: item.name,
+            })),
+          agents: result.agent.list().map((item) => ({ name: item.name })),
         })
       })
 
-      onCleanup(() => modelProbe.clear())
+      onCleanup(() => modelProbe.clear(probe))
     }
 
     return result

--- a/packages/app/src/testing/model-selection.ts
+++ b/packages/app/src/testing/model-selection.ts
@@ -3,6 +3,14 @@ type ModelKey = {
   modelID: string
 }
 
+type ModelItem = ModelKey & {
+  name: string
+}
+
+type AgentItem = {
+  name: string
+}
+
 type State = {
   agent?: string
   model?: ModelKey | null
@@ -26,6 +34,9 @@ export type ModelProbeState = {
   pick?: State
   base?: State
   current?: string
+  variants?: string[]
+  models?: ModelItem[]
+  agents?: AgentItem[]
 }
 
 export type ModelWindow = Window & {
@@ -33,6 +44,11 @@ export type ModelWindow = Window & {
     model?: {
       enabled?: boolean
       current?: ModelProbeState
+      controls?: {
+        setAgent?: (name: string | undefined) => void
+        setModel?: (value: ModelKey | undefined) => void
+        setVariant?: (value: string | undefined) => void
+      }
     }
   }
 }
@@ -45,6 +61,8 @@ const clone = (state?: State) => {
   }
 }
 
+let active: symbol | undefined
+
 export const modelEnabled = () => {
   if (typeof window === "undefined") return false
   return (window as ModelWindow).__opencode_e2e?.model?.enabled === true
@@ -56,9 +74,15 @@ const root = () => {
 }
 
 export const modelProbe = {
-  set(input: ModelProbeState) {
+  bind(id: symbol, input: NonNullable<NonNullable<ModelWindow["__opencode_e2e"]>["model"]>["controls"]) {
     const state = root()
     if (!state) return
+    active = id
+    state.controls = input
+  },
+  set(id: symbol, input: ModelProbeState) {
+    const state = root()
+    if (!state || active !== id) return
     state.current = {
       ...input,
       model: input.model ? { ...input.model } : undefined,
@@ -70,11 +94,16 @@ export const modelProbe = {
         : undefined,
       pick: clone(input.pick),
       base: clone(input.base),
+      variants: input.variants?.slice(),
+      models: input.models?.map((item) => ({ ...item })),
+      agents: input.agents?.map((item) => ({ ...item })),
     }
   },
-  clear() {
+  clear(id: symbol) {
     const state = root()
-    if (!state) return
+    if (!state || active !== id) return
+    active = undefined
     state.current = undefined
+    state.controls = undefined
   },
 }

--- a/packages/app/src/testing/prompt.ts
+++ b/packages/app/src/testing/prompt.ts
@@ -10,6 +10,13 @@ export type PromptProbeState = {
   selects: number
 }
 
+export type PromptSendState = {
+  started: number
+  count: number
+  sessionID?: string
+  directory?: string
+}
+
 export const promptEnabled = () => {
   if (typeof window === "undefined") return false
   return (window as E2EWindow).__opencode_e2e?.prompt?.enabled === true
@@ -52,5 +59,25 @@ export const promptProbe = {
     const state = root()
     if (!state) return
     state.current = undefined
+  },
+  start() {
+    const state = root()
+    if (!state) return
+    state.sent = {
+      started: (state.sent?.started ?? 0) + 1,
+      count: state.sent?.count ?? 0,
+      sessionID: state.sent?.sessionID,
+      directory: state.sent?.directory,
+    }
+  },
+  submit(input: { sessionID: string; directory: string }) {
+    const state = root()
+    if (!state) return
+    state.sent = {
+      started: state.sent?.started ?? 0,
+      count: (state.sent?.count ?? 0) + 1,
+      sessionID: input.sessionID,
+      directory: input.directory,
+    }
   },
 }

--- a/packages/app/src/testing/terminal.ts
+++ b/packages/app/src/testing/terminal.ts
@@ -23,6 +23,7 @@ export type E2EWindow = Window & {
     prompt?: {
       enabled?: boolean
       current?: import("./prompt").PromptProbeState
+      sent?: import("./prompt").PromptSendState
     }
     terminal?: {
       enabled?: boolean

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -154,6 +154,12 @@ export namespace Provider {
     )
   }
 
+  function e2eURL() {
+    const url = Env.get("OPENCODE_E2E_LLM_URL")
+    if (typeof url !== "string" || url === "") return
+    return url
+  }
+
   const BUNDLED_PROVIDERS: Record<string, (options: any) => SDK> = {
     "@ai-sdk/amazon-bedrock": createAmazonBedrock,
     "@ai-sdk/anthropic": createAnthropic,
@@ -1433,6 +1439,17 @@ export namespace Provider {
     const s = await state()
     const key = `${model.providerID}/${model.id}`
     if (s.models.has(key)) return s.models.get(key)!
+
+    const url = e2eURL()
+    if (url) {
+      const language = createOpenAICompatible({
+        name: model.providerID,
+        apiKey: "test-key",
+        baseURL: url,
+      }).chatModel(model.api.id) as LanguageModelV2
+      s.models.set(key, language)
+      return language
+    }
 
     const provider = s.providers[model.providerID]
     const sdk = await getSDK(model)

--- a/packages/opencode/test/lib/effect.ts
+++ b/packages/opencode/test/lib/effect.ts
@@ -1,14 +1,14 @@
 import { test, type TestOptions } from "bun:test"
 import { Cause, Effect, Exit, Layer } from "effect"
 import type * as Scope from "effect/Scope"
+import * as TestClock from "effect/testing/TestClock"
 import * as TestConsole from "effect/testing/TestConsole"
 
 type Body<A, E, R> = Effect.Effect<A, E, R> | (() => Effect.Effect<A, E, R>)
-const env = TestConsole.layer
 
 const body = <A, E, R>(value: Body<A, E, R>) => Effect.suspend(() => (typeof value === "function" ? value() : value))
 
-const run = <A, E, R, E2>(value: Body<A, E, R | Scope.Scope>, layer: Layer.Layer<R, E2, never>) =>
+const run = <A, E, R, E2>(value: Body<A, E, R | Scope.Scope>, layer: Layer.Layer<R, E2>) =>
   Effect.gen(function* () {
     const exit = yield* body(value).pipe(Effect.scoped, Effect.provide(layer), Effect.exit)
     if (Exit.isFailure(exit)) {
@@ -19,19 +19,32 @@ const run = <A, E, R, E2>(value: Body<A, E, R | Scope.Scope>, layer: Layer.Layer
     return yield* exit
   }).pipe(Effect.runPromise)
 
-const make = <R, E>(layer: Layer.Layer<R, E, never>) => {
+const make = <R, E>(testLayer: Layer.Layer<R, E>, liveLayer: Layer.Layer<R, E>) => {
   const effect = <A, E2>(name: string, value: Body<A, E2, R | Scope.Scope>, opts?: number | TestOptions) =>
-    test(name, () => run(value, layer), opts)
+    test(name, () => run(value, testLayer), opts)
 
   effect.only = <A, E2>(name: string, value: Body<A, E2, R | Scope.Scope>, opts?: number | TestOptions) =>
-    test.only(name, () => run(value, layer), opts)
+    test.only(name, () => run(value, testLayer), opts)
 
   effect.skip = <A, E2>(name: string, value: Body<A, E2, R | Scope.Scope>, opts?: number | TestOptions) =>
-    test.skip(name, () => run(value, layer), opts)
+    test.skip(name, () => run(value, testLayer), opts)
 
-  return { effect }
+  const live = <A, E2>(name: string, value: Body<A, E2, R | Scope.Scope>, opts?: number | TestOptions) =>
+    test(name, () => run(value, liveLayer), opts)
+
+  live.only = <A, E2>(name: string, value: Body<A, E2, R | Scope.Scope>, opts?: number | TestOptions) =>
+    test.only(name, () => run(value, liveLayer), opts)
+
+  live.skip = <A, E2>(name: string, value: Body<A, E2, R | Scope.Scope>, opts?: number | TestOptions) =>
+    test.skip(name, () => run(value, liveLayer), opts)
+
+  return { effect, live }
 }
 
-export const it = make(env)
+const testEnv = Layer.mergeAll(TestConsole.layer, TestClock.layer())
+const liveEnv = TestConsole.layer
 
-export const testEffect = <R, E>(layer: Layer.Layer<R, E, never>) => make(Layer.provideMerge(layer, env))
+export const it = make(testEnv, liveEnv)
+
+export const testEffect = <R, E>(layer: Layer.Layer<R, E>) =>
+  make(Layer.provideMerge(layer, testEnv), Layer.provideMerge(layer, liveEnv))

--- a/packages/opencode/test/lib/effect.ts
+++ b/packages/opencode/test/lib/effect.ts
@@ -41,10 +41,14 @@ const make = <R, E>(testLayer: Layer.Layer<R, E>, liveLayer: Layer.Layer<R, E>) 
   return { effect, live }
 }
 
-const testEnv = Layer.mergeAll(TestConsole.layer, TestClock.layer())
-const liveEnv = TestConsole.layer
+const env = TestConsole.layer
+const clock = Layer.mergeAll(TestConsole.layer, TestClock.layer())
 
-export const it = make(testEnv, liveEnv)
+export const it = make(env, env)
+export const clockIt = make(clock, env)
 
 export const testEffect = <R, E>(layer: Layer.Layer<R, E>) =>
-  make(Layer.provideMerge(layer, testEnv), Layer.provideMerge(layer, liveEnv))
+  make(Layer.provideMerge(layer, env), Layer.provideMerge(layer, env))
+
+export const testClockEffect = <R, E>(layer: Layer.Layer<R, E>) =>
+  make(Layer.provideMerge(layer, clock), Layer.provideMerge(layer, env))

--- a/packages/opencode/test/lib/llm-server.ts
+++ b/packages/opencode/test/lib/llm-server.ts
@@ -1,0 +1,798 @@
+import { NodeHttpServer, NodeHttpServerRequest } from "@effect/platform-node"
+import * as Http from "node:http"
+import { Deferred, Effect, Layer, ServiceMap, Stream } from "effect"
+import * as HttpServer from "effect/unstable/http/HttpServer"
+import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+
+export type Usage = { input: number; output: number }
+
+type Line = Record<string, unknown>
+
+type Flow =
+  | { type: "text"; text: string }
+  | { type: "reason"; text: string }
+  | { type: "tool-start"; id: string; name: string }
+  | { type: "tool-args"; text: string }
+  | { type: "usage"; usage: Usage }
+
+type Hit = {
+  url: URL
+  body: Record<string, unknown>
+}
+
+type Match = (hit: Hit) => boolean
+
+type Queue = {
+  item: Item
+  match?: Match
+}
+
+type Wait = {
+  count: number
+  ready: Deferred.Deferred<void>
+}
+
+type Sse = {
+  type: "sse"
+  head: unknown[]
+  tail: unknown[]
+  wait?: PromiseLike<unknown>
+  hang?: boolean
+  error?: unknown
+  reset?: boolean
+}
+
+type HttpError = {
+  type: "http-error"
+  status: number
+  body: unknown
+}
+
+export type Item = Sse | HttpError
+
+const done = Symbol("done")
+
+function line(input: unknown) {
+  if (input === done) return "data: [DONE]\n\n"
+  return `data: ${JSON.stringify(input)}\n\n`
+}
+
+function tokens(input?: Usage) {
+  if (!input) return
+  return {
+    prompt_tokens: input.input,
+    completion_tokens: input.output,
+    total_tokens: input.input + input.output,
+  }
+}
+
+function chunk(input: { delta?: Record<string, unknown>; finish?: string; usage?: Usage }) {
+  return {
+    id: "chatcmpl-test",
+    object: "chat.completion.chunk",
+    choices: [
+      {
+        delta: input.delta ?? {},
+        ...(input.finish ? { finish_reason: input.finish } : {}),
+      },
+    ],
+    ...(input.usage ? { usage: tokens(input.usage) } : {}),
+  } satisfies Line
+}
+
+function role() {
+  return chunk({ delta: { role: "assistant" } })
+}
+
+function textLine(value: string) {
+  return chunk({ delta: { content: value } })
+}
+
+function reasonLine(value: string) {
+  return chunk({ delta: { reasoning_content: value } })
+}
+
+function finishLine(reason: string, usage?: Usage) {
+  return chunk({ finish: reason, usage })
+}
+
+function toolStartLine(id: string, name: string) {
+  return chunk({
+    delta: {
+      tool_calls: [
+        {
+          index: 0,
+          id,
+          type: "function",
+          function: {
+            name,
+            arguments: "",
+          },
+        },
+      ],
+    },
+  })
+}
+
+function toolArgsLine(value: string) {
+  return chunk({
+    delta: {
+      tool_calls: [
+        {
+          index: 0,
+          function: {
+            arguments: value,
+          },
+        },
+      ],
+    },
+  })
+}
+
+function bytes(input: Iterable<unknown>) {
+  return Stream.fromIterable([...input].map(line)).pipe(Stream.encodeText)
+}
+
+function responseCreated(model: string) {
+  return {
+    type: "response.created",
+    sequence_number: 1,
+    response: {
+      id: "resp_test",
+      created_at: Math.floor(Date.now() / 1000),
+      model,
+      service_tier: null,
+    },
+  }
+}
+
+function responseCompleted(input: { seq: number; usage?: Usage }) {
+  return {
+    type: "response.completed",
+    sequence_number: input.seq,
+    response: {
+      incomplete_details: null,
+      service_tier: null,
+      usage: {
+        input_tokens: input.usage?.input ?? 0,
+        input_tokens_details: { cached_tokens: null },
+        output_tokens: input.usage?.output ?? 0,
+        output_tokens_details: { reasoning_tokens: null },
+      },
+    },
+  }
+}
+
+function responseMessage(id: string, seq: number) {
+  return {
+    type: "response.output_item.added",
+    sequence_number: seq,
+    output_index: 0,
+    item: { type: "message", id },
+  }
+}
+
+function responseText(id: string, text: string, seq: number) {
+  return {
+    type: "response.output_text.delta",
+    sequence_number: seq,
+    item_id: id,
+    delta: text,
+    logprobs: null,
+  }
+}
+
+function responseMessageDone(id: string, seq: number) {
+  return {
+    type: "response.output_item.done",
+    sequence_number: seq,
+    output_index: 0,
+    item: { type: "message", id },
+  }
+}
+
+function responseReason(id: string, seq: number) {
+  return {
+    type: "response.output_item.added",
+    sequence_number: seq,
+    output_index: 0,
+    item: { type: "reasoning", id, encrypted_content: null },
+  }
+}
+
+function responseReasonPart(id: string, seq: number) {
+  return {
+    type: "response.reasoning_summary_part.added",
+    sequence_number: seq,
+    item_id: id,
+    summary_index: 0,
+  }
+}
+
+function responseReasonText(id: string, text: string, seq: number) {
+  return {
+    type: "response.reasoning_summary_text.delta",
+    sequence_number: seq,
+    item_id: id,
+    summary_index: 0,
+    delta: text,
+  }
+}
+
+function responseReasonDone(id: string, seq: number) {
+  return {
+    type: "response.output_item.done",
+    sequence_number: seq,
+    output_index: 0,
+    item: { type: "reasoning", id, encrypted_content: null },
+  }
+}
+
+function responseTool(id: string, item: string, name: string, seq: number) {
+  return {
+    type: "response.output_item.added",
+    sequence_number: seq,
+    output_index: 0,
+    item: {
+      type: "function_call",
+      id: item,
+      call_id: id,
+      name,
+      arguments: "",
+      status: "in_progress",
+    },
+  }
+}
+
+function responseToolArgs(id: string, text: string, seq: number) {
+  return {
+    type: "response.function_call_arguments.delta",
+    sequence_number: seq,
+    output_index: 0,
+    item_id: id,
+    delta: text,
+  }
+}
+
+function responseToolArgsDone(id: string, args: string, seq: number) {
+  return {
+    type: "response.function_call_arguments.done",
+    sequence_number: seq,
+    output_index: 0,
+    item_id: id,
+    arguments: args,
+  }
+}
+
+function responseToolDone(tool: { id: string; item: string; name: string; args: string }, seq: number) {
+  return {
+    type: "response.output_item.done",
+    sequence_number: seq,
+    output_index: 0,
+    item: {
+      type: "function_call",
+      id: tool.item,
+      call_id: tool.id,
+      name: tool.name,
+      arguments: tool.args,
+      status: "completed",
+    },
+  }
+}
+
+function choices(part: unknown) {
+  if (!part || typeof part !== "object") return
+  if (!("choices" in part) || !Array.isArray(part.choices)) return
+  const choice = part.choices[0]
+  if (!choice || typeof choice !== "object") return
+  return choice
+}
+
+function flow(item: Sse) {
+  const out: Flow[] = []
+  for (const part of [...item.head, ...item.tail]) {
+    const choice = choices(part)
+    const delta =
+      choice && "delta" in choice && choice.delta && typeof choice.delta === "object" ? choice.delta : undefined
+
+    if (delta && "content" in delta && typeof delta.content === "string") {
+      out.push({ type: "text", text: delta.content })
+    }
+
+    if (delta && "reasoning_content" in delta && typeof delta.reasoning_content === "string") {
+      out.push({ type: "reason", text: delta.reasoning_content })
+    }
+
+    if (delta && "tool_calls" in delta && Array.isArray(delta.tool_calls)) {
+      for (const tool of delta.tool_calls) {
+        if (!tool || typeof tool !== "object") continue
+        const fn = "function" in tool && tool.function && typeof tool.function === "object" ? tool.function : undefined
+        if ("id" in tool && typeof tool.id === "string" && fn && "name" in fn && typeof fn.name === "string") {
+          out.push({ type: "tool-start", id: tool.id, name: fn.name })
+        }
+        if (fn && "arguments" in fn && typeof fn.arguments === "string" && fn.arguments) {
+          out.push({ type: "tool-args", text: fn.arguments })
+        }
+      }
+    }
+
+    if (part && typeof part === "object" && "usage" in part && part.usage && typeof part.usage === "object") {
+      const raw = part.usage as Record<string, unknown>
+      if (typeof raw.prompt_tokens === "number" && typeof raw.completion_tokens === "number") {
+        out.push({
+          type: "usage",
+          usage: { input: raw.prompt_tokens, output: raw.completion_tokens },
+        })
+      }
+    }
+  }
+  return out
+}
+
+function responses(item: Sse, model: string) {
+  let seq = 1
+  let msg: string | undefined
+  let reason: string | undefined
+  let hasMsg = false
+  let hasReason = false
+  let call:
+    | {
+        id: string
+        item: string
+        name: string
+        args: string
+      }
+    | undefined
+  let usage: Usage | undefined
+  const lines: unknown[] = [responseCreated(model)]
+
+  for (const part of flow(item)) {
+    if (part.type === "text") {
+      msg ??= "msg_1"
+      if (!hasMsg) {
+        hasMsg = true
+        seq += 1
+        lines.push(responseMessage(msg, seq))
+      }
+      seq += 1
+      lines.push(responseText(msg, part.text, seq))
+      continue
+    }
+
+    if (part.type === "reason") {
+      reason ||= "rs_1"
+      if (!hasReason) {
+        hasReason = true
+        seq += 1
+        lines.push(responseReason(reason, seq))
+        seq += 1
+        lines.push(responseReasonPart(reason, seq))
+      }
+      seq += 1
+      lines.push(responseReasonText(reason, part.text, seq))
+      continue
+    }
+
+    if (part.type === "tool-start") {
+      call ||= { id: part.id, item: "fc_1", name: part.name, args: "" }
+      seq += 1
+      lines.push(responseTool(call.id, call.item, call.name, seq))
+      continue
+    }
+
+    if (part.type === "tool-args") {
+      if (!call) continue
+      call.args += part.text
+      seq += 1
+      lines.push(responseToolArgs(call.item, part.text, seq))
+      continue
+    }
+
+    usage = part.usage
+  }
+
+  if (msg) {
+    seq += 1
+    lines.push(responseMessageDone(msg, seq))
+  }
+  if (reason) {
+    seq += 1
+    lines.push(responseReasonDone(reason, seq))
+  }
+  if (call && !item.hang && !item.error) {
+    seq += 1
+    lines.push(responseToolArgsDone(call.item, call.args, seq))
+    seq += 1
+    lines.push(responseToolDone(call, seq))
+  }
+  if (!item.hang && !item.error) lines.push(responseCompleted({ seq: seq + 1, usage }))
+  return { ...item, head: lines, tail: [] } satisfies Sse
+}
+
+function modelFrom(body: unknown) {
+  if (!body || typeof body !== "object") return "test-model"
+  if (!("model" in body) || typeof body.model !== "string") return "test-model"
+  return body.model
+}
+
+function send(item: Sse) {
+  const head = bytes(item.head)
+  const tail = bytes([...item.tail, ...(item.hang || item.error ? [] : [done])])
+  const empty = Stream.fromIterable<Uint8Array>([])
+  const wait = item.wait
+  const body: Stream.Stream<Uint8Array, unknown> = wait
+    ? Stream.concat(head, Stream.fromEffect(Effect.promise(() => wait)).pipe(Stream.flatMap(() => tail)))
+    : Stream.concat(head, tail)
+  let end: Stream.Stream<Uint8Array, unknown> = empty
+  if (item.error) end = Stream.concat(empty, Stream.fail(item.error))
+  else if (item.hang) end = Stream.concat(empty, Stream.never)
+
+  return HttpServerResponse.stream(Stream.concat(body, end), { contentType: "text/event-stream" })
+}
+
+const reset = Effect.fn("TestLLMServer.reset")(function* (item: Sse) {
+  const req = yield* HttpServerRequest.HttpServerRequest
+  const res = NodeHttpServerRequest.toServerResponse(req)
+  yield* Effect.sync(() => {
+    res.writeHead(200, { "content-type": "text/event-stream" })
+    for (const part of item.head) res.write(line(part))
+    for (const part of item.tail) res.write(line(part))
+    res.destroy(new Error("connection reset"))
+  })
+  return yield* Effect.never
+})
+
+function fail(item: HttpError) {
+  return HttpServerResponse.text(JSON.stringify(item.body), {
+    status: item.status,
+    contentType: "application/json",
+  })
+}
+
+export class Reply {
+  #head: unknown[] = [role()]
+  #tail: unknown[] = []
+  #usage: Usage | undefined
+  #finish: string | undefined
+  #wait: PromiseLike<unknown> | undefined
+  #hang = false
+  #error: unknown
+  #reset = false
+  #seq = 0
+
+  #id() {
+    this.#seq += 1
+    return `call_${this.#seq}`
+  }
+
+  text(value: string) {
+    this.#tail = [...this.#tail, textLine(value)]
+    return this
+  }
+
+  reason(value: string) {
+    this.#tail = [...this.#tail, reasonLine(value)]
+    return this
+  }
+
+  usage(value: Usage) {
+    this.#usage = value
+    return this
+  }
+
+  wait(value: PromiseLike<unknown>) {
+    this.#wait = value
+    return this
+  }
+
+  stop() {
+    this.#finish = "stop"
+    this.#hang = false
+    this.#error = undefined
+    this.#reset = false
+    return this
+  }
+
+  toolCalls() {
+    this.#finish = "tool_calls"
+    this.#hang = false
+    this.#error = undefined
+    this.#reset = false
+    return this
+  }
+
+  tool(name: string, input: unknown) {
+    const id = this.#id()
+    const args = JSON.stringify(input)
+    this.#tail = [...this.#tail, toolStartLine(id, name), toolArgsLine(args)]
+    return this.toolCalls()
+  }
+
+  pendingTool(name: string, input: unknown) {
+    const id = this.#id()
+    const args = JSON.stringify(input)
+    const size = Math.max(1, Math.floor(args.length / 2))
+    this.#tail = [...this.#tail, toolStartLine(id, name), toolArgsLine(args.slice(0, size))]
+    return this
+  }
+
+  hang() {
+    this.#finish = undefined
+    this.#hang = true
+    this.#error = undefined
+    this.#reset = false
+    return this
+  }
+
+  streamError(error: unknown = "boom") {
+    this.#finish = undefined
+    this.#hang = false
+    this.#error = error
+    this.#reset = false
+    return this
+  }
+
+  reset() {
+    this.#finish = undefined
+    this.#hang = false
+    this.#error = undefined
+    this.#reset = true
+    return this
+  }
+
+  item(): Item {
+    return {
+      type: "sse",
+      head: this.#head,
+      tail: this.#finish ? [...this.#tail, finishLine(this.#finish, this.#usage)] : this.#tail,
+      wait: this.#wait,
+      hang: this.#hang,
+      error: this.#error,
+      reset: this.#reset,
+    }
+  }
+}
+
+export function reply() {
+  return new Reply()
+}
+
+export function httpError(status: number, body: unknown): Item {
+  return {
+    type: "http-error",
+    status,
+    body,
+  }
+}
+
+export function raw(input: {
+  chunks?: unknown[]
+  head?: unknown[]
+  tail?: unknown[]
+  wait?: PromiseLike<unknown>
+  hang?: boolean
+  error?: unknown
+  reset?: boolean
+}): Item {
+  return {
+    type: "sse",
+    head: input.head ?? input.chunks ?? [],
+    tail: input.tail ?? [],
+    wait: input.wait,
+    hang: input.hang,
+    error: input.error,
+    reset: input.reset,
+  }
+}
+
+function item(input: Item | Reply) {
+  return input instanceof Reply ? input.item() : input
+}
+
+function hit(url: string, body: unknown) {
+  return {
+    url: new URL(url, "http://localhost"),
+    body: body && typeof body === "object" ? (body as Record<string, unknown>) : {},
+  } satisfies Hit
+}
+
+function isToolResultFollowUp(body: unknown): boolean {
+  if (!body || typeof body !== "object") return false
+  if ("messages" in body && Array.isArray(body.messages)) {
+    const last = body.messages[body.messages.length - 1]
+    return last?.role === "tool"
+  }
+  if ("input" in body && Array.isArray(body.input)) {
+    return body.input.some((item: Record<string, unknown>) => item?.type === "function_call_output")
+  }
+  return false
+}
+
+function isTitleRequest(body: unknown): boolean {
+  if (!body || typeof body !== "object") return false
+  return JSON.stringify(body).includes("Generate a title for this conversation")
+}
+
+function requestSummary(body: unknown): string {
+  if (!body || typeof body !== "object") return "empty body"
+  if ("messages" in body && Array.isArray(body.messages)) {
+    const roles = body.messages.map((m: Record<string, unknown>) => m.role).join(",")
+    return `messages=[${roles}]`
+  }
+  return `keys=[${Object.keys(body).join(",")}]`
+}
+
+namespace TestLLMServer {
+  export interface Service {
+    readonly url: string
+    readonly push: (...input: (Item | Reply)[]) => Effect.Effect<void>
+    readonly pushMatch: (match: Match, ...input: (Item | Reply)[]) => Effect.Effect<void>
+    readonly textMatch: (match: Match, value: string, opts?: { usage?: Usage }) => Effect.Effect<void>
+    readonly toolMatch: (match: Match, name: string, input: unknown) => Effect.Effect<void>
+    readonly text: (value: string, opts?: { usage?: Usage }) => Effect.Effect<void>
+    readonly tool: (name: string, input: unknown) => Effect.Effect<void>
+    readonly toolHang: (name: string, input: unknown) => Effect.Effect<void>
+    readonly reason: (value: string, opts?: { text?: string; usage?: Usage }) => Effect.Effect<void>
+    readonly fail: (message?: unknown) => Effect.Effect<void>
+    readonly error: (status: number, body: unknown) => Effect.Effect<void>
+    readonly hang: Effect.Effect<void>
+    readonly hold: (value: string, wait: PromiseLike<unknown>) => Effect.Effect<void>
+    readonly reset: Effect.Effect<void>
+    readonly hits: Effect.Effect<Hit[]>
+    readonly calls: Effect.Effect<number>
+    readonly wait: (count: number) => Effect.Effect<void>
+    readonly inputs: Effect.Effect<Record<string, unknown>[]>
+    readonly pending: Effect.Effect<number>
+    readonly misses: Effect.Effect<Hit[]>
+  }
+}
+
+export class TestLLMServer extends ServiceMap.Service<TestLLMServer, TestLLMServer.Service>()("@test/LLMServer") {
+  static readonly layer = Layer.effect(
+    TestLLMServer,
+    Effect.gen(function* () {
+      const server = yield* HttpServer.HttpServer
+      const router = yield* HttpRouter.HttpRouter
+
+      let hits: Hit[] = []
+      let list: Queue[] = []
+      let waits: Wait[] = []
+      let misses: Hit[] = []
+
+      const queue = (...input: (Item | Reply)[]) => {
+        list = [...list, ...input.map((value) => ({ item: item(value) }))]
+      }
+
+      const queueMatch = (match: Match, ...input: (Item | Reply)[]) => {
+        list = [...list, ...input.map((value) => ({ item: item(value), match }))]
+      }
+
+      const notify = Effect.fnUntraced(function* () {
+        const ready = waits.filter((item) => hits.length >= item.count)
+        if (!ready.length) return
+        waits = waits.filter((item) => hits.length < item.count)
+        yield* Effect.forEach(ready, (item) => Deferred.succeed(item.ready, void 0))
+      })
+
+      const pull = (hit: Hit) => {
+        const index = list.findIndex((entry) => !entry.match || entry.match(hit))
+        if (index === -1) return
+        const first = list[index]
+        list = [...list.slice(0, index), ...list.slice(index + 1)]
+        return first.item
+      }
+
+      const handle = Effect.fn("TestLLMServer.handle")(function* (mode: "chat" | "responses") {
+        const req = yield* HttpServerRequest.HttpServerRequest
+        const body = yield* req.json.pipe(Effect.orElseSucceed(() => ({})))
+        const current = hit(req.originalUrl, body)
+        if (isTitleRequest(body)) {
+          hits = [...hits, current]
+          yield* notify()
+          const auto: Sse = { type: "sse", head: [role()], tail: [textLine("E2E Title"), finishLine("stop")] }
+          if (mode === "responses") return send(responses(auto, modelFrom(body)))
+          return send(auto)
+        }
+        const next = pull(current)
+        if (!next) {
+          misses = [...misses, current]
+          hits = [...hits, current]
+          yield* notify()
+          if (isToolResultFollowUp(body)) {
+            const auto: Sse = { type: "sse", head: [role()], tail: [textLine("ok"), finishLine("stop")] }
+            if (mode === "responses") return send(responses(auto, modelFrom(body)))
+            return send(auto)
+          }
+          const detail = requestSummary(body)
+          const miss = mode === "responses" ? { error: { type: "error", code: "no_response", message: detail } } : { error: detail }
+          return fail({ type: "http-error", status: 500, body: miss })
+        }
+        hits = [...hits, current]
+        yield* notify()
+        if (next.type !== "sse") return fail(next)
+        if (mode === "responses") return send(responses(next, modelFrom(body)))
+        if (next.reset) {
+          yield* reset(next)
+          return HttpServerResponse.empty()
+        }
+        return send(next)
+      })
+
+      yield* router.add("POST", "/v1/chat/completions", handle("chat"))
+      yield* router.add("POST", "/v1/responses", handle("responses"))
+
+      yield* server.serve(router.asHttpEffect())
+
+      return TestLLMServer.of({
+        url:
+          server.address._tag === "TcpAddress"
+            ? `http://127.0.0.1:${server.address.port}/v1`
+            : `unix://${server.address.path}/v1`,
+        push: Effect.fn("TestLLMServer.push")(function* (...input: (Item | Reply)[]) {
+          queue(...input)
+        }),
+        pushMatch: Effect.fn("TestLLMServer.pushMatch")(function* (match: Match, ...input: (Item | Reply)[]) {
+          queueMatch(match, ...input)
+        }),
+        textMatch: Effect.fn("TestLLMServer.textMatch")(function* (
+          match: Match,
+          value: string,
+          opts?: { usage?: Usage },
+        ) {
+          const out = reply().text(value)
+          if (opts?.usage) out.usage(opts.usage)
+          queueMatch(match, out.stop().item())
+        }),
+        toolMatch: Effect.fn("TestLLMServer.toolMatch")(function* (match: Match, name: string, input: unknown) {
+          queueMatch(match, reply().tool(name, input).item())
+        }),
+        text: Effect.fn("TestLLMServer.text")(function* (value: string, opts?: { usage?: Usage }) {
+          const out = reply().text(value)
+          if (opts?.usage) out.usage(opts.usage)
+          queue(out.stop().item())
+        }),
+        tool: Effect.fn("TestLLMServer.tool")(function* (name: string, input: unknown) {
+          queue(reply().tool(name, input).item())
+        }),
+        toolHang: Effect.fn("TestLLMServer.toolHang")(function* (name: string, input: unknown) {
+          queue(reply().pendingTool(name, input).hang().item())
+        }),
+        reason: Effect.fn("TestLLMServer.reason")(function* (value: string, opts?: { text?: string; usage?: Usage }) {
+          const out = reply().reason(value)
+          if (opts?.text) out.text(opts.text)
+          if (opts?.usage) out.usage(opts.usage)
+          queue(out.stop().item())
+        }),
+        fail: Effect.fn("TestLLMServer.fail")(function* (message: unknown = "boom") {
+          queue(reply().streamError(message).item())
+        }),
+        error: Effect.fn("TestLLMServer.error")(function* (status: number, body: unknown) {
+          queue(httpError(status, body))
+        }),
+        hang: Effect.gen(function* () {
+          queue(reply().hang().item())
+        }).pipe(Effect.withSpan("TestLLMServer.hang")),
+        hold: Effect.fn("TestLLMServer.hold")(function* (value: string, wait: PromiseLike<unknown>) {
+          queue(reply().wait(wait).text(value).stop().item())
+        }),
+        reset: Effect.sync(() => {
+          hits = []
+          list = []
+          waits = []
+          misses = []
+        }),
+        hits: Effect.sync(() => [...hits]),
+        calls: Effect.sync(() => hits.length),
+        wait: Effect.fn("TestLLMServer.wait")(function* (count: number) {
+          if (hits.length >= count) return
+          const ready = yield* Deferred.make<void>()
+          waits = [...waits, { count, ready }]
+          yield* Deferred.await(ready)
+        }),
+        inputs: Effect.sync(() => hits.map((hit) => hit.body)),
+        pending: Effect.sync(() => list.length),
+        misses: Effect.sync(() => [...misses]),
+      })
+    }),
+  ).pipe(Layer.provide(HttpRouter.layer), Layer.provide(NodeHttpServer.layer(() => Http.createServer(), { port: 0 })))
+}


### PR DESCRIPTION
### Issue for this PR

Closes #299

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Restores the app E2E CI baseline in a staged way without bulk-copying upstream/dev behavior onto the current Aether implementation.

This PR:
- restores the app E2E job in `.github/workflows/test.yml`
- adds the upstream-style backend/mock-LLM/probe plumbing needed by the current migration plan
- keeps the old E2E paths in place instead of replacing the whole test stack at once
- aligns `workspace-new-session.spec.ts` with the current product behavior
- introduces temporary CI allowlists so only locally verified-passing E2E specs run in GitHub Actions
- splits the allowlist into:
  - a normal parallel batch
  - a small serial batch for concurrency-sensitive specs
- hardens `packages/app/script/e2e-local.ts` cleanup so CI-style runs exit cleanly
- updates the CI/E2E docs to reflect the current staged restoration status

The intent is to get stable E2E coverage back into CI first, then continue absorbing upstream harness and tests while keeping runner issues, harness issues, test-semantic drift, and real product bugs separate.

### How did you verify your code works?

- `bun typecheck` in `packages/app`
- `bun typecheck` in `packages/opencode`
- `bun test:e2e:local e2e/terminal/terminal-init.spec.ts`
- CI-style main batch simulation:
  - `31` allowlisted specs
  - result: `65 passed / 3 skipped`
- CI-style serial batch simulation:
  - `6` allowlisted specs
  - result: `10 passed`

Combined current CI allowlist coverage:
- `37` verified-passing specs admitted into CI
- `13` specs still excluded pending further investigation

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
