### PR TITLE
fix: restore packaged desktop sidecar connectivity

### DIFF
--- a/packages/app/src/utils/server.ts
+++ b/packages/app/src/utils/server.ts
@@ -100,6 +100,10 @@ export function createSdkForServer({
   return createOpencodeClient({
     ...config,
     baseUrl: server.url,
+    headers: {
+      ...auth,
+      ...(config.headers ?? {}),
+    },
   }) as unknown as AppClient
 }
 

--- a/packing_scripts/release-mac-desktop.sh
+++ b/packing_scripts/release-mac-desktop.sh
@@ -12,6 +12,9 @@ export OPENCODE_CHANNEL=prod
 export OPENCODE_UPDATER_CHANNEL=latest
 export RUST_TARGET=aarch64-apple-darwin
 
+echo "Preparing desktop resources..."
+bun ./scripts/prepare.ts
+
 bun run build
 npx electron-builder --mac dmg --arm64 --publish never --config electron-builder.config.ts
 


### PR DESCRIPTION
### Issue for this PR

Closes #327

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

这个 PR 修复了 macOS 打包后的 Electron 桌面应用首次启动时可能出现的 "无法连接到 Local Server" 问题。

具体来说，renderer 侧在为本地 sidecar 创建 SDK 时，之前没有把 Basic Auth 请求头传给 `createOpencodeClient()`，导致主进程可以完成 sidecar 探活，但 UI 后续请求仍然会因为缺少认证而失败。这个 PR 将认证头显式透传给客户端，保证渲染层和主进程访问本地服务时使用一致的认证方式。

另外，打包脚本现在会在构建前先执行桌面资源准备步骤，确保 sidecar 二进制在打包时已被正确同步到 Electron 资源目录中，减少打包产物与当前代码状态不一致的问题。

### How did you verify your code works?

- 检查了桌面端主进程与 renderer 的本地服务启动/连接链路
- 对比了打包前后的启动日志，确认主进程 sidecar 已 ready，而问题点位于 renderer 请求未携带认证头
- 通过 shell 语法检查确认 `packing_scripts/release-mac-desktop.sh` 修改后语法有效
- fork 仓库 CI 全部通过（guard、check-standards、typecheck、unit tests、e2e linux）

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR