### PR TITLE
fix(feishu): enhance WebSocket diagnostics and logging for connection stability

### DIFF
--- a/packages/opencode/launcher/Aether.vbs
+++ b/packages/opencode/launcher/Aether.vbs
@@ -11,5 +11,7 @@ End If
 psCmd = "powershell -NoProfile -ExecutionPolicy Bypass -Command ""Unblock-File -Path '" & exePath & "'"""
 CreateObject("WScript.Shell").Run psCmd, 0, True
 
-CreateObject("WScript.Shell").Run """" & exePath & """ web", 0, False
+Dim logPath
+logPath = scriptDir & "\aether-log.txt"
+CreateObject("WScript.Shell").Run "cmd /c """ & exePath & """ web >> """ & logPath & """ 2>&1", 0, False
 

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -509,8 +509,12 @@ class FeishuManagerImpl {
         const lastEventDesc = this._lastWsEventTime
           ? `${Math.floor((Date.now() - this._lastWsEventTime) / 1000)}s ago`
           : "never"
+        const wsClientAny = this.wsClient as any
+        const wsInstance = wsClientAny?.wsConfig?.getWSInstance?.()
+        const readyState = wsInstance?.readyState ?? -1
+        const readyStateStr = (["CONNECTING", "OPEN", "CLOSING", "CLOSED"] as const)[readyState] ?? `unknown(${readyState})`
         console.log(
-          `[feishu] alive ${Math.floor(aliveMs / 1000)}s | last message: ${lastEventDesc}`,
+          `[feishu] alive ${Math.floor(aliveMs / 1000)}s | last message: ${lastEventDesc} | ws: ${readyStateStr}`,
           localISOString(),
         )
       }, 60_000)
@@ -575,7 +579,7 @@ class FeishuManagerImpl {
   private onDisconnect(reason: string): void {
     if (this._manualStop) return
     if (this._status === "idle" || this._status === "error") return
-    console.warn("[feishu] disconnect detected:", reason)
+    console.warn("[feishu] disconnect detected:", reason, localISOString())
     this.stopHeartbeat()
     this.scheduleReconnect(reason)
   }
@@ -669,7 +673,7 @@ class FeishuManagerImpl {
 
   private async handleMessage(data: any): Promise<void> {
     try {
-      console.log("[feishu] handleMessage invoked")
+      console.log("[feishu] handleMessage invoked", localISOString())
       console.log("[feishu] received event:", JSON.stringify(data).slice(0, 500))
       const message = data?.message
       if (!message) {
@@ -707,7 +711,7 @@ class FeishuManagerImpl {
 
       text = text.replace(/@_\w+\s*/g, "").trim()
       if (!text) return
-      console.log("[feishu] text:", text)
+      console.log("[feishu] text:", text, localISOString())
 
       const isSlash = text.startsWith("/")
       const parts = isSlash ? text.trim().split(/\s+/) : []
@@ -881,12 +885,12 @@ class FeishuManagerImpl {
               })
             }
           }
-          console.log("[feishu] sending to aether, session:", sessionId)
+          console.log("[feishu] sending to aether, session:", sessionId, localISOString())
           const msg = await SessionPrompt.prompt({
             sessionID: SessionID.make(sessionId),
             parts: [{ type: "text", text: promptText }],
           })
-          console.log("[feishu] aether responded, parts:", msg?.parts?.length)
+          console.log("[feishu] aether responded, parts:", msg?.parts?.length, localISOString())
 
           const responseText = this.extractResponseText(msg)
           if (responseText) {
@@ -914,7 +918,7 @@ class FeishuManagerImpl {
                 : "—"
             const header = `${projectName}  ·  ${label}  ·  ${mode}  ·  ${modelStr}\n————————\n`
 
-            console.log("[feishu] replying:", responseText.slice(0, 100))
+            console.log("[feishu] replying:", responseText.slice(0, 100), localISOString())
             await this.replyText(messageId, header + responseText)
           } else {
             console.log("[feishu] no text in response")

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -32,6 +32,21 @@ const CONFIG_FILE = join(FEISHU_DATA_DIR, "config.json")
 const SESSION_MAP_FILE = join(FEISHU_DATA_DIR, "sessions.json")
 const HIDDEN_DIRS_FILE = join(FEISHU_DATA_DIR, "hidden_projects.json")
 
+function localISOString(d = new Date()): string {
+  const offset = -d.getTimezoneOffset()
+  const sign = offset >= 0 ? "+" : "-"
+  const pad = (n: number) => String(Math.floor(Math.abs(n))).padStart(2, "0")
+  return (
+    d.getFullYear() + "-" +
+    pad(d.getMonth() + 1) + "-" +
+    pad(d.getDate()) + "T" +
+    pad(d.getHours()) + ":" +
+    pad(d.getMinutes()) + ":" +
+    pad(d.getSeconds()) +
+    sign + pad(offset / 60) + ":" + pad(offset % 60)
+  )
+}
+
 export type FeishuStatus = "idle" | "starting" | "connected" | "reconnecting" | "error"
 
 export interface FeishuConfig {
@@ -420,7 +435,7 @@ class FeishuManagerImpl {
       const boundHandleMessage = (data: any) => {
         const gap = this._lastWsEventTime ? `gap=${Date.now() - this._lastWsEventTime}ms` : "first"
         this._lastWsEventTime = Date.now()
-        console.log("[feishu] >>> event received!", gap, new Date().toISOString())
+        console.log("[feishu] >>> event received!", gap, localISOString())
         void this.enqueueMessage(data)
       }
 
@@ -482,7 +497,7 @@ class FeishuManagerImpl {
         if (ws) {
           console.log(
             `[feishu] pong config: pingInterval=${ws.pingInterval}ms reconnectInterval=${ws.reconnectInterval}ms reconnectNonce=${ws.reconnectNonce}ms`,
-            new Date().toISOString(),
+            localISOString(),
           )
         }
       }, 5_000)
@@ -496,7 +511,7 @@ class FeishuManagerImpl {
           : "never"
         console.log(
           `[feishu] alive ${Math.floor(aliveMs / 1000)}s | last message: ${lastEventDesc}`,
-          new Date().toISOString(),
+          localISOString(),
         )
       }, 60_000)
 
@@ -530,7 +545,7 @@ class FeishuManagerImpl {
       const close = ws.addEventListener?.bind(ws)
       if (typeof close === "function") {
         close("close", (code: number, reason: Buffer) => {
-          console.log(`[feishu] socket close code=${code} reason="${reason?.toString?.() || ""}"`, new Date().toISOString())
+          console.log(`[feishu] socket close code=${code} reason="${reason?.toString?.() || ""}"`, localISOString())
           this.onDisconnect("socket_close")
         })
         close("error", () => this.onDisconnect("socket_error"))
@@ -539,7 +554,7 @@ class FeishuManagerImpl {
       const add = ws.on?.bind(ws)
       if (typeof add === "function") {
         add("close", (code: number, reason: Buffer) => {
-          console.log(`[feishu] socket close code=${code} reason="${reason?.toString?.() || ""}"`, new Date().toISOString())
+          console.log(`[feishu] socket close code=${code} reason="${reason?.toString?.() || ""}"`, localISOString())
           this.onDisconnect("socket_close")
         })
         add("error", () => this.onDisconnect("socket_error"))

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -145,6 +145,9 @@ class FeishuManagerImpl {
   private _manualStop = false
   private _lastConfig: FeishuConfig | null = null
   private _starting = false
+  // ── 诊断用字段 ─────────────────────────────────────────────────────────────
+  private _lastWsEventTime: number = 0
+  private _aliveTimer: ReturnType<typeof setInterval> | null = null
   // ─────────────────────────────────────────────────────────────────────────
 
   private static readonly HEARTBEAT_MS = 30_000
@@ -415,7 +418,9 @@ class FeishuManagerImpl {
       console.log("[feishu] _doStart called")
 
       const boundHandleMessage = (data: any) => {
-        console.log("[feishu] >>> event received!")
+        const gap = this._lastWsEventTime ? `gap=${Date.now() - this._lastWsEventTime}ms` : "first"
+        this._lastWsEventTime = Date.now()
+        console.log("[feishu] >>> event received!", gap, new Date().toISOString())
         void this.enqueueMessage(data)
       }
 
@@ -470,6 +475,31 @@ class FeishuManagerImpl {
       this.status = "connected"
       Bus.publish(FeishuEvent.Connected, { appId: config.appId })
 
+      // 5s 后打印服务端 pong 下发的实际配置（pingInterval 等）
+      setTimeout(() => {
+        const wsClientAny = this.wsClient as any
+        const ws = wsClientAny?.wsConfig?.getWS?.()
+        if (ws) {
+          console.log(
+            `[feishu] pong config: pingInterval=${ws.pingInterval}ms reconnectInterval=${ws.reconnectInterval}ms reconnectNonce=${ws.reconnectNonce}ms`,
+            new Date().toISOString(),
+          )
+        }
+      }, 5_000)
+
+      // 每 60s 打一行存活日志，方便对照时间轴定位断连时间点
+      this._aliveTimer = setInterval(() => {
+        if (this._status !== "connected") return
+        const aliveMs = Date.now() - (this._session?.createdAt ?? Date.now())
+        const lastEventDesc = this._lastWsEventTime
+          ? `${Math.floor((Date.now() - this._lastWsEventTime) / 1000)}s ago`
+          : "never"
+        console.log(
+          `[feishu] alive ${Math.floor(aliveMs / 1000)}s | last message: ${lastEventDesc}`,
+          new Date().toISOString(),
+        )
+      }, 60_000)
+
       // Compute initial directory from first visible project
       const allProjects = this.getProjects()
       const visibleProjects = allProjects.filter((p) => !(this.projectDir(p) in this._hiddenDirs))
@@ -499,13 +529,19 @@ class FeishuManagerImpl {
       ws.__aetherBound = true
       const close = ws.addEventListener?.bind(ws)
       if (typeof close === "function") {
-        close("close", () => this.onDisconnect("socket_close"))
+        close("close", (code: number, reason: Buffer) => {
+          console.log(`[feishu] socket close code=${code} reason="${reason?.toString?.() || ""}"`, new Date().toISOString())
+          this.onDisconnect("socket_close")
+        })
         close("error", () => this.onDisconnect("socket_error"))
         return
       }
       const add = ws.on?.bind(ws)
       if (typeof add === "function") {
-        add("close", () => this.onDisconnect("socket_close"))
+        add("close", (code: number, reason: Buffer) => {
+          console.log(`[feishu] socket close code=${code} reason="${reason?.toString?.() || ""}"`, new Date().toISOString())
+          this.onDisconnect("socket_close")
+        })
         add("error", () => this.onDisconnect("socket_error"))
       }
     }
@@ -579,6 +615,10 @@ class FeishuManagerImpl {
 
   private async cleanupConnection(reset = true): Promise<void> {
     this.stopHeartbeat()
+    if (this._aliveTimer) {
+      clearInterval(this._aliveTimer)
+      this._aliveTimer = null
+    }
     if (this._reconnect) {
       clearTimeout(this._reconnect)
       this._reconnect = null


### PR DESCRIPTION
## 关联 Issue

Closes #304

## 改动概述

飞书 WebSocket 偶发断连问题难以定位，本 PR 在不改动业务逻辑的前提下，全面增强诊断日志。

## 变更内容

### `packages/opencode/src/feishu/manager.ts`

- **新增 `localISOString()` 工具函数**：输出带本地时区偏移的 ISO 时间戳（修复原 `new Date().toISOString()` 输出 UTC 导致与本地时间轴对不上的问题）
- **WebSocket 事件间隔追踪**：每次收到 WS 事件时打印与上次事件的间隔（`gap=Xms`），便于发现消息中断
- **Pong 配置打印**：连接建立 5s 后打印服务端下发的 `pingInterval` / `reconnectInterval` / `reconnectNonce`
- **60s 存活定时日志**：含连接存活时长、最后一条消息距今时间、WS `readyState`（`OPEN/CLOSING/CLOSED` 等）
- **Close code/reason 日志**：`socket close` 事件回调中记录关闭码和原因字符串
- **关键路径时间戳**：`onDisconnect`、`handleMessage`、消息处理、Aether 请求/响应、回复等节点均附加时间戳

### `packages/opencode/launcher/Aether.vbs`

- 将 Aether 可执行文件的 stdout/stderr 重定向到同目录的 `aether-log.txt`，Windows 用户崩溃后可直接查看日志

## 测试

- [ ] 飞书连接正常建立，存活日志每分钟正常输出
- [ ] 断连时日志包含 close code 和 reason
- [ ] Windows 环境下 `aether-log.txt` 正常生成

🤖 Generated with [Claude Code](https://claude.com/claude-code)