### PR TITLE
fix: 对齐 Electron 打包版数据库迁移到 aether-prod

### DIFF
--- a/packages/desktop-electron/src/main/cli.ts
+++ b/packages/desktop-electron/src/main/cli.ts
@@ -1,14 +1,24 @@
 import { execFileSync, spawn } from "node:child_process"
 import { EventEmitter } from "node:events"
-import { chmodSync, readFileSync, unlinkSync, writeFileSync } from "node:fs"
-import { tmpdir } from "node:os"
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs"
+import { homedir, tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import readline from "node:readline"
 import { fileURLToPath } from "node:url"
 import { app } from "electron"
 import treeKill from "tree-kill"
 
-import { WSL_ENABLED_KEY } from "./constants"
+import { CHANNEL, WSL_ENABLED_KEY } from "./constants"
 import { store } from "./store"
 
 const CLI_INSTALL_DIR = ".opencode/bin"
@@ -192,7 +202,64 @@ export function serve(hostname: string, port: number, password: string, proxy: P
     ...proxyEnv,
   }
 
+  prepareProdMigration()
+
   return spawnCommand(args, env)
+}
+
+function dataRoot() {
+  return process.env.XDG_DATA_HOME || join(homedir(), ".local", "share")
+}
+
+function newer(src: string, dst: string) {
+  if (!existsSync(src)) return false
+  if (!existsSync(dst)) return true
+  return statSync(src).mtimeMs > statSync(dst).mtimeMs
+}
+
+function syncDb(src: string, dst: string) {
+  if (!existsSync(src)) return false
+  if (!newer(src, dst)) return false
+  mkdirSync(dirname(dst), { recursive: true })
+  copyFileSync(src, dst)
+  for (const ext of ["-wal", "-shm"]) {
+    const from = `${src}${ext}`
+    const to = `${dst}${ext}`
+    if (!existsSync(from)) {
+      rmSync(to, { force: true })
+      continue
+    }
+    copyFileSync(from, to)
+  }
+  return true
+}
+
+function clearDb(dst: string) {
+  rmSync(dst, { force: true })
+  rmSync(`${dst}-wal`, { force: true })
+  rmSync(`${dst}-shm`, { force: true })
+}
+
+function prepareProdMigration() {
+  if (!app.isPackaged) return
+  if (CHANNEL !== "prod") return
+
+  const root = dataRoot()
+  const legacy = join(root, "opencode")
+  const current = join(root, "aether")
+  const src = join(legacy, "opencode-prod.db")
+  const seeded = join(legacy, "aether-prod.db")
+  const dst = join(current, "aether-prod.db")
+
+  if (!existsSync(src)) return
+
+  const changed = syncDb(src, seeded)
+  if (!changed && existsSync(seeded) && !newer(seeded, dst)) return
+
+  if (newer(seeded, dst)) {
+    clearDb(dst)
+    console.log(`[cli] Refreshed migration source: ${seeded}`)
+  }
 }
 
 export function spawnCommand(args: string, extraEnv: Record<string, string>) {

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -1,8 +1,6 @@
 import { randomUUID } from "node:crypto"
 import { EventEmitter } from "node:events"
-import { existsSync } from "node:fs"
 import { createServer } from "node:net"
-import { homedir } from "node:os"
 import { join } from "node:path"
 import type { Event } from "electron"
 import { app, BrowserWindow, dialog } from "electron"
@@ -145,8 +143,6 @@ function setInitStep(step: InitStep) {
 }
 
 async function initialize() {
-  const needsMigration = !sqliteFileExists()
-  const sqliteDone = needsMigration ? defer<void>() : undefined
   let overlay: BrowserWindow | null = null
 
   const port = await getSidecarPort()
@@ -186,12 +182,7 @@ async function initialize() {
       setInitStep({ phase: "sqlite_waiting" })
       if (overlay) sendSqliteMigrationProgress(overlay, progress)
       if (mainWindow) sendSqliteMigrationProgress(mainWindow, progress)
-      if (progress.type === "Done") sqliteDone?.resolve()
     })
-
-    if (needsMigration) {
-      await Promise.race([sqliteDone!.promise, probe])
-    }
 
     await probe
 
@@ -203,12 +194,10 @@ async function initialize() {
     deepLinks: pendingDeepLinks,
   }
 
-  if (needsMigration) {
-    const show = await Promise.race([loadingTask.then(() => false), delay(1_000).then(() => true)])
-    if (show) {
-      overlay = createLoadingWindow(globals)
-      await delay(1_000)
-    }
+  const show = await Promise.race([loadingTask.then(() => false), delay(1_000).then(() => true)])
+  if (show) {
+    overlay = createLoadingWindow(globals)
+    await delay(1_000)
   }
 
   await loadingTask
@@ -370,13 +359,6 @@ async function getSidecarPort() {
       server.close(() => resolve(port))
     })
   })
-}
-
-function sqliteFileExists() {
-  const file = CHANNEL === "beta" ? "aether.db" : `aether-${CHANNEL}.db`
-  const xdg = process.env.XDG_DATA_HOME
-  const base = xdg && xdg.length > 0 ? xdg : join(homedir(), ".local", "share")
-  return existsSync(join(base, "opencode", file))
 }
 
 function setupAutoUpdater() {


### PR DESCRIPTION
### Issue for this PR

Closes #328

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

这个 PR 修复了 Electron 打包版数据库迁移中的顺序问题。

桌面端最终应使用 `~/.local/share/aether/aether-prod.db`，但旧逻辑里 `aether-prod.db` 的生成依赖"仅在目标不存在时复制"的一次性迁移。如果目标库已经存在旧副本，即使 `~/.local/share/opencode/opencode-prod.db` 已更新，后续也不会再刷新到最终目标库，导致应用仍显示旧会话历史。

这次修改在 Electron sidecar 启动前增加了一个最小的预迁移步骤：先在 legacy 数据目录中将 `opencode-prod.db` 同步为 `aether-prod.db`，必要时清理当前目录中的旧目标库，然后再让现有 `opencode -> aether` 迁移链路继续执行。这样最终生成的 `~/.local/share/aether/aether-prod.db` 将稳定来源于最新的 prod 数据库。

另外，主进程不再依赖旧的本地文件探测结果来预判数据库迁移状态，而是统一以后端 sidecar 的真实启动与迁移进度为准，避免 Electron 主进程和后端迁移状态分叉。

### How did you verify your code works?

- 检查了 Electron 主进程与 sidecar 的启动顺序，确认数据库预迁移会发生在 sidecar 真正打开数据库之前
- 检查了数据库迁移路径与命名，确认修复后会先在 `opencode` 目录中生成最新的 `aether-prod.db`，再进入现有目录迁移流程
- 检查了主进程初始化流程，确认不再依赖旧路径预判数据库是否存在
- fork 仓库 CI 全部通过（guard、check-standards、typecheck、unit tests、e2e linux）

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR