### PR TITLE
fix:自动更新安装流程与 UI bug 修复

### DIFF
--- a/Update/aether_darwin_installer.command
+++ b/Update/aether_darwin_installer.command
@@ -169,6 +169,10 @@ normalize_work() {
 }
 
 workdir() {
+  if [ -n "${AETHER_WORK_DIR:-}" ]; then
+    printf "%s" "$AETHER_WORK_DIR"
+    return 0
+  fi
   local dir
   dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   if [[ "$(basename "$dir")" == aether-* ]]; then

--- a/Update/aether_linux_installer.sh
+++ b/Update/aether_linux_installer.sh
@@ -490,6 +490,10 @@ normalize_work() {
 }
 
 workdir() {
+  if [ -n "${AETHER_WORK_DIR:-}" ]; then
+    printf "%s" "$AETHER_WORK_DIR"
+    return 0
+  fi
   local dir
   dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   if [[ "$(basename "$dir")" == aether_* ]]; then

--- a/Update/aether_windows_installer.bat
+++ b/Update/aether_windows_installer.bat
@@ -345,6 +345,10 @@ for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$a=$env:A; $b
 exit /b 0
 
 :work
+if defined AETHER_WORK_DIR (
+  set "%~1=%AETHER_WORK_DIR%"
+  exit /b 0
+)
 set "DIR=%~dp0"
 if "%DIR:~-1%"=="\" set "DIR=%DIR:~0,-1%"
 for %%i in ("%DIR%") do set "NAME=%%~nxi"

--- a/docs/aether-download-admin-upload.md
+++ b/docs/aether-download-admin-upload.md
@@ -4,10 +4,15 @@
 
 ## 概览
 
-Aether 下载服务分为两部分：
+Aether 下载服务分为三个渠道：
 
-- 管理员上传接口：发布某个平台的新版本安装包，并刷新 `latest` 下载别名
-- 下载接口：客户端按版本或按 `latest` 拉取 manifest 和安装包
+- **公开渠道** (`/download/`)：正式发布，支持版本化目录、manifest、OSS 推送
+- **私有测试渠道** (`/api/download2/`)：开发者测试产物，需鉴权，与公开渠道隔离
+- **手动安装渠道** (`/manual/`)：前端"手动安装"链接指向此渠道，仅存储 `latest` 安装包，无需鉴权
+
+每个渠道都有独立的管理员上传接口和独立的存储目录。
+
+**重要**：公开渠道和手动安装渠道要求配置 `DOWNLOAD_OSS_PUBLIC_BASE_URL`，下载时通过 302 重定向到 OSS。未配置时下载接口会返回错误。
 
 当前支持的平台：
 
@@ -23,10 +28,17 @@ Aether 下载服务分为两部分：
 https://aether.aiphys.cn/download
 ```
 
-管理员上传接口：
+管理员 OSS 直传接口（公开渠道）：
 
 ```text
-POST https://aether.aiphys.cn/api/download/admin/upload
+POST https://aether.aiphys.cn/api/download/admin/presign   # 获取预签名 URL
+POST https://aether.aiphys.cn/api/download/admin/commit     # 提交元数据，触发服务端处理
+```
+
+管理员 OSS 直传接口（手动安装渠道）：
+
+```text
+POST https://aether.aiphys.cn/api/manual/admin/presign      # 获取预签名 URL
 ```
 
 开发者私有测试下载接口：
@@ -39,6 +51,12 @@ GET https://aether.aiphys.cn/api/download2/...
 
 ```text
 POST https://aether.aiphys.cn/api/download2/admin/upload
+```
+
+手动安装包下载接口：
+
+```text
+GET https://aether.aiphys.cn/manual/latest/<filename>
 ```
 
 版本目录约定：
@@ -54,17 +72,210 @@ POST https://aether.aiphys.cn/api/download2/admin/upload
 - `/download/1.3.3/mac-arm64.yml`
 - `/download/1.3.3/aether-darwin-arm64.dmg`
 
-## 上传接口
+## 公开渠道 OSS 直传上传
 
-### 请求
+服务端配置了 `ALIYUN_OSS_*` 环境变量后，大文件从客户端直传 OSS，不经过服务器中转，速度更快、节省服务器带宽。
+
+流程分为三步：
+
+1. **presign** — 获取各平台文件的 OSS 预签名 PUT URL
+2. **upload** — 客户端并行直传文件到 OSS
+3. **commit** — 通知服务端完成本地写入、manifest 生成、版本记录等后续处理
+
+### Step 1: 获取预签名 URL
 
 - Method: `POST`
-- Content-Type: `multipart/form-data`
-- 鉴权方式二选一：
-  - 表单字段 `password`
-  - 请求头 `x-download-admin-password`
+- URL: `https://aether.aiphys.cn/api/download/admin/presign`
+- Content-Type: `application/json`
+- 鉴权：请求头 `x-download-admin-password`
 
-### 必填字段
+请求体示例：
+
+```json
+{
+  "mac": { "version": "1.3.3" },
+  "windows": { "version": "1.3.3" },
+  "linux": { "version": "1.3.3" }
+}
+```
+
+响应示例：
+
+```json
+{
+  "ok": true,
+  "platforms": {
+    "mac": {
+      "archive": {
+        "objectKey": "1.3.3/aether-darwin-arm64.dmg",
+        "url": "https://aether-asset.oss-cn-beijing.aliyuncs.com/1.3.3/aether-darwin-arm64.dmg?x-oss-signature-version=...",
+        "contentType": "application/x-apple-diskimage"
+      },
+      "installer": {
+        "objectKey": "1.3.3/update_darwin.command",
+        "url": "https://aether-asset.oss-cn-beijing.aliyuncs.com/1.3.3/update_darwin.command?x-oss-signature-version=...",
+        "contentType": "text/x-shellscript; charset=utf-8"
+      }
+    },
+    "windows": { ... },
+    "linux": { ... }
+  },
+  "expiresInSeconds": 1800
+}
+```
+
+### Step 2: 直传文件到 OSS
+
+使用预签名 URL 将文件 PUT 到 OSS：
+
+```bash
+# 并行上传三个平台的主包
+curl -X PUT \
+  -H 'Content-Type: application/x-apple-diskimage' \
+  --data-binary @aether-darwin-arm64.dmg \
+  '<mac archive presigned url>' &
+
+curl -X PUT \
+  -H 'Content-Type: application/zip' \
+  --data-binary @aether-windows-x64.zip \
+  '<windows archive presigned url>' &
+
+curl -X PUT \
+  -H 'Content-Type: application/zip' \
+  --data-binary @aether-linux-x64.zip \
+  '<linux archive presigned url>' &
+
+wait
+```
+
+### Step 3: 提交元数据
+
+所有文件上传到 OSS 后，调用 commit 接口通知服务端完成后续处理。
+
+- Method: `POST`
+- URL: `https://aether.aiphys.cn/api/download/admin/commit`
+- Content-Type: `application/json`
+- 鉴权：请求头 `x-download-admin-password`
+
+请求体示例：
+
+```json
+{
+  "mac": { "version": "1.3.3", "hasInstaller": true },
+  "windows": { "version": "1.3.3", "hasInstaller": true },
+  "linux": { "version": "1.3.3", "hasInstaller": true },
+  "releaseDate": "2026-04-13T00:00:00.000Z"
+}
+```
+
+字段说明：
+
+| 字段 | 必填 | 说明 |
+| --- | --- | --- |
+| `<platform>.version` | 是 | 该平台的版本号 |
+| `<platform>.hasInstaller` | 否 | 是否上传了安装脚本，默认 `false` |
+| `releaseDate` | 否 | ISO 时间字符串，不传由服务端生成 |
+
+响应格式与公开上传接口相同。
+
+服务端处理流程：
+
+1. 从 OSS 下载各平台的安装包（走内网，速度快）
+2. 计算安装包的 `sha512` 和 `size`
+3. 生成 manifest 并写入本地和 OSS
+4. 将安装包和安装脚本写入本地 `downloads/{version}/` 和 `downloads/latest/`
+5. 更新 `downloads/latest-versions.json`
+
+## 手动安装渠道 OSS 直传上传
+
+手动安装渠道的文件直传到 OSS 后即生效，无需 commit 步骤（用户下载时直接 302 重定向到 OSS）。
+
+流程分为两步：
+
+1. **presign** — 获取各平台文件的 OSS 预签名 PUT URL
+2. **upload** — 客户端并行直传文件到 OSS
+
+### Step 1: 获取预签名 URL
+
+- Method: `POST`
+- URL: `https://aether.aiphys.cn/api/manual/admin/presign`
+- Content-Type: `application/json`
+- 鉴权：请求头 `x-download-admin-password`
+
+请求体示例：
+
+```json
+{
+  "platforms": ["mac", "windows", "linux"]
+}
+```
+
+响应示例：
+
+```json
+{
+  "ok": true,
+  "platforms": {
+    "mac": {
+      "objectKey": "manual/latest/aether-darwin-arm64.dmg",
+      "url": "https://aether-asset.oss-cn-beijing.aliyuncs.com/manual/latest/aether-darwin-arm64.dmg?x-oss-signature-version=...",
+      "contentType": "application/x-apple-diskimage"
+    },
+    "windows": {
+      "objectKey": "manual/latest/aether-windows-x64.zip",
+      "url": "...",
+      "contentType": "application/zip"
+    },
+    "linux": {
+      "objectKey": "manual/latest/aether-linux-x64.zip",
+      "url": "...",
+      "contentType": "application/zip"
+    }
+  },
+  "expiresInSeconds": 1800
+}
+```
+
+### Step 2: 直传文件到 OSS
+
+```bash
+curl -X PUT \
+  -H 'Content-Type: application/x-apple-diskimage' \
+  --data-binary @aether-darwin-arm64.dmg \
+  '<mac presigned url>' &
+
+curl -X PUT \
+  -H 'Content-Type: application/zip' \
+  --data-binary @aether-windows-x64.zip \
+  '<windows presigned url>' &
+
+curl -X PUT \
+  -H 'Content-Type: application/zip' \
+  --data-binary @aether-linux-x64.zip \
+  '<linux presigned url>' &
+
+wait
+```
+
+上传完成后，用户即可通过 `/manual/latest/<filename>` 下载。
+
+## 开发者私有测试上传接口
+
+该接口用于上传"仅供开发者测试"的最新产物，不会更新公开下载版本。
+
+- Method: `POST`
+- URL: `https://aether.aiphys.cn/api/download2/admin/upload`
+- Content-Type: `multipart/form-data`
+- 鉴权：请求头 `x-download-admin-password` 或表单字段 `password`
+
+写入行为：
+
+1. 只覆盖 `downloads2/latest/`
+2. 不写入 `downloads2/<version>/`
+3. 不影响公开 `/download/latest/...` 的版本解析结果
+4. 上传成功后应通过 `/api/download2/latest/...` 访问测试产物
+
+### 文件字段
 
 至少上传一个平台文件。每个已上传平台都必须带对应版本号。
 
@@ -82,69 +293,7 @@ POST https://aether.aiphys.cn/api/download2/admin/upload
 | `winInstaller` | Windows 可选更新脚本文件，发布为 `update_windows.bat` |
 | `linuxInstaller` | Linux 可选更新脚本文件，发布为 `update_linux.sh` |
 
-### macOS 额外可选字段
-
-| 字段 | 含义 |
-| --- | --- |
-| `macNotesUrl` | 可选发布说明地址，写入 manifest 的 `notes_url` |
-| `releaseDate` | 可选发布时间，ISO 时间字符串；不传时由服务端生成 |
-
-### 兼容别名
-
-服务端兼容以下字段别名：
-
-| 主字段 | 兼容别名 |
-| --- | --- |
-| `macos` | `darwin`、`mac`、`macPackage`、`aether-darwin-arm64.dmg` |
-| `macInstaller` | `macCommand`、`installer`、`command`、`update_darwin.command` |
-| `winInstaller` | `windowsInstaller`、`update_windows.bat` |
-| `linuxInstaller` | `update_linux.sh` |
-| `macNotesUrl` | `notesUrl`、`notes_url` |
-| `macVersion` | `darwinVersion`、`mac_version` |
-| `windowsVersion` | `winVersion`、`windows_version` |
-| `linuxVersion` | `linux_version` |
-
 ### 上传示例
-
-上传 mac 主包、可选更新脚本和发布说明：
-
-```bash
-curl -X POST https://aether.aiphys.cn/api/download/admin/upload \
-  -H 'x-download-admin-password: <your-password>' \
-  -F 'macVersion=1.3.3' \
-  -F 'macos=@aether-darwin-arm64.dmg' \
-  -F 'macInstaller=@update_darwin.command' \
-  -F 'macNotesUrl=https://aether.aiphys.cn/release-notes/1.3.3'
-```
-
-一次上传多个平台：
-
-```bash
-curl -X POST https://aether.aiphys.cn/api/download/admin/upload \
-  -F 'password=<your-password>' \
-  -F 'macVersion=1.3.3' \
-  -F 'macos=@aether-darwin-arm64.dmg' \
-  -F 'macInstaller=@update_darwin.command' \
-  -F 'linuxVersion=1.3.4' \
-  -F 'linux=@aether-linux-x64.zip' \
-  -F 'linuxInstaller=@update_linux.sh' \
-  -F 'windowsVersion=1.3.5' \
-  -F 'windows=@aether-windows-x64.zip' \
-  -F 'winInstaller=@update_windows.bat'
-```
-
-## 开发者私有测试上传接口
-
-该接口用于上传“仅供开发者测试”的最新产物，不会更新公开下载版本。
-
-请求格式、字段、鉴权方式与 `/api/download/admin/upload` 相同，但写入行为不同：
-
-1. 只覆盖 `downloads2/latest/`
-2. 不写入 `downloads2/<version>/`
-3. 不影响公开 `/download/latest/...` 的版本解析结果
-4. 上传成功后应通过 `/api/download2/latest/...` 访问测试产物
-
-上传示例：
 
 ```bash
 curl -X POST https://aether.aiphys.cn/api/download2/admin/upload \
@@ -154,23 +303,44 @@ curl -X POST https://aether.aiphys.cn/api/download2/admin/upload \
   -F 'macInstaller=@update_darwin.command'
 ```
 
-## 上传成功后的行为
+### 上传响应
 
-每个已上传平台，服务端会执行以下操作：
+成功时返回的链接指向 `/api/download2/latest/...`，示例：
 
-1. 将安装包写入 `downloads/<version>/`
-2. 刷新 `/download/latest/...` 对应的最新下载别名
-3. 计算安装包的 `sha512` 和 `size`
-4. 生成并覆盖对应平台的 manifest
-5. 如果上传了对应平台的安装脚本字段，额外将脚本发布到对应版本，并同步刷新 `latest` 别名
+```json
+{
+  "ok": true,
+  "releaseDate": "2026-04-08T10:00:00.000Z",
+  "files": [
+    {
+      "platform": "mac",
+      "version": "1.4.1-dev",
+      "latestUrl": "/api/download2/latest/aether-darwin-arm64.dmg",
+      "latestManifestUrl": "/api/download2/latest/mac-arm64.yml",
+      "sha512": "<base64-sha512>",
+      "size": 93444053,
+      "latestInstallerUrl": "/api/download2/latest/update_darwin.command"
+    }
+  ]
+}
+```
 
-补充说明：
+## 手动安装包下载接口
 
-- 当前 GitHub Release 与 web 初始分发包默认不再携带 `update_*` 脚本；这些字段主要供下载服务托管 installer 在运行时拉取的更新脚本使用
-- 当前上传实现仍会写入 `downloads/latest/` 作为镜像目录
-- 但客户端下载 `latest` 时，应将其视为“当前最新公开版本”的路由别名，而不是依赖某个固定物理目录
-- 如需测试“已上传 latest 但暂不公开发布”的产物，开发者可使用 `/api/download2/...`；该路由直接读取 `downloads2/`，并要求提供 `x-download-admin-password` 请求头或 `?password=` 参数
-- 如需上传仅供开发者测试的 `latest` 产物，可使用 `/api/download2/admin/upload`；该接口只覆盖 `downloads2/latest/`
+该接口供前端"手动安装"链接使用，无需鉴权。
+
+下载路径：
+
+```text
+/manual/latest/aether-darwin-arm64.dmg
+/manual/latest/aether-windows-x64.zip
+/manual/latest/aether-linux-x64.zip
+```
+
+说明：
+
+- 通过 302 重定向到 OSS 公开地址
+- 下载成功后自动上报 analytics 事件（`download_channel = 'manual'`）
 
 ## 开发者私有测试下载接口
 
@@ -193,65 +363,20 @@ curl -X POST https://aether.aiphys.cn/api/download2/admin/upload \
 
 - `/api/download2/latest/...` 直接读取 `downloads2/latest/`，与生产 `downloads/` 目录隔离
 - `/api/download2/<version>/...` 按 `downloads2/<version>/` 目录读取文件
-- 兼容 `/api/download/<filename>` 的旧地址形式，例如 `/api/download2/latest-web-mac.yml`
-
-### 开发者私有测试上传响应
-
-成功时返回的链接指向 `/api/download2/latest/...`，示例：
-
-```json
-{
-  "ok": true,
-  "releaseDate": "2026-04-08T10:00:00.000Z",
-  "files": [
-    {
-      "platform": "mac",
-      "version": "1.4.1-dev",
-      "latestUrl": "/api/download2/latest/aether-darwin-arm64.dmg",
-      "latestManifestUrl": "/api/download2/latest/mac-arm64.yml",
-      "sha512": "<base64-sha512>",
-      "size": 93444053,
-      "latestInstallerUrl": "/api/download2/latest/update_darwin.command",
-      "notesUrl": null
-    }
-  ]
-}
-```
-
-## 上传响应
-
-成功时返回 `200 OK`，响应体示例：
-
-```json
-{
-  "ok": true,
-  "releaseDate": "2026-04-02T07:12:00.000Z",
-  "files": [
-    {
-      "platform": "mac",
-      "version": "1.3.3",
-      "url": "/download/1.3.3/aether-darwin-arm64.dmg",
-      "latestUrl": "/download/latest/aether-darwin-arm64.dmg",
-      "manifestUrl": "/download/1.3.3/mac-arm64.yml",
-      "latestManifestUrl": "/download/latest/mac-arm64.yml",
-      "sha512": "<base64-sha512>",
-      "size": 93444053,
-      "installerUrl": "/download/1.3.3/update_darwin.command",
-      "latestInstallerUrl": "/download/latest/update_darwin.command",
-      "notesUrl": "https://aether.aiphys.cn/release-notes/1.3.3"
-    }
-  ]
-}
-```
-
-说明：
-
-- `url` / `manifestUrl` 指向指定版本目录
-- `latestUrl` / `latestManifestUrl` 指向 `latest` 别名，服务端会解析到当前最新版本
-- `installerUrl` 与 `latestInstallerUrl` 在未上传对应平台安装脚本时为 `null`
-- `notesUrl` 在未提供时为 `null`
 
 ## 下载接口
+
+### 下载模式
+
+公开渠道和手动安装渠道要求配置 `DOWNLOAD_OSS_PUBLIC_BASE_URL`，通过 302 重定向到 OSS 对象地址。未配置时返回错误。
+
+例如：
+
+- `/download/latest/aether-darwin-arm64.dmg` 会先解析 `latest` 到具体版本（如 `1.4.1`），再重定向到 `https://<bucket-endpoint>/1.4.1/aether-darwin-arm64.dmg`
+- `/download/1.3.3/aether-windows-x64.zip` 会重定向到 `https://<bucket-endpoint>/1.3.3/aether-windows-x64.zip`
+- `/manual/latest/aether-darwin-arm64.dmg` 会重定向到 `https://<bucket-endpoint>/manual/latest/aether-darwin-arm64.dmg`
+
+私有测试渠道始终从本地文件系统读取，不经过 OSS 重定向。
 
 ### 最新通道
 
@@ -264,13 +389,10 @@ curl -X POST https://aether.aiphys.cn/api/download2/admin/upload \
 对应安装包：
 
 - `/download/latest/aether-darwin-arm64.dmg`
-- `/download/latest/aether-windows-x64.zip`
-- `/download/latest/aether-linux-x64.zip`
-
-如果服务端托管了更新脚本，installer 还会额外访问：
-
 - `/download/latest/update_darwin.command`
+- `/download/latest/aether-windows-x64.zip`
 - `/download/latest/update_windows.bat`
+- `/download/latest/aether-linux-x64.zip`
 - `/download/latest/update_linux.sh`
 
 解析规则：
@@ -290,28 +412,11 @@ curl -X POST https://aether.aiphys.cn/api/download2/admin/upload \
 对应安装包：
 
 - `/download/<version>/aether-darwin-arm64.dmg`
-- `/download/<version>/aether-windows-x64.zip`
-- `/download/<version>/aether-linux-x64.zip`
-
-如果服务端托管了更新脚本，installer 还会额外访问：
-
 - `/download/<version>/update_darwin.command`
+- `/download/<version>/aether-windows-x64.zip`
 - `/download/<version>/update_windows.bat`
+- `/download/<version>/aether-linux-x64.zip`
 - `/download/<version>/update_linux.sh`
-
-### 兼容旧地址
-
-以下旧地址仍然可用，默认映射到 `latest` 别名：
-
-- `/download/latest-web-mac.yml`
-- `/download/latest-web-windows.yml`
-- `/download/latest-web-linux.yml`
-- `/download/aether-darwin-arm64.dmg`
-- `/download/update_darwin.command`
-- `/download/aether-windows-x64.zip`
-- `/download/update_windows.bat`
-- `/download/aether-linux-x64.zip`
-- `/download/update_linux.sh`
 
 ## macOS Manifest 协议
 
@@ -321,7 +426,7 @@ mac 客户端应优先读取：
 /download/latest/mac-arm64.yml
 ```
 
-这里的 `latest` 同样表示“解析到当前最新公开版本的 manifest”，不是要求客户端访问某个固定目录。
+这里的 `latest` 同样表示"解析到当前最新公开版本的 manifest"，不是要求客户端访问某个固定目录。
 
 或：
 
@@ -340,7 +445,6 @@ package:
 installer:
   url: update_darwin.command
   size: 4096
-notes_url: 'https://aether.aiphys.cn/release-notes/1.3.3'
 files:
   - url: aether-darwin-arm64.dmg
     sha512: <base64-sha512>
@@ -358,7 +462,6 @@ releaseDate: '2026-04-02T07:12:00.000Z'
 | `package.size` | 主安装包字节数 |
 | `installer.url` | 可选更新脚本文件名 |
 | `installer.size` | 可选更新脚本字节数 |
-| `notes_url` | 可选发布说明地址 |
 | `files[0]` | 向后兼容字段，内容与 `package` 对应 |
 | `releaseDate` | 发布时间 |
 
@@ -369,21 +472,66 @@ releaseDate: '2026-04-02T07:12:00.000Z'
 - 如果 `package` 不存在，可回退读取 `files[0]`
 - `package.url` 和 `installer.url` 可能是相对路径，客户端应按 manifest 所在目录解析
 
+## 上传响应
+
+公开渠道 commit 成功时返回 `200 OK`，响应体示例：
+
+```json
+{
+  "ok": true,
+  "releaseDate": "2026-04-02T07:12:00.000Z",
+  "files": [
+    {
+      "platform": "mac",
+      "version": "1.3.3",
+      "url": "/download/1.3.3/aether-darwin-arm64.dmg",
+      "latestUrl": "/download/latest/aether-darwin-arm64.dmg",
+      "manifestUrl": "/download/1.3.3/mac-arm64.yml",
+      "latestManifestUrl": "/download/latest/mac-arm64.yml",
+      "sha512": "<base64-sha512>",
+      "size": 93444053,
+      "installerUrl": "/download/1.3.3/update_darwin.command",
+      "latestInstallerUrl": "/download/latest/update_darwin.command"
+    }
+  ]
+}
+```
+
+OSS 上传失败时的响应示例：
+
+```json
+{
+  "ok": true,
+  "releaseDate": "2026-04-02T07:12:00.000Z",
+  "ossWarnings": [
+    { "objectKey": "1.3.3/aether-darwin-arm64.dmg", "error": "OSS upload failed: 403 ..." }
+  ],
+  "files": [...]
+}
+```
+
+说明：
+
+- `url` / `manifestUrl` 指向指定版本目录
+- `latestUrl` / `latestManifestUrl` 指向 `latest` 别名，服务端会解析到当前最新版本
+- `installerUrl` 与 `latestInstallerUrl` 在未上传对应平台安装脚本时为 `null`
+- `ossWarnings` 仅在部分文件上传失败时出现
+
 ## 错误响应
 
 常见错误：
 
 | HTTP 状态码 | 含义 |
 | --- | --- |
-| `400` | 请求格式错误、缺少版本号、版本格式非法、`releaseDate` 非法、`macNotesUrl` 非法 |
+| `400` | 请求格式错误、缺少版本号、版本格式非法、`releaseDate` 非法 |
 | `403` | 管理员密码错误 |
-| `500` | 服务端未配置 `DOWNLOAD_ADMIN_PASSWORD` |
+| `500` | 服务端未配置 `DOWNLOAD_ADMIN_PASSWORD` 或 `DOWNLOAD_OSS_PUBLIC_BASE_URL` |
 
 错误响应示例：
 
 ```json
 {
-  "error": "Invalid mac notesUrl"
+  "error": "Invalid releaseDate"
 }
 ```
 
@@ -403,5 +551,10 @@ releaseDate: '2026-04-02T07:12:00.000Z'
 
 ## 相关代码
 
-- [upload.ts](/root/aether-site/src/pages/api/download/admin/upload.ts)
+- [presign.ts](/root/aether-site/src/pages/api/download/admin/presign.ts)（公开渠道 OSS 直传预签名）
+- [commit.ts](/root/aether-site/src/pages/api/download/admin/commit.ts)（公开渠道 OSS 直传提交）
+- [presign.ts](/root/aether-site/src/pages/api/manual/admin/presign.ts)（手动安装渠道 OSS 直传预签名）
+- [upload.ts](/root/aether-site/src/pages/api/download2/admin/upload.ts)（私有测试渠道上传）
+- [download-upload.ts](/root/aether-site/src/lib/server/download-upload.ts)
 - [downloads.ts](/root/aether-site/src/lib/server/downloads.ts)
+- [oss.ts](/root/aether-site/src/lib/server/oss.ts)

--- a/packages/app/src/components/dialog-update.tsx
+++ b/packages/app/src/components/dialog-update.tsx
@@ -7,6 +7,9 @@ import { useLanguage } from "@/context/language"
 import { usePlatform } from "@/context/platform"
 
 type UpdateState = "checking" | "up-to-date" | "available" | "downloading" | "downloaded" | "installing" | "error"
+type Props = {
+  auto?: "download" | "install"
+}
 
 const Spinner = () => <div class="size-4 animate-spin rounded-full border-2 border-icon-weak border-t-icon-base" />
 
@@ -16,7 +19,14 @@ const ProgressBar = () => (
   </div>
 )
 
-export const DialogUpdate: Component = () => {
+const paint = () =>
+  new Promise<void>((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => resolve())
+    })
+  })
+
+export const DialogUpdate: Component<Props> = (props) => {
   const dialog = useDialog()
   const language = useLanguage()
   const platform = usePlatform()
@@ -57,6 +67,7 @@ export const DialogUpdate: Component = () => {
     setState("downloading")
     setErrorMessage("")
     try {
+      await paint()
       await platform.downloadUpdate()
       const data = await sync()
       if (!data.updateAvailable) {
@@ -79,6 +90,7 @@ export const DialogUpdate: Component = () => {
     setState("installing")
     setErrorMessage("")
     try {
+      await paint()
       await platform.update()
       await platform.restart()
       setTimeout(() => {
@@ -94,8 +106,40 @@ export const DialogUpdate: Component = () => {
     }
   }
 
+  const start = async () => {
+    const data = await sync()
+    if (!data.updateAvailable) {
+      setState("up-to-date")
+      return
+    }
+    if (!props.auto) {
+      setState(data.downloaded ? "downloaded" : "available")
+      return
+    }
+    if (props.auto === "download") {
+      if (data.downloaded) {
+        setState("downloaded")
+        return
+      }
+      await downloadUpdate()
+      return
+    }
+    if (data.downloaded) {
+      setState("downloaded")
+      await installUpdate()
+      return
+    }
+    await downloadUpdate()
+    if (state() === "downloaded") {
+      await installUpdate()
+    }
+  }
+
   onMount(() => {
-    void checkVersion()
+    void start().catch((e) => {
+      setState("error")
+      setErrorMessage(e instanceof Error ? e.message : String(e))
+    })
   })
 
   return (

--- a/packages/app/src/components/dialog-update.tsx
+++ b/packages/app/src/components/dialog-update.tsx
@@ -1,4 +1,5 @@
 import { Component, createSignal, onMount, Show } from "solid-js"
+import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { Dialog } from "@opencode-ai/ui/dialog"
 import { Button } from "@opencode-ai/ui/button"
 import { Icon } from "@opencode-ai/ui/icon"
@@ -7,58 +8,44 @@ import { usePlatform } from "@/context/platform"
 
 type UpdateState = "checking" | "up-to-date" | "available" | "downloading" | "downloaded" | "installing" | "error"
 
-const detectOS = (): string => {
-  const ua = navigator.userAgent.toLowerCase()
-  if (ua.includes("mac")) return "darwin"
-  if (ua.includes("win")) return "windows"
-  return "linux"
-}
-
 const Spinner = () => <div class="size-4 animate-spin rounded-full border-2 border-icon-weak border-t-icon-base" />
 
+const ProgressBar = () => (
+  <div class="h-1.5 w-full overflow-hidden rounded-full bg-surface-weak">
+    <div class="h-full w-full animate-pulse rounded-full bg-icon-base" />
+  </div>
+)
+
 export const DialogUpdate: Component = () => {
+  const dialog = useDialog()
   const language = useLanguage()
   const platform = usePlatform()
 
   const [state, setState] = createSignal<UpdateState>("checking")
   const [remoteVersion, setRemoteVersion] = createSignal("")
-  const [downloadedVersion, setDownloadedVersion] = createSignal("")
+  const [currentVersion, setCurrentVersion] = createSignal("")
   const [errorMessage, setErrorMessage] = createSignal("")
 
-  const currentVersion = () => downloadedVersion() || platform.version || ""
-
-  const fetchApi = async (path: string, init?: RequestInit) => {
-    const res = await fetch(new URL(path, window.location.origin), init)
-    if (!res.ok) throw new Error(`Request failed: ${res.status}`)
-    return res
+  const current = () => currentVersion() || platform.version || ""
+  const cancelled = (err: unknown) => err instanceof Error && err.message === "Update cancelled"
+  const sync = async () => {
+    if (!platform.checkUpdate) throw new Error("Updates are not supported on this platform")
+    const data = await platform.checkUpdate()
+    if (data.currentVersion?.trim()) setCurrentVersion(data.currentVersion.trim())
+    setRemoteVersion(data.version?.trim() ?? "")
+    return data
   }
 
   const checkVersion = async () => {
     setState("checking")
     setErrorMessage("")
     try {
-      const os = detectOS()
-      const res = await fetchApi(`/global/web-update/check?os=${os}`)
-      const data = await res.json()
-      const current = typeof data.currentVersion === "string" ? data.currentVersion.trim() : ""
-      const remote = typeof data.remoteVersion === "string" ? data.remoteVersion.trim() : ""
-      if (current) setDownloadedVersion(current)
-      setRemoteVersion(remote)
-      if (typeof data.checkError === "string" && data.checkError) {
-        setState("error")
-        setErrorMessage(data.checkError)
-        return
-      }
-      if (data.error) {
-        setState("error")
-        setErrorMessage(data.error)
-        return
-      }
+      const data = await sync()
       if (!data.updateAvailable) {
         setState("up-to-date")
         return
       }
-      setState(data.downloaded ? "downloaded" : "downloading")
+      setState(data.downloaded ? "downloaded" : "available")
     } catch (e) {
       setState("error")
       setErrorMessage(e instanceof Error ? e.message : String(e))
@@ -66,48 +53,42 @@ export const DialogUpdate: Component = () => {
   }
 
   const downloadUpdate = async () => {
+    if (!platform.downloadUpdate) return
     setState("downloading")
     setErrorMessage("")
     try {
-      const os = detectOS()
-      const res = await fetchApi("/global/web-update/download", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ os, version: remoteVersion() }),
-      })
-      const data = await res.json()
-      if (!data.success) {
-        setState("error")
-        setErrorMessage(data.error)
+      await platform.downloadUpdate()
+      const data = await sync()
+      if (!data.updateAvailable) {
+        setState("up-to-date")
         return
       }
-      setState("downloaded")
+      setState(data.downloaded ? "downloaded" : "available")
     } catch (e) {
+      if (cancelled(e)) {
+        setState("available")
+        return
+      }
       setState("error")
       setErrorMessage(e instanceof Error ? e.message : String(e))
     }
   }
 
   const installUpdate = async () => {
+    if (!platform.update) return
     setState("installing")
     setErrorMessage("")
     try {
-      const os = detectOS()
-      const res = await fetchApi("/global/web-update/install", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ os }),
-      })
-      const data = await res.json()
-      if (!data.success) {
-        setState("error")
-        setErrorMessage(data.error)
-        return
-      }
+      await platform.update()
+      await platform.restart()
       setTimeout(() => {
-        window.close()
+        dialog.close()
       }, 1200)
     } catch (e) {
+      if (cancelled(e)) {
+        setState("downloaded")
+        return
+      }
       setState("error")
       setErrorMessage(e instanceof Error ? e.message : String(e))
     }
@@ -128,7 +109,7 @@ export const DialogUpdate: Component = () => {
         <div class="flex flex-col gap-4">
           <div class="flex justify-between items-center">
             <span class="text-13-regular text-text-weak">{language.t("update.currentVersion")}</span>
-            <span class="text-13-medium text-text-strong">{currentVersion() ? `v${currentVersion()}` : "-"}</span>
+            <span class="text-13-medium text-text-strong">{current() ? `v${current()}` : "-"}</span>
           </div>
           <div class="flex justify-between items-center">
             <span class="text-13-regular text-text-weak">{language.t("update.remoteVersion")}</span>
@@ -154,16 +135,24 @@ export const DialogUpdate: Component = () => {
           </Show>
 
           <Show when={state() === "available"}>
-            <div class="flex items-center gap-2 text-13-regular text-text-strong">
-              <Icon name="arrow-down-to-line" class="size-4" />
-              <span>{language.t("update.available")}</span>
+            <div class="flex flex-col gap-2">
+              <div class="flex items-center gap-2 text-13-regular text-text-strong">
+                <Icon name="arrow-down-to-line" class="size-4" />
+                <span>{language.t("update.available")}</span>
+              </div>
+              <Button size="small" variant="primary" onClick={downloadUpdate}>
+                {language.t("update.download")}
+              </Button>
             </div>
           </Show>
 
           <Show when={state() === "downloading"}>
-            <div class="flex items-center gap-2 text-13-regular text-text-weak">
-              <Spinner />
-              <span>{language.t("update.downloading")}</span>
+            <div class="flex flex-col gap-2">
+              <div class="flex items-center gap-2 text-13-regular text-text-weak">
+                <Spinner />
+                <span>{language.t("update.downloading")}</span>
+              </div>
+              <ProgressBar />
             </div>
           </Show>
 
@@ -186,6 +175,7 @@ export const DialogUpdate: Component = () => {
                 <Spinner />
                 <span>{language.t("update.installing")}</span>
               </div>
+              <ProgressBar />
               <div class="text-12-regular text-text-weak">{language.t("update.installHint")}</div>
             </div>
           </Show>

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -7,7 +7,7 @@ import { Switch } from "@opencode-ai/ui/switch"
 import { TextField } from "@opencode-ai/ui/text-field"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme/context"
-import { showToast } from "@opencode-ai/ui/toast"
+import { showToast, showPromiseToast } from "@opencode-ai/ui/toast"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { useModels } from "@/context/models"
@@ -133,6 +133,19 @@ export const SettingsGeneral: Component = () => {
   const check = () => {
     if (!platform.checkUpdate) return
     setStore("checking", true)
+    const install = async () => {
+      showPromiseToast(
+        (async () => {
+          await platform.update!()
+          await platform.restart!()
+        })(),
+        {
+          loading: language.t("update.installing"),
+          success: () => language.t("update.installHint"),
+          error: (err) => (err instanceof Error ? err.message : String(err)),
+        },
+      )
+    }
 
     void platform
       .checkUpdate()
@@ -148,14 +161,11 @@ export const SettingsGeneral: Component = () => {
         }
 
         const actions =
-          platform.update && platform.restart
+          platform.update
             ? [
                 {
                   label: language.t("update.install"),
-                  onClick: async () => {
-                    await platform.update!()
-                    await platform.restart!()
-                  },
+                  onClick: install,
                 },
                 {
                   label: language.t("toast.update.action.notYet"),

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -8,6 +8,7 @@ import { TextField } from "@opencode-ai/ui/text-field"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme/context"
 import { showToast, showPromiseToast } from "@opencode-ai/ui/toast"
+import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { useModels } from "@/context/models"
@@ -63,6 +64,7 @@ const playDemoSound = (id: string | undefined) => {
 }
 
 export const SettingsGeneral: Component = () => {
+  const dialog = useDialog()
   const theme = useTheme()
   const language = useLanguage()
   const platform = usePlatform()
@@ -134,6 +136,11 @@ export const SettingsGeneral: Component = () => {
     if (!platform.checkUpdate) return
     setStore("checking", true)
     const install = async () => {
+      if (platform.platform === "web") {
+        const x = await import("@/components/dialog-update")
+        dialog.show(() => <x.DialogUpdate auto="install" />)
+        return
+      }
       showPromiseToast(
         (async () => {
           await platform.update!()

--- a/packages/app/src/context/platform.tsx
+++ b/packages/app/src/context/platform.tsx
@@ -9,8 +9,10 @@ type OpenFilePickerOptions = { title?: string; multiple?: boolean; accept?: stri
 type SaveFilePickerOptions = { title?: string; defaultPath?: string }
 type UpdateStatus = {
   updateAvailable: boolean
+  currentVersion?: string
   version?: string
   downloaded?: boolean
+  requiresConfirmation?: boolean
 }
 
 export type Platform = {

--- a/packages/app/src/context/wechat.ts
+++ b/packages/app/src/context/wechat.ts
@@ -294,7 +294,7 @@ export function forceTakeover(modelStr?: string) {
 export function initWechat() {
   if (initialized) return
   initialized = true
-  window.addEventListener("beforeunload", () => {
+  window.addEventListener("pagehide", () => {
     if (!clientId) return
     try {
       const { url } = api()

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -239,12 +239,10 @@ const start = () => {
     void ping()
   }
   window.addEventListener("pagehide", hide)
-  window.addEventListener("beforeunload", hide)
   document.addEventListener("visibilitychange", focus)
   return () => {
     clearInterval(timer)
     window.removeEventListener("pagehide", hide)
-    window.removeEventListener("beforeunload", hide)
     document.removeEventListener("visibilitychange", focus)
   }
 }
@@ -380,7 +378,7 @@ const platform: Platform = {
 const boot = async () => {
   if (!(root instanceof HTMLElement)) return
   platform.version = (await readWebVersion()) || undefined
-  const stop = start()
+  let stop = start()
   await sync()
   const server: ServerConnection.Http = { type: "http", http: { url: getCurrentUrl() } }
   render(
@@ -397,7 +395,13 @@ const boot = async () => {
     ),
     root,
   )
-  window.addEventListener("unload", stop, { once: true })
+  window.addEventListener("pagehide", () => {
+    stop()
+  })
+  window.addEventListener("pageshow", (e) => {
+    if (!e.persisted) return
+    stop = start()
+  })
 }
 
 void boot()

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -256,6 +256,58 @@ const detectOS = (): string => {
   return "linux"
 }
 
+let fallbackPath = ""
+
+const webCheck = async () => {
+  const os = detectOS()
+  const res = await req(`/global/web-update/check?os=${os}`)
+  const data = await res.json()
+  if (typeof data.checkError === "string" && data.checkError) throw new Error(data.checkError)
+  return {
+    os,
+    currentVersion: typeof data.currentVersion === "string" ? data.currentVersion.trim() : "",
+    version: typeof data.remoteVersion === "string" ? data.remoteVersion.trim() : "",
+    updateAvailable: !!data.updateAvailable,
+    downloaded: !!data.downloaded,
+    workDir: typeof data.workDir === "string" ? data.workDir.trim() : "",
+    requiresConfirmation: !!data.workDirFallback,
+  }
+}
+
+const consent = (input: { requiresConfirmation: boolean; workDir: string }) => {
+  if (!input.requiresConfirmation) return false
+  const target = input.workDir || "the default location"
+  if (fallbackPath === target) return true
+  const ok = window.confirm(
+    `Aether is not installed in a standard location. The update will be installed to:\n\n${target}\n\nContinue?`,
+  )
+  if (ok) {
+    fallbackPath = target
+    return true
+  }
+  throw new Error("Update cancelled")
+}
+
+const webDownload = async (input: { os: string; version: string }, acceptFallback: boolean) => {
+  const res = await req("/global/web-update/download", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ os: input.os, version: input.version, acceptFallback }),
+  })
+  const data = await res.json()
+  if (!data.success) throw new Error(data.error)
+}
+
+const webInstall = async (input: { os: string; version: string }, acceptFallback: boolean) => {
+  const res = await req("/global/web-update/install", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ os: input.os, version: input.version, acceptFallback }),
+  })
+  const data = await res.json()
+  if (!data.success) throw new Error(data.error)
+}
+
 const platform: Platform = {
   platform: "web",
   version: undefined,
@@ -265,38 +317,28 @@ const platform: Platform = {
   restart,
   notify,
   checkUpdate: async () => {
-    const os = detectOS()
-    const res = await req(`/global/web-update/check?os=${os}`)
-    const data = await res.json()
-    if (typeof data.checkError === "string" && data.checkError) throw new Error(data.checkError)
-    return { updateAvailable: data.updateAvailable, version: data.remoteVersion, downloaded: !!data.downloaded }
+    const data = await webCheck()
+    return {
+      updateAvailable: data.updateAvailable,
+      currentVersion: data.currentVersion,
+      version: data.version,
+      downloaded: data.downloaded,
+      requiresConfirmation: data.requiresConfirmation,
+    }
   },
   downloadUpdate: async () => {
-    const os = detectOS()
-    const checkRes = await req(`/global/web-update/check?os=${os}`)
-    const checkData = await checkRes.json()
-    if (typeof checkData.checkError === "string" && checkData.checkError) throw new Error(checkData.checkError)
-    if (!checkData.updateAvailable) return
-    const dlRes = await req("/global/web-update/download", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ os, version: checkData.remoteVersion }),
-    })
-    const dlData = await dlRes.json()
-    if (!dlData.success) throw new Error(dlData.error)
+    const data = await webCheck()
+    if (!data.updateAvailable) return
+    await webDownload(data, consent(data))
   },
   update: async () => {
-    const os = detectOS()
-    const checkRes = await req(`/global/web-update/check?os=${os}`)
-    const checkData = await checkRes.json()
-    if (typeof checkData.checkError === "string" && checkData.checkError) throw new Error(checkData.checkError)
-    const installRes = await req("/global/web-update/install", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ os, version: checkData.remoteVersion }),
-    })
-    const installData = await installRes.json()
-    if (!installData.success) throw new Error(installData.error)
+    const data = await webCheck()
+    if (!data.updateAvailable) return
+    const acceptFallback = consent(data)
+    if (!data.downloaded) {
+      await webDownload(data, acceptFallback)
+    }
+    await webInstall(data, acceptFallback)
   },
   getDefaultServer: async () => {
     const stored = readDefaultServerUrl()

--- a/packages/app/src/pages/error.tsx
+++ b/packages/app/src/pages/error.tsx
@@ -254,8 +254,8 @@ export const ErrorPage: Component<ErrorPageProps> = (props) => {
   async function installUpdate() {
     if (!platform.update) return
     await platform
-      .downloadUpdate?.()
-      .then(() => platform.update!())
+      .update()
+      .then(() => platform.restart())
       .then(() => setStore("actionError", undefined))
       .catch((err) => {
         setStore("actionError", formatError(err, language.t))

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -31,7 +31,7 @@ import { createStore, produce, reconcile } from "solid-js/store"
 import { DragDropProvider, DragDropSensors, DragOverlay, SortableProvider, closestCenter } from "@thisbeyond/solid-dnd"
 import type { DragEvent } from "@thisbeyond/solid-dnd"
 import { useProviders } from "@/hooks/use-providers"
-import { showToast, Toast, toaster } from "@opencode-ai/ui/toast"
+import { showToast, showPromiseToast, Toast, toaster } from "@opencode-ai/ui/toast"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { clearWorkspaceTerminals } from "@/context/terminal"
 import { dropSessionCaches, pickSessionCacheEvictions } from "@/context/global-sync/session-cache"
@@ -385,10 +385,23 @@ export default function Layout(props: ParentProps) {
 
   const useUpdatePolling = () =>
     onMount(() => {
-      if (!platform.checkUpdate || !platform.update || !platform.restart) return
+      if (!platform.checkUpdate || !platform.update) return
 
       let toastId: number | undefined
       let interval: ReturnType<typeof setInterval> | undefined
+      const install = async () => {
+        showPromiseToast(
+          (async () => {
+            await platform.update!()
+            await platform.restart!()
+          })(),
+          {
+            loading: language.t("update.installing"),
+            success: () => language.t("update.installHint"),
+            error: (err) => (err instanceof Error ? err.message : String(err)),
+          },
+        )
+      }
 
       const showUpdateToast = (version?: string) => {
         if (toastId !== undefined) return
@@ -404,10 +417,7 @@ export default function Layout(props: ParentProps) {
                 ? [
                     {
                       label: language.t("update.install"),
-                      onClick: async () => {
-                        await platform.update!()
-                        await platform.restart!()
-                      },
+                      onClick: install,
                     },
                     {
                       label: language.t("toast.update.action.notYet"),
@@ -417,10 +427,7 @@ export default function Layout(props: ParentProps) {
                 : [
                     {
                       label: language.t("toast.update.action.installRestart"),
-                      onClick: async () => {
-                        await platform.update!()
-                        await platform.restart!()
-                      },
+                      onClick: install,
                     },
                     {
                       label: language.t("toast.update.action.notYet"),
@@ -431,9 +438,9 @@ export default function Layout(props: ParentProps) {
       }
 
       const pollUpdate = () =>
-        platform.checkUpdate!().then(async ({ updateAvailable, version, downloaded }) => {
+        platform.checkUpdate!().then(async ({ updateAvailable, version, downloaded, requiresConfirmation }) => {
           if (!updateAvailable) return
-          if (platform.platform === "web" && platform.downloadUpdate && !downloaded) {
+          if (platform.platform === "web" && platform.downloadUpdate && !downloaded && !requiresConfirmation) {
             await platform.downloadUpdate().catch(() => undefined)
             const next = await platform.checkUpdate!().catch(() => undefined)
             if (!next?.updateAvailable || !next.downloaded) return

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -390,6 +390,11 @@ export default function Layout(props: ParentProps) {
       let toastId: number | undefined
       let interval: ReturnType<typeof setInterval> | undefined
       const install = async () => {
+        if (platform.platform === "web") {
+          const x = await import("@/components/dialog-update")
+          dialog.show(() => <x.DialogUpdate auto="install" />)
+          return
+        }
         showPromiseToast(
           (async () => {
             await platform.update!()

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -4,6 +4,7 @@ import { streamSSE } from "hono/streaming"
 import z from "zod"
 import path from "path"
 import fs from "fs/promises"
+import { tmpdir } from "os"
 import { spawn } from "child_process"
 import { BusEvent } from "@/bus/bus-event"
 import { SyncEvent } from "@/sync"
@@ -65,13 +66,10 @@ const UPDATE_PKG_EXT: Record<string, string> = {
   windows: ".zip",
 }
 
-async function downloadedReady(os: string, ver: string) {
-  const script = await findInstallerScript(os)
-  if (!script) return false
+async function downloadedReady(os: string, ver: string, work: string) {
   const file = UPDATE_SCRIPT[os]
   if (!file) return false
   const ext = UPDATE_PKG_EXT[os] ?? ".dmg"
-  const work = computeWorkDir(script)
   const dl = path.join(work, "downloads")
   const upd = path.join(dl, versioned(file, ver))
   try {
@@ -105,30 +103,55 @@ function compareVer(a: string, b: string) {
 
 function getWorkDir(): string | null {
   const dir = getAppRoot()
-  const base = path.basename(dir)
-  if (base === "Aether") return dir
+  const base = path.basename(dir).toLowerCase()
+  if (base === "aether") return dir
   if (!base.startsWith("aether_")) return null
   const root = path.dirname(dir)
-  if (path.basename(root) !== "Aether") return null
+  if (path.basename(root).toLowerCase() !== "aether") return null
   return root
 }
 
-async function findInstallerScript(os: string): Promise<string | null> {
-  const name = INSTALLER_SCRIPT[os]
-  if (!name) return null
-  const dir = getWorkDir()
-  if (!dir) return null
-  const file = path.join(dir, name)
-  try {
-    await fs.access(file)
-    return file
-  } catch {
-    return null
+function getFallbackWorkDir(os: string): string | null {
+  const home = process.env.HOME || process.env.USERPROFILE || ""
+  if (!home) return null
+  if (os === "darwin") return path.join(home, "Applications", "aether")
+  if (os === "linux") return path.join(home, ".local", "share", "applications", "aether")
+  if (os === "windows") {
+    const base = process.env.LOCALAPPDATA || path.join(home, "AppData", "Local")
+    return path.join(base, "Programs", "aether")
   }
+  return null
 }
 
-function computeWorkDir(scriptPath: string): string {
-  return path.dirname(path.resolve(scriptPath))
+function resolveWorkDir(os: string): { path: string; isFallback: boolean } | null {
+  const current = getWorkDir()
+  if (current) return { path: current, isFallback: false }
+  const fb = getFallbackWorkDir(os)
+  if (!fb) return null
+  return { path: fb, isFallback: true }
+}
+
+async function fetchInstallerScript(os: string): Promise<string | null> {
+  const name = INSTALLER_SCRIPT[os]
+  if (!name) return null
+  const url = `${WEB_UPDATE_BASE}/installer/${name}`
+  const dest = path.join(tmpdir(), `aether-installer-${name}`)
+  try {
+    const res = await fetch(url)
+    if (!res.ok) {
+      log.error("failed to fetch installer script", { url, status: res.status })
+      return null
+    }
+    const buf = Buffer.from(await res.arrayBuffer())
+    await fs.writeFile(dest, buf)
+    if (os !== "windows") {
+      await fs.chmod(dest, 0o755).catch(() => undefined)
+    }
+    return dest
+  } catch (e) {
+    log.error("error fetching installer script", { url, error: e instanceof Error ? e.message : String(e) })
+    return null
+  }
 }
 
 function getAppRoot(): string {
@@ -153,6 +176,9 @@ async function readWebCurrentVersion() {
 
 async function webCheck(os: z.infer<typeof WebUpdateOS>) {
   const currentVersion = await readWebCurrentVersion()
+  const resolved = resolveWorkDir(os)
+  const workDir = resolved?.path ?? ""
+  const workDirFallback = resolved?.isFallback ?? false
   const ymlPath = INSTALLER_YML[os]
   const metaUrl = `${WEB_UPDATE_BASE}/${ymlPath}`
   try {
@@ -163,6 +189,8 @@ async function webCheck(os: z.infer<typeof WebUpdateOS>) {
         remoteVersion: "",
         updateAvailable: false,
         downloaded: false,
+        workDir,
+        workDirFallback,
         checkError: `Failed to fetch version metadata: ${res.status}`,
       }
     }
@@ -175,16 +203,20 @@ async function webCheck(os: z.infer<typeof WebUpdateOS>) {
         remoteVersion: "",
         updateAvailable: false,
         downloaded: false,
+        workDir,
+        workDirFallback,
         checkError: "Could not parse remote version from metadata",
       }
     }
     const updateAvailable = compareVer(currentVersion, remoteVersion) < 0
-    const downloaded = updateAvailable ? await downloadedReady(os, remoteVersion) : false
+    const downloaded = updateAvailable && workDir ? await downloadedReady(os, remoteVersion, workDir) : false
     return {
       currentVersion,
       remoteVersion,
       updateAvailable,
       downloaded,
+      workDir,
+      workDirFallback,
       checkError: undefined,
     }
   } catch (e) {
@@ -194,6 +226,8 @@ async function webCheck(os: z.infer<typeof WebUpdateOS>) {
       remoteVersion: "",
       updateAvailable: false,
       downloaded: false,
+      workDir,
+      workDirFallback,
       checkError: `Failed to check update: ${message}`,
     }
   }
@@ -623,6 +657,8 @@ export const GlobalRoutes = lazy(() =>
                     remoteVersion: z.string(),
                     updateAvailable: z.boolean(),
                     downloaded: z.boolean(),
+                    workDir: z.string(),
+                    workDirFallback: z.boolean(),
                     checkError: z.string().optional(),
                   }),
                 ),
@@ -669,21 +705,35 @@ export const GlobalRoutes = lazy(() =>
         z.object({
           os: WebUpdateOS,
           version: z.string().min(1),
+          acceptFallback: z.boolean().optional(),
         }),
       ),
       async (c) => {
-        const { os, version } = c.req.valid("json")
-        const scriptPath = await findInstallerScript(os)
+        const { os, version, acceptFallback } = c.req.valid("json")
+        const resolved = resolveWorkDir(os)
+        if (!resolved) {
+          return c.json({ success: false as const, error: "Could not determine aether work directory" })
+        }
+        if (resolved.isFallback && !acceptFallback) {
+          return c.json({
+            success: false as const,
+            error: `Aether is not installed in the expected location. Install to fallback path requires confirmation: ${resolved.path}`,
+          })
+        }
+        const workDir = resolved.path
+        try {
+          await fs.mkdir(workDir, { recursive: true })
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e)
+          return c.json({ success: false as const, error: `Failed to create work directory ${workDir}: ${msg}` })
+        }
+        const scriptPath = await fetchInstallerScript(os)
         if (!scriptPath) {
-          return c.json({ success: false as const, error: `Installer script not found for ${os}` })
+          return c.json({ success: false as const, error: `Failed to fetch installer script for ${os}` })
         }
         const upd = UPDATE_SCRIPT[os]
         if (!upd) return c.json({ success: false as const, error: `Update script not configured for ${os}` })
-        try {
-          await fs.chmod(scriptPath, 0o755)
-        } catch {}
-        const workDir = computeWorkDir(scriptPath)
-        if (await downloadedReady(os, version)) {
+        if (await downloadedReady(os, version, workDir)) {
           return c.json({ success: true as const, path: path.join(workDir, "downloads", versioned(upd, version)) })
         }
         const currentVersion = readWebCurrentVersion()
@@ -696,7 +746,10 @@ export const GlobalRoutes = lazy(() =>
           const exitCode = await new Promise<number>((resolve, reject) => {
             const cmd = os === "windows" ? "cmd" : "bash"
             const cmdArgs = os === "windows" ? ["/c", scriptPath, "auto", cur] : [scriptPath, "auto", cur]
-            const child = spawn(cmd, cmdArgs, { cwd: workDir })
+            const child = spawn(cmd, cmdArgs, {
+              cwd: workDir,
+              env: { ...process.env, AETHER_WORK_DIR: workDir },
+            })
             child.on("close", (code: number | null) => resolve(code ?? 1))
             child.on("error", reject)
           })
@@ -722,7 +775,7 @@ export const GlobalRoutes = lazy(() =>
             return ""
           }
           const pkg = await pick()
-          if (!pkg) return c.json({ success: false as const, error: `No dmg found in ${dl}` })
+          if (!pkg) return c.json({ success: false as const, error: `No update package found in ${dl}` })
           log.info("installer auto result", { exitCode, workDir, script: scriptInDownloads, pkg })
           if (exitCode === 20) {
             return c.json({ success: false as const, error: "Already up to date" })
@@ -765,15 +818,28 @@ export const GlobalRoutes = lazy(() =>
         z.object({
           os: WebUpdateOS,
           version: z.string().min(1).optional(),
+          acceptFallback: z.boolean().optional(),
         }),
       ),
       async (c) => {
-        const { os, version } = c.req.valid("json")
-        const scriptPath = await findInstallerScript(os)
-        if (!scriptPath) {
-          return c.json({ success: false as const, error: `Installer script not found for ${os}` })
+        const { os, version, acceptFallback } = c.req.valid("json")
+        const resolved = resolveWorkDir(os)
+        if (!resolved) {
+          return c.json({ success: false as const, error: "Could not determine aether work directory" })
         }
-        const workDir = computeWorkDir(scriptPath)
+        if (resolved.isFallback && !acceptFallback) {
+          return c.json({
+            success: false as const,
+            error: `Aether is not installed in the expected location. Install to fallback path requires confirmation: ${resolved.path}`,
+          })
+        }
+        const workDir = resolved.path
+        try {
+          await fs.mkdir(workDir, { recursive: true })
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e)
+          return c.json({ success: false as const, error: `Failed to create work directory ${workDir}: ${msg}` })
+        }
         const file = UPDATE_SCRIPT[os]
         if (!file) return c.json({ success: false as const, error: `Update script not configured for ${os}` })
         const dl = path.join(workDir, "downloads")


### PR DESCRIPTION
### Issue for this PR

Closes #343 

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

  这个 PR 主要修复了两个相关问题：一是 Web 端的更新安装流程不统一，二是页面生命周期从 unload 切到 pagehide 后带来的 BFCache 恢复问题。

  原来的问题在于，Web 端有些“安装更新”的入口会直接调用 platform.update()，只配合 toast 提示，而没有走 DialogUpdate 这个专门的更新弹窗流程。这样会导致 Web 端的更新
  体验不一致：下载、安装、错误处理、取消行为，以及非标准安装路径确认等逻辑，并不总是通过同一套状态流转来处理。与此同时，最近把清理逻辑从 unload 改成 pagehide 虽然
  方向是对的，但 pagehide 在页面进入 BFCache 时也会触发；如果这时只做清理、不做恢复，用户通过浏览器前进/后退把页面恢复出来后，应用的心跳逻辑可能不会重新启动。

  为了解决这个问题，我把 Web 端几个“安装更新”的入口改成统一打开 DialogUpdate，并传入 auto="install"，而不是直接调用 platform.update()。同时，我扩展了
  DialogUpdate，让它除了支持手动操作外，也能自动执行“检查更新 -> 下载更新 -> 安装更新”这一整套流程，但仍然复用原本的状态展示、错误处理和取消处理逻辑。这样设置页和
  自动更新提示这两个入口就都走同一条更新路径了。除此之外，我保留了 pagehide 作为清理时机，但补上了 pageshow 恢复逻辑：如果页面是从 BFCache 恢复的，就重新启动心跳。

  这些修改之所以有效，是因为它们把 Web 端更新安装统一收敛到一个已经具备完整状态管理能力的流程里，避免了不同入口各走各的逻辑。对于生命周期处理，pagehide 更适合现代
  浏览器的离开/隐藏场景，但在使用它替代 unload 时，必须同时处理 BFCache 恢复；在 pageshow 时重新启动心跳后，这个回归风险就被补上了。

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

 我做了两类验证：自动化验证和实际架构验证。

  自动化方面，我在 packages/app 目录下运行了：

  - bun typecheck
  - bun run test:unit

  这两项都通过了，说明这次修改没有引入类型错误，也没有打破现有单元测试基线。

  实际行为方面，我已经在以下架构上验证过更新流程：

  - linux-x64
  - darwin-arm

  这两个架构下都能成功完成更新安装流程，说明这次改动在 Web 更新入口统一到 DialogUpdate 后，实际下载/安装路径是可工作的。与此同时，这也覆盖了本次修改最核心的行为变
  化。


### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
