### PR TITLE
fix(e2e): ensure sqlite parent dirs exist in app e2e bootstrap path

### DIFF
--- a/packages/opencode/src/storage/db.bun.ts
+++ b/packages/opencode/src/storage/db.bun.ts
@@ -1,7 +1,15 @@
 import { Database } from "bun:sqlite"
 import { drizzle } from "drizzle-orm/bun-sqlite"
+import { mkdirSync } from "fs"
+import path from "path"
+
+function dir(file: string) {
+  if (file === ":memory:") return
+  mkdirSync(path.dirname(file), { recursive: true })
+}
 
 export function init(path: string) {
+  dir(path)
   const sqlite = new Database(path, { create: true })
   const db = drizzle({ client: sqlite })
   return db

--- a/packages/opencode/src/storage/db.node.ts
+++ b/packages/opencode/src/storage/db.node.ts
@@ -1,7 +1,15 @@
 import { DatabaseSync } from "node:sqlite"
 import { drizzle } from "drizzle-orm/node-sqlite"
+import { mkdirSync } from "fs"
+import path from "path"
+
+function dir(file: string) {
+  if (file === ":memory:") return
+  mkdirSync(path.dirname(file), { recursive: true })
+}
 
 export function init(path: string) {
+  dir(path)
   const sqlite = new DatabaseSync(path)
   const db = drizzle({ client: sqlite })
   return db

--- a/packages/opencode/test/storage/db.test.ts
+++ b/packages/opencode/test/storage/db.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test"
+import fs from "fs"
 import { rm } from "fs/promises"
+import os from "os"
 import path from "path"
 import { Global } from "../../src/global"
 import { Installation } from "../../src/installation"
+import { init } from "../../src/storage/db.bun"
 import { Database } from "../../src/storage/db"
 
 describe("Database.Path", () => {
@@ -42,6 +45,18 @@ describe("Database.Path", () => {
       expect(list.every((file) => /^aether.*\.db$/i.test(path.basename(file)))).toBeTrue()
     } finally {
       await Promise.all([rm(one, { force: true }), rm(two, { force: true }), rm(old, { force: true })])
+    }
+  })
+
+  test("init creates parent dir for file databases", async () => {
+    const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "aether-db-"))
+    const file = path.join(root, "deep", "aether.db")
+    try {
+      const db = init(file)
+      db.$client.close()
+      expect(await Bun.file(file).exists()).toBeTrue()
+    } finally {
+      await rm(root, { recursive: true, force: true })
     }
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #346

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the Linux app e2e regression introduced by the persistence rename to `aether`.

The app e2e flow in `packages/app/script/e2e-local.ts` bootstraps opencode directly instead of going through the CLI entrypoint, so it can hit SQLite initialization before `Global.ensureDirs()` runs. That caused SQLite to open paths like `.../share/aether/aether-local.db` before the parent directory existed, which failed with `SQLITE_CANTOPEN`.

This change makes the Bun and Node SQLite init paths create the parent directory for file-backed databases before opening the database. It also adds a regression test for opening a database whose parent directory does not exist yet.

### How did you verify your code works?

- Ran `bun test test/storage/db.test.ts` in `packages/opencode`
- Ran `bun typecheck` in `packages/opencode`
- Ran the app e2e CI allowlist locally with CI-style env:
  - main group: `64 passed`, `3 skipped`, `1 flaky`, exit code `0`
  - serial group: `10 passed`, exit code `0`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
