### PR TITLE
fix: provider settings — missing button text, stale list after add/delete

### DIFF
--- a/packages/app/src/components/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog-connect-provider.tsx
@@ -321,7 +321,12 @@ export function DialogConnectProvider(props: { provider: string }) {
   })
 
   async function complete() {
-    await globalSDK.client.global.dispose()
+    try {
+      await globalSDK.client.global.dispose()
+      await globalSync.bootstrap()
+    } catch (err) {
+      console.error("Failed to refresh after provider connect", err)
+    }
     dialog.close()
     showToast({
       variant: "success",

--- a/packages/app/src/components/settings-providers.tsx
+++ b/packages/app/src/components/settings-providers.tsx
@@ -136,26 +136,26 @@ export const SettingsProviders: Component = () => {
   }
 
   const disconnect = async (providerID: string, name: string) => {
-    if (isConfigCustom(providerID)) {
-      await globalSDK.client.auth.remove({ providerID }).catch(() => undefined)
+    await globalSDK.client.auth.remove({ providerID }).catch(() => undefined)
+
+    const hasConfig = !!globalSync.data.config.provider?.[providerID]
+    if (hasConfig) {
       await disableProvider(providerID, name)
       return
     }
-    await globalSDK.client.auth
-      .remove({ providerID })
-      .then(async () => {
-        await globalSDK.client.global.dispose()
-        showToast({
-          variant: "success",
-          icon: "circle-check",
-          title: language.t("provider.disconnect.toast.disconnected.title", { provider: name }),
-          description: language.t("provider.disconnect.toast.disconnected.description", { provider: name }),
-        })
-      })
-      .catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err)
-        showToast({ title: language.t("common.requestFailed"), description: message })
-      })
+
+    try {
+      await globalSDK.client.global.dispose()
+      await globalSync.bootstrap()
+    } catch (err) {
+      console.error("Failed to refresh after provider disconnect", err)
+    }
+    showToast({
+      variant: "success",
+      icon: "circle-check",
+      title: language.t("provider.disconnect.toast.disconnected.title", { provider: name }),
+      description: language.t("provider.disconnect.toast.disconnected.description", { provider: name }),
+    })
   }
 
   return (

--- a/packages/app/src/components/settings-providers.tsx
+++ b/packages/app/src/components/settings-providers.tsx
@@ -136,26 +136,32 @@ export const SettingsProviders: Component = () => {
   }
 
   const disconnect = async (providerID: string, name: string) => {
-    await globalSDK.client.auth.remove({ providerID }).catch(() => undefined)
-
-    const hasConfig = !!globalSync.data.config.provider?.[providerID]
-    if (hasConfig) {
+    if (isConfigCustom(providerID)) {
+      await globalSDK.client.auth.remove({ providerID }).catch(() => undefined)
       await disableProvider(providerID, name)
       return
     }
 
-    try {
-      await globalSDK.client.global.dispose()
-      await globalSync.bootstrap()
-    } catch (err) {
-      console.error("Failed to refresh after provider disconnect", err)
-    }
-    showToast({
-      variant: "success",
-      icon: "circle-check",
-      title: language.t("provider.disconnect.toast.disconnected.title", { provider: name }),
-      description: language.t("provider.disconnect.toast.disconnected.description", { provider: name }),
-    })
+    await globalSDK.client.auth
+      .remove({ providerID })
+      .then(async () => {
+        try {
+          await globalSDK.client.global.dispose()
+          await globalSync.bootstrap()
+        } catch (err) {
+          console.error("Failed to refresh after provider disconnect", err)
+        }
+        showToast({
+          variant: "success",
+          icon: "circle-check",
+          title: language.t("provider.disconnect.toast.disconnected.title", { provider: name }),
+          description: language.t("provider.disconnect.toast.disconnected.description", { provider: name }),
+        })
+      })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err)
+        showToast({ title: language.t("common.requestFailed"), description: message })
+      })
   }
 
   return (

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -416,6 +416,10 @@ function createGlobalSync() {
     } finally {
       bootingRoot = false
     }
+    const dirs = Object.keys(children.children)
+    if (dirs.length > 0) {
+      await Promise.all(dirs.map(bootstrapInstance))
+    }
   }
 
   onMount(() => {
@@ -480,6 +484,9 @@ function createGlobalSync() {
     setGlobalStore("reload", "pending")
     return globalSDK.client.global.config
       .update({ config })
+      .then(async () => {
+        await globalSDK.client.global.dispose()
+      })
       .then(bootstrap)
       .then(() => {
         queue.refresh()

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -207,6 +207,7 @@ export const dict = {
   "common.loading": "Laden",
   "common.loading.ellipsis": "...",
   "common.cancel": "Abbrechen",
+  "common.continue": "Weiter",
   "common.connect": "Verbinden",
   "common.disconnect": "Trennen",
   "common.submit": "Absenden",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -231,6 +231,7 @@ export const dict = {
   "common.loading.ellipsis": "...",
   "common.cancel": "Cancel",
   "common.open": "Open",
+  "common.continue": "Continue",
   "common.connect": "Connect",
   "common.disconnect": "Disconnect",
   "common.submit": "Submit",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -221,6 +221,7 @@ export const dict = {
   "common.loading": "Laster",
   "common.loading.ellipsis": "...",
   "common.cancel": "Avbryt",
+  "common.continue": "Fortsett",
   "common.connect": "Koble til",
   "common.disconnect": "Koble fra",
   "common.submit": "Send inn",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -223,6 +223,7 @@ export const dict = {
   "common.loading": "Yükleniyor",
   "common.loading.ellipsis": "...",
   "common.cancel": "İptal",
+  "common.continue": "Devam",
   "common.connect": "Bağlan",
   "common.disconnect": "Bağlantı Kes",
   "common.submit": "Gönder",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -249,6 +249,7 @@ export const dict = {
   "common.loading": "加载中",
   "common.loading.ellipsis": "...",
   "common.cancel": "取消",
+  "common.continue": "继续",
   "common.connect": "连接",
   "common.disconnect": "断开连接",
   "common.submit": "提交",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -218,6 +218,7 @@ export const dict = {
   "common.loading": "載入中",
   "common.loading.ellipsis": "...",
   "common.cancel": "取消",
+  "common.continue": "繼續",
   "common.connect": "連線",
   "common.disconnect": "中斷連線",
   "common.submit": "提交",

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -987,6 +987,7 @@ export namespace Provider {
     }
 
     const providers: Record<ProviderID, Info> = {} as Record<ProviderID, Info>
+    const connected = new Set<ProviderID>()
     const languages = new Map<string, LanguageModelV2>()
     const modelLoaders: {
       [providerID: string]: CustomModelLoader
@@ -1002,6 +1003,23 @@ export namespace Provider {
     log.info("init")
 
     const configProviders = Object.entries(config.provider ?? {})
+    const live = (providerID: ProviderID) => {
+      connected.add(providerID)
+    }
+    const hasConfigKey = (provider: (typeof configProviders)[number][1]) => {
+      const key = provider.options?.apiKey
+      return typeof key === "string" && key.trim() !== ""
+    }
+    const isConfigCustom = (provider: (typeof configProviders)[number][1]) => {
+      if (!provider.models || Object.keys(provider.models).length === 0) return false
+      if (
+        provider.npm === "@ai-sdk/openai-compatible" ||
+        provider.npm === "@ai-sdk/anthropic" ||
+        provider.npm === "@ai-sdk/google"
+      )
+        return true
+      return typeof provider.options?.baseURL === "string" && provider.options.baseURL.trim() !== ""
+    }
 
     function mergeProvider(providerID: ProviderID, provider: Partial<Info>) {
       const existing = providers[providerID]
@@ -1130,12 +1148,14 @@ export namespace Provider {
         source: "env",
         key: provider.env.length === 1 ? apiKey : undefined,
       })
+      live(providerID)
     }
 
     // load apikeys
     for (const [id, provider] of Object.entries(await Auth.all())) {
       const providerID = ProviderID.make(id)
       if (disabled.has(providerID)) continue
+      live(providerID)
       if (provider.type === "api") {
         mergeProvider(providerID, {
           source: "api",
@@ -1158,6 +1178,7 @@ export namespace Provider {
         const opts = options ?? {}
         const patch: Partial<Info> = providers[providerID] ? { options: opts } : { source: "custom", options: opts }
         mergeProvider(providerID, patch)
+        live(providerID)
       }
     }
 
@@ -1177,6 +1198,7 @@ export namespace Provider {
         const opts = result.options ?? {}
         const patch: Partial<Info> = providers[providerID] ? { options: opts } : { source: "custom", options: opts }
         mergeProvider(providerID, patch)
+        if (result.autoload) live(providerID)
       }
     }
 
@@ -1188,12 +1210,16 @@ export namespace Provider {
       if (provider.name) partial.name = provider.name
       if (provider.options) partial.options = provider.options
       mergeProvider(providerID, partial)
+      if (hasConfigKey(provider) || isConfigCustom(provider)) {
+        live(providerID)
+      }
     }
 
     for (const [id, provider] of Object.entries(providers)) {
       const providerID = ProviderID.make(id)
       if (!isProviderAllowed(providerID)) {
         delete providers[providerID]
+        connected.delete(providerID)
         continue
       }
 
@@ -1229,6 +1255,7 @@ export namespace Provider {
 
       if (Object.keys(provider.models).length === 0) {
         delete providers[providerID]
+        connected.delete(providerID)
         continue
       }
 
@@ -1250,6 +1277,7 @@ export namespace Provider {
     return {
       models: languages,
       providers,
+      connected,
       sdk,
       modelLoaders,
       varsLoaders,
@@ -1258,6 +1286,10 @@ export namespace Provider {
 
   export async function list() {
     return state().then((state) => state.providers)
+  }
+
+  export async function connected() {
+    return state().then((state) => [...state.connected].filter((id) => !!state.providers[id]))
   }
 
   async function getSDK(model: Model) {

--- a/packages/opencode/src/server/routes/provider.ts
+++ b/packages/opencode/src/server/routes/provider.ts
@@ -56,13 +56,10 @@ export const ProviderRoutes = lazy(() =>
           mapValues(filteredProviders, (x) => Provider.fromModelsDevProvider(x)),
           connected,
         )
-        const connectedIDs = Object.entries(connected)
-          .filter(([_, v]) => !!v.key)
-          .map(([k]) => k)
         return c.json({
           all: Object.values(providers),
           default: mapValues(providers, (item) => Provider.sort(Object.values(item.models))[0].id),
-          connected: connectedIDs,
+          connected: await Provider.connected(),
         })
       },
     )

--- a/packages/opencode/src/server/routes/provider.ts
+++ b/packages/opencode/src/server/routes/provider.ts
@@ -56,10 +56,13 @@ export const ProviderRoutes = lazy(() =>
           mapValues(filteredProviders, (x) => Provider.fromModelsDevProvider(x)),
           connected,
         )
+        const connectedIDs = Object.entries(connected)
+          .filter(([_, v]) => !!v.key)
+          .map(([k]) => k)
         return c.json({
           all: Object.values(providers),
           default: mapValues(providers, (item) => Provider.sort(Object.values(item.models))[0].id),
-          connected: Object.keys(connected),
+          connected: connectedIDs,
         })
       },
     )

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -56,7 +56,101 @@ test("provider loaded from config with apiKey option", async () => {
     directory: tmp.path,
     fn: async () => {
       const providers = await Provider.list()
+      const connected = await Provider.connected()
       expect(providers[ProviderID.anthropic]).toBeDefined()
+      expect(connected).toContain(ProviderID.anthropic)
+    },
+  })
+})
+
+test("opencode public provider is connected without saved auth", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await Provider.list()
+      const connected = await Provider.connected()
+      expect(providers[ProviderID.opencode]).toBeDefined()
+      expect(connected).toContain(ProviderID.opencode)
+    },
+  })
+})
+
+test("preset provider with baseURL override is not connected without credentials", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            openai: {
+              options: {
+                baseURL: "https://proxy.example.com/v1",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await Provider.list()
+      const connected = await Provider.connected()
+      expect(providers[ProviderID.openai]).toBeDefined()
+      expect(connected).not.toContain(ProviderID.openai)
+    },
+  })
+})
+
+test("custom config provider with models is connected without api key", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "local-llm": {
+              name: "Local LLM",
+              npm: "@ai-sdk/openai-compatible",
+              options: {
+                baseURL: "http://localhost:11434/v1",
+              },
+              models: {
+                llama: {
+                  name: "Llama",
+                  limit: {
+                    context: 128000,
+                    output: 4096,
+                  },
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await Provider.list()
+      const connected = await Provider.connected()
+      const providerID = ProviderID.make("local-llm")
+      expect(providers[providerID]).toBeDefined()
+      expect(connected).toContain(providerID)
     },
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #309

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes three interrelated provider settings bugs:

1. **Missing "Continue" button text**: Added `common.continue` translation to 6 locales (en, zh, zht, de, no, tr).

2. **Stale list after adding a provider**: `complete()` now calls `await bootstrap()` after `dispose()` to synchronously refresh data before closing the dialog, instead of relying on the unreliable SSE event path.

3. **Stale list after deleting a provider**:
   - **Server fix**: The `/provider` route now only includes providers with actual auth credentials (`key`) in the `connected` array. Previously, providers with only a config entry (e.g. `baseURL` in shared `opencode.jsonc`) but no API key were incorrectly marked as connected.
   - **Client fix**: `disconnect()` restores `isConfigCustom` logic (only truly custom providers with custom models go through `disableProvider`). Regular providers simply remove their auth key and refresh. Error handling via `try/catch` and `.catch()` ensures failures are reported to the user.
   - `updateConfig()` now awaits `global.dispose()` between `config.update` and `bootstrap`, ensuring server-side caches are fully cleared before fetching fresh data.
   - `bootstrap()` now synchronously awaits child store refresh (`Promise.all(dirs.map(bootstrapInstance))`), so UI reading project-level data updates immediately.

### How did you verify your code works?

- `bun typecheck` passes across all packages (verified by pre-push hook)
- Manual testing in browser: added and deleted providers (both preset and config-based), verified list refreshes immediately and providers remain visible after disconnect

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR