### PR TITLE
fix: 飞书/微信端项目与会话切换编号对齐及切换后头部信息修正

### DIFF
--- a/Aether-wechat-bridge/aether_wechat_agent.py
+++ b/Aether-wechat-bridge/aether_wechat_agent.py
@@ -408,6 +408,12 @@ class AetherAgent(Agent):
                 break
         return rows
 
+    async def _resolve_session(self, session_id: str, directory: str) -> dict:
+        if not session_id:
+            return {}
+        items = await self._list_sessions(directory)
+        return next((item for item in items if item.get("id") == session_id), {})
+
     async def _format_header(
         self, session_id: str, directory: str, conv_id: str = ""
     ) -> str:
@@ -578,9 +584,10 @@ class AetherAgent(Agent):
                 )
             chosen = items[idx]
             self._sessions[conv_id] = chosen["id"]
-            title = chosen.get("title") or chosen["id"][:8]
+            info = await self._resolve_session(chosen["id"], directory)
+            title = info.get("title") or chosen["id"][:8]
             logger.info(f"[/session] {conv_id} -> {chosen['id']}")
-            return f"✅ 已切换到会话：{title}\n   更新时间：{self._format_session_time(chosen.get('time', {}).get('updated'))}"
+            return f"✅ 已切换到会话：{title}\n   更新时间：{self._format_session_time((info or chosen).get('time', {}).get('updated'))}"
 
         if not items:
             session_id = await self._create_session(directory=directory)
@@ -876,8 +883,7 @@ class AetherAgent(Agent):
             logger.info(f"[/project] {conv_id} -> {new_dir}")
             note = "已创建新会话"
             if not created:
-                items = await self._list_sessions(new_dir)
-                item = next((row for row in items if row.get("id") == session_id), None)
+                item = await self._resolve_session(session_id, new_dir)
                 title = (item or {}).get("title") or session_id[:8]
                 note = f"已进入该项目最新会话：{title}"
             return f"✅ 已切换到：{name}\n   {new_dir}\n（{note}）"

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -1357,7 +1357,7 @@ class FeishuManagerImpl {
   }
 
   /**
-   * /project            — list top-10 non-hidden projects (current marked ◀)
+   * /project            — list top-10 visible projects with full-list numbering (current marked ◀)
    * /project list       — list ALL projects including hidden ones
    * /project <n>        — switch to project n
    * /project hide <n>   — hide project n
@@ -1452,13 +1452,14 @@ class FeishuManagerImpl {
       await this.saveSessionMap()
 
       const name = this.projectName(chosen)
-      const note = created ? "已创建新会话" : `已进入该项目最新会话：${sessionTitle}`
+      const ctx = await this.commandCtx(chatId)
+      const note = created ? "已创建新会话" : `已进入该项目最新会话：${ctx.sessionTitle}`
       console.log("[feishu] /project switched:", chatId, "->", newDir)
       await this.replyCmd(messageId, chatId, `✅ 已切换到：${name}\n   ${newDir}\n（${note}）`)
       return
     }
 
-    // /project — list top-10 non-hidden projects
+    // /project — list top-10 visible projects with full-list numbering
     if (visibleProjects.length === 0) {
       const hint =
         Object.keys(this._hiddenDirs).length > 0 ? `（有 ${Object.keys(this._hiddenDirs).length} 个项目已隐藏）` : ""
@@ -1533,10 +1534,11 @@ class FeishuManagerImpl {
       const chosen = items[idx]
       this._chatSessions[chatId] = chosen.id
       void this.clearRuntime(chatId)
+      const ctx = await this.commandCtx(chatId)
       await this.replyCmd(
         messageId,
         chatId,
-        `✅ 已切换到会话：${chosen.title}\n   更新时间：${this.formatSessionTime(chosen.time.updated)}`,
+        `✅ 已切换到会话：${ctx.sessionTitle}\n   更新时间：${this.formatSessionTime(chosen.time.updated)}`,
       )
       return
     }


### PR DESCRIPTION
## Summary

Fixes #317

- 统一项目/会话列表编号语义：展示编号始终基于完整列表，隐藏项跳过展示但保留原始编号（如 `1. xxx; 2. xxx; 4. xxx`），`/project n`、`/project hide n`、`/session n` 均按完整列表编号解析
- 飞书端：`/project n` 和 `/session n` 切换成功后，通过 `commandCtx()` 重新解析当前 session 上下文，确保回复头部（项目名、会话标题、模式、模型）与实际切换目标一致
- 微信端：新增 `_resolve_session()` 辅助方法，`/session n` 和 `/project n` 切换后重新查询真实 session 信息再生成回复文案，避免使用列表缓存中的过期数据

## 修改文件

- `packages/opencode/src/feishu/manager.ts`
- `Aether-wechat-bridge/aether_wechat_agent.py`