### PR TITLE
feat: enable web cache

### DIFF
--- a/packages/app/public/_headers
+++ b/packages/app/public/_headers
@@ -1,17 +1,26 @@
 /assets/*.js
+  Cache-Control: public, max-age=31536000, immutable
   Content-Type: application/javascript
 
 /assets/*.mjs
+  Cache-Control: public, max-age=31536000, immutable
   Content-Type: application/javascript
 
 /assets/*.css
+  Cache-Control: public, max-age=31536000, immutable
   Content-Type: text/css
 
 /*.js
+  Cache-Control: no-cache
   Content-Type: application/javascript
 
 /*.mjs
+  Cache-Control: no-cache
   Content-Type: application/javascript
 
 /*.css
+  Cache-Control: no-cache
   Content-Type: text/css
+
+/index.html
+  Cache-Control: no-cache

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -20,6 +20,38 @@ function getMimeType(filePath: string): string {
   const ext = nodePath.extname(filePath).toLowerCase()
   return MIME_TYPES[ext] ?? "application/octet-stream"
 }
+const WEB_CACHE = "public, max-age=31536000, immutable"
+const WEB_REVALIDATE = "no-cache"
+
+function webEtag(size: number, mtimeMs: number) {
+  return `W/"${size}-${mtimeMs}"`
+}
+
+function hashed(path: string) {
+  return path.startsWith("/assets/") && /-[A-Za-z0-9_-]{8,}\./.test(nodePath.basename(path))
+}
+
+async function webHeaders(reqPath: string, filePath: string) {
+  const stat = await Bun.file(filePath).stat()
+  return {
+    "content-type": getMimeType(filePath),
+    "cache-control": hashed(reqPath) ? WEB_CACHE : WEB_REVALIDATE,
+    etag: webEtag(Number(stat.size), stat.mtimeMs),
+    "last-modified": stat.mtime.toUTCString(),
+  }
+}
+
+async function webResponse(req: Request, reqPath: string, filePath: string) {
+  const file = Bun.file(filePath)
+  const headers = await webHeaders(reqPath, filePath)
+  if (req.headers.get("if-none-match") === headers.etag) {
+    return new Response(null, {
+      status: 304,
+      headers,
+    })
+  }
+  return new Response(file, { headers })
+}
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { createHash } from "node:crypto"
@@ -658,12 +690,13 @@ export namespace Server {
         const localFilePath = nodePath.join(webDir, reqPath === "/" ? "index.html" : reqPath)
         const localFile = Bun.file(localFilePath)
         if (await localFile.exists()) {
-          return new Response(localFile, { headers: { "content-type": getMimeType(localFilePath) } })
+          return webResponse(c.req.raw, reqPath, localFilePath)
         }
         // SPA fallback: serve index.html for unknown paths
-        const indexFile = Bun.file(nodePath.join(webDir, "index.html"))
+        const indexPath = nodePath.join(webDir, "index.html")
+        const indexFile = Bun.file(indexPath)
         if (await indexFile.exists()) {
-          return new Response(indexFile, { headers: { "content-type": "text/html" } })
+          return webResponse(c.req.raw, "/", indexPath)
         }
 
         // Fall back to remote proxy

--- a/packages/opencode/test/server/server-web-cache.test.ts
+++ b/packages/opencode/test/server/server-web-cache.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test"
+import { mkdir, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { Server } from "../../src/server/server"
+import { tmpdir } from "../fixture/fixture"
+
+describe("web cache headers", () => {
+  test("serves hashed assets as immutable", async () => {
+    await using tmp = await tmpdir()
+    const root = path.join(tmp.path, "bin", "web")
+    await mkdir(path.join(root, "assets"), { recursive: true })
+    await writeFile(path.join(root, "index.html"), "<!doctype html>")
+    await writeFile(path.join(root, "assets", "index-ABCDEFGH.js"), "console.log('ok')")
+
+    const old = process.execPath
+    Object.defineProperty(process, "execPath", { value: path.join(tmp.path, "bin", "aether"), configurable: true })
+
+    try {
+      const app = Server.createApp({})
+      const res = await app.request("/assets/index-ABCDEFGH.js")
+      expect(res.status).toBe(200)
+      expect(res.headers.get("cache-control")).toBe("public, max-age=31536000, immutable")
+      expect(res.headers.get("etag")).toBeTruthy()
+      expect(res.headers.get("last-modified")).toBeTruthy()
+    } finally {
+      Object.defineProperty(process, "execPath", { value: old, configurable: true })
+    }
+  })
+
+  test("revalidates index.html with etag", async () => {
+    await using tmp = await tmpdir()
+    const root = path.join(tmp.path, "bin", "web")
+    await mkdir(root, { recursive: true })
+    await writeFile(path.join(root, "index.html"), "<!doctype html>")
+
+    const old = process.execPath
+    Object.defineProperty(process, "execPath", { value: path.join(tmp.path, "bin", "aether"), configurable: true })
+
+    try {
+      const app = Server.createApp({})
+      const first = await app.request("/")
+      const tag = first.headers.get("etag")
+      expect(first.status).toBe(200)
+      expect(first.headers.get("cache-control")).toBe("no-cache")
+      expect(tag).toBeTruthy()
+
+      const next = await app.request("/", {
+        headers: { "if-none-match": tag! },
+      })
+      expect(next.status).toBe(304)
+      expect(next.headers.get("cache-control")).toBe("no-cache")
+      expect(next.headers.get("etag")).toBe(tag)
+    } finally {
+      Object.defineProperty(process, "execPath", { value: old, configurable: true })
+    }
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #355

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

原先 Web 版不会加cache headers，导致很多资源重复加载，页面初次加载慢.对于运行在本地的服务这点影响不大，然而对于部署于服务器、远程连接等情形下性能提升明显.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

测试静态文件协商缓存成功

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
