### PR TITLE
fix: provider settings — missing button text, stale list after add/delete

### DIFF
--- a/packages/app/src/components/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog-connect-provider.tsx
@@ -321,7 +321,12 @@ export function DialogConnectProvider(props: { provider: string }) {
   })
 
   async function complete() {
-    await globalSDK.client.global.dispose()
+    try {
+      await globalSDK.client.global.dispose()
+      await globalSync.bootstrap()
+    } catch (err) {
+      console.error("Failed to refresh after provider connect", err)
+    }
     dialog.close()
     showToast({
       variant: "success",

--- a/packages/app/src/components/settings-providers.tsx
+++ b/packages/app/src/components/settings-providers.tsx
@@ -136,26 +136,26 @@ export const SettingsProviders: Component = () => {
   }
 
   const disconnect = async (providerID: string, name: string) => {
-    if (isConfigCustom(providerID)) {
-      await globalSDK.client.auth.remove({ providerID }).catch(() => undefined)
+    await globalSDK.client.auth.remove({ providerID }).catch(() => undefined)
+
+    const hasConfig = !!globalSync.data.config.provider?.[providerID]
+    if (hasConfig) {
       await disableProvider(providerID, name)
       return
     }
-    await globalSDK.client.auth
-      .remove({ providerID })
-      .then(async () => {
-        await globalSDK.client.global.dispose()
-        showToast({
-          variant: "success",
-          icon: "circle-check",
-          title: language.t("provider.disconnect.toast.disconnected.title", { provider: name }),
-          description: language.t("provider.disconnect.toast.disconnected.description", { provider: name }),
-        })
-      })
-      .catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err)
-        showToast({ title: language.t("common.requestFailed"), description: message })
-      })
+
+    try {
+      await globalSDK.client.global.dispose()
+      await globalSync.bootstrap()
+    } catch (err) {
+      console.error("Failed to refresh after provider disconnect", err)
+    }
+    showToast({
+      variant: "success",
+      icon: "circle-check",
+      title: language.t("provider.disconnect.toast.disconnected.title", { provider: name }),
+      description: language.t("provider.disconnect.toast.disconnected.description", { provider: name }),
+    })
   }
 
   return (

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -416,6 +416,10 @@ function createGlobalSync() {
     } finally {
       bootingRoot = false
     }
+    const dirs = Object.keys(children.children)
+    if (dirs.length > 0) {
+      await Promise.all(dirs.map(bootstrapInstance))
+    }
   }
 
   onMount(() => {
@@ -480,6 +484,9 @@ function createGlobalSync() {
     setGlobalStore("reload", "pending")
     return globalSDK.client.global.config
       .update({ config })
+      .then(async () => {
+        await globalSDK.client.global.dispose()
+      })
       .then(bootstrap)
       .then(() => {
         queue.refresh()

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -207,6 +207,7 @@ export const dict = {
   "common.loading": "Laden",
   "common.loading.ellipsis": "...",
   "common.cancel": "Abbrechen",
+  "common.continue": "Weiter",
   "common.connect": "Verbinden",
   "common.disconnect": "Trennen",
   "common.submit": "Absenden",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -231,6 +231,7 @@ export const dict = {
   "common.loading.ellipsis": "...",
   "common.cancel": "Cancel",
   "common.open": "Open",
+  "common.continue": "Continue",
   "common.connect": "Connect",
   "common.disconnect": "Disconnect",
   "common.submit": "Submit",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -221,6 +221,7 @@ export const dict = {
   "common.loading": "Laster",
   "common.loading.ellipsis": "...",
   "common.cancel": "Avbryt",
+  "common.continue": "Fortsett",
   "common.connect": "Koble til",
   "common.disconnect": "Koble fra",
   "common.submit": "Send inn",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -223,6 +223,7 @@ export const dict = {
   "common.loading": "Yükleniyor",
   "common.loading.ellipsis": "...",
   "common.cancel": "İptal",
+  "common.continue": "Devam",
   "common.connect": "Bağlan",
   "common.disconnect": "Bağlantı Kes",
   "common.submit": "Gönder",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -249,6 +249,7 @@ export const dict = {
   "common.loading": "加载中",
   "common.loading.ellipsis": "...",
   "common.cancel": "取消",
+  "common.continue": "继续",
   "common.connect": "连接",
   "common.disconnect": "断开连接",
   "common.submit": "提交",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -218,6 +218,7 @@ export const dict = {
   "common.loading": "載入中",
   "common.loading.ellipsis": "...",
   "common.cancel": "取消",
+  "common.continue": "繼續",
   "common.connect": "連線",
   "common.disconnect": "中斷連線",
   "common.submit": "提交",


### PR DESCRIPTION
### Issue for this PR

Closes #309

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes three interrelated provider settings bugs in the web-ui:

1. **Missing "Continue" button text**: Added `common.continue` translation to 6 locales (en, zh, zht, de, no, tr) where it was absent.

2. **Stale list after adding a provider**: `complete()` now calls `await bootstrap()` after `dispose()` to synchronously refresh data before closing the dialog, instead of relying on the unreliable SSE event path.

3. **Stale list after deleting a provider**: Three changes:
   - `disconnect()` now checks `config.provider[providerID]` (not `isConfigCustom`) to decide whether the provider needs to be disabled via config. Providers with a `baseURL` but no custom models were previously misclassified and only had their (nonexistent) API key deleted.
   - `updateConfig()` now awaits `global.dispose()` between `config.update` and `bootstrap`, ensuring server-side caches are fully cleared before fetching fresh data (the server's `Config.updateGlobal` uses fire-and-forget `void Instance.disposeAll()`).
   - `bootstrap()` now synchronously awaits child store refresh (`Promise.all(dirs.map(bootstrapInstance))`), so UI reading project-level data updates immediately.

### How did you verify your code works?

- `bun typecheck` passes across all packages (verified by pre-push hook)
- Manual testing in browser: added and deleted providers (both preset and config-based), verified list refreshes immediately without restart

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR