### PR TITLE
feat(wechat-bridge): add file attachment sending from WeChat conversations

### DIFF
--- a/Aether-wechat-bridge/README.md
+++ b/Aether-wechat-bridge/README.md
@@ -18,11 +18,10 @@
 
 ```bash
 cd aether-wechat-bridge
-bun add @tencent-weixin/openclaw-weixin
 pip install -r requirements.txt
 ```
 
-需要 `Node.js >= 22` 和 `bun`，用于通过腾讯官方包 `@tencent-weixin/openclaw-weixin` 发送可下载文件附件。
+需要 `Node.js >= 22` 和 `bun`，用于发送微信文件附件。
 
 ## 使用方法
 

--- a/Aether-wechat-bridge/README.md
+++ b/Aether-wechat-bridge/README.md
@@ -18,8 +18,11 @@
 
 ```bash
 cd aether-wechat-bridge
+bun add @tencent-weixin/openclaw-weixin
 pip install -r requirements.txt
 ```
+
+需要 `Node.js >= 22` 和 `bun`，用于通过腾讯官方包 `@tencent-weixin/openclaw-weixin` 发送可下载文件附件。
 
 ## 使用方法
 
@@ -62,7 +65,7 @@ pip install -r requirements.txt
 ```bash
 在aether可执行文件下执行：
 chmod +x aether
-./aether serve 
+./aether serve
 ```
 
 ### 第三步：运行微信桥接
@@ -75,12 +78,12 @@ python aether_wechat_agent.py
 
 ## 环境变量配置
 
-| 变量 | 说明 | 默认值 |
-|------|------|--------|
-| `AETHER_URL` | Aether 服务地址 | `http://127.0.0.1:4096` |
-| `AETHER_WORK_DIR` | 工作目录 | 当前目录 |
-| `AETHER_MODEL` | 默认模型 | 配置文件中的模型 |
-| `AETHER_AGENT` | 默认 Agent | `build` |
+| 变量              | 说明            | 默认值                  |
+| ----------------- | --------------- | ----------------------- |
+| `AETHER_URL`      | Aether 服务地址 | `http://127.0.0.1:4096` |
+| `AETHER_WORK_DIR` | 工作目录        | 当前目录                |
+| `AETHER_MODEL`    | 默认模型        | 配置文件中的模型        |
+| `AETHER_AGENT`    | 默认 Agent      | `build`                 |
 
 示例：
 
@@ -99,7 +102,6 @@ python aether_wechat_agent.py
 2. **消息限制**：微信消息有长度限制，超长回复会被自动拆分
 3. **API 费用**：使用 AI 模型会产生费用，请注意用量
 4. **仅供学习**：本项目基于 iLink Bot API，仅供学习交流使用
-
 
 ### 文件操作卡住/无响应
 
@@ -124,15 +126,15 @@ python aether_wechat_agent.py
 
 **权限说明**：
 
-| 权限 | 说明 |
-|------|------|
+| 权限                 | 说明                 |
+| -------------------- | -------------------- |
 | `external_directory` | 访问工作目录外的目录 |
-| `edit` | 编辑文件 |
-| `bash` | 执行 shell 命令 |
-| `read` | 读取文件 |
-| `write` | 创建/写入文件 |
-| `glob` | 搜索文件 |
-| `grep` | 搜索文件内容 |
+| `edit`               | 编辑文件             |
+| `bash`               | 执行 shell 命令      |
+| `read`               | 读取文件             |
+| `write`              | 创建/写入文件        |
+| `glob`               | 搜索文件             |
+| `grep`               | 搜索文件内容         |
 
 **手动批准待处理权限**：
 

--- a/Aether-wechat-bridge/aether_wechat_agent.py
+++ b/Aether-wechat-bridge/aether_wechat_agent.py
@@ -1131,7 +1131,6 @@ class AetherAgent(Agent):
             if not bun:
                 logger.warning(f"[file] bun not found, skip send: {filepath}")
                 return False
-            account = getattr(self._bot_transport, "account_id", "aether") or "aether"
             ctx = self._wechat_ctx.get(conv_id, "")
             if not ctx:
                 logger.warning(f"[file] missing context token for send: {filepath}")
@@ -1156,9 +1155,6 @@ class AetherAgent(Agent):
                 "--context-token",
                 ctx,
             ]
-            logger.info(
-                f"[file] sending via tencent bun path: {filepath} base_url={base_url} account={account}"
-            )
             sub_env = (
                 {**os.environ, "BRIDGE_LOG": str(_log_file)}
                 if _log_file
@@ -1177,7 +1173,7 @@ class AetherAgent(Agent):
             )
             if out.returncode != 0:
                 detail = (out.stderr or out.stdout or "unknown error").strip()
-                logger.warning(f"[file] node send failed: {filepath} -> {detail}")
+                logger.warning(f"[file] send failed: {filepath} -> {detail}")
                 return False
             logger.info(f"[file] 已发送: {filepath}")
             return True

--- a/Aether-wechat-bridge/aether_wechat_agent.py
+++ b/Aether-wechat-bridge/aether_wechat_agent.py
@@ -12,6 +12,7 @@ Aether WeChat Bridge - 将 Aether AI 接入微信
 """
 
 import asyncio
+import subprocess
 import os
 import re
 import sys
@@ -26,6 +27,7 @@ for _s in (sys.stdout, sys.stderr):
 import json
 import base64
 import logging
+import shutil
 from pathlib import Path
 from typing import Optional
 from datetime import datetime
@@ -34,7 +36,18 @@ from urllib.parse import quote
 
 import httpx
 
+# 环境变量
+QRCODE_FILE = os.getenv("AETHER_WECHAT_QRCODE_FILE", "")
+SESSION_FILE = os.getenv("AETHER_WECHAT_SESSION_FILE", "")
+
 # 设置日志
+_log_dir = (
+    Path(SESSION_FILE).parent
+    if SESSION_FILE
+    else Path.home() / ".config" / "aether-wechat"
+)
+_log_dir.mkdir(parents=True, exist_ok=True)
+_log_file = _log_dir / "bridge.log"
 logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
 logger = logging.getLogger(__name__)
 # 确保日志 handler 的输出流也使用 UTF-8（basicConfig 可能绑定了旧的 stderr 引用）
@@ -44,6 +57,12 @@ for _h in logging.root.handlers:
             _h.stream.reconfigure(encoding="utf-8", errors="replace")
         except Exception:
             pass
+try:
+    _fh = logging.FileHandler(_log_file, encoding="utf-8")
+    _fh.setFormatter(logging.Formatter("[%(asctime)s] [%(levelname)s] %(message)s"))
+    logging.root.addHandler(_fh)
+except Exception:
+    pass
 
 # SDK imports
 from wechat_agent_sdk import Agent, ChatRequest, ChatResponse, WeChatBot
@@ -103,10 +122,6 @@ async def _request_qrcode_with_fallback(self) -> dict:
 
 _orig_request_qrcode = ILinkBotClient.request_qrcode
 ILinkBotClient.request_qrcode = _request_qrcode_with_fallback
-
-# 环境变量
-QRCODE_FILE = os.getenv("AETHER_WECHAT_QRCODE_FILE", "")
-SESSION_FILE = os.getenv("AETHER_WECHAT_SESSION_FILE", "")
 
 
 def output_qrcode_base64(qrcode_url: str) -> str:
@@ -268,6 +283,10 @@ class AetherAgent(Agent):
         self._hidden_dirs: dict[str, int] = {}  # worktree → 隐藏时的时间戳(ms)
         self._project_names: dict[str, str] = {}
         self._session_info: dict[str, dict] = {}
+        self._last_user_text: dict[str, str] = {}
+        self._last_result: dict[str, dict] = {}
+        self._bot_transport = None
+        self._sender_script = str(Path(__file__).with_name("send_file.ts"))
 
     async def on_start(self) -> None:
         """初始化 HTTP 客户端"""
@@ -962,6 +981,249 @@ class AetherAgent(Agent):
         elif self._message_sender:
             await self._message_sender(text)
 
+    _FILE_INTENT_KEYWORDS = [
+        "发给我",
+        "发来",
+        "源文件",
+        "原文件",
+        "发过来",
+        "原始文件",
+        "发文件",
+        "send me",
+        "send file",
+    ]
+
+    _BLOCKED_EXTENSIONS = frozenset(
+        [
+            ".env",
+            ".pem",
+            ".key",
+            ".p12",
+            ".pfx",
+            ".jks",
+            ".keystore",
+            ".secret",
+            ".credentials",
+            ".sqlite",
+            ".sqlite3",
+            ".db",
+            ".ldb",
+        ]
+    )
+
+    _BLOCKED_NAMES = frozenset(
+        [
+            ".env",
+            ".env.local",
+            ".env.production",
+            ".env.development",
+            ".credentials",
+            ".secret",
+        ]
+    )
+
+    _MAX_FILES_PER_TURN = 5
+    _MAX_FILE_SIZE = 30 * 1024 * 1024
+
+    def _detect_file_intent(self, text: str) -> bool:
+        lower = text.lower()
+        return any(kw in lower for kw in self._FILE_INTENT_KEYWORDS)
+
+    def _file_prompt(self, text: str) -> str:
+        if not self._detect_file_intent(text):
+            return text
+        return (
+            text
+            + "\n\n[系统提示：用户需要通过微信接收文件附件，请在回复中包含该文件在当前系统上的完整绝对路径。"
+            + "Windows 示例：E:\\\\work\\\\demo\\\\file.jpg；macOS 示例：/Users/demo/file.jpg；"
+            + "Linux 示例：/home/demo/file.jpg。系统会尝试把该绝对路径对应的文件作为附件发送给用户。]"
+        )
+
+    def _extract_read_files(self, result: dict) -> list[str]:
+        parts = result.get("parts", [])
+        files: list[str] = []
+        for part in parts:
+            if part.get("type") != "tool":
+                continue
+            state = part.get("state", {})
+            if state.get("status") != "completed":
+                continue
+            if part.get("tool") == "read":
+                fp = (state.get("input") or {}).get("filePath")
+                if fp:
+                    files.append(fp)
+        return list(dict.fromkeys(files))
+
+    def _extract_paths_from_text(self, text: str) -> list[str]:
+        tokens: list[str] = []
+        for m in re.finditer(r"`([^`]+)`", text):
+            tokens.append(m.group(1).strip())
+        for m in re.finditer(r"[A-Za-z]:\\[^\r\n`]+", text):
+            raw = m.group(0).strip()
+            if raw:
+                tokens.append(raw)
+        for m in re.finditer(r"/(?:[^\s`'\"(){}<>[\];，。、\\]+/?)+", text):
+            raw = m.group(0).strip()
+            if raw:
+                tokens.append(raw)
+        seen: dict[str, None] = {}
+        out: list[str] = []
+        for t in tokens:
+            for sep in ["，", "。", "；", "：", ",", ";"]:
+                if sep in t:
+                    t = t.split(sep, 1)[0]
+            t = t.rstrip(".,;:!?，。；：！？）】》」')\"")
+            if not t or t in seen:
+                continue
+            if not Path(t).is_file():
+                logger.info(f"[file] skip non-file token: {t}")
+                continue
+            seen[t] = None
+            out.append(t)
+        if out:
+            logger.info(f"[file] extracted paths: {out}")
+        return out
+
+    def _validate_file(self, filepath: str, directory: str) -> str | None:
+        try:
+            p = Path(filepath).resolve()
+        except Exception:
+            logger.info(f"[file] validate resolve failed: {filepath}")
+            return None
+        if not p.is_file():
+            logger.info(f"[file] validate not file: {p}")
+            return None
+        try:
+            if p.stat().st_size > self._MAX_FILE_SIZE:
+                logger.info(f"[file] validate too large: {p}")
+                return None
+        except OSError:
+            logger.info(f"[file] validate stat failed: {p}")
+            return None
+        if p.suffix.lower() in self._BLOCKED_EXTENSIONS:
+            logger.info(f"[file] validate blocked extension: {p}")
+            return None
+        if p.name.lower() in self._BLOCKED_NAMES:
+            logger.info(f"[file] validate blocked name: {p}")
+            return None
+        try:
+            p.relative_to(Path(directory).resolve())
+        except ValueError:
+            logger.info(
+                f"[file] validate outside directory: {p} not in {Path(directory).resolve()}"
+            )
+            return None
+        logger.info(f"[file] validate ok: {p}")
+        return str(p)
+
+    async def _send_file_to_conv(self, conv_id: str, filepath: str) -> bool:
+        if not self._bot_transport:
+            return False
+        try:
+            token = getattr(self._bot_transport._client, "token", "")
+            base_url = getattr(
+                self._bot_transport._client, "_base_url", DEFAULT_API_BASE
+            )
+            if not token:
+                logger.warning(f"[file] missing token for send: {filepath}")
+                return False
+            bun = shutil.which("bun")
+            if not bun:
+                logger.warning(f"[file] bun not found, skip send: {filepath}")
+                return False
+            account = getattr(self._bot_transport, "account_id", "aether") or "aether"
+            ctx = self._wechat_ctx.get(conv_id, "")
+            if not ctx:
+                logger.warning(f"[file] missing context token for send: {filepath}")
+                return False
+            script = Path(self._sender_script)
+            if not script.is_file():
+                logger.warning(f"[file] sender script missing: {script}")
+                return False
+            cmd = [
+                bun,
+                str(script),
+                "--chat-id",
+                conv_id,
+                "--file",
+                filepath,
+                "--token",
+                token,
+                "--base-url",
+                base_url,
+                "--cdn-base-url",
+                "https://novac2c.cdn.weixin.qq.com/c2c",
+                "--context-token",
+                ctx,
+            ]
+            logger.info(
+                f"[file] sending via tencent bun path: {filepath} base_url={base_url} account={account}"
+            )
+            sub_env = (
+                {**os.environ, "BRIDGE_LOG": str(_log_file)}
+                if _log_file
+                else os.environ
+            )
+            out = await asyncio.to_thread(
+                subprocess.run,
+                cmd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=120,
+                check=False,
+                env=sub_env,
+            )
+            if out.returncode != 0:
+                detail = (out.stderr or out.stdout or "unknown error").strip()
+                logger.warning(f"[file] node send failed: {filepath} -> {detail}")
+                return False
+            logger.info(f"[file] 已发送: {filepath}")
+            return True
+        except subprocess.TimeoutExpired:
+            logger.warning(f"[file] send timeout: {filepath}")
+            return False
+        except Exception as e:
+            logger.warning(f"[file] 发送失败: {filepath} -> {e}")
+            return False
+
+    async def _try_send_files(
+        self, conv_id: str, session_id: str, directory: str, response_text: str
+    ) -> None:
+        result = self._last_result.get(conv_id)
+        candidates: list[str] = []
+        if result:
+            candidates = self._extract_read_files(result)
+            if candidates:
+                logger.info(f"[file] read candidates: {candidates}")
+        if not candidates and response_text:
+            candidates = self._extract_paths_from_text(response_text)
+        logger.info(f"[file] final candidates: {candidates}")
+        if not candidates:
+            logger.info("[file] no candidates")
+            return
+        safe: list[str] = []
+        for fp in candidates[: self._MAX_FILES_PER_TURN]:
+            validated = self._validate_file(fp, directory)
+            if validated:
+                safe.append(validated)
+        logger.info(f"[file] safe candidates: {safe}")
+        if not safe:
+            logger.info("[file] no safe candidates")
+            return
+        sent = 0
+        for fp in safe:
+            ok = await self._send_file_to_conv(conv_id, fp)
+            if ok:
+                sent += 1
+        if sent == 0 and safe:
+            paths_text = chr(10).join(safe[:3])
+            await self._send_to_conv(
+                conv_id,
+                f"已识别 {len(safe)} 个文件，但通过微信发送失败。文件路径：{chr(10)}{paths_text}",
+            )
+
     async def _background_dispatch(
         self, conv_id: str, session_id: str, directory: str, task, q
     ) -> None:
@@ -974,6 +1236,11 @@ class AetherAgent(Agent):
             else:
                 response = await self._wait_for_response_polling(
                     conv_id, session_id, directory, task
+                )
+            user_text = self._last_user_text.get(conv_id, "")
+            if self._detect_file_intent(user_text):
+                await self._try_send_files(
+                    conv_id, session_id, directory, response.text
                 )
             await self._send_to_conv(conv_id, response.text)
         except asyncio.CancelledError:
@@ -1027,6 +1294,8 @@ class AetherAgent(Agent):
         ctx_token = (request.raw or {}).get("context_token", "")
         if ctx_token:
             self._wechat_ctx[conv_id] = ctx_token
+
+        self._last_user_text[conv_id] = user_text
 
         if request.group_id and request.is_at_bot:
             logger.info(f"[群聊] {request.sender_name}: {user_text}")
@@ -1094,6 +1363,17 @@ class AetherAgent(Agent):
                 )
             )
             self._tasks[conv_id] = task
+
+            if self._detect_file_intent(user_text):
+                sse_task = asyncio.create_task(
+                    self._monitor_sse(conv_id, session_id, directory, task, q)
+                )
+                self._sse_tasks[conv_id] = sse_task
+                asyncio.create_task(
+                    self._background_dispatch(conv_id, session_id, directory, task, q)
+                )
+                return ChatResponse(text="")
+
             sse_task = asyncio.create_task(
                 self._monitor_sse(conv_id, session_id, directory, task, q)
             )
@@ -1261,6 +1541,7 @@ class AetherAgent(Agent):
 
         try:
             result = await task
+            self._last_result[conv_id] = result
             return ChatResponse(
                 text=await self._wrap_message(
                     result.get("formatted", "操作已完成"),
@@ -1333,6 +1614,7 @@ class AetherAgent(Agent):
         self._pending_permissions.pop(conv_id, None)
         try:
             result = await task
+            self._last_result[conv_id] = result
             return ChatResponse(
                 text=await self._wrap_message(
                     result.get("formatted", "操作已完成"),
@@ -1670,7 +1952,7 @@ class AetherAgent(Agent):
 
     async def _send_message(self, session_id: str, text: str, directory="") -> dict:
         payload = {
-            "parts": [{"type": "text", "text": text}],
+            "parts": [{"type": "text", "text": self._file_prompt(text)}],
         }
 
         resp = await self._client.post(
@@ -1886,6 +2168,7 @@ async def main():
     )
     # 把微信客户端传给 agent，让后台任务能直接投递消息
     agent._wechat_client = bot._transport._client
+    agent._bot_transport = bot._transport
 
     try:
         await bot.run(log=print)

--- a/Aether-wechat-bridge/requirements.txt
+++ b/Aether-wechat-bridge/requirements.txt
@@ -1,2 +1,2 @@
-wechat-agent-sdk[qr]>=0.1.0
+wechat-agent-sdk[qr]>=0.2.1
 httpx[socks]>=0.27.0

--- a/Aether-wechat-bridge/send_file.ts
+++ b/Aether-wechat-bridge/send_file.ts
@@ -1,17 +1,9 @@
 import crypto from "node:crypto"
-import { appendFile } from "node:fs/promises"
 import { readFile } from "node:fs/promises"
 import path from "node:path"
 import process from "node:process"
 
 const args = process.argv.slice(2)
-
-const LOG = process.env.BRIDGE_LOG || ""
-
-const log = (msg: string) => {
-  process.stderr.write(`${msg}\n`)
-  if (LOG) appendFile(LOG, `${new Date().toISOString()} [send_file] ${msg}\n`).catch(() => {})
-}
 
 const mime = {
   ".pdf": "application/pdf",
@@ -87,7 +79,6 @@ const cvNum = ((2 & 0xff) << 16) | ((1 & 0xff) << 8) | (8 & 0xff)
 
 const post = async (url: string, body: unknown, token?: string) => {
   const text = JSON.stringify(body)
-  log(`POST ${url} body=${text.slice(0, 2000)}`)
   const res = await fetch(url, {
     method: "POST",
     headers: {
@@ -102,9 +93,6 @@ const post = async (url: string, body: unknown, token?: string) => {
     body: text,
   })
   const raw = await res.text()
-  log(
-    `RESP ${res.status} headers=${JSON.stringify(Object.fromEntries(res.headers.entries()))} body=${raw.slice(0, 2000)}`,
-  )
   if (!res.ok) throw new Error(`${res.status}: ${raw}`)
   return raw ? JSON.parse(raw) : {}
 }
@@ -114,9 +102,6 @@ const upload = async (opts: Record<string, string>, filePath: string) => {
   const key = crypto.randomBytes(16)
   const filekey = crypto.randomBytes(16).toString("hex")
   const file = mediaType(filePath)
-  log(
-    `upload: file=${filePath} kind=${file.kind} rawsize=${buf.length} cipher=${aesSize(buf.length)} key_hex=${key.toString("hex")} filekey=${filekey}`,
-  )
 
   const uploadUrlResp = await post(
     `${req(opts, "base-url").replace(/\/$/, "")}/ilink/bot/getuploadurl`,
@@ -133,15 +118,12 @@ const upload = async (opts: Record<string, string>, filePath: string) => {
     },
     req(opts, "token"),
   )
-  log(`getuploadurl resp: upload_full_url=${uploadUrlResp.upload_full_url} upload_param=${uploadUrlResp.upload_param}`)
 
   const target =
     uploadUrlResp.upload_full_url?.trim() ||
     `${req(opts, "cdn-base-url")}/upload?encrypted_query_param=${encodeURIComponent(uploadUrlResp.upload_param)}&filekey=${encodeURIComponent(filekey)}`
-  log(`cdn upload target: ${target}`)
 
   const ciphertext = enc(buf, key)
-  log(`cdn upload: ciphertext size=${ciphertext.length}`)
 
   const res = await fetch(target, {
     method: "POST",
@@ -149,17 +131,11 @@ const upload = async (opts: Record<string, string>, filePath: string) => {
     body: new Uint8Array(ciphertext),
   })
   const raw = await res.text()
-  log(
-    `cdn resp: status=${res.status} x-encrypted-param=${res.headers.get("x-encrypted-param")} body=${raw.slice(0, 500)}`,
-  )
   if (res.status !== 200) throw new Error(`cdn ${res.status}: ${raw}`)
   const param = res.headers.get("x-encrypted-param")
   if (!param) throw new Error("CDN upload response missing x-encrypted-param header")
 
   const aesBase64 = Buffer.from(key.toString("hex"), "utf-8").toString("base64")
-  log(
-    `aes_key for sendmessage: hex=${key.toString("hex")} base64(hex_as_utf8)=${aesBase64} base64(raw)=${key.toString("base64")}`,
-  )
 
   return {
     file,
@@ -210,7 +186,6 @@ const send = async (opts: Record<string, string>, media: Awaited<ReturnType<type
     },
     base_info: { channel_version: VERSION },
   }
-  log(`sendmessage body: ${JSON.stringify(body)}`)
 
   await post(`${req(opts, "base-url").replace(/\/$/, "")}/ilink/bot/sendmessage`, body, req(opts, "token"))
 }
@@ -218,17 +193,12 @@ const send = async (opts: Record<string, string>, media: Awaited<ReturnType<type
 const main = async () => {
   const opts = parse()
   const filePath = path.resolve(req(opts, "file"))
-  log(
-    `starting: file=${filePath} chat-id=${req(opts, "chat-id")} base-url=${req(opts, "base-url")} context-token=present=${Boolean(opts["context-token"])}`,
-  )
   const media = await upload(opts, filePath)
   await send(opts, media)
-  log(`done: file=${filePath}`)
   process.stdout.write(JSON.stringify({ ok: true, filePath }) + "\n")
 }
 
 main().catch((err) => {
-  log(`error: ${err instanceof Error ? err.stack || err.message : String(err)}`)
   process.stderr.write(`${err instanceof Error ? err.stack || err.message : String(err)}\n`)
   process.exit(1)
 })

--- a/Aether-wechat-bridge/send_file.ts
+++ b/Aether-wechat-bridge/send_file.ts
@@ -1,0 +1,234 @@
+import crypto from "node:crypto"
+import { appendFile } from "node:fs/promises"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import process from "node:process"
+
+const args = process.argv.slice(2)
+
+const LOG = process.env.BRIDGE_LOG || ""
+
+const log = (msg: string) => {
+  process.stderr.write(`${msg}\n`)
+  if (LOG) appendFile(LOG, `${new Date().toISOString()} [send_file] ${msg}\n`).catch(() => {})
+}
+
+const mime = {
+  ".pdf": "application/pdf",
+  ".doc": "application/msword",
+  ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ".xls": "application/vnd.ms-excel",
+  ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ".ppt": "application/vnd.ms-powerpoint",
+  ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  ".txt": "text/plain",
+  ".csv": "text/csv",
+  ".zip": "application/zip",
+  ".tar": "application/x-tar",
+  ".gz": "application/gzip",
+  ".mp3": "audio/mpeg",
+  ".ogg": "audio/ogg",
+  ".wav": "audio/wav",
+  ".mp4": "video/mp4",
+  ".mov": "video/quicktime",
+  ".webm": "video/webm",
+  ".mkv": "video/x-matroska",
+  ".avi": "video/x-msvideo",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".bmp": "image/bmp",
+} as const
+
+const parse = () => {
+  const out: Record<string, string> = {}
+  for (let i = 0; i < args.length; i += 1) {
+    const key = args[i]
+    const val = args[i + 1]
+    if (!key?.startsWith("--") || val == null) continue
+    out[key.slice(2)] = val
+    i += 1
+  }
+  return out
+}
+
+const req = (opts: Record<string, string>, key: string) => {
+  const val = opts[key]
+  if (val) return val
+  throw new Error(`Missing required arg: ${key}`)
+}
+
+const uin = () => Buffer.from(String(crypto.randomBytes(4).readUInt32BE(0)), "utf-8").toString("base64")
+
+const aesSize = (n: number) => Math.ceil((n + 1) / 16) * 16
+
+const enc = (buf: Buffer, key: Buffer) => {
+  const cipher = crypto.createCipheriv("aes-128-ecb", key, null)
+  return Buffer.concat([cipher.update(buf), cipher.final()])
+}
+
+const id = () => `aether-wechat:${Date.now()}-${crypto.randomBytes(4).toString("hex")}`
+
+const extMime = (file: string) =>
+  mime[path.extname(file).toLowerCase() as keyof typeof mime] ?? "application/octet-stream"
+
+const mediaType = (file: string) => {
+  const type = extMime(file)
+  if (type.startsWith("video/")) return { upload: 2, item: 5, kind: "video" as const }
+  if (type.startsWith("image/")) return { upload: 1, item: 2, kind: "image" as const }
+  return { upload: 3, item: 4, kind: "file" as const }
+}
+
+const VERSION = "2.1.8"
+const APP_ID = "bot"
+const cvNum = ((2 & 0xff) << 16) | ((1 & 0xff) << 8) | (8 & 0xff)
+
+const post = async (url: string, body: unknown, token?: string) => {
+  const text = JSON.stringify(body)
+  log(`POST ${url} body=${text.slice(0, 2000)}`)
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      AuthorizationType: "ilink_bot_token",
+      "Content-Length": String(Buffer.byteLength(text, "utf-8")),
+      "X-WECHAT-UIN": uin(),
+      "iLink-App-Id": APP_ID,
+      "iLink-App-ClientVersion": String(cvNum),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: text,
+  })
+  const raw = await res.text()
+  log(
+    `RESP ${res.status} headers=${JSON.stringify(Object.fromEntries(res.headers.entries()))} body=${raw.slice(0, 2000)}`,
+  )
+  if (!res.ok) throw new Error(`${res.status}: ${raw}`)
+  return raw ? JSON.parse(raw) : {}
+}
+
+const upload = async (opts: Record<string, string>, filePath: string) => {
+  const buf = await readFile(filePath)
+  const key = crypto.randomBytes(16)
+  const filekey = crypto.randomBytes(16).toString("hex")
+  const file = mediaType(filePath)
+  log(
+    `upload: file=${filePath} kind=${file.kind} rawsize=${buf.length} cipher=${aesSize(buf.length)} key_hex=${key.toString("hex")} filekey=${filekey}`,
+  )
+
+  const uploadUrlResp = await post(
+    `${req(opts, "base-url").replace(/\/$/, "")}/ilink/bot/getuploadurl`,
+    {
+      filekey,
+      media_type: file.upload,
+      to_user_id: req(opts, "chat-id"),
+      rawsize: buf.length,
+      rawfilemd5: crypto.createHash("md5").update(buf).digest("hex"),
+      filesize: aesSize(buf.length),
+      no_need_thumb: true,
+      aeskey: key.toString("hex"),
+      base_info: { channel_version: VERSION },
+    },
+    req(opts, "token"),
+  )
+  log(`getuploadurl resp: upload_full_url=${uploadUrlResp.upload_full_url} upload_param=${uploadUrlResp.upload_param}`)
+
+  const target =
+    uploadUrlResp.upload_full_url?.trim() ||
+    `${req(opts, "cdn-base-url")}/upload?encrypted_query_param=${encodeURIComponent(uploadUrlResp.upload_param)}&filekey=${encodeURIComponent(filekey)}`
+  log(`cdn upload target: ${target}`)
+
+  const ciphertext = enc(buf, key)
+  log(`cdn upload: ciphertext size=${ciphertext.length}`)
+
+  const res = await fetch(target, {
+    method: "POST",
+    headers: { "Content-Type": "application/octet-stream" },
+    body: new Uint8Array(ciphertext),
+  })
+  const raw = await res.text()
+  log(
+    `cdn resp: status=${res.status} x-encrypted-param=${res.headers.get("x-encrypted-param")} body=${raw.slice(0, 500)}`,
+  )
+  if (res.status !== 200) throw new Error(`cdn ${res.status}: ${raw}`)
+  const param = res.headers.get("x-encrypted-param")
+  if (!param) throw new Error("CDN upload response missing x-encrypted-param header")
+
+  const aesBase64 = Buffer.from(key.toString("hex"), "utf-8").toString("base64")
+  log(
+    `aes_key for sendmessage: hex=${key.toString("hex")} base64(hex_as_utf8)=${aesBase64} base64(raw)=${key.toString("base64")}`,
+  )
+
+  return {
+    file,
+    query: param,
+    aes: aesBase64,
+    size: buf.length,
+    cipher: aesSize(buf.length),
+    name: path.basename(filePath),
+  }
+}
+
+const send = async (opts: Record<string, string>, media: Awaited<ReturnType<typeof upload>>) => {
+  const item =
+    media.file.kind === "image"
+      ? {
+          type: media.file.item,
+          image_item: {
+            media: { encrypt_query_param: media.query, aes_key: media.aes, encrypt_type: 1 },
+            mid_size: media.cipher,
+          },
+        }
+      : media.file.kind === "video"
+        ? {
+            type: media.file.item,
+            video_item: {
+              media: { encrypt_query_param: media.query, aes_key: media.aes, encrypt_type: 1 },
+              video_size: media.cipher,
+            },
+          }
+        : {
+            type: media.file.item,
+            file_item: {
+              media: { encrypt_query_param: media.query, aes_key: media.aes, encrypt_type: 1 },
+              file_name: media.name,
+              len: String(media.size),
+            },
+          }
+
+  const body = {
+    msg: {
+      from_user_id: "",
+      to_user_id: req(opts, "chat-id"),
+      client_id: id(),
+      message_type: 2,
+      message_state: 2,
+      item_list: [item],
+      context_token: req(opts, "context-token"),
+    },
+    base_info: { channel_version: VERSION },
+  }
+  log(`sendmessage body: ${JSON.stringify(body)}`)
+
+  await post(`${req(opts, "base-url").replace(/\/$/, "")}/ilink/bot/sendmessage`, body, req(opts, "token"))
+}
+
+const main = async () => {
+  const opts = parse()
+  const filePath = path.resolve(req(opts, "file"))
+  log(
+    `starting: file=${filePath} chat-id=${req(opts, "chat-id")} base-url=${req(opts, "base-url")} context-token=present=${Boolean(opts["context-token"])}`,
+  )
+  const media = await upload(opts, filePath)
+  await send(opts, media)
+  log(`done: file=${filePath}`)
+  process.stdout.write(JSON.stringify({ ok: true, filePath }) + "\n")
+}
+
+main().catch((err) => {
+  log(`error: ${err instanceof Error ? err.stack || err.message : String(err)}`)
+  process.stderr.write(`${err instanceof Error ? err.stack || err.message : String(err)}\n`)
+  process.exit(1)
+})

--- a/Aether-wechat-bridge/test_file_send.py
+++ b/Aether-wechat-bridge/test_file_send.py
@@ -1,0 +1,729 @@
+"""Tests for WeChat file-sending feature in aether_wechat_agent.py.
+
+Run from repo root:
+    python Aether-wechat-bridge/test_file_send.py
+
+Tests cover:
+- intent detection (positive and negative)
+- file path extraction from text (Windows + macOS/Linux)
+- read-file extraction from tool parts
+- safety validation (workspace scope, size, blocked extensions)
+- end-to-end _try_send_files orchestration
+- command invulnerability (slash commands untouched)
+"""
+
+import asyncio
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _setup_mock_sdk():
+    mock_sdk = types.ModuleType("wechat_agent_sdk")
+    mock_sdk.Agent = type("Agent", (), {})
+    mock_sdk.ChatRequest = type("ChatRequest", (), {})
+    mock_sdk.ChatResponse = type(
+        "ChatResponse",
+        (),
+        {"__init__": lambda self, **kw: setattr(self, "__dict__", kw)},
+    )
+    mock_sdk.WeChatBot = type("WeChatBot", (), {})
+    mock_api = types.ModuleType("wechat_agent_sdk.api")
+    mock_api_client = (
+        types.ModuleModule("wechat_agent_sdk.api.client")
+        if hasattr(types, "ModuleModule")
+        else types.ModuleType("wechat_agent_sdk.api.client")
+    )
+    mock_api_client.ILinkBotClient = type(
+        "ILinkBotClient", (), {"request_qrcode": None}
+    )
+    mock_api_client.DEFAULT_API_BASE = "https://example.com"
+    mock_api_client.POLL_TIMEOUT = 30
+    mock_api_client._make_wechat_uin = lambda: ""
+    mock_api_auth = types.ModuleType("wechat_agent_sdk.api.auth")
+    mock_api_auth.login_with_qrcode = lambda *a, **kw: None
+    mock_account = types.ModuleType("wechat_agent_sdk.account")
+    mock_account_storage = types.ModuleType("wechat_agent_sdk.account.storage")
+    mock_account_storage.JsonFileStorage = type("JsonFileStorage", (), {})
+    mock_messaging = types.ModuleType("wechat_agent_sdk.messaging")
+    mock_messaging_send = types.ModuleType("wechat_agent_sdk.messaging.send")
+    mock_messaging_send.send_response = AsyncMock()
+    sys.modules["wechat_agent_sdk"] = mock_sdk
+    sys.modules["wechat_agent_sdk.api"] = mock_api
+    sys.modules["wechat_agent_sdk.api.client"] = mock_api_client
+    sys.modules["wechat_agent_sdk.api.auth"] = mock_api_auth
+    sys.modules["wechat_agent_sdk.account"] = mock_account
+    sys.modules["wechat_agent_sdk.account.storage"] = mock_account_storage
+    sys.modules["wechat_agent_sdk.messaging"] = mock_messaging
+    sys.modules["wechat_agent_sdk.messaging.send"] = mock_messaging_send
+
+
+_setup_mock_sdk()
+
+from aether_wechat_agent import AetherAgent, HELP_TEXT
+
+
+class _AgentFixture:
+    def __init__(self, tmpdir: str):
+        self.agent = AetherAgent.__new__(AetherAgent)
+        self.agent.directory = tmpdir
+        self.agent._last_user_text = {}
+        self.agent._last_result = {}
+        self.agent._bot_transport = None
+        self.agent._wechat_ctx = {}
+        self.agent._wechat_client = None
+        self.agent._message_sender = None
+        self.agent._sender_script = os.path.join(tmpdir, "send_file.ts")
+        self.tmpdir = tmpdir
+
+
+class TestFileIntentDetection(unittest.TestCase):
+    def setUp(self):
+        self.fix = _AgentFixture(tempfile.mkdtemp())
+
+    def test_positive_chinese(self):
+        for text in [
+            "把这个文件发给我",
+            "请把源文件发来",
+            "我要原文件",
+            "把那个文件发过来",
+            "给我原始文件",
+            "帮我发文件",
+        ]:
+            with self.subTest(text=text):
+                self.assertTrue(self.fix.agent._detect_file_intent(text))
+
+    def test_positive_english(self):
+        for text in [
+            "please send me the file",
+            "Send File to me",
+            "can you send me the result?",
+        ]:
+            with self.subTest(text=text):
+                self.assertTrue(self.fix.agent._detect_file_intent(text))
+
+    def test_negative(self):
+        for text in [
+            "帮我读一下这个文件",
+            "这个文件写了什么",
+            "/model",
+            "/help",
+            "你好",
+            "请解释这段代码",
+            "发送消息给小明",
+            "查看文件内容",
+        ]:
+            with self.subTest(text=text):
+                self.assertFalse(self.fix.agent._detect_file_intent(text))
+
+    def test_file_prompt_injects_absolute_path_hint(self):
+        text = "把那个.jpg文件发给我"
+        out = self.fix.agent._file_prompt(text)
+        self.assertIn(text, out)
+        self.assertIn("完整绝对路径", out)
+        self.assertIn("E:\\\\work\\\\demo\\\\file.jpg", out)
+        self.assertIn("/Users/demo/file.jpg", out)
+        self.assertIn("/home/demo/file.jpg", out)
+
+    def test_file_prompt_keeps_normal_message_unchanged(self):
+        text = "请解释这张图"
+        self.assertEqual(self.fix.agent._file_prompt(text), text)
+
+
+class TestExtractReadFiles(unittest.TestCase):
+    def setUp(self):
+        self.fix = _AgentFixture(tempfile.mkdtemp())
+
+    def test_extracts_read_tool_files(self):
+        result = {
+            "parts": [
+                {"type": "text", "text": "Here is the file"},
+                {
+                    "type": "tool",
+                    "tool": "read",
+                    "state": {
+                        "status": "completed",
+                        "input": {"filePath": "/home/user/project/main.py"},
+                        "output": "file content",
+                    },
+                },
+            ]
+        }
+        self.assertEqual(
+            self.fix.agent._extract_read_files(result), ["/home/user/project/main.py"]
+        )
+
+    def test_extracts_multiple_dedup(self):
+        result = {
+            "parts": [
+                {
+                    "type": "tool",
+                    "tool": "read",
+                    "state": {
+                        "status": "completed",
+                        "input": {"filePath": "/a/b.py"},
+                        "output": "x",
+                    },
+                },
+                {
+                    "type": "tool",
+                    "tool": "read",
+                    "state": {
+                        "status": "completed",
+                        "input": {"filePath": "/a/b.py"},
+                        "output": "y",
+                    },
+                },
+                {
+                    "type": "tool",
+                    "tool": "read",
+                    "state": {
+                        "status": "completed",
+                        "input": {"filePath": "/a/c.py"},
+                        "output": "z",
+                    },
+                },
+            ]
+        }
+        self.assertEqual(
+            self.fix.agent._extract_read_files(result), ["/a/b.py", "/a/c.py"]
+        )
+
+    def test_ignores_non_read_tools(self):
+        result = {
+            "parts": [
+                {
+                    "type": "tool",
+                    "tool": "write",
+                    "state": {
+                        "status": "completed",
+                        "input": {"filePath": "/a/output.py"},
+                        "output": "wrote",
+                    },
+                },
+            ]
+        }
+        self.assertEqual(self.fix.agent._extract_read_files(result), [])
+
+    def test_ignores_incomplete_status(self):
+        result = {
+            "parts": [
+                {
+                    "type": "tool",
+                    "tool": "read",
+                    "state": {
+                        "status": "running",
+                        "input": {"filePath": "/a/reading.py"},
+                    },
+                },
+            ]
+        }
+        self.assertEqual(self.fix.agent._extract_read_files(result), [])
+
+    def test_empty(self):
+        self.assertEqual(self.fix.agent._extract_read_files({}), [])
+        self.assertEqual(self.fix.agent._extract_read_files({"parts": []}), [])
+
+
+class TestExtractPathsFromText(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.fix = _AgentFixture(self.tmpdir)
+
+    def _create(self, name: str) -> str:
+        p = Path(self.tmpdir) / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("test", encoding="utf-8")
+        return str(p)
+
+    def test_windows_path(self):
+        fp = self._create("readme.md")
+        text = f"文件内容在 `{fp}` 中"
+        files = self.fix.agent._extract_paths_from_text(text)
+        self.assertTrue(
+            any(Path(f).samefile(Path(fp)) for f in files), f"Expected {fp} in {files}"
+        )
+
+    def test_windows_path_with_spaces(self):
+        fp = self._create("26 GF long/Long-Paper-V1.pdf")
+        text = f"完整路径是：{fp}"
+        files = self.fix.agent._extract_paths_from_text(text)
+        self.assertTrue(
+            any(Path(f).samefile(Path(fp)) for f in files), f"Expected {fp} in {files}"
+        )
+
+    def test_unix_style_path(self):
+        fp = self._create("config.json")
+        text = f"请查看 {fp}"
+        files = self.fix.agent._extract_paths_from_text(text)
+        self.assertTrue(any(Path(f).samefile(Path(fp)) for f in files))
+
+    def test_backtick_path(self):
+        fp = self._create("notes.txt")
+        text = f"结果在 `{fp}`"
+        files = self.fix.agent._extract_paths_from_text(text)
+        self.assertTrue(any(Path(f).samefile(Path(fp)) for f in files))
+
+    def test_nonexistent_ignored(self):
+        text = "文件在 `C:\\nonexistent\\file.txt`"
+        self.assertEqual(self.fix.agent._extract_paths_from_text(text), [])
+
+    def test_mac_style_path(self):
+        fp = self._create("src/main.ts")
+        text = f"Created {fp}"
+        files = self.fix.agent._extract_paths_from_text(text)
+        self.assertTrue(any(Path(f).samefile(Path(fp)) for f in files))
+
+    def test_dedup(self):
+        fp = self._create("dup.txt")
+        text = f"`{fp}` and also `{fp}`"
+        self.assertEqual(len(self.fix.agent._extract_paths_from_text(text)), 1)
+
+    def test_chinese_trailing_punct(self):
+        fp = self._create("data.csv")
+        text = f"文件：{fp}，请查看"
+        files = self.fix.agent._extract_paths_from_text(text)
+        self.assertTrue(any(Path(f).samefile(Path(fp)) for f in files))
+
+    def test_slash_path_mac(self):
+        tmpdir2 = tempfile.mkdtemp()
+        fp = Path(tmpdir2) / "report.md"
+        fp.write_text("# Report", encoding="utf-8")
+        native_path = str(fp)
+        text = f"Generated report at {native_path}"
+        files = self.fix.agent._extract_paths_from_text(text)
+        self.assertTrue(
+            any(Path(f).samefile(fp) for f in files),
+            f"Expected {native_path} in {files}",
+        )
+
+
+class TestValidateFile(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.fix = _AgentFixture(self.tmpdir)
+
+    def _create(self, name: str, size: int = 100) -> str:
+        p = Path(self.tmpdir) / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(b"x" * size)
+        return str(p)
+
+    def test_valid_file(self):
+        self.assertIsNotNone(
+            self.fix.agent._validate_file(self._create("good.txt"), self.tmpdir)
+        )
+
+    def test_nonexistent(self):
+        self.assertIsNone(
+            self.fix.agent._validate_file(
+                os.path.join(self.tmpdir, "nope.txt"), self.tmpdir
+            )
+        )
+
+    def test_directory(self):
+        sub = os.path.join(self.tmpdir, "subdir")
+        os.makedirs(sub, exist_ok=True)
+        self.assertIsNone(self.fix.agent._validate_file(sub, self.tmpdir))
+
+    def test_outside_workspace(self):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as f:
+            f.write(b"secret")
+            external = f.name
+        try:
+            self.assertIsNone(self.fix.agent._validate_file(external, self.tmpdir))
+        finally:
+            os.unlink(external)
+
+    def test_blocked_extensions(self):
+        for ext in [
+            ".env",
+            ".pem",
+            ".key",
+            ".p12",
+            ".pfx",
+            ".jks",
+            ".keystore",
+            ".secret",
+            ".credentials",
+            ".sqlite",
+            ".sqlite3",
+            ".db",
+            ".ldb",
+        ]:
+            with self.subTest(ext=ext):
+                self.assertIsNone(
+                    self.fix.agent._validate_file(
+                        self._create(f"bad{ext}"), self.tmpdir
+                    )
+                )
+
+    def test_allowed_code_files(self):
+        for name in [
+            "main.py",
+            "index.ts",
+            "config.json",
+            "readme.md",
+            "style.css",
+            "app.jsx",
+            "lib.rs",
+        ]:
+            with self.subTest(name=name):
+                self.assertIsNotNone(
+                    self.fix.agent._validate_file(self._create(name), self.tmpdir)
+                )
+
+    def test_nested_subdir_file(self):
+        nested = Path(self.tmpdir) / "src" / "deep" / "file.py"
+        nested.parent.mkdir(parents=True, exist_ok=True)
+        nested.write_text("code", encoding="utf-8")
+        self.assertIsNotNone(self.fix.agent._validate_file(str(nested), self.tmpdir))
+
+
+class TestSendFileToConv(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.fix = _AgentFixture(self.tmpdir)
+
+    def test_no_transport_returns_false(self):
+        self.fix.agent._bot_transport = None
+        ok = asyncio.get_event_loop().run_until_complete(
+            self.fix.agent._send_file_to_conv("conv1", "/some/file.txt")
+        )
+        self.assertFalse(ok)
+
+    @patch("aether_wechat_agent.shutil.which", return_value="bun")
+    @patch("aether_wechat_agent.subprocess.run")
+    def test_subprocess_exception_returns_false(self, run_mock, _which):
+        transport = MagicMock()
+        transport._client.token = "tok"
+        transport._client._base_url = "https://example.com"
+        transport.account_id = "aether"
+        self.fix.agent._bot_transport = transport
+        self.fix.agent._wechat_ctx = {"conv1": "ctx"}
+        fp = str(Path(self.tmpdir) / "test.txt")
+        Path(fp).write_text("hello", encoding="utf-8")
+        Path(self.fix.agent._sender_script).write_text("", encoding="utf-8")
+        run_mock.side_effect = RuntimeError("upload failed")
+        ok = asyncio.get_event_loop().run_until_complete(
+            self.fix.agent._send_file_to_conv("conv1", fp)
+        )
+        self.assertFalse(ok)
+
+    @patch("aether_wechat_agent.shutil.which", return_value="bun")
+    @patch("aether_wechat_agent.subprocess.run")
+    def test_transport_success(self, run_mock, _which):
+        transport = MagicMock()
+        transport._client.token = "tok123"
+        transport._client._base_url = "https://example.com"
+        transport.account_id = "aether"
+        self.fix.agent._bot_transport = transport
+        self.fix.agent._wechat_ctx = {"conv1": "ctx123"}
+        fp = str(Path(self.tmpdir) / "test.txt")
+        Path(fp).write_text("hello", encoding="utf-8")
+        Path(self.fix.agent._sender_script).write_text("", encoding="utf-8")
+        run_mock.return_value = types.SimpleNamespace(
+            returncode=0, stdout='{"ok":true}', stderr=""
+        )
+        ok = asyncio.get_event_loop().run_until_complete(
+            self.fix.agent._send_file_to_conv("conv1", fp)
+        )
+        self.assertTrue(ok)
+        cmd = run_mock.call_args.args[0]
+        self.assertIn("--chat-id", cmd)
+        self.assertIn("conv1", cmd)
+        self.assertIn("--context-token", cmd)
+        self.assertIn("ctx123", cmd)
+        self.assertIn("--cdn-base-url", cmd)
+
+    @patch("aether_wechat_agent.shutil.which", return_value="bun")
+    def test_missing_context_returns_false(self, _which):
+        transport = MagicMock()
+        transport._client.token = "tok123"
+        transport._client._base_url = "https://example.com"
+        transport.account_id = "aether"
+        self.fix.agent._bot_transport = transport
+        fp = str(Path(self.tmpdir) / "test.txt")
+        Path(fp).write_text("hello", encoding="utf-8")
+        Path(self.fix.agent._sender_script).write_text("", encoding="utf-8")
+        ok = asyncio.get_event_loop().run_until_complete(
+            self.fix.agent._send_file_to_conv("conv1", fp)
+        )
+        self.assertFalse(ok)
+
+
+class TestTrySendFiles(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.fix = _AgentFixture(self.tmpdir)
+
+    def test_no_candidates_silently_returns(self):
+        async def run():
+            await self.fix.agent._try_send_files(
+                "conv1", "sid", self.tmpdir, "no paths here"
+            )
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+    def test_all_blocked_no_send(self):
+        env_file = Path(self.tmpdir) / ".env"
+        env_file.write_text("SECRET=123", encoding="utf-8")
+        self.fix.agent._last_result["conv1"] = {
+            "parts": [
+                {
+                    "type": "tool",
+                    "tool": "read",
+                    "state": {
+                        "status": "completed",
+                        "input": {"filePath": str(env_file)},
+                        "output": "env",
+                    },
+                },
+            ]
+        }
+        self.fix.agent._send_file_to_conv = AsyncMock(return_value=False)
+
+        async def run():
+            await self.fix.agent._try_send_files("conv1", "sid", self.tmpdir, "")
+
+        asyncio.get_event_loop().run_until_complete(run())
+        self.fix.agent._send_file_to_conv.assert_not_called()
+
+    def test_sends_valid_files(self):
+        good = Path(self.tmpdir) / "result.txt"
+        good.write_text("data", encoding="utf-8")
+        self.fix.agent._last_result["conv1"] = {
+            "parts": [
+                {
+                    "type": "tool",
+                    "tool": "read",
+                    "state": {
+                        "status": "completed",
+                        "input": {"filePath": str(good)},
+                        "output": "content",
+                    },
+                },
+            ]
+        }
+        self.fix.agent._send_file_to_conv = AsyncMock(return_value=True)
+
+        async def run():
+            await self.fix.agent._try_send_files("conv1", "sid", self.tmpdir, "")
+
+        asyncio.get_event_loop().run_until_complete(run())
+        self.fix.agent._send_file_to_conv.assert_called_once_with("conv1", str(good))
+
+    def test_mixed_valid_and_blocked(self):
+        good = Path(self.tmpdir) / "ok.py"
+        good.write_text("code", encoding="utf-8")
+        bad = Path(self.tmpdir) / "secret.key"
+        bad.write_text("key", encoding="utf-8")
+        self.fix.agent._last_result["conv1"] = {
+            "parts": [
+                {
+                    "type": "tool",
+                    "tool": "read",
+                    "state": {
+                        "status": "completed",
+                        "input": {"filePath": str(good)},
+                        "output": "g",
+                    },
+                },
+                {
+                    "type": "tool",
+                    "tool": "read",
+                    "state": {
+                        "status": "completed",
+                        "input": {"filePath": str(bad)},
+                        "output": "b",
+                    },
+                },
+            ]
+        }
+        sent_files = []
+        self.fix.agent._send_file_to_conv = AsyncMock(
+            side_effect=lambda cid, fp: sent_files.append(fp)
+        )
+
+        async def run():
+            await self.fix.agent._try_send_files("conv1", "sid", self.tmpdir, "")
+
+        asyncio.get_event_loop().run_until_complete(run())
+        self.assertEqual(len(sent_files), 1)
+        self.assertTrue(Path(sent_files[0]).samefile(good))
+
+    def test_fallback_to_text_paths(self):
+        good = Path(self.tmpdir) / "from_text.md"
+        good.write_text("# doc", encoding="utf-8")
+        self.fix.agent._last_result["conv1"] = {"parts": []}
+        self.fix.agent._send_file_to_conv = AsyncMock(return_value=True)
+        text = f"文件已生成：`{good}`"
+
+        async def run():
+            await self.fix.agent._try_send_files("conv1", "sid", self.tmpdir, text)
+
+        asyncio.get_event_loop().run_until_complete(run())
+        self.fix.agent._send_file_to_conv.assert_called_once()
+
+    def test_all_send_fail_sends_path_notice(self):
+        good = Path(self.tmpdir) / "fail.txt"
+        good.write_text("x", encoding="utf-8")
+        self.fix.agent._last_result["conv1"] = {
+            "parts": [
+                {
+                    "type": "tool",
+                    "tool": "read",
+                    "state": {
+                        "status": "completed",
+                        "input": {"filePath": str(good)},
+                        "output": "x",
+                    },
+                },
+            ]
+        }
+        self.fix.agent._send_file_to_conv = AsyncMock(return_value=False)
+        sent_messages = []
+        self.fix.agent._send_to_conv = AsyncMock(
+            side_effect=lambda cid, txt: sent_messages.append(txt)
+        )
+
+        async def run():
+            await self.fix.agent._try_send_files("conv1", "sid", self.tmpdir, "")
+
+        asyncio.get_event_loop().run_until_complete(run())
+        self.assertTrue(any("发送失败" in m for m in sent_messages))
+
+    def test_max_5_files(self):
+        parts = []
+        for i in range(8):
+            p = Path(self.tmpdir) / f"f{i}.txt"
+            p.write_text(str(i), encoding="utf-8")
+            parts.append(
+                {
+                    "type": "tool",
+                    "tool": "read",
+                    "state": {
+                        "status": "completed",
+                        "input": {"filePath": str(p)},
+                        "output": "x",
+                    },
+                }
+            )
+        self.fix.agent._last_result["conv1"] = {"parts": parts}
+        sent_files = []
+        self.fix.agent._send_file_to_conv = AsyncMock(
+            side_effect=lambda cid, fp: sent_files.append(fp)
+        )
+
+        async def run():
+            await self.fix.agent._try_send_files("conv1", "sid", self.tmpdir, "")
+
+        asyncio.get_event_loop().run_until_complete(run())
+        self.assertLessEqual(len(sent_files), 5)
+
+
+class TestBackgroundDispatchIntegration(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.fix = _AgentFixture(self.tmpdir)
+
+    def test_no_intent_skips_file_send(self):
+        self.fix.agent._last_user_text["conv1"] = "请解释这段代码"
+        self.fix.agent._send_to_conv = AsyncMock()
+        self.fix.agent._try_send_files = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.text = "这段代码是..."
+        self.fix.agent._wait_for_response = AsyncMock(return_value=mock_resp)
+
+        async def run():
+            await self.fix.agent._background_dispatch(
+                "conv1", "sid", self.tmpdir, MagicMock(), MagicMock()
+            )
+
+        asyncio.get_event_loop().run_until_complete(run())
+        self.fix.agent._try_send_files.assert_not_called()
+
+    def test_with_intent_calls_file_send(self):
+        self.fix.agent._last_user_text["conv1"] = "把源文件发给我"
+        self.fix.agent._send_to_conv = AsyncMock()
+        self.fix.agent._try_send_files = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.text = "文件内容如上"
+        self.fix.agent._wait_for_response = AsyncMock(return_value=mock_resp)
+
+        async def run():
+            await self.fix.agent._background_dispatch(
+                "conv1", "sid", self.tmpdir, MagicMock(), MagicMock()
+            )
+
+        asyncio.get_event_loop().run_until_complete(run())
+        self.fix.agent._try_send_files.assert_called_once_with(
+            "conv1", "sid", self.tmpdir, "文件内容如上"
+        )
+
+    def test_file_send_exception_doesnt_crash(self):
+        self.fix.agent._last_user_text["conv1"] = "发给我"
+        self.fix.agent._send_to_conv = AsyncMock()
+        self.fix.agent._try_send_files = AsyncMock(side_effect=RuntimeError("boom"))
+        mock_resp = MagicMock()
+        mock_resp.text = "结果"
+        self.fix.agent._wait_for_response = AsyncMock(return_value=mock_resp)
+
+        async def run():
+            await self.fix.agent._background_dispatch(
+                "conv1", "sid", self.tmpdir, MagicMock(), MagicMock()
+            )
+
+        asyncio.get_event_loop().run_until_complete(run())
+        self.fix.agent._send_to_conv.assert_called()
+
+
+class TestSlashCommandsUntouched(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.fix = _AgentFixture(self.tmpdir)
+
+    def test_help_text_unchanged(self):
+        self.assertIn("/help", HELP_TEXT)
+        self.assertIn("/new", HELP_TEXT)
+        self.assertIn("/model", HELP_TEXT)
+
+    def test_commands_no_file_intent(self):
+        for cmd in [
+            "/new",
+            "/stop",
+            "/compact",
+            "/model",
+            "/model list",
+            "/agent build",
+            "/variant",
+            "/approval auto",
+            "/project",
+            "/project list",
+            "/session",
+            "/help",
+        ]:
+            with self.subTest(cmd=cmd):
+                self.assertFalse(self.fix.agent._detect_file_intent(cmd))
+
+    def test_file_prompt_keeps_commands_unchanged(self):
+        for cmd in [
+            "/new",
+            "/stop",
+            "/compact",
+            "/model",
+            "/project",
+            "/session",
+            "/help",
+        ]:
+            with self.subTest(cmd=cmd):
+                self.assertEqual(self.fix.agent._file_prompt(cmd), cmd)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,9 @@
         "@opencode-ai/plugin": "workspace:*",
         "@opencode-ai/script": "workspace:*",
         "@opencode-ai/sdk": "workspace:*",
+        "@tencent-weixin/openclaw-weixin": "2.1.8",
         "typescript": "catalog:",
+        "wechat-ilink-client": "0.1.0",
       },
       "devDependencies": {
         "@actions/artifact": "5.0.1",
@@ -2155,6 +2157,8 @@
 
     "@tediousjs/connection-string": ["@tediousjs/connection-string@0.5.0", "https://registry.npmmirror.com/@tediousjs/connection-string/-/connection-string-0.5.0.tgz", {}, "sha512-7qSgZbincDDDFyRweCIEvZULFAw5iz/DeunhvuxpL31nfntX3P4Yd4HkHBRg9H8CdqY1e5WFN1PZIz/REL9MVQ=="],
 
+    "@tencent-weixin/openclaw-weixin": ["@tencent-weixin/openclaw-weixin@2.1.8", "", { "dependencies": { "qrcode-terminal": "0.12.0", "zod": "4.3.6" } }, "sha512-YM2fumDI+NvslhFH4gsek+scgCwTdyz7eMDyfNadCTXPjh9hoosn8tcMF0P90gQJEGEud7AJXiKKd8IKGNCfRA=="],
+
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "https://registry.npmmirror.com/@testing-library/dom/-/dom-10.4.1.tgz", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
     "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "https://registry.npmmirror.com/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
@@ -4135,6 +4139,8 @@
 
     "pure-rand": ["pure-rand@8.0.0", "https://registry.npmmirror.com/pure-rand/-/pure-rand-8.0.0.tgz", {}, "sha512-7rgWlxG2gAvFPIQfUreo1XYlNvrQ9VnQPFWdncPkdl3icucLK0InOxsaafbvxGTnI6Bk/Rxmslg0lQlRCuzOXw=="],
 
+    "qrcode-terminal": ["qrcode-terminal@0.12.0", "", { "bin": { "qrcode-terminal": "./bin/qrcode-terminal.js" } }, "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ=="],
+
     "qs": ["qs@6.15.0", "https://registry.npmmirror.com/qs/-/qs-6.15.0.tgz", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
 
     "quansync": ["quansync@0.2.11", "https://registry.npmmirror.com/quansync/-/quansync-0.2.11.tgz", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
@@ -4837,6 +4843,8 @@
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "https://registry.npmmirror.com/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
+    "wechat-ilink-client": ["wechat-ilink-client@0.1.0", "", { "optionalDependencies": { "qrcode-terminal": "^0.12.0" } }, "sha512-/gsWGEGEsWA7C5cgfKtguCL7QPdT95I1HfHHiRcHtwQppwVfgD8aDL4m4soANp1qQDl5RgiJ7q9gh9X5cXUfqA=="],
+
     "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "https://registry.npmmirror.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "whatwg-url": ["whatwg-url@5.0.0", "https://registry.npmmirror.com/whatwg-url/-/whatwg-url-5.0.0.tgz", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
@@ -5456,6 +5464,8 @@
     "@tanstack/router-utils/diff": ["diff@8.0.3", "https://registry.npmmirror.com/diff/-/diff-8.0.3.tgz", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 
     "@tanstack/server-functions-plugin/@babel/code-frame": ["@babel/code-frame@7.27.1", "https://registry.npmmirror.com/@babel/code-frame/-/code-frame-7.27.1.tgz", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
+
+    "@tencent-weixin/openclaw-weixin/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "https://registry.npmmirror.com/aria-query/-/aria-query-5.3.0.tgz", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,9 @@
     "@opencode-ai/plugin": "workspace:*",
     "@opencode-ai/script": "workspace:*",
     "@opencode-ai/sdk": "workspace:*",
-    "typescript": "catalog:"
+    "@tencent-weixin/openclaw-weixin": "2.1.8",
+    "typescript": "catalog:",
+    "wechat-ilink-client": "0.1.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Issue for this PR

Closes #315

### Type of change

- [x] New feature

### What does this PR do?

Adds the ability for WeChat users to request and receive file attachments through the Aether WeChat bridge. When a user sends a message containing file-sending intent keywords (e.g. "send me", "发给我"), the bridge:

1. Injects a system prompt into the LLM request asking it to include absolute file paths in its response
2. Extracts file paths from the LLM response (from `read` tool calls or from text)
3. Validates files (workspace scope, size ≤30MB, blocked extensions/names like `.env`, `.key`)
4. Sends validated files as WeChat attachments via a new `send_file.ts` Bun script that handles CDN upload (AES encryption) and message delivery through the iLink Bot API

Also includes:
- `send_file.ts`: standalone Bun script for WeChat file upload/send
- `test_file_send.py`: unit tests covering intent detection, path extraction, validation, and send orchestration
- Cleaned up debug logging and README formatting

### How did you verify your code works?

- Ran `test_file_send.py` covering intent detection (positive/negative), path extraction (Windows/macOS/Linux), file validation (workspace scope, blocked extensions, size limits), send orchestration, and slash command immunity
- Manual testing with WeChat conversation file requests

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR