### PR TITLE
feat: improve session batch management, Feishu file detection, and minor UI/file fixes

### DIFF
--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -999,6 +999,14 @@ export const dict = {
   "session.delete.confirm": 'Delete session "{{name}}"?',
   "session.delete.button": "Delete session",
 
+  "session.select": "Select",
+  "session.selectAll": "Select all",
+  "session.deselectAll": "Deselect all",
+  "session.cancelSelect": "Cancel",
+  "session.batch.archive": "Archive ({{count}})",
+  "session.batch.delete": "Delete ({{count}})",
+  "session.batch.delete.confirm": "Delete {{count}} sessions?",
+
   "workspace.new": "New workspace",
   "workspace.type.local": "local",
   "workspace.type.sandbox": "sandbox",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -888,6 +888,14 @@ export const dict = {
   "session.delete.confirm": '删除会话 "{{name}}"？',
   "session.delete.button": "删除会话",
 
+  "session.select": "选择",
+  "session.selectAll": "全选",
+  "session.deselectAll": "取消全选",
+  "session.cancelSelect": "取消",
+  "session.batch.archive": "归档 ({{count}})",
+  "session.batch.delete": "删除 ({{count}})",
+  "session.batch.delete.confirm": "删除 {{count}} 个会话？",
+
   "workspace.new": "新建工作区",
   "workspace.type.local": "本地",
   "workspace.type.sandbox": "沙盒",

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -89,6 +89,9 @@ export type SessionItemProps = {
   unarchiveSession?: (session: Session) => Promise<void>
   deleteSession?: (session: Session) => Promise<void>
   renameSession?: (session: Session, title: string) => Promise<void>
+  selectMode?: Accessor<boolean>
+  selected?: Accessor<boolean>
+  onToggleSelect?: (session: Session) => void
 }
 
 const sessionHref = (slug: string, session: Session, hash?: string) =>
@@ -111,6 +114,9 @@ const SessionRow = (props: {
   warmPress: () => void
   warmFocus: () => void
   cancelHoverPrefetch: () => void
+  selectMode?: Accessor<boolean>
+  selected?: Accessor<boolean>
+  onToggleSelect?: () => void
 }): JSX.Element => (
   <A
     href={sessionHref(props.slug, props.session)}
@@ -119,7 +125,12 @@ const SessionRow = (props: {
     onPointerEnter={props.warmHover}
     onPointerLeave={props.cancelHoverPrefetch}
     onFocus={props.warmFocus}
-    onClick={() => {
+    onClick={(e) => {
+      if (props.selectMode?.()) {
+        e.preventDefault()
+        props.onToggleSelect?.()
+        return
+      }
       props.setHoverSession(undefined)
       if (props.sidebarOpened()) return
       props.clearHoverProjectSoon()
@@ -129,20 +140,45 @@ const SessionRow = (props: {
       class="shrink-0 size-6 flex items-center justify-center"
       style={{ color: props.tint() ?? "var(--icon-interactive-base)" }}
     >
-      <Switch fallback={<Icon name="dash" size="small" class="text-icon-weak" />}>
-        <Match when={props.isWorking()}>
-          <Spinner class="size-[15px]" />
-        </Match>
-        <Match when={props.hasPermissions()}>
-          <div class="size-1.5 rounded-full bg-surface-warning-strong" />
-        </Match>
-        <Match when={props.hasError()}>
-          <div class="size-1.5 rounded-full bg-text-diff-delete-base" />
-        </Match>
-        <Match when={props.unseenCount() > 0}>
-          <div class="size-1.5 rounded-full bg-text-interactive-base" />
-        </Match>
-      </Switch>
+      <Show
+        when={props.selectMode?.()}
+        fallback={
+          <Switch fallback={<Icon name="dash" size="small" class="text-icon-weak" />}>
+            <Match when={props.isWorking()}>
+              <Spinner class="size-[15px]" />
+            </Match>
+            <Match when={props.hasPermissions()}>
+              <div class="size-1.5 rounded-full bg-surface-warning-strong" />
+            </Match>
+            <Match when={props.hasError()}>
+              <div class="size-1.5 rounded-full bg-text-diff-delete-base" />
+            </Match>
+            <Match when={props.unseenCount() > 0}>
+              <div class="size-1.5 rounded-full bg-text-interactive-base" />
+            </Match>
+          </Switch>
+        }
+      >
+        <div
+          class={`size-3.5 rounded-sm border flex items-center justify-center transition-colors ${
+            props.selected?.()
+              ? "bg-text-interactive-base border-text-interactive-base"
+              : "border-icon-weak bg-transparent"
+          }`}
+        >
+          <Show when={props.selected?.()}>
+            <svg viewBox="0 0 12 12" fill="none" width="8" height="8" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M2 6.5L4.5 9L10 3"
+                stroke="white"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </Show>
+        </div>
+      </Show>
     </div>
     <Show when={props.session.readingMode}>
       <span class="shrink-0 rounded bg-surface-raised-base px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-text-muted">
@@ -346,6 +382,9 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
       warmPress={() => warm(2, "high")}
       warmFocus={() => warm(2, "high")}
       cancelHoverPrefetch={cancelHoverPrefetch}
+      selectMode={props.selectMode}
+      selected={props.selected}
+      onToggleSelect={() => props.onToggleSelect?.(props.session)}
     />
   )
 
@@ -427,7 +466,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
             </Show>
           </div>
 
-          <Show when={!renaming()}>
+          <Show when={!renaming() && !props.selectMode?.()}>
             <div
               class={`absolute ${props.dense ? "top-0.5 right-0.5" : "top-1 right-1"} flex items-center gap-0.5 transition-opacity`}
               classList={{

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -7,6 +7,8 @@ import { base64Encode } from "@opencode-ai/util/encode"
 import { getFilename } from "@opencode-ai/util/path"
 import { Button } from "@opencode-ai/ui/button"
 import { Collapsible } from "@opencode-ai/ui/collapsible"
+import { Dialog } from "@opencode-ai/ui/dialog"
+import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { DropdownMenu } from "@opencode-ai/ui/dropdown-menu"
 import { Icon } from "@opencode-ai/ui/icon"
 import { IconButton } from "@opencode-ai/ui/icon-button"
@@ -19,6 +21,72 @@ import { useGlobalSDK } from "@/context/global-sdk"
 import { useLanguage } from "@/context/language"
 import { NewSessionItem, SessionItem, SessionSkeleton } from "./sidebar-items"
 import { childMapByParent, sortedRootSessions, workspaceKey } from "./helpers"
+
+function createBatchSelect(
+  sessions: Accessor<Session[]>,
+  archiveSession: (s: Session) => Promise<void>,
+  deleteSession: (s: Session) => Promise<void>,
+  dialog: ReturnType<typeof useDialog>,
+  language: ReturnType<typeof useLanguage>,
+) {
+  const [selectMode, setSelectMode] = createSignal(false)
+  const [selectedIds, setSelectedIds] = createSignal<Set<string>>(new Set<string>())
+
+  const enterSelect = () => setSelectMode(true)
+  const cancelSelect = () => {
+    setSelectMode(false)
+    setSelectedIds(new Set<string>())
+  }
+  const toggleSelect = (session: Session) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(session.id)) next.delete(session.id)
+      else next.add(session.id)
+      return next
+    })
+  }
+  const selectAll = () => setSelectedIds(new Set(sessions().map((s) => s.id)))
+  const deselectAll = () => setSelectedIds(new Set<string>())
+
+  const batchArchive = async () => {
+    const ids = selectedIds()
+    await Promise.all(sessions().filter((s) => ids.has(s.id)).map((s) => archiveSession(s)))
+    cancelSelect()
+  }
+
+  const batchDelete = () => {
+    const targets = sessions().filter((s) => selectedIds().has(s.id))
+    const count = targets.length
+    if (count === 0) return
+    dialog.show(() => (
+      <Dialog title={language.t("session.delete.title")} fit>
+        <div class="flex flex-col gap-4 pl-6 pr-2.5 pb-3">
+          <span class="text-14-regular text-text-strong">
+            {language.t("session.batch.delete.confirm", { count })}
+          </span>
+          <div class="flex justify-end gap-2">
+            <Button variant="ghost" size="large" onClick={() => dialog.close()}>
+              {language.t("common.cancel")}
+            </Button>
+            <Button
+              variant="primary"
+              size="large"
+              onClick={async () => {
+                await Promise.all(targets.map((s) => deleteSession(s)))
+                dialog.close()
+                cancelSelect()
+              }}
+            >
+              {language.t("session.batch.delete", { count })}
+            </Button>
+          </div>
+        </div>
+      </Dialog>
+    ))
+  }
+
+  return { selectMode, selectedIds, enterSelect, cancelSelect, toggleSelect, selectAll, deselectAll, batchArchive, batchDelete }
+}
 
 type InlineEditorComponent = (props: {
   id: string
@@ -159,6 +227,7 @@ const WorkspaceActions = (props: {
   setHoverSession: WorkspaceSidebarContext["setHoverSession"]
   clearHoverProjectSoon: WorkspaceSidebarContext["clearHoverProjectSoon"]
   navigateToNewSession: () => void
+  onEnterSelect: () => void
 }): JSX.Element => (
   <div
     class="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5 transition-opacity"
@@ -202,6 +271,14 @@ const WorkspaceActions = (props: {
             }}
           >
             <DropdownMenu.ItemLabel>{props.language.t("common.rename")}</DropdownMenu.ItemLabel>
+          </DropdownMenu.Item>
+          <DropdownMenu.Item
+            onSelect={() => {
+              props.setMenuOpen(false)
+              props.onEnterSelect()
+            }}
+          >
+            <DropdownMenu.ItemLabel>{props.language.t("session.select")}</DropdownMenu.ItemLabel>
           </DropdownMenu.Item>
           <DropdownMenu.Item
             disabled={props.local() || props.busy()}
@@ -343,60 +420,122 @@ const WorkspaceSessionList = (props: {
   hasMore: Accessor<boolean>
   loadMore: () => Promise<void>
   language: ReturnType<typeof useLanguage>
-}): JSX.Element => (
-  <nav class="flex flex-col gap-1">
-    <Show when={props.showNew()}>
-      <NewSessionItem
-        slug={props.slug()}
-        mobile={props.mobile}
-        sidebarExpanded={props.ctx.sidebarExpanded}
-        clearHoverProjectSoon={props.ctx.clearHoverProjectSoon}
-        setHoverSession={props.ctx.setHoverSession}
-      />
-    </Show>
-    <Show when={props.loading()}>
-      <SessionSkeleton />
-    </Show>
-    <For each={props.sessions()}>
-      {(session) => (
-        <SessionItem
-          session={session}
-          list={props.sessions()}
-          navList={props.ctx.navList}
-          slug={props.slug()}
-          mobile={props.mobile}
-          popover={props.popover}
-          children={props.children()}
-          sidebarExpanded={props.ctx.sidebarExpanded}
-          sidebarHovering={props.ctx.sidebarHovering}
-          nav={props.ctx.nav}
-          hoverSession={props.ctx.hoverSession}
-          setHoverSession={props.ctx.setHoverSession}
-          clearHoverProjectSoon={props.ctx.clearHoverProjectSoon}
-          prefetchSession={props.ctx.prefetchSession}
-          archiveSession={props.ctx.archiveSession}
-          deleteSession={props.ctx.deleteSession}
-          renameSession={props.ctx.renameSession}
-        />
-      )}
-    </For>
-    <Show when={props.hasMore()}>
-      <div class="relative w-full py-1">
-        <Button
-          variant="ghost"
-          class="flex w-full text-left justify-start text-14-regular text-text-weak pl-9 pr-10"
-          size="large"
-          onClick={(e: MouseEvent) => {
-            props.loadMore()
-            ;(e.currentTarget as HTMLButtonElement).blur()
-          }}
-        >
-          {props.language.t("common.loadMore")}
-        </Button>
-      </div>
-    </Show>
-  </nav>
-)
+  selectMode: Accessor<boolean>
+  selectedIds: Accessor<Set<string>>
+  onToggleSelect: (session: Session) => void
+  onSelectAll: () => void
+  onDeselectAll: () => void
+  onBatchArchive: () => Promise<void>
+  onBatchDelete: () => void
+  onCancelSelect: () => void
+}): JSX.Element => {
+  const selectedCount = createMemo(() => props.selectedIds().size)
+  const allSelected = createMemo(
+    () => props.sessions().length > 0 && props.selectedIds().size === props.sessions().length,
+  )
+
+  return (
+    <div class="flex flex-col gap-1">
+      <Show when={props.selectMode()}>
+        <div class="flex items-center gap-1 pl-2 pr-1 py-0.5">
+          <Button
+            variant="ghost"
+            size="small"
+            class="text-12-regular text-text-weak px-1 h-6 shrink-0"
+            onClick={() => (allSelected() ? props.onDeselectAll() : props.onSelectAll())}
+          >
+            {allSelected() ? props.language.t("session.deselectAll") : props.language.t("session.selectAll")}
+          </Button>
+          <div class="flex-1" />
+          <Show when={selectedCount() > 0}>
+            <Tooltip value={props.language.t("session.batch.delete", { count: selectedCount() })} placement="top">
+              <IconButton
+                icon="trash"
+                variant="ghost"
+                class="size-6 rounded-md"
+                aria-label={props.language.t("session.batch.delete", { count: selectedCount() })}
+                onClick={props.onBatchDelete}
+              />
+            </Tooltip>
+            <Tooltip value={props.language.t("session.batch.archive", { count: selectedCount() })} placement="top">
+              <IconButton
+                icon="archive"
+                variant="ghost"
+                class="size-6 rounded-md"
+                aria-label={props.language.t("session.batch.archive", { count: selectedCount() })}
+                onClick={() => void props.onBatchArchive()}
+              />
+            </Tooltip>
+          </Show>
+          <Tooltip value={props.language.t("session.cancelSelect")} placement="top">
+            <IconButton
+              icon="close"
+              variant="ghost"
+              class="size-6 rounded-md"
+              aria-label={props.language.t("session.cancelSelect")}
+              onClick={props.onCancelSelect}
+            />
+          </Tooltip>
+        </div>
+      </Show>
+      <nav class="flex flex-col gap-1">
+        <Show when={props.showNew() && !props.selectMode()}>
+          <NewSessionItem
+            slug={props.slug()}
+            mobile={props.mobile}
+            sidebarExpanded={props.ctx.sidebarExpanded}
+            clearHoverProjectSoon={props.ctx.clearHoverProjectSoon}
+            setHoverSession={props.ctx.setHoverSession}
+          />
+        </Show>
+        <Show when={props.loading()}>
+          <SessionSkeleton />
+        </Show>
+        <For each={props.sessions()}>
+          {(session) => (
+            <SessionItem
+              session={session}
+              list={props.sessions()}
+              navList={props.ctx.navList}
+              slug={props.slug()}
+              mobile={props.mobile}
+              popover={props.popover}
+              children={props.children()}
+              sidebarExpanded={props.ctx.sidebarExpanded}
+              sidebarHovering={props.ctx.sidebarHovering}
+              nav={props.ctx.nav}
+              hoverSession={props.ctx.hoverSession}
+              setHoverSession={props.ctx.setHoverSession}
+              clearHoverProjectSoon={props.ctx.clearHoverProjectSoon}
+              prefetchSession={props.ctx.prefetchSession}
+              archiveSession={props.ctx.archiveSession}
+              deleteSession={props.ctx.deleteSession}
+              renameSession={props.ctx.renameSession}
+              selectMode={props.selectMode}
+              selected={() => props.selectedIds().has(session.id)}
+              onToggleSelect={props.onToggleSelect}
+            />
+          )}
+        </For>
+        <Show when={props.hasMore() && !props.selectMode()}>
+          <div class="relative w-full py-1">
+            <Button
+              variant="ghost"
+              class="flex w-full text-left justify-start text-14-regular text-text-weak pl-9 pr-10"
+              size="large"
+              onClick={(e: MouseEvent) => {
+                props.loadMore()
+                ;(e.currentTarget as HTMLButtonElement).blur()
+              }}
+            >
+              {props.language.t("common.loadMore")}
+            </Button>
+          </div>
+        </Show>
+      </nav>
+    </div>
+  )
+}
 
 export const SortableWorkspace = (props: {
   ctx: WorkspaceSidebarContext
@@ -409,6 +548,7 @@ export const SortableWorkspace = (props: {
   const params = useParams()
   const globalSync = useGlobalSync()
   const language = useLanguage()
+  const dialog = useDialog()
   const sortable = createSortable(props.directory)
   const [workspaceStore, setWorkspaceStore] = globalSync.child(props.directory, { bootstrap: false })
   const [menu, setMenu] = createStore({
@@ -439,6 +579,9 @@ export const SortableWorkspace = (props: {
     setWorkspaceStore("limit", (limit) => (limit ?? 0) + 5)
     await globalSync.project.loadSessions(props.directory)
   }
+
+  const { selectMode, selectedIds, enterSelect, cancelSelect, toggleSelect, selectAll, deselectAll, batchArchive, batchDelete } =
+    createBatchSelect(sessions, props.ctx.archiveSession, props.ctx.deleteSession, dialog, language)
 
   const workspaceEditActive = createMemo(() => props.ctx.editorOpen(`workspace:${props.directory}`))
   const header = () => (
@@ -527,6 +670,7 @@ export const SortableWorkspace = (props: {
                 setHoverSession={props.ctx.setHoverSession}
                 clearHoverProjectSoon={props.ctx.clearHoverProjectSoon}
                 navigateToNewSession={() => props.ctx.createSession(props.directory)}
+                onEnterSelect={enterSelect}
               />
             </div>
           </div>
@@ -545,6 +689,14 @@ export const SortableWorkspace = (props: {
             hasMore={hasMore}
             loadMore={loadMore}
             language={language}
+            selectMode={selectMode}
+            selectedIds={selectedIds}
+            onToggleSelect={toggleSelect}
+            onSelectAll={selectAll}
+            onDeselectAll={deselectAll}
+            onBatchArchive={batchArchive}
+            onBatchDelete={batchDelete}
+            onCancelSelect={cancelSelect}
           />
           <ArchivedSessionList
             directory={props.directory}
@@ -569,6 +721,7 @@ export const LocalWorkspace = (props: {
 }): JSX.Element => {
   const globalSync = useGlobalSync()
   const language = useLanguage()
+  const dialog = useDialog()
   const workspace = createMemo(() => {
     const [store, setStore] = globalSync.child(props.project.worktree)
     return { store, setStore }
@@ -584,6 +737,9 @@ export const LocalWorkspace = (props: {
     workspace().setStore("limit", (limit) => (limit ?? 0) + 5)
     await globalSync.project.loadSessions(props.project.worktree)
   }
+
+  const { selectMode, selectedIds, cancelSelect, toggleSelect, selectAll, deselectAll, batchArchive, batchDelete } =
+    createBatchSelect(sessions, props.ctx.archiveSession, props.ctx.deleteSession, dialog, language)
 
   return (
     <div
@@ -602,6 +758,14 @@ export const LocalWorkspace = (props: {
         hasMore={hasMore}
         loadMore={loadMore}
         language={language}
+        selectMode={selectMode}
+        selectedIds={selectedIds}
+        onToggleSelect={toggleSelect}
+        onSelectAll={selectAll}
+        onDeselectAll={deselectAll}
+        onBatchArchive={batchArchive}
+        onBatchDelete={batchDelete}
+        onCancelSelect={cancelSelect}
       />
       <ArchivedSessionList
         directory={props.project.worktree}

--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -418,11 +418,10 @@ export const SessionQuestionDock: Component<{
           </div>
           <IconButton
             data-slot="question-collapse-button"
-            data-collapsed={store.collapsed ? "true" : "false"}
             icon="chevron-down"
             size="normal"
-            variant="ghost"
-            style={{ transform: `rotate(${store.collapsed ? 180 : 0}deg)` }}
+            variant="primary"
+            style={{ transform: `rotate(${store.collapsed ? 180 : 0}deg)`, opacity: 0.6 }}
             onMouseDown={(event) => {
               event.preventDefault()
               event.stopPropagation()

--- a/packages/app/src/pages/session/composer/session-todo-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-todo-dock.tsx
@@ -185,8 +185,8 @@ export function SessionTodoDock(props: {
               data-collapsed={store.collapsed ? "true" : "false"}
               icon="chevron-down"
               size="normal"
-              variant="ghost"
-              style={{ transform: `rotate(${turn() * 180}deg)` }}
+              variant="primary"
+              style={{ transform: `rotate(${turn() * 180}deg)`, opacity: 0.6 }}
               onMouseDown={(event) => {
                 event.preventDefault()
                 event.stopPropagation()

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -834,9 +834,9 @@ class FeishuManagerImpl {
           console.log("[feishu] using model:", model ?? "(default)")
 
           let promptText = text
-          if (this.detectFileSendIntent(text)) {
+          if (this.mightWantFile(text)) {
             promptText +=
-              "\n\n[系统提示：用户需要通过飞书接收文件附件，请在回复中包含该文件在当前系统上的完整绝对路径。Windows 示例：E:\\\\work\\\\demo\\\\file.md；macOS/Linux 示例：/Users/demo/file.md 或 /home/demo/file.md。系统将自动把该路径对应的文件作为附件发送给用户。]"
+              "\n\n[系统提示：如果用户的意图是获取某个文件，请在回复中包含该文件在当前系统上的完整绝对路径。Windows 示例：E:\\\\work\\\\demo\\\\file.md；macOS/Linux 示例：/Users/demo/file.md 或 /home/demo/file.md。系统将自动把该路径对应的文件作为附件发送给用户。如果用户无需获取文件，请忽略本提示，正常回复即可。]"
           }
           const intent = this.detectSummaryIntent(text)
           if (intent.isSummary) {
@@ -902,16 +902,14 @@ class FeishuManagerImpl {
             console.log("[feishu] no text in response")
           }
 
-          if (this.detectFileSendIntent(text)) {
-            let filesToSend = this.extractReadFiles(msg)
-            if (filesToSend.length === 0 && responseText) {
-              filesToSend = this.extractFilePathsFromText(responseText)
-            }
-            if (filesToSend.length > 0) {
-              console.log("[feishu] sending", filesToSend.length, "requested file(s)")
-              for (const filePath of filesToSend.slice(0, 5)) {
-                await this.replyFile(messageId, filePath)
-              }
+          let filesToSend = this.extractReadFiles(msg)
+          if (filesToSend.length === 0 && responseText) {
+            filesToSend = this.extractFilePathsFromText(responseText).slice(0, 1)
+          }
+          if (filesToSend.length > 0) {
+            console.log("[feishu] sending", filesToSend.length, "requested file(s)")
+            for (const filePath of filesToSend.slice(0, 5)) {
+              await this.replyFile(messageId, filePath)
             }
           }
         },
@@ -1020,6 +1018,14 @@ class FeishuManagerImpl {
     return textParts.map((p: any) => p.text).join("\n")
   }
 
+  /** Coarse filter: does this message possibly involve a file request? */
+  private mightWantFile(text: string): boolean {
+    const lower = text.toLowerCase()
+    return ["文件", "file", "发", "给我", "附件", "代码", "doc", "word", "excel", "pdf", "下载", "export", "ppt", "md", "markdown"].some((w) =>
+      lower.includes(w),
+    )
+  }
+
   /** Extract file paths that were read by the AI during this turn (from ToolParts). */
   private extractReadFiles(msg: any): string[] {
     if (!msg?.parts) return []
@@ -1031,14 +1037,6 @@ class FeishuManagerImpl {
       }
     }
     return [...new Set(files)]
-  }
-
-  /** Detect if the user is explicitly asking to receive a file. */
-  private detectFileSendIntent(text: string): boolean {
-    const lower = text.toLowerCase()
-    return ["发给我", "发来", "源文件", "原文件", "发过来", "原始文件", "send me", "send file"].some((w) =>
-      lower.includes(w),
-    )
   }
 
   /** Extract existing absolute file paths mentioned in text (e.g. in AI response). */

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -828,7 +828,7 @@ export namespace File {
             }
           }
 
-          const content = (await Filesystem.readText(full).catch(() => "")).trim()
+          const content = await Filesystem.readText(full).catch(() => "")
 
           if (Instance.project.vcs === "git") {
             let diff = (


### PR DESCRIPTION
Closes #324

## Changes

### feat: batch select and actions for sessions in workspace sidebar

Add a batch selection mode to the workspace sidebar session list.

- New "Select" entry in the workspace dropdown menu to enter selection mode
- Clicking a session toggles its checkbox instead of navigating
- Toolbar with "Select all" / "Deselect all" and batch archive / delete buttons
- Batch delete shows a confirmation dialog with session count
- "New session" and "Load more" are hidden during selection mode
- Cancel button exits selection mode and clears all selections

### refactor: improve Feishu file request detection and messaging

- Replace strict `detectFileSendIntent` (8 exact phrases) with a broader `mightWantFile` coarse keyword filter covering common file-related terms
- Remove the intent gate on file sending: always attempt to send files the AI read during the session (`extractReadFiles`), regardless of keyword match
- Soften the injected system prompt hint so the model only appends a file path when it actually applies, reducing false positives

### fix: remove unnecessary `.trim()` from file content reading

Remove `.trim()` in `file/index.ts` so file content is passed through as-is, preserving meaningful leading/trailing whitespace.

### style: update collapse button variant in session docks

Switch collapse/expand chevron buttons in `session-question-dock` and `session-todo-dock` from `ghost` to `primary` variant with `opacity: 0.6` for better visual affordance. Also removes redundant `data-collapsed` attribute from the question dock button.