### PR TITLE
Fix PDF night mode contrast & add KaTeX \slashed macro

### DIFF
--- a/packages/app/public/pdf-viewer-aether.css
+++ b/packages/app/public/pdf-viewer-aether.css
@@ -182,17 +182,17 @@ body.aether-pdf-viewer #viewerContainer {
 }
 
 body.aether-pdf-viewer[data-night-mode="on"] #viewerContainer {
-  background: #0f1012;
+  background: #2a2c30;
 }
 
 body.aether-pdf-viewer[data-night-mode="on"] .pdfViewer .page,
 body.aether-pdf-viewer[data-night-mode="on"] .pdfViewer .dummyPage {
-  background: #050608;
-  box-shadow: 0 1px 4px rgb(0 0 0 / 0.55);
+  background: #2a2c30;
+  box-shadow: 0 1px 4px rgb(0 0 0 / 0.4);
 }
 
 body.aether-pdf-viewer[data-night-mode="on"] .pdfViewer .page canvas {
-  filter: invert(1);
+  filter: invert(0.85) brightness(1.2) contrast(1.05);
 }
 
 body.aether-pdf-viewer[data-night-mode="on"] .textLayer,

--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -376,6 +376,10 @@ registerCustomTheme("OpenCode", () => {
   } as unknown as ThemeRegistrationResolved)
 })
 
+const katexMacros: Record<string, string> = {
+  "\\slashed": "\\not\\!#1",
+}
+
 function renderMathInText(text: string): string {
   let result = text
 
@@ -386,6 +390,7 @@ function renderMathInText(text: string): string {
       return katex.renderToString(math, {
         displayMode: true,
         throwOnError: false,
+        macros: katexMacros,
       })
     } catch {
       return `$$${math}$$`
@@ -399,6 +404,7 @@ function renderMathInText(text: string): string {
       return katex.renderToString(math, {
         displayMode: false,
         throwOnError: false,
+        macros: katexMacros,
       })
     } catch {
       return `$${math}$`
@@ -488,6 +494,7 @@ export const { use: useMarked, provider: MarkedProvider } = createSimpleContext(
       markedKatex({
         throwOnError: false,
         nonStandard: true,
+        macros: katexMacros,
       }),
       markedShiki({
         async highlight(code, lang) {


### PR DESCRIPTION
Closes #333

## Summary

- **PDF night mode**: replaced pure-black background (`#050608`) and full `invert(1)` filter with a softer dark-grey (`#2a2c30`) background and `invert(0.85) brightness(1.2) contrast(1.05)` — less eye strain while keeping readability
- **KaTeX `\slashed` macro**: added a custom macro table passed to every `katex.renderToString` call so that `\slashed{X}` renders as `\not\!X` (Feynman slash notation used in physics)

## Changed files

| File | Change |
|---|---|
| `packages/app/public/pdf-viewer-aether.css` | Soften night mode colours and filter |
| `packages/ui/src/context/marked.tsx` | Add `katexMacros` and pass to all three KaTeX render sites |

## Test plan

- [ ] Open a PDF, enable night mode — background should be dark grey, text should be readable without harsh glare
- [ ] Send a chat message containing `$\slashed{p}$` — should render correctly instead of erroring