### PR TITLE
feat(file): support HTTP Range requests for files

### DIFF
--- a/packages/app/public/pdf-viewer-aether.js
+++ b/packages/app/public/pdf-viewer-aether.js
@@ -803,12 +803,7 @@
       standardFontDataUrl: STANDARD_FONT_DATA_URL,
     };
 
-    await app.open(config.src);
-    const doc = await window.pdfjsLib.getDocument(loadOpts).promise;
-    if (doc?._pdfInfo) {
-      doc._pdfInfo.fingerprints = [config.src];
-    }
-    await app.load(doc);
+    await app.open(config.src, loadOpts);
   }
 
   async function applyConfig(nextConfig) {

--- a/packages/app/public/pdf-viewer-aether.js
+++ b/packages/app/public/pdf-viewer-aether.js
@@ -5,6 +5,7 @@
   const ORIGIN = window.location.origin;
   const C_MAP_URL = "/pdfjs-ref/web/cmaps/";
   const STANDARD_FONT_DATA_URL = "/pdfjs-ref/web/standard_fonts/";
+  const RANGE_CHUNK_SIZE = 65536;
   const DEFAULT_SCALE = {
     full: "auto",
     compact: "page-width",
@@ -797,6 +798,10 @@
     const loadOpts = {
       url: config.src,
       httpHeaders: config.authHeader ? { Authorization: config.authHeader } : undefined,
+      rangeChunkSize: RANGE_CHUNK_SIZE,
+      disableRange: false,
+      disableStream: true,
+      disableAutoFetch: true,
       useWorkerFetch: false,
       cMapUrl: C_MAP_URL,
       cMapPacked: true,

--- a/packages/app/src/context/file.tsx
+++ b/packages/app/src/context/file.tsx
@@ -50,6 +50,78 @@ function errorMessage(error: unknown, fallback: string) {
   return fallback
 }
 
+const image = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "bmp",
+  "webp",
+  "ico",
+  "tif",
+  "tiff",
+  "svg",
+  "svgz",
+  "avif",
+  "apng",
+  "jxl",
+  "heic",
+  "heif",
+  "raw",
+  "cr2",
+  "nef",
+  "arw",
+  "dng",
+  "orf",
+  "raf",
+  "pef",
+  "x3f",
+])
+
+const binary = new Set([
+  "pdf",
+  "exe",
+  "dll",
+  "pdb",
+  "bin",
+  "so",
+  "dylib",
+  "wav",
+  "mp3",
+  "ogg",
+  "flac",
+  "aac",
+  "m4a",
+  "mp4",
+  "avi",
+  "mov",
+  "webm",
+  "mkv",
+  "zip",
+  "tar",
+  "gz",
+  "bz2",
+  "7z",
+  "rar",
+  "xz",
+  "ttf",
+  "otf",
+  "woff",
+  "woff2",
+  "db",
+  "sqlite",
+  "wasm",
+])
+
+const preview = (file: string) => {
+  const ext = file.split(".").pop()?.toLowerCase() ?? ""
+  if (!ext) return "text" as const
+  if (ext === "pdf") return "pdf" as const
+  if (image.has(ext)) return "image" as const
+  if (binary.has(ext)) return "binary" as const
+  return "text" as const
+}
+
 export const { use: useFile, provider: FileProvider } = createSimpleContext({
   name: "File",
   gate: false,
@@ -244,14 +316,15 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
       )
     }
 
-    const setLoaded = (file: string, content: FileState["content"]) => {
+    const setLoaded = (file: string, next: { content?: FileState["content"]; metadata?: FileState["metadata"] }) => {
       setStore(
         "file",
         file,
         produce((draft) => {
           draft.loaded = true
           draft.loading = false
-          draft.content = content
+          draft.content = next.content
+          draft.metadata = next.metadata
         }),
       )
     }
@@ -288,15 +361,15 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
 
       setLoading(file)
 
-      const promise = sdk.client.file
-        .read({ path: file })
-        .then((x) => {
+      const promise = (preview(file) === "text"
+        ? sdk.client.file.read({ path: file }).then((x) => ({ content: x.data }))
+        : sdk.client.file.metadata({ path: file }).then((x) => ({ metadata: x.data })))
+        .then((next) => {
           if (scope() !== directory) return
-          const content = x.data
-          setLoaded(file, content)
+          setLoaded(file, next)
 
-          if (!content) return
-          touchFileContent(file, approxBytes(content))
+          if (!("content" in next) || !next.content) return
+          touchFileContent(file, approxBytes(next.content))
           evictContent(new Set([file]))
         })
         .catch((e) => {

--- a/packages/app/src/context/file/types.ts
+++ b/packages/app/src/context/file/types.ts
@@ -1,4 +1,4 @@
-import type { FileContent } from "@opencode-ai/sdk/v2"
+import type { FileContent, FileMetadata } from "@opencode-ai/sdk/v2"
 
 export type FileSelection = {
   startLine: number
@@ -30,6 +30,7 @@ export type FileState = {
   loaded?: boolean
   loading?: boolean
   error?: string
+  metadata?: FileMetadata
   content?: FileContent
 }
 

--- a/packages/app/src/pages/session/file-tabs.tsx
+++ b/packages/app/src/pages/session/file-tabs.tsx
@@ -389,13 +389,23 @@ export function FileTabContent(props: { tab: string }) {
     return ext === "py" || ext === "pyw"
   })
 
+  const state = createMemo(() => {
+    const p = path()
+    if (!p) return
+    return file.get(p)
+  })
+  const meta = createMemo(() => state()?.metadata)
+  const contents = createMemo(() => state()?.content?.content ?? "")
+  const isImageFile = createMemo(() => meta()?.previewKind === "image")
+
   const isPDF = createMemo(() => {
+    if (meta()?.previewKind === "pdf") return true
     const p = path()
     if (!p) return false
     return p.split(".").pop()?.toLowerCase() === "pdf"
   })
 
-  const pdfPreviewUrl = createMemo(() => {
+  const rawPreviewUrl = createMemo(() => {
     const p = path()
     if (!p) return ""
     return `${sdk.url}/file/raw?path=${encodeURIComponent(p)}&directory=${encodeURIComponent(sdk.directory)}`
@@ -529,14 +539,9 @@ export function FileTabContent(props: { tab: string }) {
       setIsRunning(false)
     }
   }
-  const state = createMemo(() => {
-    const p = path()
-    if (!p) return
-    return file.get(p)
-  })
-  const contents = createMemo(() => state()?.content?.content ?? "")
-  
   const isTextFile = createMemo(() => {
+    const info = meta()
+    if (info) return info.previewKind === "text"
     const content = state()?.content
     if (!content) return true
     if (content.type === "binary") return false
@@ -952,11 +957,18 @@ export function FileTabContent(props: { tab: string }) {
   }
 
   const renderFile = (source: string) => {
+    if (isImageFile()) {
+      return (
+        <div class="flex h-full min-h-0 items-center justify-center p-6" data-file-content>
+          <img src={rawPreviewUrl()} alt={path() ?? "image"} class="max-h-full max-w-full object-contain" />
+        </div>
+      )
+    }
     if (isPDF()) {
       return (
         <div class="relative h-full min-h-0 overflow-hidden" data-file-content>
           <PdfViewerShell
-            src={pdfPreviewUrl()}
+            src={rawPreviewUrl()}
             authHeader={pdfAuthHeader()}
             mode="compact"
             class="size-full"
@@ -978,6 +990,18 @@ export function FileTabContent(props: { tab: string }) {
       return (
         <div class="relative px-6 pb-40 select-text" data-file-content>
           <pre class="text-sm font-mono leading-relaxed whitespace-pre-wrap break-words text-text-base">{source}</pre>
+        </div>
+      )
+    }
+    if (!isTextFile()) {
+      return (
+        <div class="flex h-full min-h-0 items-center justify-center px-6 py-10 text-center" data-file-content>
+          <div class="space-y-2">
+            <div class="text-sm font-medium text-text-base">该文件暂不支持内联文本预览</div>
+            <div class="text-xs text-text-weak">
+              {meta()?.mimeType ?? state()?.content?.mimeType ?? "application/octet-stream"}
+            </div>
+          </div>
         </div>
       )
     }
@@ -1194,6 +1218,4 @@ export function FileTabContent(props: { tab: string }) {
     </Tabs.Content>
   )
 }
-
-
 

--- a/packages/app/src/utils/server.ts
+++ b/packages/app/src/utils/server.ts
@@ -108,23 +108,7 @@ export function createSdkForServer({
 }
 
 export function addPreferenceMethods(client: AppClient, baseUrl: string, auth?: Record<string, string>): AppClient {
-  const headers: Record<string, string> = { "Content-Type": "application/json", ...auth }
-  client.session.preference = {
-    async get(input) {
-      const resp = await fetch(`${baseUrl}/session/${input.sessionID}/preference`, { headers })
-      const data = await resp.json()
-      return { data }
-    },
-    async update(input) {
-      const { sessionID, ...body } = input
-      const resp = await fetch(`${baseUrl}/session/${sessionID}/preference`, {
-        method: "PATCH",
-        headers,
-        body: JSON.stringify(body),
-      })
-      const data = await resp.json()
-      return { data }
-    },
-  }
+  void baseUrl
+  void auth
   return client
 }

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -48,6 +48,22 @@ export namespace File {
     })
   export type Node = z.infer<typeof Node>
 
+  export const Metadata = z
+    .object({
+      path: z.string(),
+      name: z.string(),
+      kind: z.enum(["file", "directory"]),
+      size: z.number().int().nonnegative(),
+      mimeType: z.string(),
+      previewKind: z.enum(["text", "image", "pdf", "binary", "directory"]),
+      inline: z.boolean(),
+      range: z.boolean(),
+    })
+    .meta({
+      ref: "FileMetadata",
+    })
+  export type Metadata = z.infer<typeof Metadata>
+
   export const Content = z
     .object({
       type: z.enum(["text", "binary"]),
@@ -299,6 +315,23 @@ export namespace File {
   const isBinaryByExtension = (file: string) => binary.has(ext(file))
   const isImage = (mimeType: string) => mimeType.startsWith("image/")
   const getImageMimeType = (file: string) => mime[ext(file)] || "image/" + ext(file)
+  const isPdf = (file: string, mimeType?: string) =>
+    path.extname(file).toLowerCase() === ".pdf" || mimeType?.toLowerCase() === "application/pdf"
+  const isInline = (file: string, mimeType: string) =>
+    isTextByExtension(file) ||
+    isTextByName(file) ||
+    mimeType.startsWith("text/") ||
+    mimeType === "application/json" ||
+    mimeType.endsWith("+json")
+
+  function preview(file: string, mimeType: string, kind: "file" | "directory"): Metadata["previewKind"] {
+    if (kind === "directory") return "directory"
+    if (isPdf(file, mimeType)) return "pdf"
+    if (isImageByExtension(file) || isImage(mimeType)) return "image"
+    if (isInline(file, mimeType)) return "text"
+    if (isBinaryByExtension(file)) return "binary"
+    return shouldEncode(mimeType) ? "binary" : "text"
+  }
 
   function shouldEncode(mimeType: string) {
     const type = mimeType.toLowerCase()
@@ -582,6 +615,28 @@ export namespace File {
     await fs.promises.mkdir(targetDir, { recursive: true })
     await fs.promises.rename(resolvedOld, newPath)
     return newPath
+  }
+
+  export async function metadata(filePath: string): Promise<Metadata> {
+    const resolved = path.join(Instance.directory, filePath)
+    if (!Instance.containsPath(resolved)) {
+      throw new Error("Access denied: path escapes project directory")
+    }
+
+    const stat = await fs.promises.stat(resolved)
+    const kind = stat.isDirectory() ? "directory" : "file"
+    const mimeType = kind === "directory" ? "inode/directory" : Filesystem.mimeType(resolved)
+    const previewKind = preview(filePath, mimeType, kind)
+    return {
+      path: filePath,
+      name: path.basename(resolved),
+      kind,
+      size: Number(stat.size),
+      mimeType,
+      previewKind,
+      inline: previewKind === "text",
+      range: kind === "file",
+    }
   }
 
   export interface Interface {

--- a/packages/opencode/src/server/routes/file.ts
+++ b/packages/opencode/src/server/routes/file.ts
@@ -12,7 +12,7 @@ import { errors } from "../error"
 import { $ } from "bun"
 import { spawn } from "bun"
 import path from "path"
-import type { Stats } from "fs"
+import { createReadStream, type Stats } from "fs"
 import { parsePDF } from "../../knowledge/document"
 import {
   startConversion,
@@ -24,6 +24,7 @@ import {
 } from "../../pdf-converter"
 import { generateTaskID, computeOutputPaths } from "../../pdf-converter/util"
 import { checkPythonAvailable } from "../../pdf-converter/pdf-renderer"
+import { Filesystem } from "../../util/filesystem"
 import {
   startTranslation,
   getTranslateTask,
@@ -52,6 +53,40 @@ const ascii = (input: string) => {
 const attachment = (name: string) => `attachment; filename="${ascii(name)}"; filename*=UTF-8''${encode(name)}`
 
 const resolvePath = (input: string) => (path.isAbsolute(input) ? input : path.join(Instance.directory, input))
+const resolveFile = (input: string) => {
+  const resolved = resolvePath(input)
+  if (!Instance.containsPath(resolved)) throw new Error("Access denied: path escapes project directory")
+  return resolved
+}
+
+const etag = (stat: Stats) => `W/"${Number(stat.size)}-${stat.mtimeMs}"`
+
+function bytes(input: string | undefined, size: number) {
+  if (!input) return
+  const match = input.match(/^bytes=(\d*)-(\d*)$/)
+  if (!match) return "invalid" as const
+  const left = match[1]
+  const right = match[2]
+  if (!left && !right) return "invalid" as const
+
+  if (!left) {
+    const len = Number(right)
+    if (!Number.isInteger(len) || len <= 0) return "invalid" as const
+    const start = Math.max(size - len, 0)
+    return { start, end: size - 1 }
+  }
+
+  const start = Number(left)
+  const end = right ? Number(right) : size - 1
+  if (!Number.isInteger(start) || !Number.isInteger(end) || start < 0 || end < start || start >= size) {
+    return "invalid" as const
+  }
+
+  return {
+    start,
+    end: Math.min(end, size - 1),
+  }
+}
 
 const requireDirectory = async (input: string) => {
   try {
@@ -322,6 +357,44 @@ export const FileRoutes = lazy(() =>
 
         const content = await File.list(path)
         return c.json(content)
+      },
+    )
+    .get(
+      "/file/metadata",
+      describeRoute({
+        summary: "Read file metadata",
+        description: "Read lightweight metadata for a file or directory without loading file contents.",
+        operationId: "file.metadata",
+        responses: {
+          200: {
+            description: "File metadata",
+            content: {
+              "application/json": {
+                schema: resolver(File.Metadata),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "query",
+        z.object({
+          path: z.string(),
+        }),
+      ),
+      async (c) => {
+        try {
+          return c.json(await File.metadata(c.req.valid("query").path))
+        } catch (err) {
+          if (err instanceof Error && /ENOENT/.test(err.message)) {
+            return c.json({ error: "File not found" }, 404)
+          }
+          if (err instanceof Error && /Access denied/.test(err.message)) {
+            return c.json({ error: err.message }, 400)
+          }
+          throw err
+        }
       },
     )
     .get(
@@ -1150,40 +1223,93 @@ export const FileRoutes = lazy(() =>
         return c.json({ ok })
       },
     )
-    // ====== 原始文件内容（用于 <img src> 等二进制文件） ======
+    // ====== 原始文件内容（用于 <img src> / PDF 预览等） ======
     .get(
       "/file/raw",
       describeRoute({
         summary: "Serve raw file",
-        description: "Serve a file's raw binary content with appropriate Content-Type.",
+        description: "Serve a file's raw bytes with support for range requests.",
         operationId: "file.raw",
         responses: {
           200: { description: "File content" },
+          206: { description: "Partial file content" },
+          416: { description: "Invalid range" },
           ...errors(400, 404),
         },
       }),
       validator("query", z.object({ path: z.string() })),
       async (c) => {
-        const filePath = c.req.valid("query").path
-        const absPath = path.isAbsolute(filePath) ? filePath : path.join(Instance.directory, filePath)
-        const file = Bun.file(absPath)
-        if (!(await file.exists())) {
-          return c.json({ error: "File not found" }, 404)
+        try {
+          const abs = resolveFile(c.req.valid("query").path)
+          const stat = await fs.stat(abs)
+          if (!stat.isFile()) {
+            return c.json({ error: "Path must point to a file" }, 400)
+          }
+
+          const type = Filesystem.mimeType(abs)
+          const base = {
+            "Accept-Ranges": "bytes",
+            "Cache-Control": "max-age=3600",
+            "Content-Type": type,
+            ETag: etag(stat),
+            "Last-Modified": stat.mtime.toUTCString(),
+          }
+          const range = bytes(c.req.header("range"), Number(stat.size))
+          if (range === "invalid") {
+            return new Response(null, {
+              status: 416,
+              headers: {
+                ...base,
+                "Content-Range": `bytes */${Number(stat.size)}`,
+              },
+            })
+          }
+
+          if (!range) {
+            if (c.req.method === "HEAD") {
+              return new Response(null, {
+                headers: {
+                  ...base,
+                  "Content-Length": String(Number(stat.size)),
+                },
+              })
+            }
+            return new Response(Bun.file(abs), {
+              headers: {
+                ...base,
+                "Content-Length": String(Number(stat.size)),
+              },
+            })
+          }
+
+          if (c.req.method === "HEAD") {
+            return new Response(null, {
+              status: 206,
+              headers: {
+                ...base,
+                "Content-Length": String(range.end - range.start + 1),
+                "Content-Range": `bytes ${range.start}-${range.end}/${Number(stat.size)}`,
+              },
+            })
+          }
+
+          return new Response(createReadStream(abs, { start: range.start, end: range.end }) as any, {
+            status: 206,
+            headers: {
+              ...base,
+              "Content-Length": String(range.end - range.start + 1),
+              "Content-Range": `bytes ${range.start}-${range.end}/${Number(stat.size)}`,
+            },
+          })
+        } catch (err) {
+          if (err instanceof Error && /ENOENT/.test(err.message)) {
+            return c.json({ error: "File not found" }, 404)
+          }
+          if (err instanceof Error && /Access denied/.test(err.message)) {
+            return c.json({ error: err.message }, 400)
+          }
+          throw err
         }
-        const ext = absPath.split(".").pop()?.toLowerCase() ?? ""
-        const mimeMap: Record<string, string> = {
-          png: "image/png",
-          jpg: "image/jpeg",
-          jpeg: "image/jpeg",
-          gif: "image/gif",
-          svg: "image/svg+xml",
-          webp: "image/webp",
-          pdf: "application/pdf",
-        }
-        const contentType = mimeMap[ext] || "application/octet-stream"
-        return new Response(file, {
-          headers: { "Content-Type": contentType, "Cache-Control": "max-age=3600" },
-        })
       },
     )
     // ====== Markdown 翻译路由 ======

--- a/packages/opencode/src/server/routes/file.ts
+++ b/packages/opencode/src/server/routes/file.ts
@@ -36,6 +36,12 @@ import { detectDataJson, chunkByContent, chunksFromDataJson } from "../../markdo
 import fs from "fs/promises"
 import { linux, missing, windows, wsl, wslPath } from "../pick-folder"
 
+export type ServerEnv = {
+  Variables: {
+    cors?: string[]
+  }
+}
+
 const encode = (input: string) =>
   encodeURIComponent(input).replace(/['()*]/g, (part) => `%${part.charCodeAt(0).toString(16).toUpperCase()}`)
 
@@ -88,6 +94,32 @@ function bytes(input: string | undefined, size: number) {
   }
 }
 
+function origin(input: string | undefined, list?: string[]) {
+  if (!input) return
+  if (input.startsWith("http://localhost:")) return input
+  if (input.startsWith("http://127.0.0.1:")) return input
+  if (input === "tauri://localhost" || input === "http://tauri.localhost" || input === "https://tauri.localhost") {
+    return input
+  }
+  if (/^https:\/\/([a-z0-9-]+\.)*opencode\.ai$/.test(input)) {
+    return input
+  }
+  if (list?.includes(input)) {
+    return input
+  }
+}
+
+function raw(input: string | undefined, list?: string[]) {
+  const value = origin(input, list)
+  if (!value) return
+  return {
+    "Access-Control-Allow-Credentials": "true",
+    "Access-Control-Allow-Origin": value,
+    "Access-Control-Expose-Headers": "Accept-Ranges, Content-Length, Content-Range, ETag, Last-Modified",
+    Vary: "Origin",
+  }
+}
+
 const requireDirectory = async (input: string) => {
   try {
     const dir = resolvePath(input)
@@ -100,7 +132,7 @@ const requireDirectory = async (input: string) => {
 }
 
 export const FileRoutes = lazy(() =>
-  new Hono()
+  new Hono<ServerEnv>()
     .get(
       "/file/active-tasks",
       describeRoute({
@@ -1240,6 +1272,7 @@ export const FileRoutes = lazy(() =>
       validator("query", z.object({ path: z.string() })),
       async (c) => {
         try {
+          const cors = raw(c.req.header("origin"), c.get("cors") as string[] | undefined)
           const abs = resolveFile(c.req.valid("query").path)
           const stat = await fs.stat(abs)
           if (!stat.isFile()) {
@@ -1260,6 +1293,7 @@ export const FileRoutes = lazy(() =>
               status: 416,
               headers: {
                 ...base,
+                ...cors,
                 "Content-Range": `bytes */${Number(stat.size)}`,
               },
             })
@@ -1270,6 +1304,7 @@ export const FileRoutes = lazy(() =>
               return new Response(null, {
                 headers: {
                   ...base,
+                  ...cors,
                   "Content-Length": String(Number(stat.size)),
                 },
               })
@@ -1277,6 +1312,7 @@ export const FileRoutes = lazy(() =>
             return new Response(Bun.file(abs), {
               headers: {
                 ...base,
+                ...cors,
                 "Content-Length": String(Number(stat.size)),
               },
             })
@@ -1287,6 +1323,7 @@ export const FileRoutes = lazy(() =>
               status: 206,
               headers: {
                 ...base,
+                ...cors,
                 "Content-Length": String(range.end - range.start + 1),
                 "Content-Range": `bytes ${range.start}-${range.end}/${Number(stat.size)}`,
               },
@@ -1297,6 +1334,7 @@ export const FileRoutes = lazy(() =>
             status: 206,
             headers: {
               ...base,
+              ...cors,
               "Content-Length": String(range.end - range.start + 1),
               "Content-Range": `bytes ${range.start}-${range.end}/${Number(stat.size)}`,
             },

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -52,7 +52,7 @@ import { ProjectRoutes } from "./routes/project"
 import { SessionRoutes } from "./routes/session"
 import { PtyRoutes } from "./routes/pty"
 import { McpRoutes } from "./routes/mcp"
-import { FileRoutes } from "./routes/file"
+import { FileRoutes, type ServerEnv } from "./routes/file"
 import { ConfigRoutes } from "./routes/config"
 import { ExperimentalRoutes } from "./routes/experimental"
 import { ProviderRoutes } from "./routes/provider"
@@ -93,10 +93,27 @@ export namespace Server {
 
   export const Default = lazy(() => createApp({}))
 
-  export const createApp = (opts: { cors?: string[]; onBrowserConnectionChange?: (count: number) => void }): Hono => {
+  export const createApp = (opts: { cors?: string[]; onBrowserConnectionChange?: (count: number) => void }): Hono<ServerEnv> => {
     SessionPreference.clear()
-    const app = new Hono()
+    const app = new Hono<ServerEnv>()
     let sseConnectionCount = 0
+    const corsware = cors({
+      credentials: true,
+      origin(input) {
+        if (!input) return
+        if (input.startsWith("http://localhost:")) return input
+        if (input.startsWith("http://127.0.0.1:")) return input
+        if (input === "tauri://localhost" || input === "http://tauri.localhost" || input === "https://tauri.localhost") {
+          return input
+        }
+        if (/^https:\/\/([a-z0-9-]+\.)*opencode\.ai$/.test(input)) {
+          return input
+        }
+        if (opts?.cors?.includes(input)) {
+          return input
+        }
+      },
+    })
     return app
       .onError((err, c) => {
         log.error("failed", {
@@ -143,33 +160,13 @@ export namespace Server {
           timer.stop()
         }
       })
-      .use(
-        cors({
-          credentials: true,
-          origin(input) {
-            if (!input) return
-
-            if (input.startsWith("http://localhost:")) return input
-            if (input.startsWith("http://127.0.0.1:")) return input
-            if (
-              input === "tauri://localhost" ||
-              input === "http://tauri.localhost" ||
-              input === "https://tauri.localhost"
-            )
-              return input
-
-            // *.opencode.ai (https only, adjust if needed)
-            if (/^https:\/\/([a-z0-9-]+\.)*opencode\.ai$/.test(input)) {
-              return input
-            }
-            if (opts?.cors?.includes(input)) {
-              return input
-            }
-
-            return
-          },
-        }),
-      )
+      .use((c, next) => {
+        if (c.req.path === "/file/raw") {
+          c.set("cors", opts.cors)
+          return next()
+        }
+        return corsware(c, next)
+      })
       .route("/global", GlobalRoutes())
       .put(
         "/auth/:providerID",

--- a/packages/opencode/test/server/file-download.test.ts
+++ b/packages/opencode/test/server/file-download.test.ts
@@ -71,6 +71,31 @@ describe("file endpoints", () => {
     expect(await res.text()).toBe("hello")
   })
 
+  test("serves raw file ranges with inline cors headers", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "range.txt"), "hello world")
+      },
+    })
+
+    const app = Server.createApp({ cors: ["https://assets.example.com"] })
+    const res = await app.request(`/file/raw?path=${encodeURIComponent("range.txt")}`, {
+      headers: {
+        origin: "https://assets.example.com",
+        "x-opencode-directory": tmp.path,
+        range: "bytes=0-4",
+      },
+    })
+
+    expect(res.status).toBe(206)
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://assets.example.com")
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true")
+    expect(res.headers.get("Access-Control-Expose-Headers")).toContain("Content-Range")
+    expect(res.headers.get("Vary")).toContain("Origin")
+    expect(res.headers.get("Content-Range")).toBe("bytes 0-4/11")
+    expect(await res.text()).toBe("hello")
+  })
+
   test("rejects raw path traversal", async () => {
     await using tmp = await tmpdir()
     const app = Server.Default()

--- a/packages/opencode/test/server/file-download.test.ts
+++ b/packages/opencode/test/server/file-download.test.ts
@@ -3,7 +3,7 @@ import path from "path"
 import { Server } from "../../src/server/server"
 import { tmpdir } from "../fixture/fixture"
 
-describe("file.download endpoint", () => {
+describe("file endpoints", () => {
   test("serves uploaded-style unicode filenames without 500", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
@@ -21,5 +21,68 @@ describe("file.download endpoint", () => {
     expect(res.status).toBe(200)
     expect(res.headers.get("Content-Disposition")).toContain("filename*=")
     expect(await res.text()).toBe("hello")
+  })
+
+  test("returns metadata for pdf previews", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "guide.pdf"), Buffer.from("%PDF-1.7"))
+      },
+    })
+
+    const app = Server.Default()
+    const res = await app.request(`/file/metadata?path=${encodeURIComponent("guide.pdf")}`, {
+      headers: {
+        "x-opencode-directory": tmp.path,
+      },
+    })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      path: "guide.pdf",
+      name: "guide.pdf",
+      kind: "file",
+      size: 8,
+      mimeType: "application/pdf",
+      previewKind: "pdf",
+      inline: false,
+      range: true,
+    })
+  })
+
+  test("serves raw file ranges", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "range.txt"), "hello world")
+      },
+    })
+
+    const app = Server.Default()
+    const res = await app.request(`/file/raw?path=${encodeURIComponent("range.txt")}`, {
+      headers: {
+        "x-opencode-directory": tmp.path,
+        range: "bytes=0-4",
+      },
+    })
+
+    expect(res.status).toBe(206)
+    expect(res.headers.get("Content-Range")).toBe("bytes 0-4/11")
+    expect(res.headers.get("Accept-Ranges")).toBe("bytes")
+    expect(await res.text()).toBe("hello")
+  })
+
+  test("rejects raw path traversal", async () => {
+    await using tmp = await tmpdir()
+    const app = Server.Default()
+    const res = await app.request(`/file/raw?path=${encodeURIComponent("../../../etc/passwd")}`, {
+      headers: {
+        "x-opencode-directory": tmp.path,
+      },
+    })
+
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({
+      error: "Access denied: path escapes project directory",
+    })
   })
 })

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -24,6 +24,10 @@ import type {
   ConfigSkillsToggleResponses,
   ConfigUpdateErrors,
   ConfigUpdateResponses,
+  DatabaseLegacyMergeResponses,
+  DatabaseLegacyMergeStateResetResponses,
+  DatabaseLegacyMergeStateResponses,
+  DatabaseLegacyStatusResponses,
   EventSubscribeResponses,
   EventTuiCommandExecute,
   EventTuiPromptAppend,
@@ -36,6 +40,11 @@ import type {
   ExperimentalWorkspaceListResponses,
   ExperimentalWorkspaceRemoveErrors,
   ExperimentalWorkspaceRemoveResponses,
+  FeishuEventsResponses,
+  FeishuSessionClearResponses,
+  FeishuStartResponses,
+  FeishuStatusResponses,
+  FeishuStopResponses,
   FileActiveTasksResponses,
   FileAddToGitignoreErrors,
   FileAddToGitignoreResponses,
@@ -47,7 +56,11 @@ import type {
   FileDeleteResponses,
   FileDownloadErrors,
   FileDownloadResponses,
+  FileEnsureDirectoryErrors,
+  FileEnsureDirectoryResponses,
   FileListResponses,
+  FileMetadataErrors,
+  FileMetadataResponses,
   FileOpenErrors,
   FileOpenInExplorerErrors,
   FileOpenInExplorerResponses,
@@ -97,6 +110,13 @@ import type {
   GlobalSyncEventSubscribeResponses,
   GlobalUpgradeErrors,
   GlobalUpgradeResponses,
+  GlobalWebUpdateCheckErrors,
+  GlobalWebUpdateCheckResponses,
+  GlobalWebUpdateCurrentResponses,
+  GlobalWebUpdateDownloadErrors,
+  GlobalWebUpdateDownloadResponses,
+  GlobalWebUpdateInstallErrors,
+  GlobalWebUpdateInstallResponses,
   InstanceDisposeResponses,
   KnowledgeConfigGetResponses,
   KnowledgeConfigSetResponses,
@@ -184,10 +204,16 @@ import type {
   ReadingModeAnnotationsGetResponses,
   ReadingModeAnnotationsUpdateErrors,
   ReadingModeAnnotationsUpdateResponses,
+  ReadingModePagePdfErrors,
+  ReadingModePagePdfResponses,
+  ReadingModePageTextErrors,
+  ReadingModePageTextResponses,
   ReadingModePdfGetErrors,
   ReadingModePdfGetResponses,
   ReadingModeSessionCreateErrors,
   ReadingModeSessionCreateResponses,
+  ReadingModeSessionFromFileErrors,
+  ReadingModeSessionFromFileResponses,
   ReadingModeSessionUpdateErrors,
   ReadingModeSessionUpdateResponses,
   SessionAbortErrors,
@@ -213,6 +239,10 @@ import type {
   SessionMessageResponses,
   SessionMessagesErrors,
   SessionMessagesResponses,
+  SessionPreferenceGetErrors,
+  SessionPreferenceGetResponses,
+  SessionPreferenceUpdateErrors,
+  SessionPreferenceUpdateResponses,
   SessionPromptAsyncErrors,
   SessionPromptAsyncResponses,
   SessionPromptErrors,
@@ -261,6 +291,7 @@ import type {
   VcsDiffResponses,
   VcsGetResponses,
   WechatEventsResponses,
+  WechatPingResponses,
   WechatSessionClearResponses,
   WechatStartResponses,
   WechatStatusResponses,
@@ -366,6 +397,111 @@ export class Proxy extends HeyApiClient {
     )
     return (options?.client ?? this.client).patch<GlobalProxyUpdateResponses, GlobalProxyUpdateErrors, ThrowOnError>({
       url: "/global/proxy",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+}
+
+export class WebUpdate extends HeyApiClient {
+  /**
+   * Get current web version
+   *
+   * Read the current web app version from local update state.
+   */
+  public current<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<GlobalWebUpdateCurrentResponses, unknown, ThrowOnError>({
+      url: "/global/web-update/current",
+      ...options,
+    })
+  }
+
+  /**
+   * Check web update
+   *
+   * Check for available web application updates by fetching remote version metadata.
+   */
+  public check<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<
+      GlobalWebUpdateCheckResponses,
+      GlobalWebUpdateCheckErrors,
+      ThrowOnError
+    >({ url: "/global/web-update/check", ...options })
+  }
+
+  /**
+   * Download web update script
+   *
+   * Download the update/install script for the specified OS and version.
+   */
+  public download<ThrowOnError extends boolean = false>(
+    parameters?: {
+      os?: "darwin" | "linux" | "windows"
+      version?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "body", key: "os" },
+            { in: "body", key: "version" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      GlobalWebUpdateDownloadResponses,
+      GlobalWebUpdateDownloadErrors,
+      ThrowOnError
+    >({
+      url: "/global/web-update/download",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Execute web update script
+   *
+   * Execute the previously downloaded update script to install the new version.
+   */
+  public install<ThrowOnError extends boolean = false>(
+    parameters?: {
+      os?: "darwin" | "linux" | "windows"
+      version?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "body", key: "os" },
+            { in: "body", key: "version" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      GlobalWebUpdateInstallResponses,
+      GlobalWebUpdateInstallErrors,
+      ThrowOnError
+    >({
+      url: "/global/web-update/install",
       ...options,
       ...params,
       headers: {
@@ -528,6 +664,11 @@ export class Global extends HeyApiClient {
   private _proxy?: Proxy
   get proxy(): Proxy {
     return (this._proxy ??= new Proxy({ client: this.client }))
+  }
+
+  private _webUpdate?: WebUpdate
+  get webUpdate(): WebUpdate {
+    return (this._webUpdate ??= new WebUpdate({ client: this.client }))
   }
 
   private _syncEvent?: SyncEvent
@@ -1024,7 +1165,7 @@ export class Skills extends HeyApiClient {
   /**
    * List default skills
    *
-   * List all default skills from the .opencode/skills/ directory.
+   * List all default skills from the .aether/skills/ directory.
    */
   public list<ThrowOnError extends boolean = false>(
     parameters?: {
@@ -1054,7 +1195,7 @@ export class Skills extends HeyApiClient {
   /**
    * Create or update a default skill
    *
-   * Create or update a skill in .opencode/skills/.
+   * Create or update a skill in .aether/skills/.
    */
   public save<ThrowOnError extends boolean = false>(
     parameters?: {
@@ -1097,7 +1238,7 @@ export class Skills extends HeyApiClient {
   /**
    * Delete a default skill
    *
-   * Delete a skill from .opencode/skills/.
+   * Delete a skill from .aether/skills/.
    */
   public delete<ThrowOnError extends boolean = false>(
     parameters: {
@@ -1129,7 +1270,7 @@ export class Skills extends HeyApiClient {
   /**
    * Add default skills to project config
    *
-   * Add the default skills from .opencode/skills/ to the project's opencode.jsonc skills.paths.
+   * Add the default skills from .aether/skills/ to the project's aether.jsonc skills.paths.
    */
   public addDefaults<ThrowOnError extends boolean = false>(
     parameters?: {
@@ -1706,6 +1847,96 @@ export class Worktree extends HeyApiClient {
     )
     return (options?.client ?? this.client).post<WorktreeResetResponses, WorktreeResetErrors, ThrowOnError>({
       url: "/experimental/worktree/reset",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+}
+
+export class Preference extends HeyApiClient {
+  /**
+   * Get session preference
+   *
+   * Retrieve the current preference for a session from in-memory store.
+   */
+  public get<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<
+      SessionPreferenceGetResponses,
+      SessionPreferenceGetErrors,
+      ThrowOnError
+    >({
+      url: "/session/{sessionID}/preference",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Update session preference
+   *
+   * Patch preference for a session. Stored in memory and broadcast via SSE.
+   */
+  public update<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+      agent?: string
+      model?: {
+        providerID: string
+        modelID: string
+      }
+      variant?: string
+      autoAccept?: boolean
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "agent" },
+            { in: "body", key: "model" },
+            { in: "body", key: "variant" },
+            { in: "body", key: "autoAccept" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).patch<
+      SessionPreferenceUpdateResponses,
+      SessionPreferenceUpdateErrors,
+      ThrowOnError
+    >({
+      url: "/session/{sessionID}/preference",
       ...options,
       ...params,
       headers: {
@@ -2673,6 +2904,11 @@ export class Session2 extends HeyApiClient {
       ...params,
     })
   }
+
+  private _preference?: Preference
+  get preference(): Preference {
+    return (this._preference ??= new Preference({ client: this.client }))
+  }
 }
 
 export class Part extends HeyApiClient {
@@ -3164,6 +3400,149 @@ export class Provider extends HeyApiClient {
   }
 }
 
+export class State extends HeyApiClient {
+  /**
+   * Reset merge state
+   *
+   * Mark copy completion state as consumed so restart will not re-show the completion toast.
+   */
+  public reset<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<DatabaseLegacyMergeStateResetResponses, unknown, ThrowOnError>({
+      url: "/database/legacy/merge/state/reset",
+      ...options,
+      ...params,
+    })
+  }
+}
+
+export class Merge extends HeyApiClient {
+  /**
+   * Get merge state
+   *
+   * Get legacy database copy state.
+   */
+  public state<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<DatabaseLegacyMergeStateResponses, unknown, ThrowOnError>({
+      url: "/database/legacy/merge/state",
+      ...options,
+      ...params,
+    })
+  }
+
+  private _state?: State
+  get state2(): State {
+    return (this._state ??= new State({ client: this.client }))
+  }
+}
+
+export class Legacy extends HeyApiClient {
+  /**
+   * Scan legacy databases
+   *
+   * Scan current data directory and report whether the latest legacy database should be copied.
+   */
+  public status<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<DatabaseLegacyStatusResponses, unknown, ThrowOnError>({
+      url: "/database/legacy/status",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Copy latest legacy database
+   *
+   * Copy the latest legacy database into aether-prod.db when the target database is missing.
+   */
+  public merge<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<DatabaseLegacyMergeResponses, unknown, ThrowOnError>({
+      url: "/database/legacy/merge",
+      ...options,
+      ...params,
+    })
+  }
+
+  private _merge?: Merge
+  get merge2(): Merge {
+    return (this._merge ??= new Merge({ client: this.client }))
+  }
+}
+
+export class Database extends HeyApiClient {
+  private _legacy?: Legacy
+  get legacy(): Legacy {
+    return (this._legacy ??= new Legacy({ client: this.client }))
+  }
+}
+
 export class File extends HeyApiClient {
   /**
    * List active conversion/translation tasks
@@ -3370,6 +3749,38 @@ export class File extends HeyApiClient {
   }
 
   /**
+   * Read file metadata
+   *
+   * Read lightweight metadata for a file or directory without loading file contents.
+   */
+  public metadata<ThrowOnError extends boolean = false>(
+    parameters: {
+      directory?: string
+      workspace?: string
+      path: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "query", key: "path" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<FileMetadataResponses, FileMetadataErrors, ThrowOnError>({
+      url: "/file/metadata",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
    * Read file
    *
    * Read the content of a specified file.
@@ -3502,6 +3913,45 @@ export class File extends HeyApiClient {
       ...options,
       ...params,
     })
+  }
+
+  /**
+   * Ensure directory exists
+   *
+   * Create a directory at the given absolute path if it does not exist, including any intermediate directories.
+   */
+  public ensureDirectory<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      path?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "path" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<FileEnsureDirectoryResponses, FileEnsureDirectoryErrors, ThrowOnError>(
+      {
+        url: "/file/ensure-directory",
+        ...options,
+        ...params,
+        headers: {
+          "Content-Type": "application/json",
+          ...options?.headers,
+          ...params.headers,
+        },
+      },
+    )
   }
 
   /**
@@ -3915,7 +4365,7 @@ export class File extends HeyApiClient {
   /**
    * Serve raw file
    *
-   * Serve a file's raw binary content with appropriate Content-Type.
+   * Serve a file's raw bytes with support for range requests.
    */
   public raw<ThrowOnError extends boolean = false>(
     parameters: {
@@ -5542,6 +5992,36 @@ export class Wechat extends HeyApiClient {
   }
 
   /**
+   * Ping WeChat lease
+   *
+   * Renew the WeChat lock lease or detect if stolen by another client
+   */
+  public ping<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<WechatPingResponses, unknown, ThrowOnError>({
+      url: "/wechat/ping",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
    * Get WeChat status
    *
    * Get the current WeChat bridge status
@@ -5609,6 +6089,165 @@ export class Wechat extends HeyApiClient {
 
 export class Session4 extends HeyApiClient {
   /**
+   * Clear Feishu session
+   *
+   * Clear the saved Feishu configuration and session data
+   */
+  public clear<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).delete<FeishuSessionClearResponses, unknown, ThrowOnError>({
+      url: "/feishu/session",
+      ...options,
+      ...params,
+    })
+  }
+}
+
+export class Feishu extends HeyApiClient {
+  /**
+   * Start Feishu bridge
+   *
+   * Start the Feishu bridge service with WebSocket connection
+   */
+  public start<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<FeishuStartResponses, unknown, ThrowOnError>({
+      url: "/feishu/start",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Stop Feishu bridge
+   *
+   * Stop the Feishu bridge service
+   */
+  public stop<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<FeishuStopResponses, unknown, ThrowOnError>({
+      url: "/feishu/stop",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get Feishu status
+   *
+   * Get the current Feishu bridge status
+   */
+  public status<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<FeishuStatusResponses, unknown, ThrowOnError>({
+      url: "/feishu/status",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Subscribe to Feishu events
+   *
+   * Get real-time Feishu events via SSE
+   */
+  public events<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).sse.get<FeishuEventsResponses, unknown, ThrowOnError>({
+      url: "/feishu/events",
+      ...options,
+      ...params,
+    })
+  }
+
+  private _session?: Session4
+  get session(): Session4 {
+    return (this._session ??= new Session4({ client: this.client }))
+  }
+}
+
+export class Session5 extends HeyApiClient {
+  /**
    * Create reading mode session
    */
   public create<ThrowOnError extends boolean = false>(
@@ -5641,6 +6280,55 @@ export class Session4 extends HeyApiClient {
   }
 
   /**
+   * Open reading mode from a workspace PDF file
+   */
+  public fromFile<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      path?: string
+      settings?: {
+        translatePrompt?: string
+        questionPrompt?: string
+        firstReadPrompt?: string
+        contextPageRange?: 0 | 1 | 2
+        autoFirstRead?: boolean
+      }
+      forceNew?: boolean
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "path" },
+            { in: "body", key: "settings" },
+            { in: "body", key: "forceNew" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      ReadingModeSessionFromFileResponses,
+      ReadingModeSessionFromFileErrors,
+      ThrowOnError
+    >({
+      url: "/reading-mode/session/from-file",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
    * Update reading mode session settings
    */
   public update<ThrowOnError extends boolean = false>(
@@ -5656,6 +6344,7 @@ export class Session4 extends HeyApiClient {
         autoFirstRead?: boolean
       }
       firstReadCompleted?: boolean
+      firstReadDismissed?: boolean
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -5669,6 +6358,7 @@ export class Session4 extends HeyApiClient {
             { in: "query", key: "workspace" },
             { in: "body", key: "settings" },
             { in: "body", key: "firstReadCompleted" },
+            { in: "body", key: "firstReadDismissed" },
           ],
         },
       ],
@@ -5800,9 +6490,89 @@ export class Pdf extends HeyApiClient {
 }
 
 export class ReadingMode extends HeyApiClient {
-  private _session?: Session4
-  get session(): Session4 {
-    return (this._session ??= new Session4({ client: this.client }))
+  /**
+   * Get extracted text for reading mode PDF pages
+   */
+  public pageText<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      sessionID?: string
+      startPage?: number
+      endPage?: number
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "sessionID" },
+            { in: "body", key: "startPage" },
+            { in: "body", key: "endPage" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<ReadingModePageTextResponses, ReadingModePageTextErrors, ThrowOnError>(
+      {
+        url: "/reading-mode/page-text",
+        ...options,
+        ...params,
+        headers: {
+          "Content-Type": "application/json",
+          ...options?.headers,
+          ...params.headers,
+        },
+      },
+    )
+  }
+
+  /**
+   * Get a ranged PDF subdocument for reading mode
+   */
+  public pagePdf<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      sessionID?: string
+      startPage?: number
+      endPage?: number
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "sessionID" },
+            { in: "body", key: "startPage" },
+            { in: "body", key: "endPage" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<ReadingModePagePdfResponses, ReadingModePagePdfErrors, ThrowOnError>({
+      url: "/reading-mode/page-pdf",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  private _session?: Session5
+  get session(): Session5 {
+    return (this._session ??= new Session5({ client: this.client }))
   }
 
   private _annotations?: Annotations
@@ -6220,6 +6990,11 @@ export class OpencodeClient extends HeyApiClient {
     return (this._provider ??= new Provider({ client: this.client }))
   }
 
+  private _database?: Database
+  get database(): Database {
+    return (this._database ??= new Database({ client: this.client }))
+  }
+
   private _file?: File
   get file(): File {
     return (this._file ??= new File({ client: this.client }))
@@ -6253,6 +7028,11 @@ export class OpencodeClient extends HeyApiClient {
   private _wechat?: Wechat
   get wechat(): Wechat {
     return (this._wechat ??= new Wechat({ client: this.client }))
+  }
+
+  private _feishu?: Feishu
+  get feishu(): Feishu {
+    return (this._feishu ??= new Feishu({ client: this.client }))
   }
 
   private _readingMode?: ReadingMode

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -362,6 +362,23 @@ export type EventCommandExecuted = {
   }
 }
 
+export type EventSessionPreferenceUpdated = {
+  type: "session.preference.updated"
+  properties: {
+    sessionID: string
+    preference: {
+      sessionID: string
+      agent?: string
+      model?: {
+        providerID: string
+        modelID: string
+      }
+      variant?: string
+      autoAccept?: boolean
+    }
+  }
+}
+
 export type FileDiff = {
   file: string
   before: string
@@ -560,6 +577,37 @@ export type EventWechatError = {
   properties: {
     code: string
     message: string
+  }
+}
+
+export type EventFeishuStatus = {
+  type: "feishu.status"
+  properties: {
+    status: "idle" | "starting" | "connected" | "reconnecting" | "error"
+    message?: string
+  }
+}
+
+export type EventFeishuConnected = {
+  type: "feishu.connected"
+  properties: {
+    appId: string
+  }
+}
+
+export type EventFeishuError = {
+  type: "feishu.error"
+  properties: {
+    code: string
+    message: string
+  }
+}
+
+export type EventFeishuReconnecting = {
+  type: "feishu.reconnecting"
+  properties: {
+    attempt: number
+    delay: number
   }
 }
 
@@ -1059,6 +1107,7 @@ export type Event =
   | EventMcpToolsChanged
   | EventMcpBrowserOpenFailed
   | EventCommandExecuted
+  | EventSessionPreferenceUpdated
   | EventSessionDiff
   | EventSessionError
   | EventVcsBranchUpdated
@@ -1074,6 +1123,10 @@ export type Event =
   | EventWechatQrcode
   | EventWechatConnected
   | EventWechatError
+  | EventFeishuStatus
+  | EventFeishuConnected
+  | EventFeishuError
+  | EventFeishuReconnecting
   | EventMessageUpdated
   | EventMessageRemoved
   | EventMessagePartUpdated
@@ -2060,6 +2113,17 @@ export type FileNode = {
   ignored: boolean
 }
 
+export type FileMetadata = {
+  path: string
+  name: string
+  kind: "file" | "directory"
+  size: number
+  mimeType: string
+  previewKind: "text" | "image" | "pdf" | "binary" | "directory"
+  inline: boolean
+  range: boolean
+}
+
 export type FileContent = {
   type: "text" | "binary"
   content: string
@@ -2267,6 +2331,24 @@ export type GlobalHealthResponses = {
 
 export type GlobalHealthResponse = GlobalHealthResponses[keyof GlobalHealthResponses]
 
+export type GlobalWebUpdateCurrentData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/global/web-update/current"
+}
+
+export type GlobalWebUpdateCurrentResponses = {
+  /**
+   * Current local web version
+   */
+  200: {
+    currentVersion: string
+  }
+}
+
+export type GlobalWebUpdateCurrentResponse = GlobalWebUpdateCurrentResponses[keyof GlobalWebUpdateCurrentResponses]
+
 export type GlobalPingData = {
   body?: {
     id: string
@@ -2386,6 +2468,108 @@ export type GlobalDisposeResponses = {
 }
 
 export type GlobalDisposeResponse = GlobalDisposeResponses[keyof GlobalDisposeResponses]
+
+export type GlobalWebUpdateCheckData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/global/web-update/check"
+}
+
+export type GlobalWebUpdateCheckErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type GlobalWebUpdateCheckError = GlobalWebUpdateCheckErrors[keyof GlobalWebUpdateCheckErrors]
+
+export type GlobalWebUpdateCheckResponses = {
+  /**
+   * Version check result
+   */
+  200: {
+    currentVersion: string
+    remoteVersion: string
+    updateAvailable: boolean
+    downloaded: boolean
+    checkError?: string
+  }
+}
+
+export type GlobalWebUpdateCheckResponse = GlobalWebUpdateCheckResponses[keyof GlobalWebUpdateCheckResponses]
+
+export type GlobalWebUpdateDownloadData = {
+  body?: {
+    os: "darwin" | "linux" | "windows"
+    version: string
+  }
+  path?: never
+  query?: never
+  url: "/global/web-update/download"
+}
+
+export type GlobalWebUpdateDownloadErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type GlobalWebUpdateDownloadError = GlobalWebUpdateDownloadErrors[keyof GlobalWebUpdateDownloadErrors]
+
+export type GlobalWebUpdateDownloadResponses = {
+  /**
+   * Download result
+   */
+  200:
+    | {
+        success: true
+        path: string
+      }
+    | {
+        success: false
+        error: string
+      }
+}
+
+export type GlobalWebUpdateDownloadResponse = GlobalWebUpdateDownloadResponses[keyof GlobalWebUpdateDownloadResponses]
+
+export type GlobalWebUpdateInstallData = {
+  body?: {
+    os: "darwin" | "linux" | "windows"
+    version?: string
+  }
+  path?: never
+  query?: never
+  url: "/global/web-update/install"
+}
+
+export type GlobalWebUpdateInstallErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type GlobalWebUpdateInstallError = GlobalWebUpdateInstallErrors[keyof GlobalWebUpdateInstallErrors]
+
+export type GlobalWebUpdateInstallResponses = {
+  /**
+   * Install result
+   */
+  200:
+    | {
+        success: true
+      }
+    | {
+        success: false
+        error: string
+      }
+}
+
+export type GlobalWebUpdateInstallResponse = GlobalWebUpdateInstallResponses[keyof GlobalWebUpdateInstallResponses]
 
 export type GlobalUpgradeData = {
   body?: {
@@ -4310,6 +4494,100 @@ export type PermissionRespondResponses = {
 
 export type PermissionRespondResponse = PermissionRespondResponses[keyof PermissionRespondResponses]
 
+export type SessionPreferenceGetData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/preference"
+}
+
+export type SessionPreferenceGetErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionPreferenceGetError = SessionPreferenceGetErrors[keyof SessionPreferenceGetErrors]
+
+export type SessionPreferenceGetResponses = {
+  /**
+   * Session preference
+   */
+  200: {
+    sessionID: string
+    agent?: string
+    model?: {
+      providerID: string
+      modelID: string
+    }
+    variant?: string
+    autoAccept?: boolean
+  } | null
+}
+
+export type SessionPreferenceGetResponse = SessionPreferenceGetResponses[keyof SessionPreferenceGetResponses]
+
+export type SessionPreferenceUpdateData = {
+  body?: {
+    agent?: string
+    model?: {
+      providerID: string
+      modelID: string
+    }
+    variant?: string
+    autoAccept?: boolean
+  }
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/preference"
+}
+
+export type SessionPreferenceUpdateErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionPreferenceUpdateError = SessionPreferenceUpdateErrors[keyof SessionPreferenceUpdateErrors]
+
+export type SessionPreferenceUpdateResponses = {
+  /**
+   * Preference updated
+   */
+  200: {
+    sessionID: string
+    agent?: string
+    model?: {
+      providerID: string
+      modelID: string
+    }
+    variant?: string
+    autoAccept?: boolean
+  }
+}
+
+export type SessionPreferenceUpdateResponse = SessionPreferenceUpdateResponses[keyof SessionPreferenceUpdateResponses]
+
 export type PermissionReplyData = {
   body?: {
     reply: "once" | "always" | "reject"
@@ -4688,6 +4966,145 @@ export type ProviderOauthCallbackResponses = {
 
 export type ProviderOauthCallbackResponse = ProviderOauthCallbackResponses[keyof ProviderOauthCallbackResponses]
 
+export type DatabaseLegacyStatusData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/database/legacy/status"
+}
+
+export type DatabaseLegacyStatusResponses = {
+  /**
+   * Legacy database scan status
+   */
+  200: {
+    directory: string
+    target: string
+    has_legacy: boolean
+    message: string
+    dismissed: boolean
+    should_merge: boolean
+    source_count: number
+    legacy_count: number
+    files: Array<{
+      name: string
+      path: string
+      channel: string
+      mtime: number
+    }>
+    naming: {
+      [key: string]: number
+    }
+    versions: {
+      [key: string]: number
+    }
+  }
+}
+
+export type DatabaseLegacyStatusResponse = DatabaseLegacyStatusResponses[keyof DatabaseLegacyStatusResponses]
+
+export type DatabaseLegacyMergeStateData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/database/legacy/merge/state"
+}
+
+export type DatabaseLegacyMergeStateResponses = {
+  /**
+   * Merge state
+   */
+  200: {
+    state: "idle" | "running" | "done" | "error"
+    updated: number
+    error?: string
+    details?: Array<string>
+  }
+}
+
+export type DatabaseLegacyMergeStateResponse =
+  DatabaseLegacyMergeStateResponses[keyof DatabaseLegacyMergeStateResponses]
+
+export type DatabaseLegacyMergeStateResetData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/database/legacy/merge/state/reset"
+}
+
+export type DatabaseLegacyMergeStateResetResponses = {
+  /**
+   * Reset merge state
+   */
+  200: {
+    state: "idle" | "running" | "done" | "error"
+    updated: number
+    error?: string
+    details?: Array<string>
+  }
+}
+
+export type DatabaseLegacyMergeStateResetResponse =
+  DatabaseLegacyMergeStateResetResponses[keyof DatabaseLegacyMergeStateResetResponses]
+
+export type DatabaseLegacyMergeData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/database/legacy/merge"
+}
+
+export type DatabaseLegacyMergeResponses = {
+  /**
+   * Copy result
+   */
+  200: {
+    status: {
+      directory: string
+      target: string
+      has_legacy: boolean
+      message: string
+      dismissed: boolean
+      should_merge: boolean
+      source_count: number
+      legacy_count: number
+      files: Array<{
+        name: string
+        path: string
+        channel: string
+        mtime: number
+      }>
+      naming: {
+        [key: string]: number
+      }
+      versions: {
+        [key: string]: number
+      }
+    }
+    mode: "noop" | "copy"
+    merge_state: {
+      state: "idle" | "running" | "done" | "error"
+      updated: number
+      error?: string
+      details?: Array<string>
+    }
+  }
+}
+
+export type DatabaseLegacyMergeResponse = DatabaseLegacyMergeResponses[keyof DatabaseLegacyMergeResponses]
+
 export type FileActiveTasksData = {
   body?: never
   path?: never
@@ -4940,6 +5357,39 @@ export type FileCreateResponses = {
 
 export type FileCreateResponse = FileCreateResponses[keyof FileCreateResponses]
 
+export type FileMetadataData = {
+  body?: never
+  path?: never
+  query: {
+    directory?: string
+    workspace?: string
+    path: string
+  }
+  url: "/file/metadata"
+}
+
+export type FileMetadataErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type FileMetadataError = FileMetadataErrors[keyof FileMetadataErrors]
+
+export type FileMetadataResponses = {
+  /**
+   * File metadata
+   */
+  200: FileMetadata
+}
+
+export type FileMetadataResponse = FileMetadataResponses[keyof FileMetadataResponses]
+
 export type FileReadData = {
   body?: never
   path?: never
@@ -5069,6 +5519,39 @@ export type FileUploadResponses = {
 }
 
 export type FileUploadResponse = FileUploadResponses[keyof FileUploadResponses]
+
+export type FileEnsureDirectoryData = {
+  body?: {
+    path: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/file/ensure-directory"
+}
+
+export type FileEnsureDirectoryErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type FileEnsureDirectoryError = FileEnsureDirectoryErrors[keyof FileEnsureDirectoryErrors]
+
+export type FileEnsureDirectoryResponses = {
+  /**
+   * Directory ensured
+   */
+  200: {
+    ok: boolean
+    path: string
+  }
+}
+
+export type FileEnsureDirectoryResponse = FileEnsureDirectoryResponses[keyof FileEnsureDirectoryResponses]
 
 export type FileSummarizeData = {
   body?: {
@@ -5405,6 +5888,10 @@ export type FileRawErrors = {
    * Not found
    */
   404: NotFoundError
+  /**
+   * Invalid range
+   */
+  416: unknown
 }
 
 export type FileRawError = FileRawErrors[keyof FileRawErrors]
@@ -5414,6 +5901,10 @@ export type FileRawResponses = {
    * File content
    */
   200: unknown
+  /**
+   * Partial file content
+   */
+  206: unknown
 }
 
 export type FileTranslateMarkdownCheckData = {
@@ -6768,6 +7259,28 @@ export type WechatStopResponses = {
 
 export type WechatStopResponse = WechatStopResponses[keyof WechatStopResponses]
 
+export type WechatPingData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/wechat/ping"
+}
+
+export type WechatPingResponses = {
+  /**
+   * Ping result
+   */
+  200: {
+    ok: boolean
+    stolen: boolean
+  }
+}
+
+export type WechatPingResponse = WechatPingResponses[keyof WechatPingResponses]
+
 export type WechatStatusData = {
   body?: never
   path?: never
@@ -6836,6 +7349,117 @@ export type WechatSessionClearResponses = {
 
 export type WechatSessionClearResponse = WechatSessionClearResponses[keyof WechatSessionClearResponses]
 
+export type FeishuStartData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/feishu/start"
+}
+
+export type FeishuStartResponses = {
+  /**
+   * Bridge started
+   */
+  200: {
+    success: boolean
+    code?: string
+    message?: string
+    status?: string
+    appId?: string
+  }
+}
+
+export type FeishuStartResponse = FeishuStartResponses[keyof FeishuStartResponses]
+
+export type FeishuStopData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/feishu/stop"
+}
+
+export type FeishuStopResponses = {
+  /**
+   * Bridge stopped
+   */
+  200: {
+    success: boolean
+  }
+}
+
+export type FeishuStopResponse = FeishuStopResponses[keyof FeishuStopResponses]
+
+export type FeishuStatusData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/feishu/status"
+}
+
+export type FeishuStatusResponses = {
+  /**
+   * Status
+   */
+  200: {
+    status: "idle" | "starting" | "connected" | "reconnecting" | "error"
+    appId: string | null
+    hasConfig: boolean
+    error: {
+      code: string
+      message: string
+    } | null
+  }
+}
+
+export type FeishuStatusResponse = FeishuStatusResponses[keyof FeishuStatusResponses]
+
+export type FeishuEventsData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/feishu/events"
+}
+
+export type FeishuEventsResponses = {
+  /**
+   * Event stream
+   */
+  200: unknown
+}
+
+export type FeishuSessionClearData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/feishu/session"
+}
+
+export type FeishuSessionClearResponses = {
+  /**
+   * Session cleared
+   */
+  200: {
+    success: boolean
+  }
+}
+
+export type FeishuSessionClearResponse = FeishuSessionClearResponses[keyof FeishuSessionClearResponses]
+
 export type ReadingModeSessionCreateData = {
   body?: never
   path?: never
@@ -6864,6 +7488,129 @@ export type ReadingModeSessionCreateResponses = {
 
 export type ReadingModeSessionCreateResponse =
   ReadingModeSessionCreateResponses[keyof ReadingModeSessionCreateResponses]
+
+export type ReadingModeSessionFromFileData = {
+  body?: {
+    path: string
+    settings?: {
+      translatePrompt?: string
+      questionPrompt?: string
+      firstReadPrompt?: string
+      contextPageRange?: 0 | 1 | 2
+      autoFirstRead?: boolean
+    }
+    forceNew?: boolean
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/reading-mode/session/from-file"
+}
+
+export type ReadingModeSessionFromFileErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type ReadingModeSessionFromFileError = ReadingModeSessionFromFileErrors[keyof ReadingModeSessionFromFileErrors]
+
+export type ReadingModeSessionFromFileResponses = {
+  /**
+   * Existing or newly created reading mode session
+   */
+  200: {
+    action: "existing" | "created"
+    session: Session
+  }
+}
+
+export type ReadingModeSessionFromFileResponse =
+  ReadingModeSessionFromFileResponses[keyof ReadingModeSessionFromFileResponses]
+
+export type ReadingModePageTextData = {
+  body?: {
+    sessionID: string
+    startPage: number
+    endPage: number
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/reading-mode/page-text"
+}
+
+export type ReadingModePageTextErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type ReadingModePageTextError = ReadingModePageTextErrors[keyof ReadingModePageTextErrors]
+
+export type ReadingModePageTextResponses = {
+  /**
+   * Extracted page text
+   */
+  200: {
+    pageCount: number
+    pages: Array<{
+      pageNumber: number
+      text: string
+    }>
+    combinedText: string
+  }
+}
+
+export type ReadingModePageTextResponse = ReadingModePageTextResponses[keyof ReadingModePageTextResponses]
+
+export type ReadingModePagePdfData = {
+  body?: {
+    sessionID: string
+    startPage: number
+    endPage: number
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/reading-mode/page-pdf"
+}
+
+export type ReadingModePagePdfErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type ReadingModePagePdfError = ReadingModePagePdfErrors[keyof ReadingModePagePdfErrors]
+
+export type ReadingModePagePdfResponses = {
+  /**
+   * PDF binary for the requested page range
+   */
+  200: unknown
+}
 
 export type ReadingModeAnnotationsGetData = {
   body?: never


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

对于非文本文件，将/file/content拆分为metadata和raw，分别负责原先json中的metadata和数据流.
修改/file/raw接口支持HTTP Range requests(206)，同步对pdf-viewer添加了rangeChunkSize参数.
由于cors middleware 会在 response finalized 后重建响应导致/file/raw被错误添加Transfer-Encoding: chunked，在cors中做了特判，不影响其余接口.
修改后加载大文件例如pdf不再卡顿.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
在linux平台上做了测试.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
