### PR TITLE
feat: unify chat session UX, indexed command pickers, and /p <path>

### DIFF
--- a/Aether-wechat-bridge/aether_wechat_agent.py
+++ b/Aether-wechat-bridge/aether_wechat_agent.py
@@ -181,6 +181,7 @@ HELP_TEXT = """📋 可用命令：
 /p, /project  查看最近项目
 /p l          查看全部项目
 /p n          切换编号项目
+/p <path>     切换到指定路径
 
 /s, /session  查看最近会话
 /s l          查看全部会话
@@ -218,6 +219,8 @@ HELP_LIST_TEXT = """📋 全部命令：
   查看全部项目（l = list）
 /p n, /project n
   切换到编号 n 的项目
+/p <path>, /project <path>
+  切换到指定路径（如 /p E:\\work\\foo 或 /p /home/user/foo）
 /project hide n
   隐藏编号 n 的项目，重新在桌面端或消息端使用后自动恢复
 
@@ -274,6 +277,7 @@ class AetherAgent(Agent):
         self._conv_dirs: dict[str, str] = {}
         self._pending_questions: dict[str, dict] = {}
         self._pending_permissions: dict[str, dict] = {}
+        self._pending_confirm_create: dict[str, dict] = {}
         self._tasks: dict[str, object] = {}
         self._sse_tasks: dict[str, object] = {}
         self._accumulated_text: dict[str, str] = {}
@@ -352,11 +356,29 @@ class AetherAgent(Agent):
             return ""
         if re.fullmatch(r"/+", text):
             return "/"
-        if re.fullmatch(r"[A-Za-z]:/?", text):
-            return f"{text[0].lower()}:/"
-        if re.fullmatch(r"[A-Za-z]:/+", text):
-            return f"{text[0].lower()}:/"
+        if len(text) >= 2 and text[1] == ":" and text[0].isalpha():
+            text = text[0].lower() + text[1:]
+        if re.fullmatch(r"[a-z]:/?$", text):
+            return f"{text[0]}:/"
         return text.rstrip("/")
+
+    def _is_absolute_path(self, text: str) -> bool:
+        normed = self._norm_dir(text)
+        if not normed or normed == "/":
+            return False
+        if normed.startswith("/"):
+            return True
+        if re.match(r"[a-z]:/", normed):
+            return True
+        return False
+
+    def _is_root_dir(self, text: str) -> bool:
+        normed = self._norm_dir(text)
+        if normed == "/":
+            return True
+        if re.fullmatch(r"[a-z]:/$", normed):
+            return True
+        return False
 
     def _project_name(self, item: dict) -> str:
         directory = self._project_dir(item)
@@ -926,6 +948,8 @@ class AetherAgent(Agent):
         return self._cmd_set_model(conv_id, model_str)
 
     async def _cmd_project(self, conv_id: str, arg: str) -> str:
+        if arg and self._is_absolute_path(arg):
+            return await self._cmd_project_by_path(conv_id, arg)
         all_projects = await self._get_projects()
         if not all_projects:
             return "❌ 无法获取项目列表，请检查 Aether 服务是否正常。"
@@ -986,21 +1010,7 @@ class AetherAgent(Agent):
                 return f"❌ 请输入 1~{len(all_projects)} 之间的数字。"
             chosen = all_projects[idx]
             new_dir = self._project_dir(chosen)
-            self._conv_dirs[conv_id] = new_dir
-            session_id, created = await self._ensure_session(new_dir)
-            self._sessions[conv_id] = session_id
-            self._session_list.pop(conv_id, None)
-            if new_dir in self._hidden_dirs:
-                del self._hidden_dirs[new_dir]
-                self._save_hidden_dirs()
-            name = self._project_name(chosen)
-            logger.info(f"[/project] {conv_id} -> {new_dir}")
-            note = "已创建新会话"
-            if not created:
-                item = await self._resolve_session(session_id, new_dir)
-                title = (item or {}).get("title") or session_id[:8]
-                note = f"已进入该项目最新会话：{title}"
-            return f"✅ 已切换到：{name}\n   {new_dir}\n（{note}）"
+            return await self._switch_to_project(conv_id, new_dir)
 
         # /project（列表）
         if not projects:
@@ -1018,12 +1028,84 @@ class AetherAgent(Agent):
             lines.append(f"{idx}. {self._project_name(item)}{tag}")
             lines.append(f"   {directory}")
         lines.append("")
-        lines.append("💡 /p n 切换 | /p l 查看全部")
+        lines.append("💡 /p n 切换 | /p l 查看全部 | /p <path> 指定路径")
         if self._hidden_dirs:
             lines.append(
                 f"ℹ️ 已隐藏 {len(self._hidden_dirs)} 个项目（重新使用后自动恢复）"
             )
         return chr(10).join(lines)
+
+    async def _cmd_project_by_path(self, conv_id: str, raw_path: str) -> str:
+        normed = self._norm_dir(raw_path)
+        if self._is_root_dir(normed):
+            return "❌ 路径不合法：不能使用根目录。"
+
+        all_projects = await self._get_projects()
+        existing = next(
+            (p for p in all_projects if self._project_dir(p) == normed), None
+        )
+        dir_exists = Path(normed).exists()
+
+        if existing:
+            if not dir_exists:
+                Path(normed).mkdir(parents=True, exist_ok=True)
+            return await self._switch_to_project(conv_id, normed)
+
+        if dir_exists:
+            return await self._switch_to_new_project(conv_id, normed)
+
+        self._pending_confirm_create[conv_id] = {"path": normed}
+        return f"📂 路径不存在：{normed}\n回复 y 确认创建该文件夹并初始化项目，回复 n 取消。"
+
+    async def _confirm_create_project(self, conv_id: str, yes: bool) -> str:
+        pending = self._pending_confirm_create.pop(conv_id, None)
+        if not pending:
+            return "没有待确认的创建请求。"
+        if not yes:
+            return "已取消创建。"
+        normed = pending["path"]
+        Path(normed).mkdir(parents=True, exist_ok=True)
+        return await self._switch_to_new_project(conv_id, normed)
+
+    async def _switch_to_project(self, conv_id: str, new_dir: str) -> str:
+        self._conv_dirs[conv_id] = new_dir
+        if new_dir in self._hidden_dirs:
+            del self._hidden_dirs[new_dir]
+            self._save_hidden_dirs()
+        session_id, created = await self._ensure_session(new_dir)
+        self._sessions[conv_id] = session_id
+        self._session_list.pop(conv_id, None)
+        name = await self._get_project_name(new_dir)
+        logger.info(f"[/project] {conv_id} -> {new_dir}")
+        note = "已创建新会话"
+        if not created:
+            item = await self._resolve_session(session_id, new_dir)
+            title = (item or {}).get("title") or session_id[:8]
+            note = f"已进入该项目最新会话：{title}"
+        return f"✅ 已切换到：{name}\n   {new_dir}\n（{note}）"
+
+    async def _switch_to_new_project(self, conv_id: str, new_dir: str) -> str:
+        self._conv_dirs[conv_id] = new_dir
+        session_id, created = await self._ensure_session(new_dir)
+        self._sessions[conv_id] = session_id
+        self._session_list.pop(conv_id, None)
+        headers = {"x-opencode-directory": quote(new_dir, safe="")}
+        try:
+            resp = await self._client.post(
+                f"{self.base_url}/project/git/init", headers=headers
+            )
+            resp.raise_for_status()
+            logger.info(f"[/project] git initialized for {new_dir}")
+        except Exception as e:
+            logger.warning(f"初始化 git 失败: {e}")
+        name = self._base(new_dir)
+        logger.info(f"[/project] created+switched {conv_id} -> {new_dir}")
+        note = "已创建新会话"
+        if not created:
+            item = await self._resolve_session(session_id, new_dir)
+            title = (item or {}).get("title") or session_id[:8]
+            note = f"已进入该项目最新会话：{title}"
+        return f"✅ 已切换到：{name}\n   {new_dir}\n（{note}）"
 
     def _cmd_set_model(self, conv_id: str, model_str: str) -> str:
         if "/" not in model_str:
@@ -1043,6 +1125,7 @@ class AetherAgent(Agent):
         return f"✅ 已切换模型：{model_str}\n（仅对当前对话生效，/new 后将重置）"
 
     def _clear_runtime(self, conv_id: str) -> None:
+        self._pending_confirm_create.pop(conv_id, None)
         pending = self._pending_questions.pop(conv_id, None)
         if pending:
             task = pending.get("task")
@@ -1408,6 +1491,20 @@ class AetherAgent(Agent):
                     slash_reply, session_id, directory, conv_id
                 )
             return ChatResponse(text=slash_reply)
+
+        if conv_id in self._pending_confirm_create:
+            lower = user_text.strip().lower()
+            if lower in {"y", "yes", "确认"}:
+                reply = await self._confirm_create_project(conv_id, True)
+            elif lower in {"n", "no", "取消"}:
+                reply = await self._confirm_create_project(conv_id, False)
+            else:
+                reply = "请回复 y 确认创建或 n 取消。"
+            session_id = self._sessions.get(conv_id)
+            directory = self._conv_dirs.get(conv_id) or self.directory
+            if session_id:
+                reply = await self._wrap_message(reply, session_id, directory, conv_id)
+            return ChatResponse(text=reply)
 
         if conv_id in self._pending_questions:
             return await self._handle_question_reply(conv_id, user_text)

--- a/Aether-wechat-bridge/aether_wechat_agent.py
+++ b/Aether-wechat-bridge/aether_wechat_agent.py
@@ -30,7 +30,7 @@ import logging
 import shutil
 from pathlib import Path
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, timezone
 from io import BytesIO
 from urllib.parse import quote
 
@@ -488,11 +488,15 @@ class AetherAgent(Agent):
         self, directory: str, fresh: bool = False
     ) -> tuple[str, bool]:
         if fresh:
-            return await self._create_session(directory=directory), True
+            return await self._create_session(
+                directory=directory, title=self._platform_title()
+            ), True
         items = await self._list_sessions(directory)
         if items:
             return items[0]["id"], False
-        return await self._create_session(directory=directory), True
+        return await self._create_session(
+            directory=directory, title=self._platform_title()
+        ), True
 
     async def _list_agents(self) -> list[dict]:
         resp = await self._client.get(f"{self.base_url}/agent")
@@ -609,7 +613,9 @@ class AetherAgent(Agent):
             return f"✅ 已切换到会话：{title}\n   更新时间：{self._format_session_time((info or chosen).get('time', {}).get('updated'))}"
 
         if not items:
-            session_id = await self._create_session(directory=directory)
+            session_id = await self._create_session(
+                directory=directory, title=self._platform_title()
+            )
             self._sessions[conv_id] = session_id
             logger.info(f"[/session] 为 {conv_id} 创建新会话 {session_id[:8]}...")
             return "📂 当前项目下还没有任何会话，已自动创建一个新会话并切换。"
@@ -642,7 +648,9 @@ class AetherAgent(Agent):
             self._session_list.pop(conv_id, None)
             self._clear_runtime(conv_id)
             directory = self._conv_dirs.get(conv_id) or self.directory
-            session_id = await self._create_session(directory)
+            session_id = await self._create_session(
+                directory, title=self._platform_title()
+            )
             self._sessions[conv_id] = session_id
             if old:
                 logger.info(f"[/new] 清除会话 {old[:8]}... for {conv_id}")
@@ -1934,12 +1942,23 @@ class AetherAgent(Agent):
             return "reject"
         return None
 
-    async def _create_session(self, directory: str = "") -> str:
+    def _platform_title(self) -> str:
+        ts = (
+            datetime.now(timezone.utc)
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z")
+        )
+        return f"微信对话 - {ts}"
+
+    async def _create_session(self, directory: str = "", title: str = "") -> str:
         headers = (
             {"x-opencode-directory": quote(directory, safe="")} if directory else {}
         )
+        payload: dict = {}
+        if title:
+            payload["title"] = title
         resp = await self._client.post(
-            f"{self.base_url}/session", json={}, headers=headers
+            f"{self.base_url}/session", json=payload, headers=headers
         )
         resp.raise_for_status()
         return resp.json()["id"]

--- a/Aether-wechat-bridge/aether_wechat_agent.py
+++ b/Aether-wechat-bridge/aether_wechat_agent.py
@@ -230,13 +230,17 @@ HELP_LIST_TEXT = """📋 全部命令：
 
 /approval
   查看审批模式
+/approval n
+  按编号切换审批模式（1=auto, 2=ask）
 /approval <name>
-  切换审批模式（name 可选：auto、ask）
+  按名称切换审批模式（name 可选：auto、ask）
 
-/variant
-  查看当前变体
-/variant <name>
-  切换到指定变体（name 为变体名）
+/thinkinglevel
+  查看当前模型可用的思考等级
+/thinkinglevel n
+  按编号切换思考等级
+/thinkinglevel <name>
+  按名称切换思考等级
 
 /h, /help
   显示常用命令
@@ -671,8 +675,8 @@ class AetherAgent(Agent):
             return self._cmd_set_model(conv_id, arg)
         if cmd in {"/a", "/agent"}:
             return await self._cmd_agent(conv_id, arg)
-        if cmd == "/variant":
-            return await self._cmd_variant(conv_id, arg)
+        if cmd == "/thinkinglevel":
+            return await self._cmd_thinking(conv_id, arg)
         if cmd == "/approval":
             return await self._cmd_approval(conv_id, arg)
         if cmd in {"/p", "/project"}:
@@ -754,48 +758,131 @@ class AetherAgent(Agent):
         pref = await self._get_preference(session_id, directory) if session_id else None
         current = (pref or {}).get("agent") or self.default_agent
         if not arg:
-            sample = "、".join(names[:10]) or "（暂无可用模式）"
-            return f"🧠 当前模式：{current}\n可用模式：{sample}"
-        if arg not in names:
-            sample = "、".join(names[:10]) or "（暂无可用模式）"
-            return f"❌ 未找到模式：{arg}\n可用模式：{sample}"
+            if not names:
+                return "❌ 暂无可用模式。"
+            lines = ["🧠 可用模式：", ""]
+            for i, name in enumerate(names, start=1):
+                tag = " ★（当前）" if name == current else ""
+                lines.append(f"  {i}. {name}{tag}")
+            lines.extend(["", "💡 /a 编号或名称 切换模式"])
+            return chr(10).join(lines)
+        pick = None
+        if arg.isdigit():
+            n = int(arg)
+            if n < 1 or n > len(names):
+                return f"❌ 编号超出范围，请输入 1~{len(names)} 之间的数字。"
+            pick = names[n - 1]
+        else:
+            pick = arg if arg in names else None
+        if not pick:
+            return f"❌ 未找到模式：{arg}，发送 /a 查看可用模式。"
         if session_id:
-            await self._set_preference(session_id, directory, agent=arg)
-        logger.info(f"[/agent] {conv_id} -> {arg}")
-        return f"✅ 已切换模式：{arg}\n（仅对当前对话生效，/new 后将重置）"
+            await self._set_preference(session_id, directory, agent=pick)
+        logger.info(f"[/agent] {conv_id} -> {pick}")
+        return f"✅ 已切换模式：{pick}\n（仅对当前对话生效，/new 后将重置）"
 
-    async def _cmd_variant(self, conv_id: str, arg: str) -> str:
+    async def _list_thinking(
+        self, conv_id: str
+    ) -> tuple[list[str], Optional[str], bool]:
         session_id = self._sessions.get(conv_id)
         directory = self._conv_dirs.get(conv_id) or self.directory
         pref = await self._get_preference(session_id, directory) if session_id else None
-        current = (pref or {}).get("variant") or "（默认）"
+        pref_model = (pref or {}).get("model") if pref else None
+        current_model = (
+            f"{pref_model['providerID']}/{pref_model['modelID']}"
+            if pref_model
+            else self.default_model
+        )
+        if not current_model or "/" not in current_model:
+            return [], (pref or {}).get("variant"), False
+        provider_id, model_id = current_model.split("/", 1)
+        headers = (
+            {"x-opencode-directory": quote(directory, safe="")} if directory else {}
+        )
+        try:
+            resp = await self._client.get(f"{self.base_url}/provider", headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as e:
+            logger.error(f"获取思考等级失败: {e}")
+            return [], (pref or {}).get("variant"), True
+        for provider in data.get("all", []):
+            if provider.get("id") != provider_id:
+                continue
+            model = (provider.get("models") or {}).get(model_id) or {}
+            names = list((model.get("variants") or {}).keys())
+            return names, (pref or {}).get("variant"), True
+        return [], (pref or {}).get("variant"), True
+
+    async def _cmd_thinking(self, conv_id: str, arg: str) -> str:
+        names, current, ok = await self._list_thinking(conv_id)
+        if not ok:
+            return "❌ 请先使用 /m 选择模型后再切换思考等级。"
+        items = ["默认", *names]
         if not arg:
-            return f"🔀 当前变体：{current}"
+            lines = ["🔀 可用思考等级：", ""]
+            for i, name in enumerate(items, start=1):
+                tag = (
+                    " ★（当前）"
+                    if (name == "默认" and not current) or name == current
+                    else ""
+                )
+                lines.append(f"  {i}. {name}{tag}")
+            lines.extend(["", "💡 /thinkinglevel 编号或名称 切换思考等级"])
+            return chr(10).join(lines)
+        pick = None
+        if arg.isdigit():
+            n = int(arg)
+            if n < 1 or n > len(items):
+                return f"❌ 编号超出范围，请输入 1~{len(items)} 之间的数字。"
+            pick = items[n - 1]
+        else:
+            pick = arg if arg in items else "默认" if arg == "default" else None
+        if not pick:
+            return f"❌ 未找到思考等级：{arg}，发送 /thinkinglevel 查看可用思考等级。"
+        session_id = self._sessions.get(conv_id)
+        directory = self._conv_dirs.get(conv_id) or self.directory
         if session_id:
-            await self._set_preference(session_id, directory, variant=arg)
-        logger.info(f"[/variant] {conv_id} -> {arg}")
-        return f"✅ 已切换变体：{arg}\n（仅对当前对话生效，/new 后将重置）"
+            await self._set_preference(
+                session_id, directory, variant=None if pick == "默认" else pick
+            )
+        logger.info(f"[/thinkinglevel] {conv_id} -> {pick}")
+        return f"✅ 已切换思考等级：{pick}\n（仅对当前对话生效，/new 后将重置）"
 
     async def _cmd_approval(self, conv_id: str, arg: str) -> str:
         session_id = self._sessions.get(conv_id)
         directory = self._conv_dirs.get(conv_id) or self.directory
         pref = await self._get_preference(session_id, directory) if session_id else None
         auto = (pref or {}).get("autoAccept")
+        names = ["auto", "ask"]
         if not arg:
-            mode = "自动批准" if auto else "手动审批"
-            return f"🔐 当前审批模式：{mode}\n可用模式：auto、ask"
-        if arg not in {"auto", "ask"}:
-            return "❌ 仅支持 /approval auto 或 /approval ask"
+            lines = [
+                "🔐 可用审批模式：",
+                "",
+                f"  1. auto（自动批准）{' ★（当前）' if auto else ''}",
+                f"  2. ask（手动审批）{' ★（当前）' if not auto else ''}",
+                "",
+                "💡 /approval 编号或名称 切换审批模式",
+            ]
+            return chr(10).join(lines)
+        pick = None
+        if arg.isdigit():
+            n = int(arg)
+            pick = names[n - 1] if 1 <= n <= 2 else None
+        else:
+            pick = arg if arg in {"auto", "ask"} else None
+        if not pick:
+            return "❌ 仅支持 1(auto) 或 2(ask)。"
         if session_id:
             await self._set_preference(
-                session_id, directory, autoAccept=(arg == "auto")
+                session_id, directory, autoAccept=(pick == "auto")
             )
-        logger.info(f"[/approval] {conv_id} -> {arg}")
-        if arg == "auto" and conv_id in self._pending_permissions:
+        logger.info(f"[/approval] {conv_id} -> {pick}")
+        if pick == "auto" and conv_id in self._pending_permissions:
             await self._handle_permission_reply(conv_id, "2")
         return (
             "✅ 已开启自动接受权限\n（后续权限请求将自动批准）"
-            if arg == "auto"
+            if pick == "auto"
             else "✅ 已停止自动接受权限\n（后续权限请求将需要你确认）"
         )
 

--- a/Aether-wechat-bridge/aether_wechat_agent.py
+++ b/Aether-wechat-bridge/aether_wechat_agent.py
@@ -1390,6 +1390,16 @@ class AetherAgent(Agent):
 
         except httpx.HTTPStatusError as e:
             logger.error(f"HTTP 错误: {e.response.status_code}")
+            try:
+                body = e.response.json()
+                if (
+                    body.get("name") == "NotFoundError"
+                    and isinstance(body.get("data", {}).get("message"), str)
+                    and body["data"]["message"].startswith("Session not found:")
+                ):
+                    return ChatResponse(text="会话已不存在")
+            except Exception:
+                pass
             return ChatResponse(text="服务暂时不可用，请稍后重试")
         except httpx.RequestError as e:
             logger.error(f"连接错误: {e}")
@@ -1978,6 +1988,23 @@ class AetherAgent(Agent):
         resp.raise_for_status()
         body = resp.text.strip()
         if not body:
+            check = await self._client.get(
+                f"{self.base_url}/session/{session_id}",
+                headers={"x-opencode-directory": quote(directory, safe="")}
+                if directory
+                else {},
+            )
+            if check.status_code == 404:
+                try:
+                    d = check.json()
+                    if (
+                        d.get("name") == "NotFoundError"
+                        and isinstance(d.get("data", {}).get("message"), str)
+                        and d["data"]["message"].startswith("Session not found:")
+                    ):
+                        return {"formatted": "会话已不存在"}
+                except Exception:
+                    pass
             return {"formatted": "❌ 服务端返回空响应，请检查模型是否有效"}
         try:
             return self._extract_response(resp.json())

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -7,6 +7,7 @@ import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { GlobalBus } from "@/bus/global"
 import { Instance } from "@/project/instance"
+import { InstanceBootstrap } from "@/project/bootstrap"
 import { Project } from "@/project/project"
 import { Session } from "@/session"
 import { SessionPrompt } from "@/session/prompt"
@@ -90,10 +91,10 @@ export interface FeishuSession {
 }
 
 const HELP_TEXT =
-  "📋 可用命令：\n\n/n, /new            开启新对话\n/stop               停止当前执行\n/c, /compact        压缩当前上下文\n\n/m, /model          查看可用模型\n/m l                查看全部模型\n/m n                切换编号模型\n\n/a, /agent          查看当前模式\n/a n | /a <name>    切换指定模式\n\n/thinkinglevel      查看思考等级\n/thinkinglevel n    切换编号思考等级\n\n/approval           查看审批模式\n/approval n         切换编号审批模式\n\n/p, /project        查看最近项目\n/p l                查看全部项目\n/p n                切换编号项目\n\n/s, /session        查看最近会话\n/s l                查看全部会话\n/s n                切换编号会话\n\n/h, /help           显示帮助信息\n/help list          显示全部命令"
+  "📋 可用命令：\n\n/n, /new            开启新对话\n/stop               停止当前执行\n/c, /compact        压缩当前上下文\n\n/m, /model          查看可用模型\n/m l                查看全部模型\n/m n                切换编号模型\n\n/a, /agent          查看当前模式\n/a n | /a <name>    切换指定模式\n\n/thinkinglevel      查看思考等级\n/thinkinglevel n    切换编号思考等级\n\n/approval           查看审批模式\n/approval n         切换编号审批模式\n\n/p, /project        查看最近项目\n/p l                查看全部项目\n/p n                切换编号项目\n/p <path>           切换到指定路径\n\n/s, /session        查看最近会话\n/s l                查看全部会话\n/s n                切换编号会话\n\n/h, /help           显示帮助信息\n/help list          显示全部命令"
 
 const HELP_LIST_TEXT =
-  "📋 全部命令：\n\n/n, /new\n  开启新对话，清空当前会话上下文\n\n/stop\n  停止当前执行中的任务\n\n/c, /compact\n  压缩当前会话上下文\n\n/m, /model\n  查看可用模型\n/m l, /model list\n  查看全部模型（l = list）\n/m n, /model n\n  切换到编号 n 的模型（n 为全量模型编号）\n\n/a, /agent\n  查看当前模式\n/a n, /agent n\n  按编号切换模式\n/a <name>, /agent <name>\n  按名称切换模式（如 build、plan、docs）\n\n/thinkinglevel\n  查看当前模型可用的思考等级\n/thinkinglevel n\n  按编号切换思考等级\n/thinkinglevel <name>\n  按名称切换思考等级\n\n/approval\n  查看审批模式\n/approval n\n  按编号切换审批模式（1=auto, 2=ask）\n/approval <name>\n  切换审批模式（name 可选：auto、ask）\n\n/p, /project\n  查看最近项目\n/p l, /project list\n  查看全部项目（l = list）\n/p n, /project n\n  切换到编号 n 的项目\n/project hide n\n  隐藏编号 n 的项目，重新在桌面端或消息端使用后自动恢复\n\n/s, /session\n  查看最近会话\n/s l, /session list\n  查看当前项目下全部会话（l = list）\n/s n, /session n\n  切换到当前项目下编号 n 的会话\n\n/h, /help\n  显示常用命令\n/help list\n  显示全部命令"
+  "📋 全部命令：\n\n/n, /new\n  开启新对话，清空当前会话上下文\n\n/stop\n  停止当前执行中的任务\n\n/c, /compact\n  压缩当前会话上下文\n\n/m, /model\n  查看可用模型\n/m l, /model list\n  查看全部模型（l = list）\n/m n, /model n\n  切换到编号 n 的模型（n 为全量模型编号）\n\n/a, /agent\n  查看当前模式\n/a n, /agent n\n  按编号切换模式\n/a <name>, /agent <name>\n  按名称切换模式（如 build、plan、docs）\n\n/thinkinglevel\n  查看当前模型可用的思考等级\n/thinkinglevel n\n  按编号切换思考等级\n/thinkinglevel <name>\n  按名称切换思考等级\n\n/approval\n  查看审批模式\n/approval n\n  按编号切换审批模式（1=auto, 2=ask）\n/approval <name>\n  切换审批模式（name 可选：auto、ask）\n\n/p, /project\n  查看最近项目\n/p l, /project list\n  查看全部项目（l = list）\n/p n, /project n\n  切换到编号 n 的项目\n/p <path>, /project <path>\n  切换到指定路径（如 /p E:\\work\\foo 或 /p /home/user/foo）\n/project hide n\n  隐藏编号 n 的项目，重新在桌面端或消息端使用后自动恢复\n\n/s, /session\n  查看最近会话\n/s l, /session list\n  查看当前项目下全部会话（l = list）\n/s n, /session n\n  切换到当前项目下编号 n 的会话\n\n/h, /help\n  显示常用命令\n/help list\n  显示全部命令"
 
 export const FeishuEvent = {
   StatusChanged: BusEvent.define(
@@ -181,6 +182,7 @@ class FeishuManagerImpl {
   // ── Pending interaction state ─────────────────────────────────────────────
   private _pendingQuestions: Record<string, Question.Request> = {}
   private _pendingPermissions: Record<string, Permission.Request> = {}
+  private _pendingConfirmCreate: Record<string, { path: string }> = {}
   private _activePrompt = new Map<
     string,
     {
@@ -234,14 +236,24 @@ class FeishuManagerImpl {
     const text = (dir || "").replace(/\\/g, "/")
     if (!text) return ""
     if (/^\/+$/.test(text)) return "/"
-    if (/^[A-Za-z]:\/?$/.test(text)) return `${text[0].toLowerCase()}:/`
+    if (/^[A-Za-z]:/.test(text)) {
+      const lower = `${text[0].toLowerCase()}${text.slice(1)}`
+      if (/^[a-z]:\/?$/.test(lower)) return `${lower[0]}:/`
+      return lower.replace(/\/+$/, "")
+    }
     return text.replace(/\/+$/, "")
+  }
+
+  private isAbsolutePath(p: string): boolean {
+    const n = this.normDir(p)
+    if (!n || n === "/") return false
+    return n.startsWith("/") || /^[a-z]:/.test(n)
   }
 
   private isRootDir(dir: string): boolean {
     const text = this.normDir(dir)
     if (text === "/") return true
-    return /^[a-z]:\//.test(text) && text.length <= 3
+    return /^[a-z]:/.test(text) && text.length <= 3
   }
 
   private projectDir(item: Project.RecentInfo): string {
@@ -344,6 +356,7 @@ class FeishuManagerImpl {
   private async clearRuntime(chatId: string): Promise<void> {
     delete this._pendingQuestions[chatId]
     delete this._pendingPermissions[chatId]
+    delete this._pendingConfirmCreate[chatId]
     this._activePrompt.delete(chatId)
   }
 
@@ -715,6 +728,7 @@ class FeishuManagerImpl {
     this._modelList = []
     this._pendingQuestions = {}
     this._pendingPermissions = {}
+    this._pendingConfirmCreate = {}
     this._activePrompt.clear()
     for (const unsub of this._busUnsubs) unsub()
     this._busUnsubs = []
@@ -840,6 +854,19 @@ class FeishuManagerImpl {
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err)
           await this.replyText(messageId, `命令执行出错: ${msg}`)
+        }
+        return
+      }
+
+      const pendingConfirm = this._pendingConfirmCreate[chatId]
+      if (pendingConfirm) {
+        const lower = text.trim().toLowerCase()
+        if (lower === "y" || lower === "yes" || lower === "确认") {
+          await this.confirmCreateProject(chatId, messageId, true)
+        } else if (lower === "n" || lower === "no" || lower === "取消") {
+          await this.confirmCreateProject(chatId, messageId, false)
+        } else {
+          await this.replyText(messageId, "请回复 y 确认创建或 n 取消。")
         }
         return
       }
@@ -1537,6 +1564,10 @@ class FeishuManagerImpl {
    * /project hide <n>   — hide project n
    */
   private async cmdProject(messageId: string, chatId: string, arg: string): Promise<void> {
+    if (arg && this.isAbsolutePath(arg)) {
+      await this.cmdProjectByPath(messageId, chatId, arg)
+      return
+    }
     const allProjects = this.getProjects()
     if (allProjects.length === 0) {
       await this.replyCmd(messageId, chatId, "❌ 无法获取项目列表，请检查 Aether 是否正常运行。")
@@ -1587,49 +1618,7 @@ class FeishuManagerImpl {
       }
       const chosen = allProjects[idx]
       const newDir = this.projectDir(chosen)
-
-      // Clear session mapping for this chat so next message uses the new project
-      for (const key of Object.keys(this.sessionMap)) {
-        if (key.startsWith(`${chatId}:`)) delete this.sessionMap[key]
-      }
-      this._chatDirs[chatId] = newDir
-      void this.clearRuntime(chatId)
-
-      // Auto-unhide if it was hidden
-      if (newDir in this._hiddenDirs) {
-        delete this._hiddenDirs[newDir]
-        await this.saveHiddenDirs()
-      }
-
-      // Find or create a session in the new project
-      const {
-        sessionId: newSessionId,
-        sessionTitle,
-        created,
-      } = await Instance.provide({
-        directory: newDir,
-        fn: async () => {
-          const recent = [...Session.list({ directory: newDir, roots: true, limit: 1 })]
-          if (recent.length > 0) {
-            return {
-              sessionId: recent[0].id,
-              sessionTitle: recent[0].title ?? recent[0].id.slice(0, 8),
-              created: false,
-            }
-          } else {
-            const session = await Session.create({ title: `飞书对话 - ${new Date().toISOString()}` })
-            return { sessionId: session.id, sessionTitle: session.title, created: true }
-          }
-        },
-      })
-      this._chatSessions[chatId] = newSessionId
-      await this.saveSessionMap()
-
-      const name = this.projectName(chosen)
-      const ctx = await this.commandCtx(chatId)
-      const note = created ? "已创建新会话" : `已进入该项目最新会话：${ctx.sessionTitle}`
-      console.log("[feishu] /project switched:", chatId, "->", newDir)
-      await this.replyCmd(messageId, chatId, `✅ 已切换到：${name}\n   ${newDir}\n（${note}）`)
+      await this.switchToProject(messageId, chatId, newDir)
       return
     }
 
@@ -1653,7 +1642,7 @@ class FeishuManagerImpl {
       count++
     }
     lines.push("")
-    lines.push("💡 /p n 切换 | /p l 查看全部")
+    lines.push("💡 /p n 切换 | /p l 查看全部 | /p <path> 指定路径")
     if (Object.keys(this._hiddenDirs).length > 0) {
       lines.push(`ℹ️ 已隐藏 ${Object.keys(this._hiddenDirs).length} 个项目（重新使用后自动恢复）`)
     }
@@ -1663,6 +1652,144 @@ class FeishuManagerImpl {
   private formatSessionTime(timestamp: number): string {
     const d = new Date(timestamp)
     return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")} ${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`
+  }
+
+  private async cmdProjectByPath(messageId: string, chatId: string, rawPath: string): Promise<void> {
+    const normed = this.normDir(rawPath)
+    if (this.isRootDir(normed)) {
+      await this.replyCmd(messageId, chatId, "❌ 路径不合法：不能使用根目录。")
+      return
+    }
+
+    const allProjects = this.getProjects()
+    const existing = allProjects.find((p) => this.projectDir(p) === normed)
+    const dirExists = existsSync(normed)
+
+    if (existing) {
+      if (!dirExists) {
+        await mkdir(normed, { recursive: true })
+      }
+      const newDir = this.projectDir(existing)
+      await this.switchToProject(messageId, chatId, newDir)
+      return
+    }
+
+    if (dirExists) {
+      await this.switchToNewProject(messageId, chatId, normed)
+      return
+    }
+
+    this._pendingConfirmCreate[chatId] = { path: normed }
+    await this.replyCmd(
+      messageId,
+      chatId,
+      `📂 路径不存在：${normed}\n回复 y 确认创建该文件夹并初始化项目，回复 n 取消。`,
+    )
+  }
+
+  private async confirmCreateProject(chatId: string, messageId: string, yes: boolean): Promise<void> {
+    const pending = this._pendingConfirmCreate[chatId]
+    if (!pending) return
+    delete this._pendingConfirmCreate[chatId]
+
+    if (!yes) {
+      await this.replyCmd(messageId, chatId, "已取消创建。")
+      return
+    }
+
+    await mkdir(pending.path, { recursive: true })
+    await this.switchToNewProject(messageId, chatId, pending.path)
+  }
+
+  private async switchToProject(messageId: string, chatId: string, newDir: string): Promise<void> {
+    for (const key of Object.keys(this.sessionMap)) {
+      if (key.startsWith(`${chatId}:`)) delete this.sessionMap[key]
+    }
+    this._chatDirs[chatId] = newDir
+    void this.clearRuntime(chatId)
+
+    if (newDir in this._hiddenDirs) {
+      delete this._hiddenDirs[newDir]
+      await this.saveHiddenDirs()
+    }
+
+    const {
+      sessionId: newSessionId,
+      sessionTitle,
+      created,
+    } = await Instance.provide({
+      directory: newDir,
+      fn: async () => {
+        const recent = [...Session.list({ directory: newDir, roots: true, limit: 1 })]
+        if (recent.length > 0) {
+          return {
+            sessionId: recent[0].id,
+            sessionTitle: recent[0].title ?? recent[0].id.slice(0, 8),
+            created: false,
+          }
+        }
+        const session = await Session.create({ title: `飞书对话 - ${new Date().toISOString()}` })
+        return { sessionId: session.id, sessionTitle: session.title, created: true }
+      },
+    })
+    this._chatSessions[chatId] = newSessionId
+    await this.saveSessionMap()
+
+    const name = this.baseName(newDir)
+    const note = created ? "已创建新会话" : `已进入该项目最新会话：${sessionTitle}`
+    console.log("[feishu] /project switched:", chatId, "->", newDir)
+    await this.replyCmd(messageId, chatId, `✅ 已切换到：${name}\n   ${newDir}\n（${note}）`)
+  }
+
+  private async switchToNewProject(messageId: string, chatId: string, newDir: string): Promise<void> {
+    for (const key of Object.keys(this.sessionMap)) {
+      if (key.startsWith(`${chatId}:`)) delete this.sessionMap[key]
+    }
+    this._chatDirs[chatId] = newDir
+    void this.clearRuntime(chatId)
+
+    const { project } = await Project.fromDirectory(newDir)
+    if (project.vcs !== "git") {
+      const initialized = await Project.initGit({ directory: newDir, project })
+      await Instance.reload({
+        directory: newDir,
+        worktree: newDir,
+        project: initialized,
+        init: InstanceBootstrap,
+      })
+    }
+
+    const {
+      sessionId: newSessionId,
+      sessionTitle,
+      created,
+    } = await Instance.provide({
+      directory: newDir,
+      init: InstanceBootstrap,
+      fn: async () => {
+        const recent = [...Session.list({ directory: newDir, roots: true, limit: 1 })]
+        if (recent.length > 0) {
+          return {
+            sessionId: recent[0].id,
+            sessionTitle: recent[0].title ?? recent[0].id.slice(0, 8),
+            created: false,
+          }
+        }
+        const session = await Session.create({ title: `飞书对话 - ${new Date().toISOString()}` })
+        return { sessionId: session.id, sessionTitle: session.title, created: true }
+      },
+    })
+    this._chatSessions[chatId] = newSessionId
+    await this.saveSessionMap()
+
+    const name = this.baseName(newDir)
+    const note = created ? "已创建新会话" : `已进入该项目最新会话：${sessionTitle}`
+    console.log("[feishu] /project created+switched:", chatId, "->", newDir)
+    await this.replyCmd(messageId, chatId, `✅ 已切换到：${name}\n   ${newDir}\n（${note}）`)
+  }
+
+  private baseName(dir: string): string {
+    return dir.replace(/\\/g, "/").replace(/\/+$/, "").split("/").at(-1) || dir
   }
 
   /**

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -90,10 +90,10 @@ export interface FeishuSession {
 }
 
 const HELP_TEXT =
-  "📋 可用命令：\n\n/n, /new      开启新对话\n/stop         停止当前执行\n/c, /compact  压缩当前上下文\n\n/m, /model    查看可用模型\n/m l          查看全部模型\n/m n          切换编号模型\n\n/a, /agent    查看当前模式\n/a <name>     切换指定模式\n\n/p, /project  查看最近项目\n/p l          查看全部项目\n/p n          切换编号项目\n\n/s, /session  查看最近会话\n/s l          查看全部会话\n/s n          切换编号会话\n\n/h, /help     显示帮助信息\n/help list    显示全部命令"
+  "📋 可用命令：\n\n/n, /new            开启新对话\n/stop               停止当前执行\n/c, /compact        压缩当前上下文\n\n/m, /model          查看可用模型\n/m l                查看全部模型\n/m n                切换编号模型\n\n/a, /agent          查看当前模式\n/a n | /a <name>    切换指定模式\n\n/thinkinglevel      查看思考等级\n/thinkinglevel n    切换编号思考等级\n\n/approval           查看审批模式\n/approval n         切换编号审批模式\n\n/p, /project        查看最近项目\n/p l                查看全部项目\n/p n                切换编号项目\n\n/s, /session        查看最近会话\n/s l                查看全部会话\n/s n                切换编号会话\n\n/h, /help           显示帮助信息\n/help list          显示全部命令"
 
 const HELP_LIST_TEXT =
-  "📋 全部命令：\n\n/n, /new\n  开启新对话，清空当前会话上下文\n\n/stop\n  停止当前执行中的任务\n\n/c, /compact\n  压缩当前会话上下文\n\n/m, /model\n  查看可用模型\n/m l, /model list\n  查看全部模型（l = list）\n/m n, /model n\n  切换到编号 n 的模型（n 为全量模型编号）\n\n/a, /agent\n  查看当前模式\n/a <name>, /agent <name>\n  切换模式（如 build、plan、docs）\n\n/p, /project\n  查看最近项目\n/p l, /project list\n  查看全部项目（l = list）\n/p n, /project n\n  切换到编号 n 的项目\n/project hide n\n  隐藏编号 n 的项目，重新在桌面端或消息端使用后自动恢复\n\n/s, /session\n  查看最近会话\n/s l, /session list\n  查看当前项目下全部会话（l = list）\n/s n, /session n\n  切换到当前项目下编号 n 的会话\n\n/approval\n  查看审批模式\n/approval <name>\n  切换审批模式（name 可选：auto、ask）\n\n/variant\n  查看当前变体\n/variant <name>\n  切换到指定变体（name 为变体名）\n\n/h, /help\n  显示常用命令\n/help list\n  显示全部命令"
+  "📋 全部命令：\n\n/n, /new\n  开启新对话，清空当前会话上下文\n\n/stop\n  停止当前执行中的任务\n\n/c, /compact\n  压缩当前会话上下文\n\n/m, /model\n  查看可用模型\n/m l, /model list\n  查看全部模型（l = list）\n/m n, /model n\n  切换到编号 n 的模型（n 为全量模型编号）\n\n/a, /agent\n  查看当前模式\n/a n, /agent n\n  按编号切换模式\n/a <name>, /agent <name>\n  按名称切换模式（如 build、plan、docs）\n\n/thinkinglevel\n  查看当前模型可用的思考等级\n/thinkinglevel n\n  按编号切换思考等级\n/thinkinglevel <name>\n  按名称切换思考等级\n\n/approval\n  查看审批模式\n/approval n\n  按编号切换审批模式（1=auto, 2=ask）\n/approval <name>\n  切换审批模式（name 可选：auto、ask）\n\n/p, /project\n  查看最近项目\n/p l, /project list\n  查看全部项目（l = list）\n/p n, /project n\n  切换到编号 n 的项目\n/project hide n\n  隐藏编号 n 的项目，重新在桌面端或消息端使用后自动恢复\n\n/s, /session\n  查看最近会话\n/s l, /session list\n  查看当前项目下全部会话（l = list）\n/s n, /session n\n  切换到当前项目下编号 n 的会话\n\n/h, /help\n  显示常用命令\n/help list\n  显示全部命令"
 
 export const FeishuEvent = {
   StatusChanged: BusEvent.define(
@@ -1224,8 +1224,8 @@ class FeishuManagerImpl {
         await this.cmdAgent(messageId, chatId, rest)
       } else if (command === "/approval") {
         await this.cmdApproval(messageId, chatId, rest)
-      } else if (command === "/variant") {
-        await this.cmdVariant(messageId, chatId, rest)
+      } else if (command === "/thinkinglevel") {
+        await this.cmdThinkingLevel(messageId, chatId, rest)
       } else if (command === "/p" || command === "/project") {
         const arg = rest === "l" ? "list" : rest.startsWith("h ") ? `hide ${rest.slice(2).trim()}` : rest
         await this.cmdProject(messageId, chatId, arg)
@@ -1349,6 +1349,22 @@ class FeishuManagerImpl {
     return lines.join("\n")
   }
 
+  private async thinking(chatId: string) {
+    const ctx = await this.commandCtx(chatId)
+    const model = this.resolveModel(chatId)
+    if (!model) return { names: [], current: ctx.pref?.variant }
+    const all = await Instance.provide({
+      directory: ctx.dir,
+      fn: () => Provider.list(),
+    })
+    const info = all[model.providerID]
+    const item = info?.models?.[model.modelID] as { variants?: Record<string, unknown> } | undefined
+    return {
+      names: Object.keys(item?.variants ?? {}),
+      current: ctx.pref?.variant,
+    }
+  }
+
   /** /compact — compress the current session context */
   private async cmdCompact(messageId: string, chatId: string): Promise<void> {
     const ctx = await this.commandCtx(chatId)
@@ -1404,17 +1420,34 @@ class FeishuManagerImpl {
     const visible = agents.filter((a) => !a.hidden)
     const names = visible.map((a) => a.name)
     if (!arg) {
-      const sample = names.slice(0, 10).join("、") || "（暂无可用模式）"
-      await this.replyCmd(messageId, chatId, `🧠 可用模式：${sample}`)
+      if (names.length === 0) {
+        await this.replyCmd(messageId, chatId, "❌ 暂无可用模式。")
+        return
+      }
+      const lines = ["🧠 可用模式：", ""]
+      names.forEach((name, i) => {
+        lines.push(`  ${i + 1}. ${name}${name === current ? " ★（当前）" : ""}`)
+      })
+      lines.push("", "💡 /a 编号或名称 切换模式")
+      await this.replyCmd(messageId, chatId, lines.join("\n"))
       return
     }
-    if (!names.includes(arg)) {
-      const sample = names.slice(0, 10).join("、") || "（暂无可用模式）"
-      await this.replyCmd(messageId, chatId, `❌ 未找到模式：${arg}\n可用模式：${sample}`)
+    const n = parseInt(arg, 10)
+    const next = /^\d+$/.test(arg)
+      ? n >= 1 && n <= names.length
+        ? names[n - 1]
+        : undefined
+      : names.find((name) => name === arg)
+    if (!next) {
+      if (/^\d+$/.test(arg)) {
+        await this.replyCmd(messageId, chatId, `❌ 编号超出范围，请输入 1~${names.length} 之间的数字。`)
+        return
+      }
+      await this.replyCmd(messageId, chatId, `❌ 未找到模式：${arg}，发送 /a 查看可用模式。`)
       return
     }
-    await this.setPref(chatId, { agent: arg })
-    await this.replyCmd(messageId, chatId, `✅ 已切换模式：${arg}\n（仅对当前对话生效，/new 后将重置）`)
+    await this.setPref(chatId, { agent: next })
+    await this.replyCmd(messageId, chatId, `✅ 已切换模式：${next}\n（仅对当前对话生效，/new 后将重置）`)
   }
 
   /**
@@ -1424,17 +1457,27 @@ class FeishuManagerImpl {
   private async cmdApproval(messageId: string, chatId: string, arg: string): Promise<void> {
     const ctx = await this.commandCtx(chatId)
     const auto = ctx.pref?.autoAccept ?? false
+    const names = ["auto", "ask"] as const
     if (!arg) {
-      const mode = auto ? "自动批准" : "手动审批"
-      await this.replyCmd(messageId, chatId, `🔐 当前审批模式：${mode}\n可用模式：auto、ask`)
+      const lines = [
+        "🔐 可用审批模式：",
+        "",
+        `  1. auto（自动批准）${auto ? " ★（当前）" : ""}`,
+        `  2. ask（手动审批）${auto ? "" : " ★（当前）"}`,
+        "",
+        "💡 /approval 编号或名称 切换审批模式",
+      ]
+      await this.replyCmd(messageId, chatId, lines.join("\n"))
       return
     }
-    if (arg !== "auto" && arg !== "ask") {
-      await this.replyCmd(messageId, chatId, "❌ 仅支持 /approval auto 或 /approval ask")
+    const n = parseInt(arg, 10)
+    const next = /^\d+$/.test(arg) ? names[n - 1] : names.find((name) => name === arg)
+    if (!next) {
+      await this.replyCmd(messageId, chatId, "❌ 仅支持 1(auto) 或 2(ask)。")
       return
     }
-    await this.setPref(chatId, { autoAccept: arg === "auto" })
-    if (arg === "auto") {
+    await this.setPref(chatId, { autoAccept: next === "auto" })
+    if (next === "auto") {
       const pending = this._pendingPermissions[chatId]
       if (pending) {
         delete this._pendingPermissions[chatId]
@@ -1451,19 +1494,40 @@ class FeishuManagerImpl {
     }
   }
 
-  /**
-   * /variant        — show current variant
-   * /variant <name> — switch to named variant
-   */
-  private async cmdVariant(messageId: string, chatId: string, arg: string): Promise<void> {
-    const ctx = await this.commandCtx(chatId)
-    const current = ctx.pref?.variant || "（默认）"
-    if (!arg) {
-      await this.replyCmd(messageId, chatId, `🔀 当前变体：${current}`)
+  private async cmdThinkingLevel(messageId: string, chatId: string, arg: string): Promise<void> {
+    const model = this.resolveModel(chatId)
+    if (!model) {
+      await this.replyCmd(messageId, chatId, "❌ 请先使用 /m 选择模型后再切换思考等级。")
       return
     }
-    await this.setPref(chatId, { variant: arg })
-    await this.replyCmd(messageId, chatId, `✅ 已切换变体：${arg}\n（仅对当前对话生效，/new 后将重置）`)
+    const info = await this.thinking(chatId)
+    const names = ["默认", ...info.names]
+    if (!arg) {
+      const lines = ["🔀 可用思考等级：", ""]
+      names.forEach((name, i) => {
+        const active = name === "默认" ? !info.current : name === info.current
+        lines.push(`  ${i + 1}. ${name}${active ? " ★（当前）" : ""}`)
+      })
+      lines.push("", "💡 /thinkinglevel 编号或名称 切换思考等级")
+      await this.replyCmd(messageId, chatId, lines.join("\n"))
+      return
+    }
+    const n = parseInt(arg, 10)
+    const next = /^\d+$/.test(arg)
+      ? n >= 1 && n <= names.length
+        ? names[n - 1]
+        : undefined
+      : names.find((name) => name === arg || (name === "默认" && arg === "default"))
+    if (!next) {
+      if (/^\d+$/.test(arg)) {
+        await this.replyCmd(messageId, chatId, `❌ 编号超出范围，请输入 1~${names.length} 之间的数字。`)
+        return
+      }
+      await this.replyCmd(messageId, chatId, `❌ 未找到思考等级：${arg}，发送 /thinkinglevel 查看可用思考等级。`)
+      return
+    }
+    await this.setPref(chatId, { variant: next === "默认" ? undefined : next })
+    await this.replyCmd(messageId, chatId, `✅ 已切换思考等级：${next}\n（仅对当前对话生效，/new 后将重置）`)
   }
 
   /**

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -413,7 +413,7 @@ class FeishuManagerImpl {
     if (!create) return
     const session = await Instance.provide({
       directory: dir,
-      fn: () => Session.create({ title: `飞书对话 ${chatId.slice(-6)}` }),
+      fn: () => Session.create({ title: `飞书对话 - ${new Date().toISOString()}` }),
     })
     this._chatSessions[chatId] = session.id
     return session.id
@@ -893,7 +893,7 @@ class FeishuManagerImpl {
         console.log("[feishu] creating new session...")
         const session = await Instance.provide({
           directory: effectiveDir,
-          fn: () => Session.create({ title: `飞书对话 ${chatId.slice(-6)}` }),
+          fn: () => Session.create({ title: `飞书对话 - ${new Date().toISOString()}` }),
         })
         sessionId = session.id
         console.log("[feishu] session created:", sessionId)
@@ -1245,7 +1245,7 @@ class FeishuManagerImpl {
     const dir = this.effectiveDir(chatId)
     const session = await Instance.provide({
       directory: dir,
-      fn: () => Session.create({ title: `飞书对话 ${chatId.slice(-6)}` }),
+      fn: () => Session.create({ title: `飞书对话 - ${new Date().toISOString()}` }),
     })
     this._chatSessions[chatId] = session.id
     await this.saveSessionMap()
@@ -1544,7 +1544,7 @@ class FeishuManagerImpl {
               created: false,
             }
           } else {
-            const session = await Session.create({ title: `飞书对话 ${chatId.slice(-6)}` })
+            const session = await Session.create({ title: `飞书对话 - ${new Date().toISOString()}` })
             return { sessionId: session.id, sessionTitle: session.title, created: true }
           }
         },
@@ -1648,7 +1648,7 @@ class FeishuManagerImpl {
     if (!items.length) {
       const session = await Instance.provide({
         directory: effectiveDir,
-        fn: () => Session.create({ title: `飞书对话 ${chatId.slice(-6)}` }),
+        fn: () => Session.create({ title: `飞书对话 - ${new Date().toISOString()}` }),
       })
       this._chatSessions[chatId] = session.id
       await this.replyCmd(messageId, chatId, "📂 当前项目下还没有任何会话，已自动创建一个新会话并切换。")

--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -20,7 +20,16 @@ import { Agent } from "@/agent/agent"
 import { SessionPreference } from "@/session/preference"
 import { Question } from "@/question"
 import { Permission } from "@/permission"
+import { NotFoundError } from "@/storage/db"
 import { legacyPlatformDir, platformDir } from "@/persist/naming"
+
+function isSessionNotFound(err: unknown): boolean {
+  return (
+    NotFoundError.isInstance(err) &&
+    typeof err.data?.message === "string" &&
+    err.data.message.startsWith("Session not found:")
+  )
+}
 
 function dir() {
   return platformDir("feishu")
@@ -861,7 +870,7 @@ class FeishuManagerImpl {
       try {
         const messageId = data?.message?.message_id
         if (messageId) {
-          const errMsg = err instanceof Error ? err.message : String(err)
+          const errMsg = isSessionNotFound(err) ? "会话已不存在" : err instanceof Error ? err.message : String(err)
           await this.replyText(messageId, `处理消息时出错: ${errMsg}`)
         }
       } catch (e2) {
@@ -977,7 +986,7 @@ class FeishuManagerImpl {
       }
     } catch (err) {
       console.error("[feishu] prompt error:", err)
-      const errMsg = err instanceof Error ? err.message : String(err)
+      const errMsg = isSessionNotFound(err) ? "会话已不存在" : err instanceof Error ? err.message : String(err)
       await this.replyText(messageId, `处理消息时出错: ${errMsg}`).catch(() => {})
     } finally {
       this._activePrompt.delete(chatId)


### PR DESCRIPTION
### Issue for this PR

Closes #350
Closes #356

### Type of change

- [x] New feature
- [x] Refactor / code improvement

### What does this PR do?

Four commits addressing two issues:

1. **`93a6ce5` feat: unify feishu/wechat session title format with ISO timestamp** (#350)
   - Both bridges now use ISO timestamp (`飞书对话 - 2026-04-19T...`) for new session titles, replacing inconsistent formats.

2. **`1a7785` fix: unify missing session errors in feishu and wechat** (#350)
   - Standardized error messages when session/project lookup fails across both bridges.

3. **`77a8585` feat: add indexed mode and thinking level commands** (#350)
   - WeChat bridge gains `/a n` indexed agent switching and `/thinkinglevel` command (previously only available in Feishu).
   - Both bridges now support `/approval` indexed switching.
   - `/model` now uses a unified indexed picker across both bridges.

4. **`18f28c1` feat: add /p <path> to switch project by absolute path** (#356)
   - `/p <path>` (e.g. `/p E:\work\foo`) lets users switch project by absolute path on both bridges.
   - Three cases: existing project → switch directly; new directory → init git and switch; non-existent path → y/n confirm before creating.
   - Refactors project-switching into shared helpers (`_switch_to_project`/`switchToProject`, `_switch_to_new_project`/`switchToNewProject`) to reduce duplication.

### How did you verify your code works?

- Manually tested `/p <path>` with existing, new, and non-existent paths (confirm/cancel) on both bridges.
- Verified `/thinkinglevel`, `/approval`, `/a n` indexed switching works on WeChat bridge.
- Verified existing `/p n`, `/m n`, `/s n` flows still work unchanged.
- `bun typecheck` passes.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR