### PR TITLE
fix: reduce automatic update polling frequency

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -468,7 +468,7 @@ export default function Layout(props: ParentProps) {
 
         if (interval !== undefined) return
         void pollUpdate()
-        interval = setInterval(pollUpdate, 10 * 60 * 1000)
+        interval = setInterval(pollUpdate, 24 * 60 * 60 * 1000)
       })
 
       onCleanup(() => {


### PR DESCRIPTION
### Issue for this PR

Closes #357

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This keeps the startup update check but changes the recurring automatic update poll from every 10 minutes to every 24 hours. That reduces repeated remote version checks and unnecessary background auto-download attempts in the offline web update flow.

### How did you verify your code works?

Ran typecheck under arm64 and reviewed the polling logic in  to confirm the interval changed from  to  while preserving the immediate startup poll.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
