### PR TITLE
fix: harden offline web updater recovery

### DIFF
--- a/Update/offline-update-regression-checklist.md
+++ b/Update/offline-update-regression-checklist.md
@@ -1,0 +1,94 @@
+# Offline updates
+
+Short manual checks for desktop update recovery.
+
+## Scope
+
+Cover offline web update behavior across Windows and Linux.
+
+Focus on these regressions:
+- No flashing terminal windows during Windows download, install, and relaunch
+- Partial downloads never enable install
+- In-progress manual download state survives while the same app/server process stays alive
+- Failed update or install offers a restart-from-scratch recovery path
+- Linux downloaded zip plus script installs and relaunches into the new version
+
+## Environment/setup
+
+Prepare:
+- A build with the offline web update flow enabled
+- Test machines for Windows and Linux
+- An update target that is newer than the installed app
+- A way to interrupt downloads and simulate install failure
+- Access to app logs if the UI result is unclear
+
+Before each run:
+- Start from a known app version
+- Clear any old downloaded update artifacts unless the scenario says otherwise
+- Confirm the update UI detects the newer version
+
+## Scenario checklist
+
+### 1. Verify silent Windows execution
+
+- [ ] On Windows, start the update download and complete the install flow
+- [ ] Watch for any terminal or console windows during download, install, and relaunch
+
+Expected:
+- No terminal window flashes at any step
+- Update completes through the normal UI flow
+- App relaunches into the new version
+
+### 2. Verify partial download recovery
+
+- [ ] Start downloading an update
+- [ ] Interrupt the download before completion
+- [ ] Return to the update screen without manually repairing files
+- [ ] Restart the update flow as prompted
+
+Expected:
+- Install never becomes available for the partial download
+- UI does not treat the partial artifact as a valid ready-to-install update
+- Recovery path offers restart/update again
+- Restarted download can complete normally and then enable install
+
+### 3. Verify in-memory manual download persistence
+
+- [ ] Start a manual download but do not finish it
+- [ ] Close and reopen the update surface while keeping the same app/server process alive
+- [ ] Revisit the update flow
+
+Expected:
+- State is remembered within the same live process
+- Reopen shows recovery or resume guidance, not install
+- UI does not present the interrupted download as complete
+
+### 4. Verify failed update/install recovery
+
+- [ ] Force an update or install failure
+- [ ] Observe the post-failure UI
+- [ ] Use the offered recovery action
+
+Expected:
+- Failure state is visible and understandable
+- A restart-from-scratch path is available
+- Recovery clears the broken state enough to retry cleanly
+- Retried flow can proceed to a successful install
+
+### 5. Verify Linux install from downloaded artifacts
+
+- [ ] On Linux, complete the offline download so the zip and install script are present
+- [ ] Trigger install using the downloaded artifacts
+- [ ] Let the app restart
+
+Expected:
+- Installer uses the downloaded zip and script successfully
+- Install completes without requiring a fresh download
+- App restarts into the new version
+- Updated app is functional after relaunch
+
+## Notes
+
+These are manual cross-platform regressions.
+
+Do not treat this checklist as automated coverage.

--- a/Update/update_darwin.command
+++ b/Update/update_darwin.command
@@ -8,6 +8,7 @@ base="$(basename "$self")"
 work="$(dirname "$self")"
 launch=""
 launch_note=""
+copy_note=""
 restart="0"
 prune="0"
 
@@ -211,77 +212,27 @@ prune_versions() {
 }
 
 write_launch() {
-  local root target
-  root="$1"
+  local final target
+  final="$1"
 build_app() {
-    local dir app bin
+    local dir app bin cmd
     dir="$1"
     app="$dir/Aether.app"
     bin="$app/Contents/MacOS/Aether"
+    cmd="$final/Aether.command"
     rm -rf "$app"
     mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
     cat >"$bin" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 
-root="$root"
-cmp() {
-  local a="\${1#v}"
-  local b="\${2#v}"
-  a="\${a%%-*}"
-  b="\${b%%-*}"
-  local aa bb i x y
-  IFS=. read -r -a aa <<<"\$a"
-  IFS=. read -r -a bb <<<"\$b"
-  for i in 0 1 2 3; do
-    x="\${aa[\$i]:-0}"
-    y="\${bb[\$i]:-0}"
-    x=\$((10#\$x))
-    y=\$((10#\$y))
-    if [ "\$x" -lt "\$y" ]; then
-      echo lt
-      return 0
-    fi
-    if [ "\$x" -gt "\$y" ]; then
-      echo gt
-      return 0
-    fi
-  done
-  echo eq
-}
-
-pick() {
-  local dir ver best best_ver item
-  shopt -s nullglob
-  for item in "\$root"/aether_*; do
-    [ -d "\$item" ] || continue
-    ver=""
-    if [ -f "\$item/.aether_web_version" ]; then
-      ver="\$(tr -d '[:space:]' <"\$item/.aether_web_version")"
-    fi
-    if [ -z "\$ver" ]; then
-      dir="\$(basename "\$item")"
-      if [[ "\$dir" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
-        ver="\${BASH_REMATCH[1]}"
-      fi
-    fi
-    [ -n "\$ver" ] || continue
-    if [ -z "\${best:-}" ] || [ "\$(cmp "\$best_ver" "\$ver")" = "lt" ]; then
-      best="\$item"
-      best_ver="\$ver"
-    fi
-  done
-  shopt -u nullglob
-  printf "%s" "\${best:-}"
-}
-
-app="\$(pick)"
-if [ -n "\$app" ] && [ -f "\$app/Aether.command" ]; then
-  nohup "\$app/Aether.command" >/dev/null 2>&1 &
+cmd="$cmd"
+if [ -f "\$cmd" ]; then
+  nohup "\$cmd" >/dev/null 2>&1 &
   exit 0
 fi
 
-echo "No active version found under: $root"
+echo "Launch target not found: $cmd"
 exit 1
 EOF
     chmod +x "$bin"
@@ -326,14 +277,48 @@ EOF
   launch_note="无法写入 /Applications，已回退到 $launch。手动复制该 App 到 /Applications后，从 app 启动器中运行Aether，或在\"$HOME/Applications\"文件夹中双击Aether.app运行。"
 }
 
+stop() {
+  local dir="$1"
+  [ -n "$dir" ] || return 0
+  pkill -f "$dir/Aether.command" >/dev/null 2>&1 || true
+  pkill -f "$dir/aether web" >/dev/null 2>&1 || true
+  pkill -f "$dir/aether serve" >/dev/null 2>&1 || true
+}
+
+boot() {
+  local dir="$1"
+  [ -x "$dir/Aether.command" ] || return 1
+  nohup "$dir/Aether.command" >/dev/null 2>&1 &
+}
+
+mirror_dir() {
+  local cur root dst tmp
+  cur="${AETHER_CURRENT_DIR:-}"
+  [ -n "$cur" ] || return 1
+  root="$(cd "$cur/.." && pwd)"
+  dst="$root/aether_$ver"
+  if [ -d "$dst" ]; then
+    dst="${dst}_new"
+  fi
+  tmp="${dst}.copy"
+  rm -rf "$tmp" "$dst"
+  mkdir -p "$tmp" || return 1
+  ditto "$target" "$tmp" || {
+    rm -rf "$tmp"
+    return 1
+  }
+  mv "$tmp" "$dst" || {
+    rm -rf "$tmp"
+    return 1
+  }
+  printf "%s" "$dst"
+}
+
 if [ "$base" != "downloads" ]; then
   fail "规范错误：update_darwin.command 必须放在 .../aether/downloads 目录。当前: $self"
 fi
 if [ "$(basename "$work")" != "aether" ]; then
   fail "规范错误：工作目录必须是 .../aether。当前: $work"
-fi
-if [ ! -f "$work/aether_darwin_installer.command" ]; then
-  fail "规范错误：缺少 .../aether/aether_darwin_installer.command"
 fi
 
 echo "[0/4] 工作目录: $work"
@@ -404,20 +389,31 @@ fi
 printf "%s\n" "$ver" >"$target/.aether_web_version"
 rm -f "$work/.aether_web_version" >/dev/null 2>&1 || true
 
-rm -rf "$work/current" >/dev/null 2>&1 || true
-write_launch "$work"
-prune_versions "$work" 5 "$target"
+  rm -rf "$work/current" >/dev/null 2>&1 || true
+  prune_versions "$work" 5 "$target"
+
+  copy_target=""
+  if copy_target="$(mirror_dir || true)" && [ -n "$copy_target" ]; then
+    copy_note="已复制新版本到当前软件目录附近：$copy_target"
+  fi
+  final_target="$target"
+  if [ -n "$copy_target" ]; then
+    final_target="$copy_target"
+  fi
+  write_launch "$final_target"
 
 if [ "$restart" = "1" ]; then
-  if [ -n "$old" ]; then
-    pkill -f "$old/Aether.command" >/dev/null 2>&1 || true
-    pkill -f "$old/aether web" >/dev/null 2>&1 || true
-    pkill -f "$old/aether serve" >/dev/null 2>&1 || true
+  stop "$old"
+  stop "$target"
+  stop "${AETHER_CURRENT_DIR:-}"
+  stop "$copy_target"
+  if [ -n "$copy_target" ]; then
+    if ! boot "$copy_target" && ! boot "$target"; then
+      fail "重启失败：无法启动 $target/Aether.command"
+    fi
+  elif ! boot "$target"; then
+    fail "重启失败：无法启动 $target/Aether.command"
   fi
-  pkill -f "$target/Aether.command" >/dev/null 2>&1 || true
-  pkill -f "$target/aether web" >/dev/null 2>&1 || true
-  pkill -f "$target/aether serve" >/dev/null 2>&1 || true
-  nohup "$target/Aether.command" >/dev/null 2>&1 &
 fi
 
 if [ "$prune" -gt 0 ]; then
@@ -429,7 +425,13 @@ fi
 echo "[4/4] 完成"
 echo "当前版本: $ver"
 echo "版本目录: $target"
+if [ -n "$copy_target" ]; then
+  echo "复制目录: $copy_target"
+fi
 echo "启动入口: $launch"
 if [ -n "$launch_note" ]; then
   echo "$launch_note"
+fi
+if [ -n "$copy_note" ]; then
+  echo "$copy_note"
 fi

--- a/Update/update_linux.sh
+++ b/Update/update_linux.sh
@@ -391,7 +391,7 @@ EOF
 }
 
 write_launch() {
-  local work="$1"
+  local app="$1/Aether.sh"
   local home
   home="$(pick_home)"
   local desk="$home/Desktop"
@@ -402,61 +402,9 @@ write_launch() {
 #!/usr/bin/env bash
 set -euo pipefail
 
-root="$work"
-
-cmp() {
-  local a="\${1#v}"
-  local b="\${2#v}"
-  local aa bb i x y
-  a="\${a%%-*}"
-  b="\${b%%-*}"
-  IFS=. read -r -a aa <<<"\$a"
-  IFS=. read -r -a bb <<<"\$b"
-  for i in 0 1 2 3; do
-    x="\${aa[\$i]:-0}"
-    y="\${bb[\$i]:-0}"
-    x=\$((10#\$x))
-    y=\$((10#\$y))
-    if [ "\$x" -lt "\$y" ]; then
-      echo lt
-      return 0
-    fi
-    if [ "\$x" -gt "\$y" ]; then
-      echo gt
-      return 0
-    fi
-  done
-  echo eq
-}
-
-pick() {
-  local dir ver best best_ver item
-  shopt -s nullglob
-  for item in "\$root"/aether_*; do
-    [ -d "\$item" ] || continue
-    ver=""
-    if [ -f "\$item/.aether_web_version" ]; then
-      ver="\$(tr -d '[:space:]' <"\$item/.aether_web_version")"
-    fi
-    if [ -z "\$ver" ]; then
-      dir="\$(basename "\$item")"
-      if [[ "\$dir" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
-        ver="\${BASH_REMATCH[1]}"
-      fi
-    fi
-    [ -n "\$ver" ] || continue
-    if [ -z "\${best:-}" ] || [ "\$(cmp "\$best_ver" "\$ver")" = "lt" ]; then
-      best="\$item"
-      best_ver="\$ver"
-    fi
-  done
-  shopt -u nullglob
-  printf "%s" "\${best:-}"
-}
-
-app="\$(pick)"
-[ -n "\$app" ] || exit 1
-exec "\$app/Aether.sh" "\$@"
+app="$app"
+[ -x "\$app" ] || exit 1
+exec "\$app" "\$@"
 EOF
   chmod +x "$launch" || return 1
   printf "%s" "$launch"
@@ -478,6 +426,29 @@ boot() {
     return 0
   fi
   nohup "$app" >/dev/null 2>&1 < /dev/null &
+}
+
+mirror_dir() {
+  local cur root dst tmp
+  cur="${AETHER_CURRENT_DIR:-}"
+  [ -n "$cur" ] || return 1
+  root="$(cd "$cur/.." && pwd)"
+  dst="$root/aether_$ver"
+  if [ -d "$dst" ]; then
+    dst="${dst}_new"
+  fi
+  tmp="${dst}.copy"
+  rm -rf "$tmp" "$dst" 2>/dev/null || true
+  mkdir -p "$tmp" || return 1
+  cp -R "$target"/. "$tmp" || {
+    rm -rf "$tmp" 2>/dev/null || true
+    return 1
+  }
+  mv "$tmp" "$dst" || {
+    rm -rf "$tmp" 2>/dev/null || true
+    return 1
+  }
+  printf "%s" "$dst"
 }
 
 if [ "$mode" = "help" ] || [ "$mode" = "--help" ] || [ "$mode" = "-h" ]; then
@@ -573,13 +544,23 @@ rm -rf "$work/current" 2>/dev/null || true
 fix_libssl "$target"
 prune_versions "$work" 5 "$target"
 
-launch="$(write_launch "$work" || true)"
+copy_target="$(mirror_dir || true)"
+if [ -n "$copy_target" ]; then
+  copy_note="[install] Copied the new version near the current app location: $copy_target"
+else
+  copy_note=""
+fi
+start_target="$target"
+if [ -n "$copy_target" ]; then
+  start_target="$copy_target"
+fi
+launch="$(write_launch "$start_target" || true)"
 if [ -n "$launch" ]; then
   echo "[install] Desktop launcher: $launch"
   echo "[install] To start Aether, right-click the Aether.sh file on your desktop and choose Run as a Program."
 else
   echo "[install] Warning: failed to create Desktop launcher."
-  echo "[install] To start Aether, open $target, right-click Aether.sh, and choose Run as a Program."
+  echo "[install] To start Aether, open $start_target, right-click Aether.sh, and choose Run as a Program."
 fi
 
 if [ "$prune" -gt 0 ]; then
@@ -591,7 +572,14 @@ fi
 if [ "$restart" = "1" ]; then
   stop "$old"
   stop "$target"
-  if ! boot "$target"; then
+  stop "${AETHER_CURRENT_DIR:-}"
+  stop "$copy_target"
+  if [ -n "$copy_target" ]; then
+    if ! boot "$copy_target" && ! boot "$target"; then
+      echo "[install] Failed to restart Aether from $target/Aether.sh"
+      exit "$run_err"
+    fi
+  elif ! boot "$target"; then
     echo "[install] Failed to restart Aether from $target/Aether.sh"
     exit "$run_err"
   fi
@@ -599,4 +587,10 @@ fi
 
 echo "[4/4] Done"
 echo "Version directory: $target"
+if [ -n "$copy_target" ]; then
+  echo "Mirror directory: $copy_target"
+fi
+if [ -n "$copy_note" ]; then
+  echo "$copy_note"
+fi
 exit "$ok"

--- a/Update/update_linux.sh
+++ b/Update/update_linux.sh
@@ -12,11 +12,15 @@ arg=""
 tmp=""
 next=""
 prune="0"
+restart="0"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     install|help|-h|--help)
       mode="$1"
+      ;;
+    --restart)
+      restart="1"
       ;;
     *)
       if [ -z "$arg" ]; then
@@ -458,6 +462,24 @@ EOF
   printf "%s" "$launch"
 }
 
+stop() {
+  local dir="$1"
+  [ -n "$dir" ] || return 0
+  pkill -f "$dir/Aether.sh" >/dev/null 2>&1 || true
+  pkill -f "$dir/aether web" >/dev/null 2>&1 || true
+  pkill -f "$dir/aether serve" >/dev/null 2>&1 || true
+}
+
+boot() {
+  local app="$1/Aether.sh"
+  [ -x "$app" ] || return 1
+  if command -v setsid >/dev/null 2>&1; then
+    setsid "$app" >/dev/null 2>&1 < /dev/null &
+    return 0
+  fi
+  nohup "$app" >/dev/null 2>&1 < /dev/null &
+}
+
 if [ "$mode" = "help" ] || [ "$mode" = "--help" ] || [ "$mode" = "-h" ]; then
   help
   exit "$ok"
@@ -536,6 +558,7 @@ if [ -z "$src" ]; then
 fi
 
 echo "[2/4] Extracting and installing to: $target"
+old="$(active_dir "$work")"
 rm -rf "$next" "$target" 2>/dev/null || true
 mkdir -p "$next" || exit "$run_err"
 cp -R "$src"/. "$next" || exit "$run_err"
@@ -563,6 +586,15 @@ if [ "$prune" -gt 0 ]; then
   echo "[3/4] Keeping the latest 5 versions; removed $prune older version directories."
 else
   echo "[3/4] Keeping the latest 5 versions; no older version directories needed removal."
+fi
+
+if [ "$restart" = "1" ]; then
+  stop "$old"
+  stop "$target"
+  if ! boot "$target"; then
+    echo "[install] Failed to restart Aether from $target/Aether.sh"
+    exit "$run_err"
+  fi
 fi
 
 echo "[4/4] Done"

--- a/Update/update_windows.bat
+++ b/Update/update_windows.bat
@@ -12,6 +12,9 @@ for %%i in ("%SELF%\..") do set "WORK=%%~fi"
 set "PRUNE=0"
 set "LAUNCH="
 set "NOTE="
+set "COPY_NOTE="
+set "MIRROR="
+set "START="
 set "CUR="
 set "CMP="
 set "RV="
@@ -23,10 +26,6 @@ if /I not "%BASE%"=="downloads" (
 for %%i in ("%WORK%") do set "WORK_NAME=%%~nxi"
 if /I not "%WORK_NAME%"=="aether" (
   echo Spec error: work directory must be ...\aether. Current: %WORK%
-  exit /b 1
-)
-if not exist "%WORK%\aether_windows_installer.bat" (
-  echo Spec error: missing ...\aether\aether_windows_installer.bat
   exit /b 1
 )
 
@@ -43,11 +42,16 @@ echo [1/4] Package: %PKG_NAME%
 echo       Target version: %VER%
 
 call :installed "%WORK%" CUR
+call :active_dir
 if defined CUR (
   call :cmp "%CUR%" "%VER%"
   if /I "!CMP!"=="eq" (
-    echo [2/4] Version %VER% is already installed. Skipping install.
-    exit /b 0
+    if defined OLD set "TARGET=%OLD%"
+    if not defined OLD if exist "%WORK%\aether_%VER%" set "TARGET=%WORK%\aether_%VER%"
+    if exist "%TARGET%" (
+      echo [2/4] Version %VER% is already installed. Skipping install.
+      goto :post_install
+    )
   )
 )
 
@@ -74,18 +78,21 @@ robocopy "%SRC%" "%NEXT%" /MIR /NFL /NDL /NJH /NJS /NP >nul
 set "RC=%ERRORLEVEL%"
 if %RC% GEQ 8 goto :fail
 
-call :active_dir
 if exist "%TARGET%" rmdir /s /q "%TARGET%" >nul 2>nul
 move "%NEXT%" "%TARGET%" >nul || goto :fail
 
+:post_install
 echo %VER%>"%TARGET%\.aether_web_version"
 if exist "%WORK%\.aether_web_version" del /f /q "%WORK%\.aether_web_version" >nul 2>nul
 
 if exist "%WORK%\current" rmdir "%WORK%\current" >nul 2>nul
 if exist "%WORK%\current" rmdir /s /q "%WORK%\current" >nul 2>nul
 
-call :write_launch
 call :prune_versions || goto :fail
+call :mirror
+if not errorlevel 1 if defined MIRROR set "START=%MIRROR%"
+if not defined START set "START=%TARGET%"
+call :write_launch "%START%"
 
 if "%RESTART%"=="1" call :restart
 
@@ -94,14 +101,16 @@ call :print_prune
 echo [4/4] Done
 echo Current version: %VER%
 echo Version directory: %TARGET%
+if defined MIRROR echo Mirror directory: %MIRROR%
 echo Launch entry: %LAUNCH%
 if defined NOTE echo %NOTE%
+if defined COPY_NOTE echo %COPY_NOTE%
 
 call :clean_tmp
 exit /b 0
 
 :write_launch
-set "CMD=%TARGET%\Aether.vbs"
+set "CMD=%~1\Aether.vbs"
 set "OUT=%TEMP%\aether-launch-%RANDOM%%RANDOM%.txt"
 if exist "%OUT%" del /f /q "%OUT%" >nul 2>nul
 powershell -NoProfile -Command "$cmd=$env:CMD; $out=$env:OUT; $w=New-Object -ComObject WScript.Shell; $desk=[Environment]::GetFolderPath('DesktopDirectory'); if(-not $desk){ $desk=$w.SpecialFolders.Item('Desktop') }; $menu=[Environment]::GetFolderPath('Programs'); if(-not $menu){ $menu=Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs' }; $desk2=[Environment]::GetFolderPath('CommonDesktopDirectory'); $menu2=[Environment]::GetFolderPath('CommonPrograms'); $all=@($desk,$menu,$desk2,$menu2) | Where-Object { $_ } | Select-Object -Unique; foreach($dir in $all){ $lnk=Join-Path $dir 'Aether.lnk'; try { if(Test-Path $lnk){ Remove-Item -LiteralPath $lnk -Force -ErrorAction Stop } } catch {} }; $mk={ param($path,$target) try { $dir=Split-Path -Parent $path; if($dir -and -not (Test-Path $dir)){ New-Item -ItemType Directory -Path $dir -Force | Out-Null }; if(Test-Path $path){ Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue }; $s=$w.CreateShortcut($path); $s.TargetPath=$target; $s.WorkingDirectory=(Split-Path -Parent $target); $s.Save(); if(-not (Test-Path $path)){ return $false }; $hit=$w.CreateShortcut($path); return $hit.TargetPath -eq $target } catch { return $false } }; $launch=''; $note=''; $desk_ok=$false; $menu_ok=$false; $desk2_ok=$false; $menu2_ok=$false; if($desk){ $desk_ok=& $mk (Join-Path $desk 'Aether.lnk') $cmd }; if($menu){ $menu_ok=& $mk (Join-Path $menu 'Aether.lnk') $cmd }; if($desk2){ $desk2_ok=& $mk (Join-Path $desk2 'Aether.lnk') $cmd }; if($menu2){ $menu2_ok=& $mk (Join-Path $menu2 'Aether.lnk') $cmd }; if($desk_ok){ $launch=Join-Path $desk 'Aether.lnk'; $note='Double-click Aether.vbs on your desktop to run it.' } elseif($desk2_ok){ $launch=Join-Path $desk2 'Aether.lnk'; $note='Double-click Aether.vbs on your desktop to run it.' } elseif($menu_ok){ $launch=Join-Path $menu 'Aether.lnk'; $note='Run Aether.vbs from the Start Menu.' } elseif($menu2_ok){ $launch=Join-Path $menu2 'Aether.lnk'; $note='Run Aether.vbs from the Start Menu.' } else { $launch=$cmd; $note='Shortcut creation failed. Open File Explorer, find this path, and double-click the file to run it.' }; [IO.File]::WriteAllLines($out, @($launch,$note))"
@@ -126,10 +135,38 @@ if "%PRUNE%"=="0" (
 echo [3/4] Keeping the latest 5 versions; removed %PRUNE% older version directories.
 exit /b 0
 
+:mirror
+if not defined AETHER_CURRENT_DIR exit /b 1
+for %%i in ("%AETHER_CURRENT_DIR%\..") do set "MROOT=%%~fi"
+if not defined MROOT exit /b 1
+set "MIRROR=%MROOT%\aether_%VER%"
+if exist "%MIRROR%" set "MIRROR=%MROOT%\aether_%VER%_new"
+set "MCOPY=%MIRROR%.copy"
+if exist "%MCOPY%" rmdir /s /q "%MCOPY%" >nul 2>nul
+if exist "%MIRROR%" rmdir /s /q "%MIRROR%" >nul 2>nul
+mkdir "%MCOPY%" >nul 2>nul || (
+  set "COPY_NOTE=Warning: failed to prepare mirror directory near %AETHER_CURRENT_DIR%"
+  exit /b 1
+)
+robocopy "%TARGET%" "%MCOPY%" /MIR /NFL /NDL /NJH /NJS /NP >nul
+set "RC=%ERRORLEVEL%"
+if %RC% GEQ 8 (
+  set "COPY_NOTE=Warning: failed to copy the new version near %AETHER_CURRENT_DIR%"
+  if exist "%MCOPY%" rmdir /s /q "%MCOPY%" >nul 2>nul
+  exit /b 1
+)
+move "%MCOPY%" "%MIRROR%" >nul || (
+  set "COPY_NOTE=Warning: failed to finalize the copied version near %AETHER_CURRENT_DIR%"
+  if exist "%MCOPY%" rmdir /s /q "%MCOPY%" >nul 2>nul
+  exit /b 1
+)
+set "COPY_NOTE=Copied the new version near the current app location: %MIRROR%"
+exit /b 0
+
 :restart
-powershell -NoProfile -Command "& { $names=@('aether.exe','wscript.exe','cscript.exe','node.exe','bun.exe'); $roots=@(); if($env:OLD){ $roots += [IO.Path]::GetFullPath($env:OLD) }; if($env:TARGET){ $roots += [IO.Path]::GetFullPath($env:TARGET) }; $roots += (Get-ChildItem -Path $env:WORK -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }); $roots=$roots | Where-Object { $_ } | Select-Object -Unique; Get-CimInstance Win32_Process | Where-Object { $n=$_.Name.ToLowerInvariant(); if($names -notcontains $n){ return $false }; $cmd=$_.CommandLine; $exe=$_.ExecutablePath; foreach($r in $roots){ if(($cmd -and $cmd -like ('*' + $r + '*')) -or ($exe -and $exe -like ($r + '*'))){ return $true } }; return $false } | Sort-Object ProcessId -Descending | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue } }"
+powershell -NoProfile -Command "& { $names=@('aether.exe','wscript.exe','cscript.exe','node.exe','bun.exe'); $roots=@(); if($env:OLD){ $roots += [IO.Path]::GetFullPath($env:OLD) }; if($env:TARGET){ $roots += [IO.Path]::GetFullPath($env:TARGET) }; if($env:AETHER_CURRENT_DIR){ $roots += [IO.Path]::GetFullPath($env:AETHER_CURRENT_DIR) }; if($env:MIRROR){ $roots += [IO.Path]::GetFullPath($env:MIRROR) }; $roots += (Get-ChildItem -Path $env:WORK -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }); $roots=$roots | Where-Object { $_ } | Select-Object -Unique; Get-CimInstance Win32_Process | Where-Object { $n=$_.Name.ToLowerInvariant(); if($names -notcontains $n){ return $false }; $cmd=$_.CommandLine; $exe=$_.ExecutablePath; foreach($r in $roots){ if(($cmd -and $cmd -like ('*' + $r + '*')) -or ($exe -and $exe -like ($r + '*'))){ return $true } }; return $false } | Sort-Object ProcessId -Descending | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue } }"
 timeout /t 1 /nobreak >nul
-start "" "%TARGET%\Aether.vbs"
+start "" "%START%\Aether.vbs"
 exit /b 0
 
 :active_dir

--- a/packages/app/src/components/dialog-update.tsx
+++ b/packages/app/src/components/dialog-update.tsx
@@ -1,4 +1,5 @@
-import { Component, createSignal, onMount, Show } from "solid-js"
+import { Component, onMount, Show } from "solid-js"
+import { createStore } from "solid-js/store"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { Dialog } from "@opencode-ai/ui/dialog"
 import { Button } from "@opencode-ai/ui/button"
@@ -6,7 +7,7 @@ import { Icon } from "@opencode-ai/ui/icon"
 import { useLanguage } from "@/context/language"
 import { usePlatform } from "@/context/platform"
 
-type UpdateState = "checking" | "up-to-date" | "available" | "downloading" | "downloaded" | "installing" | "error"
+type View = "checking" | "up-to-date" | "available" | "downloading" | "downloaded" | "installing" | "recovery" | "recovering" | "error"
 type Props = {
   auto?: "download" | "install"
 }
@@ -30,65 +31,83 @@ export const DialogUpdate: Component<Props> = (props) => {
   const dialog = useDialog()
   const language = useLanguage()
   const platform = usePlatform()
+  const [store, setStore] = createStore({
+    state: "checking" as View,
+    remoteVersion: "",
+    currentVersion: "",
+    error: "",
+  })
 
-  const [state, setState] = createSignal<UpdateState>("checking")
-  const [remoteVersion, setRemoteVersion] = createSignal("")
-  const [currentVersion, setCurrentVersion] = createSignal("")
-  const [errorMessage, setErrorMessage] = createSignal("")
-
-  const current = () => currentVersion() || platform.version || ""
+  const current = () => store.currentVersion || platform.version || ""
   const cancelled = (err: unknown) => err instanceof Error && err.message === "Update cancelled"
   const sync = async () => {
     if (!platform.checkUpdate) throw new Error("Updates are not supported on this platform")
     const data = await platform.checkUpdate()
-    if (data.currentVersion?.trim()) setCurrentVersion(data.currentVersion.trim())
-    setRemoteVersion(data.version?.trim() ?? "")
+    setStore("currentVersion", data.currentVersion?.trim() ?? "")
+    setStore("remoteVersion", data.version?.trim() ?? "")
+    setStore("error", data.updateError?.trim() ?? "")
+    return data
+  }
+
+  const apply = async () => {
+    const data = await sync()
+    if (!data.updateAvailable) {
+      setStore("state", "up-to-date")
+      return data
+    }
+    if (data.status === "downloading") {
+      setStore("state", "downloading")
+      return data
+    }
+    if (data.status === "downloaded") {
+      setStore("state", "downloaded")
+      return data
+    }
+    if (data.status === "installing") {
+      setStore("state", "installing")
+      return data
+    }
+    if (data.status === "recovery") {
+      setStore("state", "recovery")
+      return data
+    }
+    setStore("state", "available")
     return data
   }
 
   const checkVersion = async () => {
-    setState("checking")
-    setErrorMessage("")
+    setStore("state", "checking")
+    setStore("error", "")
     try {
-      const data = await sync()
-      if (!data.updateAvailable) {
-        setState("up-to-date")
-        return
-      }
-      setState(data.downloaded ? "downloaded" : "available")
-    } catch (e) {
-      setState("error")
-      setErrorMessage(e instanceof Error ? e.message : String(e))
+      await apply()
+    } catch (err) {
+      setStore("state", "error")
+      setStore("error", err instanceof Error ? err.message : String(err))
     }
   }
 
   const downloadUpdate = async () => {
     if (!platform.downloadUpdate) return
-    setState("downloading")
-    setErrorMessage("")
+    setStore("state", "downloading")
+    setStore("error", "")
     try {
       await paint()
       await platform.downloadUpdate()
-      const data = await sync()
-      if (!data.updateAvailable) {
-        setState("up-to-date")
+      await apply()
+    } catch (err) {
+      if (cancelled(err)) {
+        setStore("state", "available")
         return
       }
-      setState(data.downloaded ? "downloaded" : "available")
-    } catch (e) {
-      if (cancelled(e)) {
-        setState("available")
-        return
-      }
-      setState("error")
-      setErrorMessage(e instanceof Error ? e.message : String(e))
+      setStore("state", "recovery")
+      setStore("error", err instanceof Error ? err.message : String(err))
     }
   }
 
   const installUpdate = async () => {
     if (!platform.update) return
-    setState("installing")
-    setErrorMessage("")
+    setStore("state", "installing")
+    setStore("error", "")
     try {
       await paint()
       await platform.update()
@@ -96,49 +115,60 @@ export const DialogUpdate: Component<Props> = (props) => {
       setTimeout(() => {
         dialog.close()
       }, 1200)
-    } catch (e) {
-      if (cancelled(e)) {
-        setState("downloaded")
+    } catch (err) {
+      if (cancelled(err)) {
+        setStore("state", "downloaded")
         return
       }
-      setState("error")
-      setErrorMessage(e instanceof Error ? e.message : String(e))
+      setStore("state", "recovery")
+      setStore("error", err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const recoverUpdate = async () => {
+    if (!platform.recoverUpdate) return
+    setStore("state", "recovering")
+    if (!store.error) setStore("error", language.t("update.recoverHint"))
+    try {
+      await paint()
+      await platform.recoverUpdate()
+      await platform.restart()
+      setTimeout(() => {
+        dialog.close()
+      }, 1200)
+    } catch (err) {
+      if (cancelled(err)) {
+        setStore("state", "recovery")
+        return
+      }
+      setStore("state", "recovery")
+      setStore("error", err instanceof Error ? err.message : String(err))
     }
   }
 
   const start = async () => {
-    const data = await sync()
-    if (!data.updateAvailable) {
-      setState("up-to-date")
-      return
-    }
-    if (!props.auto) {
-      setState(data.downloaded ? "downloaded" : "available")
-      return
-    }
+    const data = await apply()
+    if (!data.updateAvailable || !props.auto) return
     if (props.auto === "download") {
-      if (data.downloaded) {
-        setState("downloaded")
-        return
-      }
+      if (data.status !== "available") return
       await downloadUpdate()
       return
     }
-    if (data.downloaded) {
-      setState("downloaded")
+    if (data.status === "downloaded") {
       await installUpdate()
       return
     }
+    if (data.status !== "available") return
     await downloadUpdate()
-    if (state() === "downloaded") {
+    if (store.state === "downloaded") {
       await installUpdate()
     }
   }
 
   onMount(() => {
-    void start().catch((e) => {
-      setState("error")
-      setErrorMessage(e instanceof Error ? e.message : String(e))
+    void start().catch((err) => {
+      setStore("state", "error")
+      setStore("error", err instanceof Error ? err.message : String(err))
     })
   })
 
@@ -158,27 +188,27 @@ export const DialogUpdate: Component<Props> = (props) => {
           <div class="flex justify-between items-center">
             <span class="text-13-regular text-text-weak">{language.t("update.remoteVersion")}</span>
             <span class="text-13-medium text-text-strong">
-              {state() === "checking" ? "..." : remoteVersion() ? `v${remoteVersion()}` : "-"}
+              {store.state === "checking" ? "..." : store.remoteVersion ? `v${store.remoteVersion}` : "-"}
             </span>
           </div>
         </div>
 
         <div class="flex flex-col gap-3">
-          <Show when={state() === "checking"}>
+          <Show when={store.state === "checking"}>
             <div class="flex items-center gap-2 text-13-regular text-text-weak">
               <Spinner />
               <span>{language.t("update.checking")}</span>
             </div>
           </Show>
 
-          <Show when={state() === "up-to-date"}>
+          <Show when={store.state === "up-to-date"}>
             <div class="flex items-center gap-2 text-13-regular text-text-dimmed-green">
               <Icon name="circle-check" class="size-4" />
               <span>{language.t("update.upToDate")}</span>
             </div>
           </Show>
 
-          <Show when={state() === "available"}>
+          <Show when={store.state === "available"}>
             <div class="flex flex-col gap-2">
               <div class="flex items-center gap-2 text-13-regular text-text-strong">
                 <Icon name="arrow-down-to-line" class="size-4" />
@@ -190,7 +220,7 @@ export const DialogUpdate: Component<Props> = (props) => {
             </div>
           </Show>
 
-          <Show when={state() === "downloading"}>
+          <Show when={store.state === "downloading"}>
             <div class="flex flex-col gap-2">
               <div class="flex items-center gap-2 text-13-regular text-text-weak">
                 <Spinner />
@@ -200,7 +230,7 @@ export const DialogUpdate: Component<Props> = (props) => {
             </div>
           </Show>
 
-          <Show when={state() === "downloaded"}>
+          <Show when={store.state === "downloaded"}>
             <div class="flex flex-col gap-2">
               <div class="flex items-center gap-2 text-13-regular text-text-dimmed-green">
                 <Icon name="circle-check" class="size-4" />
@@ -213,22 +243,37 @@ export const DialogUpdate: Component<Props> = (props) => {
             </Button>
           </Show>
 
-          <Show when={state() === "installing"}>
+          <Show when={store.state === "installing" || store.state === "recovering"}>
             <div class="flex flex-col gap-2">
               <div class="flex items-center gap-2 text-13-regular text-text-weak">
                 <Spinner />
-                <span>{language.t("update.installing")}</span>
+                <span>{language.t(store.state === "recovering" ? "update.recovering" : "update.installing")}</span>
               </div>
               <ProgressBar />
-              <div class="text-12-regular text-text-weak">{language.t("update.installHint")}</div>
+              <div class="text-12-regular text-text-weak">
+                {language.t(store.state === "recovering" ? "update.recoverHint" : "update.installHint")}
+              </div>
             </div>
           </Show>
 
-          <Show when={state() === "error"}>
+          <Show when={store.state === "recovery"}>
+            <div class="flex flex-col gap-2">
+              <div class="flex items-center gap-2 text-13-regular text-text-dimmed-red">
+                <Icon name="warning" class="size-4" />
+                <span>{store.error || language.t("update.recoverHint")}</span>
+              </div>
+              <div class="text-12-regular text-text-weak">{language.t("update.recoverHint")}</div>
+            </div>
+            <Button size="small" variant="primary" onClick={recoverUpdate}>
+              {language.t("update.recover")}
+            </Button>
+          </Show>
+
+          <Show when={store.state === "error"}>
             <div class="flex items-center gap-2 text-13-regular text-text-dimmed-red">
               <Icon name="warning" class="size-4" />
               <span>
-                {language.t("update.checkFailed")}: {errorMessage()}
+                {language.t("update.checkFailed")}: {store.error}
               </span>
             </div>
             <Button size="small" variant="secondary" onClick={checkVersion}>

--- a/packages/app/src/context/platform.tsx
+++ b/packages/app/src/context/platform.tsx
@@ -7,11 +7,14 @@ type PickerPaths = string | string[] | null
 type OpenDirectoryPickerOptions = { title?: string; multiple?: boolean }
 type OpenFilePickerOptions = { title?: string; multiple?: boolean; accept?: string[]; extensions?: string[] }
 type SaveFilePickerOptions = { title?: string; defaultPath?: string }
+type UpdateStage = "available" | "downloading" | "downloaded" | "installing" | "recovery"
 type UpdateStatus = {
   updateAvailable: boolean
   currentVersion?: string
   version?: string
   downloaded?: boolean
+  status?: UpdateStage
+  updateError?: string
   requiresConfirmation?: boolean
 }
 
@@ -63,6 +66,9 @@ export type Platform = {
 
   /** Install updates */
   update?(): Promise<void>
+
+  /** Restart update from scratch */
+  recoverUpdate?(): Promise<void>
 
   /** Fetch override */
   fetch?: typeof fetch

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -261,12 +261,21 @@ const webCheck = async () => {
   const res = await req(`/global/web-update/check?os=${os}`)
   const data = await res.json()
   if (typeof data.checkError === "string" && data.checkError) throw new Error(data.checkError)
+  const status =
+    data.status === "downloading" ||
+    data.status === "downloaded" ||
+    data.status === "installing" ||
+    data.status === "recovery"
+      ? data.status
+      : "available"
   return {
     os,
     currentVersion: typeof data.currentVersion === "string" ? data.currentVersion.trim() : "",
     version: typeof data.remoteVersion === "string" ? data.remoteVersion.trim() : "",
     updateAvailable: !!data.updateAvailable,
     downloaded: !!data.downloaded,
+    status,
+    updateError: typeof data.updateError === "string" ? data.updateError.trim() : "",
     workDir: typeof data.workDir === "string" ? data.workDir.trim() : "",
     requiresConfirmation: !!data.workDirFallback,
   }
@@ -286,11 +295,11 @@ const consent = (input: { requiresConfirmation: boolean; workDir: string }) => {
   throw new Error("Update cancelled")
 }
 
-const webDownload = async (input: { os: string; version: string }, acceptFallback: boolean) => {
+const webDownload = async (input: { os: string; version: string }, acceptFallback: boolean, force = false) => {
   const res = await req("/global/web-update/download", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ os: input.os, version: input.version, acceptFallback }),
+    body: JSON.stringify({ os: input.os, version: input.version, acceptFallback, force }),
   })
   const data = await res.json()
   if (!data.success) throw new Error(data.error)
@@ -321,22 +330,45 @@ const platform: Platform = {
       currentVersion: data.currentVersion,
       version: data.version,
       downloaded: data.downloaded,
+      status: data.status,
+      updateError: data.updateError,
       requiresConfirmation: data.requiresConfirmation,
     }
   },
   downloadUpdate: async () => {
     const data = await webCheck()
     if (!data.updateAvailable) return
+    if (data.status === "recovery") throw new Error(data.updateError || "Update needs to restart from scratch")
     await webDownload(data, consent(data))
   },
   update: async () => {
     const data = await webCheck()
     if (!data.updateAvailable) return
     const acceptFallback = consent(data)
+    if (data.status === "recovery") {
+      await webDownload(data, acceptFallback, true)
+      const next = await webCheck()
+      if (!next.updateAvailable || next.status !== "downloaded") {
+        throw new Error(next.updateError || "Update restart did not finish downloading")
+      }
+      await webInstall(next, acceptFallback)
+      return
+    }
     if (!data.downloaded) {
       await webDownload(data, acceptFallback)
     }
     await webInstall(data, acceptFallback)
+  },
+  recoverUpdate: async () => {
+    const data = await webCheck()
+    if (!data.updateAvailable) return
+    const acceptFallback = consent(data)
+    await webDownload(data, acceptFallback, true)
+    const next = await webCheck()
+    if (!next.updateAvailable || next.status !== "downloaded") {
+      throw new Error(next.updateError || "Update restart did not finish downloading")
+    }
+    await webInstall(next, acceptFallback)
   },
   getDefaultServer: async () => {
     const stored = readDefaultServerUrl()

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -496,6 +496,9 @@ export const dict = {
   "update.install": "Update & Restart",
   "update.installing": "Installing...",
   "update.installHint": "Installing the update will close Aether.",
+  "update.recover": "Restart Update",
+  "update.recovering": "Restarting update...",
+  "update.recoverHint": "A previous update attempt left incomplete files. Restart the whole update flow from scratch.",
   "update.checkFailed": "Check failed",
   "update.retry": "Retry",
 

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -484,6 +484,9 @@ export const dict = {
   "update.install": "更新并重启",
   "update.installing": "正在安装...",
   "update.installHint": "安装更新会关闭 Aether。",
+  "update.recover": "重新开始更新",
+  "update.recovering": "正在重新开始更新...",
+  "update.recoverHint": "之前的更新流程留下了不完整文件，需要从头重新下载并安装。",
   "update.checkFailed": "检查失败",
   "update.retry": "重试",
 

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -443,13 +443,17 @@ export default function Layout(props: ParentProps) {
       }
 
       const pollUpdate = () =>
-        platform.checkUpdate!().then(async ({ updateAvailable, version, downloaded, requiresConfirmation }) => {
+        platform.checkUpdate!().then(async ({ updateAvailable, version, downloaded, requiresConfirmation, status }) => {
           if (!updateAvailable) return
-          if (platform.platform === "web" && platform.downloadUpdate && !downloaded && !requiresConfirmation) {
+          if (platform.platform === "web" && platform.downloadUpdate && status === "available" && !requiresConfirmation) {
             await platform.downloadUpdate().catch(() => undefined)
             const next = await platform.checkUpdate!().catch(() => undefined)
             if (!next?.updateAvailable || !next.downloaded) return
             showUpdateToast(next.version)
+            return
+          }
+          if (platform.platform === "web" && status === "recovery") {
+            showUpdateToast(version)
             return
           }
           if (!downloaded && platform.platform === "web") return

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -1035,15 +1035,17 @@ export const GlobalRoutes = lazy(() =>
           await writeUpdateState(workDir, updateState(next, "installing"))
           const args = version ? [run, version] : [run]
           if (os === "darwin" || os === "linux" || os === "windows") args.push("--restart")
+          const env = resolved.isFallback ? { ...process.env, AETHER_CURRENT_DIR: getAppRoot() } : process.env
           const child =
             os === "windows"
               ? spawn("cmd", ["/c", ...args], {
                   detached: true,
                   stdio: "ignore",
                   cwd: path.join(workDir, "downloads"),
+                  env,
                   windowsHide: true,
                 })
-              : spawn("bash", args, { detached: true, stdio: "ignore", cwd: path.join(workDir, "downloads") })
+              : spawn("bash", args, { detached: true, stdio: "ignore", cwd: path.join(workDir, "downloads"), env })
           child.unref()
           return c.json({ success: true as const })
         } catch (e) {

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -39,8 +39,28 @@ const PingInput = z.object({
 })
 
 const WebUpdateOS = z.enum(["darwin", "linux", "windows"])
+const WebUpdateStatus = z.enum(["available", "downloading", "downloaded", "installing", "recovery"])
+const WebUpdateState = z.object({
+  status: z.enum(["downloading", "downloaded", "installing", "error"]),
+  version: z.string().min(1),
+  server: z.string().min(1),
+  at: z.number().int(),
+  error: z.string().optional(),
+})
 
 const WEB_UPDATE_BASE = "https://aether.aiphys.cn/download"
+const UPDATE_PKG_PREFIX: Record<string, string> = {
+  darwin: "aether-darwin",
+  linux: "aether-linux-x64",
+  windows: "aether-windows-x64",
+}
+const UPDATE_RUN = (() => {
+  try {
+    return crypto.randomUUID()
+  } catch {
+    return `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  }
+})()
 
 const INSTALLER_YML: Record<string, string> = {
   darwin: "latest/mac-arm64.yml",
@@ -66,10 +86,63 @@ const UPDATE_PKG_EXT: Record<string, string> = {
   windows: ".zip",
 }
 
+function updateStatePath(work: string) {
+  return path.join(work, "downloads", "web-update-state.json")
+}
+
+function updateState(version: string, status: z.infer<typeof WebUpdateState>["status"], error?: string) {
+  return {
+    version,
+    status,
+    server: UPDATE_RUN,
+    at: Date.now(),
+    ...(error?.trim() ? { error: error.trim() } : {}),
+  }
+}
+
+async function readUpdateState(work: string) {
+  try {
+    const text = await fs.readFile(updateStatePath(work), "utf-8")
+    const parsed = WebUpdateState.safeParse(JSON.parse(text))
+    if (!parsed.success) return null
+    return parsed.data
+  } catch {
+    return null
+  }
+}
+
+async function writeUpdateState(work: string, state: z.infer<typeof WebUpdateState>) {
+  const file = updateStatePath(work)
+  await fs.mkdir(path.dirname(file), { recursive: true })
+  await fs.writeFile(file, `${JSON.stringify(state, null, 2)}\n`, "utf-8")
+}
+
+async function clearUpdateState(work: string) {
+  await fs.rm(updateStatePath(work), { force: true }).catch(() => undefined)
+}
+
+function updateScriptPrefix(name: string) {
+  const idx = name.lastIndexOf(".")
+  return `${idx < 0 ? name : name.slice(0, idx)}-`
+}
+
+function packageMatch(os: string, ver: string, name: string) {
+  const ext = UPDATE_PKG_EXT[os] ?? ".dmg"
+  const prefix = UPDATE_PKG_PREFIX[os] ?? "aether"
+  return name.startsWith(prefix) && name.includes(ver) && name.toLowerCase().endsWith(ext)
+}
+
+async function packagePath(os: string, ver: string, work: string) {
+  const dl = path.join(work, "downloads")
+  const files = await fs.readdir(dl).catch(() => [])
+  const list = files.filter((x) => packageMatch(os, ver, x)).sort()
+  if (list.length === 0) return ""
+  return path.join(dl, list[list.length - 1])
+}
+
 async function downloadedReady(os: string, ver: string, work: string) {
   const file = UPDATE_SCRIPT[os]
   if (!file) return false
-  const ext = UPDATE_PKG_EXT[os] ?? ".dmg"
   const dl = path.join(work, "downloads")
   const upd = path.join(dl, versioned(file, ver))
   try {
@@ -77,8 +150,67 @@ async function downloadedReady(os: string, ver: string, work: string) {
   } catch {
     return false
   }
+  const pkg = await packagePath(os, ver, work)
+  if (!pkg) return false
+  try {
+    await fs.access(pkg)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function resetUpdate(os: string, ver: string, work: string) {
+  const dl = path.join(work, "downloads")
+  const file = UPDATE_SCRIPT[os]
+  const ext = UPDATE_PKG_EXT[os] ?? ".dmg"
+  const prefix = UPDATE_PKG_PREFIX[os] ?? "aether"
   const files = await fs.readdir(dl).catch(() => [])
-  return files.some((x) => x.toLowerCase().endsWith(ext) && x.includes(ver))
+  const list = files.filter(
+    (x) =>
+      (x.startsWith(prefix) && x.toLowerCase().endsWith(ext)) ||
+      (file ? x.startsWith(updateScriptPrefix(file)) && x.endsWith(path.extname(file)) : false) ||
+      x === "last-result.yml" ||
+      x === "web-update-state.json",
+  )
+  await Promise.all(list.map((x) => fs.rm(path.join(dl, x), { force: true }).catch(() => undefined)))
+  await fs.rm(path.join(work, `.aether_${ver}.next`), { force: true, recursive: true }).catch(() => undefined)
+  await fs.rm(path.join(work, `aether_${ver}`), { force: true, recursive: true }).catch(() => undefined)
+  await clearUpdateState(work)
+}
+
+async function resolveUpdateStatus(os: z.infer<typeof WebUpdateOS>, ver: string, work: string) {
+  const state = await readUpdateState(work)
+  const ready = await downloadedReady(os, ver, work)
+  if (!state) {
+    if (ready) return { status: "downloaded" as const, error: "" }
+    return { status: "available" as const, error: "" }
+  }
+  if (state.version !== ver) {
+    return { status: "recovery" as const, error: "A previous update attempt targeted a different version. Restart the update from scratch." }
+  }
+  if (state.status === "downloaded") {
+    if (ready) return { status: "downloaded" as const, error: state.error ?? "" }
+    return { status: "recovery" as const, error: "Downloaded update files are incomplete. Restart the update from scratch." }
+  }
+  if (state.status === "downloading") {
+    if (state.server === UPDATE_RUN) return { status: "downloading" as const, error: state.error ?? "" }
+    return {
+      status: "recovery" as const,
+      error: state.error ?? "The previous download did not finish. Restart the update from scratch.",
+    }
+  }
+  if (state.status === "installing") {
+    if (state.server === UPDATE_RUN) return { status: "installing" as const, error: state.error ?? "" }
+    return {
+      status: "recovery" as const,
+      error: state.error ?? "The previous install did not finish. Restart the update from scratch.",
+    }
+  }
+  return {
+    status: "recovery" as const,
+    error: state.error ?? "The previous update failed. Restart the update from scratch.",
+  }
 }
 
 function versioned(name: string, ver: string) {
@@ -189,8 +321,10 @@ async function webCheck(os: z.infer<typeof WebUpdateOS>) {
         remoteVersion: "",
         updateAvailable: false,
         downloaded: false,
+        status: "available" as const,
         workDir,
         workDirFallback,
+        updateError: undefined,
         checkError: `Failed to fetch version metadata: ${res.status}`,
       }
     }
@@ -203,20 +337,26 @@ async function webCheck(os: z.infer<typeof WebUpdateOS>) {
         remoteVersion: "",
         updateAvailable: false,
         downloaded: false,
+        status: "available" as const,
         workDir,
         workDirFallback,
+        updateError: undefined,
         checkError: "Could not parse remote version from metadata",
       }
     }
     const updateAvailable = compareVer(currentVersion, remoteVersion) < 0
-    const downloaded = updateAvailable && workDir ? await downloadedReady(os, remoteVersion, workDir) : false
+    if (!updateAvailable && workDir) await clearUpdateState(workDir)
+    const state = updateAvailable && workDir ? await resolveUpdateStatus(os, remoteVersion, workDir) : null
+    const downloaded = state?.status === "downloaded"
     return {
       currentVersion,
       remoteVersion,
       updateAvailable,
       downloaded,
+      status: state?.status ?? "available",
       workDir,
       workDirFallback,
+      updateError: state?.error || undefined,
       checkError: undefined,
     }
   } catch (e) {
@@ -226,8 +366,10 @@ async function webCheck(os: z.infer<typeof WebUpdateOS>) {
       remoteVersion: "",
       updateAvailable: false,
       downloaded: false,
+      status: "available" as const,
       workDir,
       workDirFallback,
+      updateError: undefined,
       checkError: `Failed to check update: ${message}`,
     }
   }
@@ -657,8 +799,10 @@ export const GlobalRoutes = lazy(() =>
                     remoteVersion: z.string(),
                     updateAvailable: z.boolean(),
                     downloaded: z.boolean(),
+                    status: WebUpdateStatus,
                     workDir: z.string(),
                     workDirFallback: z.boolean(),
+                    updateError: z.string().optional(),
                     checkError: z.string().optional(),
                   }),
                 ),
@@ -706,10 +850,11 @@ export const GlobalRoutes = lazy(() =>
           os: WebUpdateOS,
           version: z.string().min(1),
           acceptFallback: z.boolean().optional(),
+          force: z.boolean().optional(),
         }),
       ),
       async (c) => {
-        const { os, version, acceptFallback } = c.req.valid("json")
+        const { os, version, acceptFallback, force } = c.req.valid("json")
         const resolved = resolveWorkDir(os)
         if (!resolved) {
           return c.json({ success: false as const, error: "Could not determine aether work directory" })
@@ -721,6 +866,22 @@ export const GlobalRoutes = lazy(() =>
           })
         }
         const workDir = resolved.path
+        const upd = UPDATE_SCRIPT[os]
+        if (!upd) return c.json({ success: false as const, error: `Update script not configured for ${os}` })
+        const state = await resolveUpdateStatus(os, version, workDir)
+        if (force) await resetUpdate(os, version, workDir)
+        if (!force && state.status === "downloaded") {
+          return c.json({ success: true as const, path: path.join(workDir, "downloads", versioned(upd, version)) })
+        }
+        if (!force && state.status === "downloading") {
+          return c.json({ success: false as const, error: "Update download is already in progress" })
+        }
+        if (!force && state.status === "installing") {
+          return c.json({ success: false as const, error: "Update install is already in progress" })
+        }
+        if (!force && state.status === "recovery") {
+          return c.json({ success: false as const, error: state.error || "Update needs to restart from scratch" })
+        }
         try {
           await fs.mkdir(workDir, { recursive: true })
         } catch (e) {
@@ -731,24 +892,22 @@ export const GlobalRoutes = lazy(() =>
         if (!scriptPath) {
           return c.json({ success: false as const, error: `Failed to fetch installer script for ${os}` })
         }
-        const upd = UPDATE_SCRIPT[os]
-        if (!upd) return c.json({ success: false as const, error: `Update script not configured for ${os}` })
-        if (await downloadedReady(os, version, workDir)) {
-          return c.json({ success: true as const, path: path.join(workDir, "downloads", versioned(upd, version)) })
-        }
         const currentVersion = readWebCurrentVersion()
         log.info("running installer auto mode", { os, script: scriptPath, version, workDir })
         try {
           const cur = await currentVersion
           if (compareVer(cur, version) >= 0) {
+            await clearUpdateState(workDir)
             return c.json({ success: false as const, error: "No upgrade needed" })
           }
+          await writeUpdateState(workDir, updateState(version, "downloading"))
           const exitCode = await new Promise<number>((resolve, reject) => {
             const cmd = os === "windows" ? "cmd" : "bash"
             const cmdArgs = os === "windows" ? ["/c", scriptPath, "auto", cur] : [scriptPath, "auto", cur]
             const child = spawn(cmd, cmdArgs, {
               cwd: workDir,
               env: { ...process.env, AETHER_WORK_DIR: workDir },
+              windowsHide: os === "windows",
             })
             child.on("close", (code: number | null) => resolve(code ?? 1))
             child.on("error", reject)
@@ -759,33 +918,32 @@ export const GlobalRoutes = lazy(() =>
           try {
             await fs.access(scriptInDownloads)
           } catch {
+            await writeUpdateState(workDir, updateState(version, "error", `Downloaded update script missing: ${scriptInDownloads}`))
             return c.json({ success: false as const, error: `Downloaded update script missing: ${scriptInDownloads}` })
           }
           try {
             await fs.chmod(scriptInDownloads, 0o755)
           } catch {}
 
-          const pick = async () => {
-            const files = await fs.readdir(dl)
-            const ext = UPDATE_PKG_EXT[os] ?? ".dmg"
-            const list = files.filter((x) => x.toLowerCase().endsWith(ext) && x.includes(version)).sort()
-            if (list.length > 0) return path.join(dl, list[list.length - 1])
-            const any = files.filter((x) => x.toLowerCase().endsWith(ext)).sort()
-            if (any.length > 0) return path.join(dl, any[any.length - 1])
-            return ""
+          const pkg = await packagePath(os, version, workDir)
+          if (!pkg) {
+            await writeUpdateState(workDir, updateState(version, "error", `No update package found in ${dl}`))
+            return c.json({ success: false as const, error: `No update package found in ${dl}` })
           }
-          const pkg = await pick()
-          if (!pkg) return c.json({ success: false as const, error: `No update package found in ${dl}` })
           log.info("installer auto result", { exitCode, workDir, script: scriptInDownloads, pkg })
           if (exitCode === 20) {
+            await clearUpdateState(workDir)
             return c.json({ success: false as const, error: "Already up to date" })
           }
           if (exitCode === 10) {
+            await writeUpdateState(workDir, updateState(version, "downloaded"))
             return c.json({ success: true as const, path: scriptInDownloads, package: pkg })
           }
+          await writeUpdateState(workDir, updateState(version, "error", `Installer exited with code ${exitCode}`))
           return c.json({ success: false as const, error: `Installer exited with code ${exitCode}` })
         } catch (e) {
           const message = e instanceof Error ? e.message : String(e)
+          await writeUpdateState(workDir, updateState(version, "error", `Download failed: ${message}`)).catch(() => undefined)
           return c.json({ success: false as const, error: `Download failed: ${message}` })
         }
       },
@@ -857,23 +1015,42 @@ export const GlobalRoutes = lazy(() =>
         try {
           await fs.access(run)
         } catch {
+          await writeUpdateState(workDir, updateState(version ?? "latest", "error", `Update script not found: ${run}`)).catch(
+            () => undefined,
+          )
           return c.json({ success: false as const, error: `Update script not found: ${run}` })
+        }
+        const next = version || (await readUpdateState(workDir))?.version || "latest"
+        const state = version ? await resolveUpdateStatus(os, version, workDir) : null
+        if (version && state?.status !== "downloaded") {
+          const msg = state?.error || "Update files are not ready. Restart the update from scratch."
+          await writeUpdateState(workDir, updateState(version, "error", msg)).catch(() => undefined)
+          return c.json({ success: false as const, error: msg })
         }
         try {
           await fs.chmod(run, 0o755)
         } catch {}
         log.info("launching update script", { os, updater: run, workDir, version })
         try {
+          await writeUpdateState(workDir, updateState(next, "installing"))
           const args = version ? [run, version] : [run]
           if (os === "darwin" || os === "linux" || os === "windows") args.push("--restart")
           const child =
             os === "windows"
-              ? spawn("cmd", ["/c", ...args], { detached: true, stdio: "ignore", cwd: path.join(workDir, "downloads") })
+              ? spawn("cmd", ["/c", ...args], {
+                  detached: true,
+                  stdio: "ignore",
+                  cwd: path.join(workDir, "downloads"),
+                  windowsHide: true,
+                })
               : spawn("bash", args, { detached: true, stdio: "ignore", cwd: path.join(workDir, "downloads") })
           child.unref()
           return c.json({ success: true as const })
         } catch (e) {
           const message = e instanceof Error ? e.message : String(e)
+          await writeUpdateState(workDir, updateState(next, "error", `Failed to execute update script: ${message}`)).catch(
+            () => undefined,
+          )
           return c.json({ success: false as const, error: `Failed to execute update script: ${message}` })
         }
       },


### PR DESCRIPTION
### Issue for this PR

Closes #361

### Type of change

- [x] Bug fix
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This PR hardens the offline web update flow by replacing the weak ready-to-install check with a persisted update state machine. It blocks install until the full artifact set is present, adds a restart-from-scratch recovery path after interrupted or failed runs, hides Windows updater shells, fixes Linux `--restart` handling, and adds a manual regression checklist for the updated flow.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/app`
- Ran `bun typecheck` in `packages/opencode`
- Added and reviewed `Update/offline-update-regression-checklist.md` for manual cross-platform regression coverage

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR