### PR TITLE
refactor(feishu): async delivery, interactive Q&A, error surfacing, and tighter file intent

### DIFF
--- a/Aether-wechat-bridge/aether_wechat_agent.py
+++ b/Aether-wechat-bridge/aether_wechat_agent.py
@@ -984,10 +984,8 @@ class AetherAgent(Agent):
     _FILE_INTENT_KEYWORDS = [
         "发给我",
         "发来",
-        "源文件",
-        "原文件",
+        "文件给我",
         "发过来",
-        "原始文件",
         "发文件",
         "send me",
         "send file",

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -49,13 +49,21 @@ function localISOString(d = new Date()): string {
   const sign = offset >= 0 ? "+" : "-"
   const pad = (n: number) => String(Math.floor(Math.abs(n))).padStart(2, "0")
   return (
-    d.getFullYear() + "-" +
-    pad(d.getMonth() + 1) + "-" +
-    pad(d.getDate()) + "T" +
-    pad(d.getHours()) + ":" +
-    pad(d.getMinutes()) + ":" +
+    d.getFullYear() +
+    "-" +
+    pad(d.getMonth() + 1) +
+    "-" +
+    pad(d.getDate()) +
+    "T" +
+    pad(d.getHours()) +
+    ":" +
+    pad(d.getMinutes()) +
+    ":" +
     pad(d.getSeconds()) +
-    sign + pad(offset / 60) + ":" + pad(offset % 60)
+    sign +
+    pad(offset / 60) +
+    ":" +
+    pad(offset % 60)
   )
 }
 
@@ -165,6 +173,8 @@ class FeishuManagerImpl {
   private _pendingQuestions: Record<string, Question.Request> = {}
   private _pendingPermissions: Record<string, Permission.Request> = {}
   private _queues = new Map<string, Promise<void>>()
+  private _processingChat: string | null = null
+  private _processedIds = new Map<string, number>()
   private _heartbeat: ReturnType<typeof setInterval> | null = null
   private _heartbeatFails = 0
   private _reconnect: ReturnType<typeof setTimeout> | null = null
@@ -662,6 +672,8 @@ class FeishuManagerImpl {
   }
 
   private async handleMessage(data: any): Promise<void> {
+    const chatIdForTracking = data?.message?.chat_id
+    if (chatIdForTracking) this._processingChat = chatIdForTracking
     try {
       console.log("[feishu] handleMessage invoked", localISOString())
       console.log("[feishu] received event:", JSON.stringify(data).slice(0, 500))
@@ -937,12 +949,33 @@ class FeishuManagerImpl {
       } catch (e2) {
         console.error("[feishu] failed to send error reply:", e2)
       }
+    } finally {
+      if (this._processingChat === chatIdForTracking) this._processingChat = null
     }
   }
 
   private enqueueMessage(data: any): Promise<void> {
     const chatId = data?.message?.chat_id
     if (!chatId) return this.handleMessage(data)
+
+    const messageId = data?.message?.message_id ?? ""
+    if (messageId) {
+      if (this._processedIds.has(messageId)) return Promise.resolve()
+      this._processedIds.set(messageId, Date.now())
+      this.evictProcessedIds()
+    }
+
+    if (this._processingChat === chatId) {
+      const mid = data?.message?.message_id
+      if (mid) {
+        void this.replyText(
+          mid,
+          "当前会话正在生成回复，请等待当前对话结束后再发送；如需立即开始新问题，请先 /new 或切换 /session n。如需停止本会话请输入 /stop",
+        )
+      }
+      return Promise.resolve()
+    }
+
     const prev = this._queues.get(chatId) ?? Promise.resolve()
     const next = prev
       .catch(() => {})
@@ -952,6 +985,14 @@ class FeishuManagerImpl {
       })
     this._queues.set(chatId, next)
     return next
+  }
+
+  private evictProcessedIds(): void {
+    const now = Date.now()
+    const maxAge = 300_000
+    for (const [id, ts] of this._processedIds) {
+      if (now - ts > maxAge) this._processedIds.delete(id)
+    }
   }
 
   /** Detect if the user is asking for a chat summary and extract time range. */
@@ -1033,9 +1074,23 @@ class FeishuManagerImpl {
   /** Coarse filter: does this message possibly involve a file request? */
   private mightWantFile(text: string): boolean {
     const lower = text.toLowerCase()
-    return ["文件", "file", "发", "给我", "附件", "代码", "doc", "word", "excel", "pdf", "下载", "export", "ppt", "md", "markdown"].some((w) =>
-      lower.includes(w),
-    )
+    return [
+      "文件",
+      "file",
+      "发",
+      "给我",
+      "附件",
+      "代码",
+      "doc",
+      "word",
+      "excel",
+      "pdf",
+      "下载",
+      "export",
+      "ppt",
+      "md",
+      "markdown",
+    ].some((w) => lower.includes(w))
   }
 
   /** Extract file paths that were read by the AI during this turn (from ToolParts). */

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -965,7 +965,24 @@ class FeishuManagerImpl {
       this.evictProcessedIds()
     }
 
-    if (this._processingChat === chatId) {
+    const shouldBlock = (() => {
+      if (this._processingChat !== chatId) return false
+      const message = data?.message
+      if (!message || message.message_type !== "text") return true
+      let content: any
+      try {
+        content = JSON.parse(message.content)
+      } catch {
+        return true
+      }
+      const text = (content.text || "").replace(/@_\w+\s*/g, "").trim()
+      if (!text) return true
+      if (!text.startsWith("/")) return true
+      const cmd = text.trim().split(/\s+/)[0].toLowerCase()
+      return cmd === "/c" || cmd === "/compact"
+    })()
+
+    if (shouldBlock) {
       const mid = data?.message?.message_id
       if (mid) {
         void this.replyText(

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -172,9 +172,16 @@ class FeishuManagerImpl {
   // ── Pending interaction state ─────────────────────────────────────────────
   private _pendingQuestions: Record<string, Question.Request> = {}
   private _pendingPermissions: Record<string, Permission.Request> = {}
-  private _queues = new Map<string, Promise<void>>()
-  private _processingChat: string | null = null
+  private _activePrompt = new Map<
+    string,
+    {
+      sessionId: string
+      messageId: string
+      directory: string
+    }
+  >()
   private _processedIds = new Map<string, number>()
+  private _busUnsubs: (() => void)[] = []
   private _heartbeat: ReturnType<typeof setInterval> | null = null
   private _heartbeatFails = 0
   private _reconnect: ReturnType<typeof setTimeout> | null = null
@@ -328,6 +335,7 @@ class FeishuManagerImpl {
   private async clearRuntime(chatId: string): Promise<void> {
     delete this._pendingQuestions[chatId]
     delete this._pendingPermissions[chatId]
+    this._activePrompt.delete(chatId)
   }
 
   private async commandCtx(chatId: string): Promise<{
@@ -502,6 +510,42 @@ class FeishuManagerImpl {
       }
       GlobalBus.on("event", this._globalBusListener)
 
+      const onQuestion = (event: { directory?: string; payload: any }) => {
+        if (event.payload?.type !== "question.asked") return
+        const q = event.payload.properties as Question.Request
+        for (const [chatId, info] of this._activePrompt) {
+          if (info.sessionId === q.sessionID) {
+            this._pendingQuestions[chatId] = q
+            void this.replyText(info.messageId, this.formatQuestionRequest(q))
+            return
+          }
+        }
+      }
+      GlobalBus.on("event", onQuestion)
+      this._busUnsubs.push(() => GlobalBus.off("event", onQuestion))
+
+      const onPermission = (event: { directory?: string; payload: any }) => {
+        if (event.payload?.type !== "permission.asked") return
+        const p = event.payload.properties as Permission.Request
+        for (const [chatId, info] of this._activePrompt) {
+          if (info.sessionId === p.sessionID) {
+            const pref = SessionPreference.get(info.sessionId)
+            if (pref?.autoAccept) {
+              void Instance.provide({
+                directory: info.directory,
+                fn: () => Permission.reply({ requestID: p.id, reply: "always" }),
+              })
+              return
+            }
+            this._pendingPermissions[chatId] = p
+            void this.replyText(info.messageId, this.formatPermissionRequest(p))
+            return
+          }
+        }
+      }
+      GlobalBus.on("event", onPermission)
+      this._busUnsubs.push(() => GlobalBus.off("event", onPermission))
+
       this._session = {
         connected: true,
         appId: config.appId,
@@ -662,7 +706,9 @@ class FeishuManagerImpl {
     this._modelList = []
     this._pendingQuestions = {}
     this._pendingPermissions = {}
-    this._queues.clear()
+    this._activePrompt.clear()
+    for (const unsub of this._busUnsubs) unsub()
+    this._busUnsubs = []
     if (!reset) return
     this._connectedModel = null
     this._chatDirs = {}
@@ -672,8 +718,6 @@ class FeishuManagerImpl {
   }
 
   private async handleMessage(data: any): Promise<void> {
-    const chatIdForTracking = data?.message?.chat_id
-    if (chatIdForTracking) this._processingChat = chatIdForTracking
     try {
       console.log("[feishu] handleMessage invoked", localISOString())
       console.log("[feishu] received event:", JSON.stringify(data).slice(0, 500))
@@ -741,24 +785,16 @@ class FeishuManagerImpl {
 
       if (cmd === "/stop") {
         const hasPending = chatId in this._pendingQuestions || chatId in this._pendingPermissions
-        const currentSid = this._chatSessions[chatId]
-        if (!currentSid) {
+        const active = this._activePrompt.get(chatId)
+        if (!active && !hasPending) {
           await this.replyText(messageId, "没有任务在执行")
           return
         }
-        const busy = await Instance.provide({
-          directory: effectiveDir,
-          fn: () => SessionStatus.get(SessionID.make(currentSid)),
-        }).catch(() => ({ type: "idle" as const }))
-        if (busy.type !== "busy" && !hasPending) {
-          await this.replyText(messageId, "没有任务在执行")
-          return
-        }
-        if (busy.type === "busy") {
+        if (active) {
           try {
             await Instance.provide({
-              directory: effectiveDir,
-              fn: () => SessionPrompt.cancel(SessionID.make(currentSid)),
+              directory: active.directory,
+              fn: () => SessionPrompt.cancel(SessionID.make(active.sessionId)),
             })
           } catch {}
         }
@@ -778,19 +814,13 @@ class FeishuManagerImpl {
           await this.replyText(messageId, this.formatPermissionRequest(pendingP))
           return
         }
-        const currentSid = this._chatSessions[chatId]
-        if (currentSid) {
-          const busy = await Instance.provide({
-            directory: effectiveDir,
-            fn: () => SessionStatus.get(SessionID.make(currentSid)),
-          }).catch(() => null)
-          if (busy?.type === "busy") {
-            await this.replyText(
-              messageId,
-              "当前会话正在生成回复，请等待当前对话结束后再发送；如需立即开始新问题，请先 /new 或切换 /session n。如需停止本会话请输入 /stop",
-            )
-            return
-          }
+        const active = this._activePrompt.get(chatId)
+        if (active) {
+          await this.replyText(
+            messageId,
+            "当前会话正在生成回复，请等待当前对话结束后再发送；如需立即开始新问题，请先 /new 或切换 /session n。如需停止本会话请输入 /stop",
+          )
+          return
         }
         if (!(chatId in this._chatSessions)) {
           await this.replyText(messageId, "没有任务在执行")
@@ -807,137 +837,25 @@ class FeishuManagerImpl {
 
       const pendingQ = this._pendingQuestions[chatId]
       if (pendingQ) {
-        await this.replyText(messageId, this.formatQuestionRequest(pendingQ))
+        await this.handleQuestionReply(chatId, messageId, text, pendingQ)
         return
       }
       const pendingP = this._pendingPermissions[chatId]
       if (pendingP) {
-        await this.replyText(messageId, this.formatPermissionRequest(pendingP))
+        await this.handlePermissionReply(chatId, messageId, text, pendingP)
         return
       }
-      const currentSid = this._chatSessions[chatId]
-      if (currentSid) {
-        const busy = await Instance.provide({
-          directory: effectiveDir,
-          fn: () => SessionStatus.get(SessionID.make(currentSid)),
-        }).catch(() => null)
-        if (busy?.type === "busy") {
-          await this.replyText(
-            messageId,
-            "当前会话正在生成回复，请等待当前对话结束后再发送；如需立即开始新问题，请先 /new 或切换 /session n。如需停止本会话请输入 /stop",
-          )
-          return
-        }
+
+      const active = this._activePrompt.get(chatId)
+      if (active) {
+        await this.replyText(
+          messageId,
+          "当前会话正在生成回复，请等待当前对话结束后再发送；如需立即开始新问题，请先 /new 或切换 /session n。如需停止本会话请输入 /stop",
+        )
+        return
       }
 
-      await Instance.provide({
-        directory: effectiveDir,
-        fn: async () => {
-          const sessionKey = `${chatId}:${rootId}`
-          let sessionId = this._chatSessions[chatId] ?? this.sessionMap[sessionKey]
-
-          if (!sessionId) {
-            const recent = [...Session.list({ directory: effectiveDir, roots: true, limit: 1 })]
-            if (recent.length > 0) {
-              sessionId = recent[0].id
-              console.log("[feishu] reusing existing session:", sessionId)
-            } else {
-              console.log("[feishu] creating new session...")
-              const session = await Session.create({
-                title: `飞书对话 ${chatId.slice(-6)}`,
-              })
-              sessionId = session.id
-              console.log("[feishu] session created:", sessionId)
-            }
-            this._chatSessions[chatId] = sessionId
-            this.sessionMap[sessionKey] = sessionId
-            await this.saveSessionMap()
-          }
-
-          const model = this.resolveModel(chatId)
-          console.log("[feishu] using model:", model ?? "(default)")
-
-          let promptText = text
-          if (this.mightWantFile(text)) {
-            promptText +=
-              "\n\n[系统提示：如果用户的意图是获取某个文件，请在回复中包含该文件在当前系统上的完整绝对路径。Windows 示例：E:\\\\work\\\\demo\\\\file.md；macOS/Linux 示例：/Users/demo/file.md 或 /home/demo/file.md。系统将自动把该路径对应的文件作为附件发送给用户。如果用户无需获取文件，请忽略本提示，正常回复即可。]"
-          }
-          const intent = this.detectSummaryIntent(text)
-          if (intent.isSummary) {
-            console.log("[feishu] summary intent detected, fetching chat history...")
-            const history = await this.fetchChatHistory(chatId, { today: intent.today, count: intent.count })
-            if (history) {
-              promptText = `${text}\n\n以下是群聊记录，请据此进行总结：\n\n${history}`
-            } else {
-              await this.replyText(
-                messageId,
-                "⚠️ 未能获取群聊记录（可能需要在飞书开放平台开启 im:message.group_msg 权限）",
-              )
-              return
-            }
-          }
-
-          const pref = sessionId ? SessionPreference.get(sessionId) : undefined
-          if (pref?.autoAccept) {
-            const session = await Session.get(SessionID.make(sessionId))
-            if (!session.permission?.some((r) => r.permission === "*" && r.action === "allow")) {
-              await Session.setPermission({
-                sessionID: SessionID.make(sessionId),
-                permission: [{ permission: "*", pattern: "*", action: "allow" }],
-              })
-            }
-          }
-          console.log("[feishu] sending to aether, session:", sessionId, localISOString())
-          const msg = await SessionPrompt.prompt({
-            sessionID: SessionID.make(sessionId),
-            parts: [{ type: "text", text: promptText }],
-          })
-          console.log("[feishu] aether responded, parts:", msg?.parts?.length, localISOString())
-
-          const responseText = this.extractResponseText(msg)
-          if (responseText) {
-            const projectItem = this.getProjects().find(
-              (p) => this.normDir(this.projectDir(p)) === this.normDir(effectiveDir),
-            )
-            const projectName = this.clip(
-              projectItem
-                ? this.projectName(projectItem)
-                : (effectiveDir.replace(/\\/g, "/").replace(/\/+$/, "").split("/").at(-1) ?? effectiveDir),
-              24,
-            )
-            const sessionInfo = [...Session.list({ directory: effectiveDir, roots: true, limit: 100 })].find(
-              (s) => s.id === sessionId,
-            )
-            const label = this.clip(sessionInfo?.title ?? sessionId.slice(0, 8), 24)
-            const pref = SessionPreference.get(sessionId)
-            const modeName = pref?.agent ?? "build"
-            const mode = modeName.charAt(0).toUpperCase() + modeName.slice(1)
-            const model = this.resolveModel(chatId)
-            const modelStr = model
-              ? `${model.providerID}/${model.modelID}`
-              : this._connectedModel
-                ? `${this._connectedModel.providerID}/${this._connectedModel.modelID}`
-                : "—"
-            const header = `${projectName}  ·  ${label}  ·  ${mode}  ·  ${modelStr}\n————————\n`
-
-            console.log("[feishu] replying:", responseText.slice(0, 100), localISOString())
-            await this.replyText(messageId, header + responseText)
-          } else {
-            console.log("[feishu] no text in response")
-          }
-
-          let filesToSend = this.extractReadFiles(msg)
-          if (filesToSend.length === 0 && responseText) {
-            filesToSend = this.extractFilePathsFromText(responseText).slice(0, 1)
-          }
-          if (filesToSend.length > 0) {
-            console.log("[feishu] sending", filesToSend.length, "requested file(s)")
-            for (const filePath of filesToSend.slice(0, 5)) {
-              await this.replyFile(messageId, filePath)
-            }
-          }
-        },
-      })
+      await this.startPrompt(chatId, messageId, text, effectiveDir, rootId)
     } catch (err) {
       console.error("[feishu] handleMessage error:", err)
       try {
@@ -949,59 +867,131 @@ class FeishuManagerImpl {
       } catch (e2) {
         console.error("[feishu] failed to send error reply:", e2)
       }
+    }
+  }
+
+  private async startPrompt(
+    chatId: string,
+    messageId: string,
+    text: string,
+    effectiveDir: string,
+    rootId: string,
+  ): Promise<void> {
+    this._activePrompt.set(chatId, { sessionId: "", messageId, directory: effectiveDir })
+    const sessionKey = `${chatId}:${rootId}`
+    let sessionId = this._chatSessions[chatId] ?? this.sessionMap[sessionKey]
+
+    if (!sessionId) {
+      const recent = await Instance.provide({
+        directory: effectiveDir,
+        fn: () => [...Session.list({ directory: effectiveDir, roots: true, limit: 1 })],
+      })
+      if (recent.length > 0) {
+        sessionId = recent[0].id
+        console.log("[feishu] reusing existing session:", sessionId)
+      } else {
+        console.log("[feishu] creating new session...")
+        const session = await Instance.provide({
+          directory: effectiveDir,
+          fn: () => Session.create({ title: `飞书对话 ${chatId.slice(-6)}` }),
+        })
+        sessionId = session.id
+        console.log("[feishu] session created:", sessionId)
+      }
+      this._chatSessions[chatId] = sessionId
+      this.sessionMap[sessionKey] = sessionId
+      await this.saveSessionMap()
+    }
+
+    this._activePrompt.set(chatId, { sessionId, messageId, directory: effectiveDir })
+
+    const model = this.resolveModel(chatId)
+    console.log("[feishu] using model:", model ?? "(default)")
+
+    let promptText = text
+    if (this.mightWantFile(text)) {
+      promptText +=
+        "\n\n[系统提示：如果用户的意图是获取某个文件，请在回复中包含该文件在当前系统上的完整绝对路径。Windows 示例：E:\\\\work\\\\demo\\\\file.md；macOS/Linux 示例：/Users/demo/file.md 或 /home/demo/file.md。系统将自动把该路径对应的文件作为附件发送给用户。如果用户无需获取文件，请忽略本提示，正常回复即可。]"
+    }
+    const intent = this.detectSummaryIntent(text)
+    if (intent.isSummary) {
+      console.log("[feishu] summary intent detected, fetching chat history...")
+      const history = await this.fetchChatHistory(chatId, { today: intent.today, count: intent.count })
+      if (history) {
+        promptText = `${text}\n\n以下是群聊记录，请据此进行总结：\n\n${history}`
+      } else {
+        await this.replyText(messageId, "⚠️ 未能获取群聊记录（可能需要在飞书开放平台开启 im:message.group_msg 权限）")
+        return
+      }
+    }
+
+    const pref = sessionId ? SessionPreference.get(sessionId) : undefined
+    if (pref?.autoAccept) {
+      const session = await Instance.provide({
+        directory: effectiveDir,
+        fn: () => Session.get(SessionID.make(sessionId)),
+      })
+      if (!session.permission?.some((r) => r.permission === "*" && r.action === "allow")) {
+        await Instance.provide({
+          directory: effectiveDir,
+          fn: () =>
+            Session.setPermission({
+              sessionID: SessionID.make(sessionId),
+              permission: [{ permission: "*", pattern: "*", action: "allow" }],
+            }),
+        })
+      }
+    }
+
+    console.log("[feishu] sending to aether, session:", sessionId, localISOString())
+
+    try {
+      const msg = await Instance.provide({
+        directory: effectiveDir,
+        fn: () =>
+          SessionPrompt.prompt({
+            sessionID: SessionID.make(sessionId),
+            parts: [{ type: "text", text: promptText }],
+          }),
+      })
+      console.log("[feishu] aether responded, parts:", msg?.parts?.length, localISOString())
+
+      const responseText = this.extractResponseText(msg)
+      if (responseText) {
+        const header = await this.formatHeader(chatId)
+        console.log("[feishu] replying:", responseText.slice(0, 100), localISOString())
+        await this.replyText(messageId, header + responseText)
+      } else {
+        console.log("[feishu] no text in response")
+      }
+
+      let filesToSend = this.extractReadFiles(msg)
+      if (filesToSend.length === 0 && responseText) {
+        filesToSend = this.extractFilePathsFromText(responseText).slice(0, 1)
+      }
+      if (filesToSend.length > 0) {
+        console.log("[feishu] sending", filesToSend.length, "requested file(s)")
+        for (const filePath of filesToSend.slice(0, 5)) {
+          await this.replyFile(messageId, filePath)
+        }
+      }
+    } catch (err) {
+      console.error("[feishu] prompt error:", err)
+      const errMsg = err instanceof Error ? err.message : String(err)
+      await this.replyText(messageId, `处理消息时出错: ${errMsg}`).catch(() => {})
     } finally {
-      if (this._processingChat === chatIdForTracking) this._processingChat = null
+      this._activePrompt.delete(chatId)
     }
   }
 
   private enqueueMessage(data: any): Promise<void> {
-    const chatId = data?.message?.chat_id
-    if (!chatId) return this.handleMessage(data)
-
     const messageId = data?.message?.message_id ?? ""
     if (messageId) {
       if (this._processedIds.has(messageId)) return Promise.resolve()
       this._processedIds.set(messageId, Date.now())
       this.evictProcessedIds()
     }
-
-    const shouldBlock = (() => {
-      if (this._processingChat !== chatId) return false
-      const message = data?.message
-      if (!message || message.message_type !== "text") return true
-      let content: any
-      try {
-        content = JSON.parse(message.content)
-      } catch {
-        return true
-      }
-      const text = (content.text || "").replace(/@_\w+\s*/g, "").trim()
-      if (!text) return true
-      if (!text.startsWith("/")) return true
-      const cmd = text.trim().split(/\s+/)[0].toLowerCase()
-      return cmd === "/c" || cmd === "/compact"
-    })()
-
-    if (shouldBlock) {
-      const mid = data?.message?.message_id
-      if (mid) {
-        void this.replyText(
-          mid,
-          "当前会话正在生成回复，请等待当前对话结束后再发送；如需立即开始新问题，请先 /new 或切换 /session n。如需停止本会话请输入 /stop",
-        )
-      }
-      return Promise.resolve()
-    }
-
-    const prev = this._queues.get(chatId) ?? Promise.resolve()
-    const next = prev
-      .catch(() => {})
-      .then(() => this.handleMessage(data))
-      .finally(() => {
-        if (this._queues.get(chatId) === next) this._queues.delete(chatId)
-      })
-    this._queues.set(chatId, next)
-    return next
+    return this.handleMessage(data)
   }
 
   private evictProcessedIds(): void {
@@ -1679,6 +1669,129 @@ class FeishuManagerImpl {
 
   // ─────────────────────────────────────────────────────────────────────────
 
+  private async formatHeader(chatId: string): Promise<string> {
+    const active = this._activePrompt.get(chatId)
+    const sessionId = active?.sessionId ?? this._chatSessions[chatId] ?? ""
+    const effectiveDir = active?.directory ?? this.effectiveDir(chatId)
+    const projectItem = this.getProjects().find((p) => this.normDir(this.projectDir(p)) === this.normDir(effectiveDir))
+    const projectName = this.clip(
+      projectItem
+        ? this.projectName(projectItem)
+        : (effectiveDir.replace(/\\/g, "/").replace(/\/+$/, "").split("/").at(-1) ?? effectiveDir),
+      24,
+    )
+    const label = sessionId ? this.clip(await this.sessionTitle(sessionId, effectiveDir), 24) : "—"
+    const pref = sessionId ? SessionPreference.get(sessionId) : undefined
+    const modeName = pref?.agent ?? "build"
+    const mode = modeName.charAt(0).toUpperCase() + modeName.slice(1)
+    const model = this.resolveModel(chatId)
+    const modelStr = model
+      ? `${model.providerID}/${model.modelID}`
+      : this._connectedModel
+        ? `${this._connectedModel.providerID}/${this._connectedModel.modelID}`
+        : "—"
+    return `${projectName}  ·  ${label}  ·  ${mode}  ·  ${modelStr}\n————————\n`
+  }
+
+  private async sessionTitle(sessionId: string, directory: string): Promise<string> {
+    const info = await Instance.provide({
+      directory,
+      fn: () => [...Session.list({ directory, roots: true, limit: 100 })].find((s) => s.id === sessionId),
+    })
+    return info?.title ?? sessionId.slice(0, 8)
+  }
+
+  private parseQuestionAnswers(text: string, questions: Question.Info[]): string[][] | null {
+    const trimmed = text.trim()
+    if (!trimmed) return null
+    const answers: string[][] = []
+    for (const info of questions) {
+      const options = info.options ?? []
+      if (options.length > 0 && trimmed.match(/^\d+$/)) {
+        const idx = parseInt(trimmed) - 1
+        if (idx >= 0 && idx < options.length) {
+          answers.push([options[idx].label])
+          continue
+        }
+        if (!info.custom) return null
+      } else if (options.length > 0 && !info.custom) {
+        const match = options.find((o) => o.label === trimmed)
+        if (!match) return null
+        answers.push([match.label])
+        continue
+      }
+      answers.push([trimmed])
+    }
+    return answers
+  }
+
+  private async handleQuestionReply(
+    chatId: string,
+    messageId: string,
+    text: string,
+    pending: Question.Request,
+  ): Promise<void> {
+    const answers = this.parseQuestionAnswers(text, pending.questions)
+    if (!answers) {
+      await this.replyText(messageId, "未识别，请回复答案或数字编号。\n\n" + this.formatQuestionRequest(pending))
+      return
+    }
+    const active = this._activePrompt.get(chatId)
+    delete this._pendingQuestions[chatId]
+    try {
+      await Instance.provide({
+        directory: active?.directory ?? this.effectiveDir(chatId),
+        fn: () => Question.reply({ requestID: pending.id, answers }),
+      })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      this._pendingQuestions[chatId] = pending
+      await this.replyText(messageId, `❌ 提交答案失败: ${msg}\n请重新发送您的答案。`)
+      return
+    }
+    await this.replyText(messageId, "已提交回答，请等待当前对话继续处理。")
+  }
+
+  private parsePermissionReply(text: string): Permission.Reply | null {
+    const trimmed = text.trim()
+    if (trimmed === "1") return "once"
+    if (trimmed === "2") return "always"
+    if (trimmed === "3") return "reject"
+    return null
+  }
+
+  private async handlePermissionReply(
+    chatId: string,
+    messageId: string,
+    text: string,
+    pending: Permission.Request,
+  ): Promise<void> {
+    const reply = this.parsePermissionReply(text)
+    if (!reply) {
+      await this.replyText(messageId, "未识别，请回复数字编号。\n\n" + this.formatPermissionRequest(pending))
+      return
+    }
+    const active = this._activePrompt.get(chatId)
+    delete this._pendingPermissions[chatId]
+    try {
+      await Instance.provide({
+        directory: active?.directory ?? this.effectiveDir(chatId),
+        fn: () => Permission.reply({ requestID: pending.id, reply }),
+      })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      this._pendingPermissions[chatId] = pending
+      await this.replyText(messageId, `❌ 提交授权失败: ${msg}\n请重新发送您的选择。`)
+      return
+    }
+    const notice = {
+      once: "已收到授权：允许一次，继续处理中。",
+      always: "已收到授权：始终允许，继续处理中。",
+      reject: "已收到你的选择：拒绝，正在继续处理。",
+    }[reply]
+    await this.replyText(messageId, notice)
+  }
+
   private formatQuestionRequest(q: Question.Request): string {
     const parts = ["🤔 Agent 需要您回答：", ""]
     for (let i = 0; i < q.questions.length; i++) {
@@ -1728,6 +1841,22 @@ class FeishuManagerImpl {
       })
     } catch (err) {
       console.error("[feishu] reply error:", err)
+    }
+  }
+
+  private async sendToChat(chatId: string, text: string): Promise<void> {
+    if (!this.larkClient) return
+    try {
+      await this.larkClient.im.message.create({
+        params: { receive_id_type: "chat_id" },
+        data: {
+          receive_id: chatId,
+          msg_type: "text",
+          content: JSON.stringify({ text }),
+        },
+      })
+    } catch (err) {
+      console.error("[feishu] send error:", err)
     }
   }
 

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -1065,9 +1065,17 @@ class FeishuManagerImpl {
   }
 
   private extractResponseText(msg: any): string | null {
-    if (!msg?.parts) return null
+    if (!msg?.parts) {
+      const error = msg?.info?.error
+      if (error) return `AI 服务错误: ${error?.data?.message || error?.name || "未知错误"}`
+      return null
+    }
     const textParts = msg.parts.filter((p: any) => p.type === "text")
-    if (textParts.length === 0) return null
+    if (textParts.length === 0) {
+      const error = msg?.info?.error
+      if (error) return `AI 服务错误: ${error?.data?.message || error?.name || "未知错误"}`
+      return null
+    }
     return textParts.map((p: any) => p.text).join("\n")
   }
 

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -1074,23 +1074,7 @@ class FeishuManagerImpl {
   /** Coarse filter: does this message possibly involve a file request? */
   private mightWantFile(text: string): boolean {
     const lower = text.toLowerCase()
-    return [
-      "文件",
-      "file",
-      "发",
-      "给我",
-      "附件",
-      "代码",
-      "doc",
-      "word",
-      "excel",
-      "pdf",
-      "下载",
-      "export",
-      "ppt",
-      "md",
-      "markdown",
-    ].some((w) => lower.includes(w))
+    return ["发给我", "发来", "文件给我", "发过来", "发文件", "send me", "send file"].some((w) => lower.includes(w))
   }
 
   /** Extract file paths that were read by the AI during this turn (from ToolParts). */


### PR DESCRIPTION
### Issue for this PR

Closes #344

### Type of change

- [x] Refactor / code improvement
- [x] Bug fix

### What does this PR do?

Refactors the Feishu message handling pipeline to resolve several usability and reliability issues:

1. **Async message delivery**: Replaces the per-chat promise queue (`_queues`) with an `_activePrompt` tracking map. `startPrompt()` is fire-and-forget — the handler returns immediately and the prompt runs asynchronously. Follow-up messages get a busy hint instead of being silently queued.

2. **Interactive question and permission replies**: Subscribes to `question.asked` and `permission.asked` bus events during an active prompt. When the agent asks a question or requests permission, the bot relays it to the chat and the user can reply inline. Added `handleQuestionReply()` and `handlePermissionReply()` for parsing and submitting answers.

3. **Surface LLM API errors**: `extractResponseText()` now checks `msg.info.error` and shows the error message to the user instead of silently returning null.

4. **Tighter file-intent keywords**: Narrowed `mightWantFile` in both Feishu and WeChat bridges to reduce false positives (e.g., removed generic terms like "文件", "代码").

5. **Selective busy blocking**: `/stop` and other slash commands now pass through during a busy session; only plain text and `/compact` get the busy hint.

Also adds `_processedIds` deduplication in `enqueueMessage()` and cleanup of bus subscriptions on disconnect.

### How did you verify your code works?

- Ran `bun typecheck` across all packages — passes.
- Verified the Feishu bot connects, sends messages, and handles async prompt lifecycle locally.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR