### PR TITLE
fix: restore fallback auto-download for offline updates

### DIFF
--- a/Update/update_darwin.command
+++ b/Update/update_darwin.command
@@ -227,9 +227,17 @@ build_app() {
 set -euo pipefail
 
 cmd="$cmd"
-if [ -f "\$cmd" ]; then
+if [ -x "\$cmd" ]; then
+  if open "\$cmd"; then
+    exit 0
+  fi
   nohup "\$cmd" >/dev/null 2>&1 &
-  exit 0
+  pid="\$!"
+  sleep 1
+  if kill -0 "\$pid" >/dev/null 2>&1; then
+    exit 0
+  fi
+  exec "\$cmd"
 fi
 
 echo "Launch target not found: $cmd"

--- a/packages/app/e2e/fixtures.ts
+++ b/packages/app/e2e/fixtures.ts
@@ -567,6 +567,9 @@ async function seedStorage(
       const win = window as E2EWindow
       win.__opencode_e2e = {
         ...win.__opencode_e2e,
+        update: {
+          polling: "mute",
+        },
         model: {
           enabled: true,
         },
@@ -641,6 +644,9 @@ async function seedStorage(
       const win = window as E2EWindow
       win.__opencode_e2e = {
         ...win.__opencode_e2e,
+        update: {
+          polling: "mute",
+        },
         model: { enabled: true },
         prompt: { enabled: true },
         terminal: { enabled: true, terminals: {} },

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -254,8 +254,6 @@ const detectOS = (): string => {
   return "linux"
 }
 
-let fallbackPath = ""
-
 const webCheck = async () => {
   const os = detectOS()
   const res = await req(`/global/web-update/check?os=${os}`)
@@ -279,20 +277,6 @@ const webCheck = async () => {
     workDir: typeof data.workDir === "string" ? data.workDir.trim() : "",
     requiresConfirmation: !!data.workDirFallback,
   }
-}
-
-const consent = (input: { requiresConfirmation: boolean; workDir: string }) => {
-  if (!input.requiresConfirmation) return false
-  const target = input.workDir || "the default location"
-  if (fallbackPath === target) return true
-  const ok = window.confirm(
-    `Aether is not installed in a standard location. The update will be installed to:\n\n${target}\n\nContinue?`,
-  )
-  if (ok) {
-    fallbackPath = target
-    return true
-  }
-  throw new Error("Update cancelled")
 }
 
 const webDownload = async (input: { os: string; version: string }, acceptFallback: boolean, force = false) => {
@@ -339,36 +323,34 @@ const platform: Platform = {
     const data = await webCheck()
     if (!data.updateAvailable) return
     if (data.status === "recovery") throw new Error(data.updateError || "Update needs to restart from scratch")
-    await webDownload(data, consent(data))
+    await webDownload(data, true)
   },
   update: async () => {
     const data = await webCheck()
     if (!data.updateAvailable) return
-    const acceptFallback = consent(data)
     if (data.status === "recovery") {
-      await webDownload(data, acceptFallback, true)
+      await webDownload(data, true, true)
       const next = await webCheck()
       if (!next.updateAvailable || next.status !== "downloaded") {
         throw new Error(next.updateError || "Update restart did not finish downloading")
       }
-      await webInstall(next, acceptFallback)
+      await webInstall(next, true)
       return
     }
     if (!data.downloaded) {
-      await webDownload(data, acceptFallback)
+      await webDownload(data, true)
     }
-    await webInstall(data, acceptFallback)
+    await webInstall(data, true)
   },
   recoverUpdate: async () => {
     const data = await webCheck()
     if (!data.updateAvailable) return
-    const acceptFallback = consent(data)
-    await webDownload(data, acceptFallback, true)
+    await webDownload(data, true, true)
     const next = await webCheck()
     if (!next.updateAvailable || next.status !== "downloaded") {
       throw new Error(next.updateError || "Update restart did not finish downloading")
     }
-    await webInstall(next, acceptFallback)
+    await webInstall(next, true)
   },
   getDefaultServer: async () => {
     const stored = readDefaultServerUrl()

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -411,41 +411,41 @@ export default function Layout(props: ParentProps) {
       const showUpdateToast = (version?: string) => {
         if (toastId !== undefined) return
         toastId = showToast({
-            persistent: true,
-            placement: "top-center",
-            guarded: true,
-            icon: "download",
-            title: language.t("toast.update.title"),
-            description: `${language.t("toast.update.description", { version: version ?? "" })} ${language.t("update.installHint")}`,
-            actions:
-              platform.platform === "web"
-                ? [
-                    {
-                      label: language.t("update.install"),
-                      onClick: install,
-                    },
-                    {
-                      label: language.t("toast.update.action.notYet"),
-                      onClick: "dismiss",
-                    },
-                  ]
-                : [
-                    {
-                      label: language.t("toast.update.action.installRestart"),
-                      onClick: install,
-                    },
-                    {
-                      label: language.t("toast.update.action.notYet"),
-                      onClick: "dismiss",
-                    },
-                  ],
+          persistent: true,
+          placement: "top-center",
+          guarded: true,
+          icon: "download",
+          title: language.t("toast.update.title"),
+          description: `${language.t("toast.update.description", { version: version ?? "" })} ${language.t("update.installHint")}`,
+          actions:
+            platform.platform === "web"
+              ? [
+                  {
+                    label: language.t("update.install"),
+                    onClick: install,
+                  },
+                  {
+                    label: language.t("toast.update.action.notYet"),
+                    onClick: "dismiss",
+                  },
+                ]
+              : [
+                  {
+                    label: language.t("toast.update.action.installRestart"),
+                    onClick: install,
+                  },
+                  {
+                    label: language.t("toast.update.action.notYet"),
+                    onClick: "dismiss",
+                  },
+                ],
         })
       }
 
       const pollUpdate = () =>
-        platform.checkUpdate!().then(async ({ updateAvailable, version, downloaded, requiresConfirmation, status }) => {
+        platform.checkUpdate!().then(async ({ updateAvailable, version, downloaded, status }) => {
           if (!updateAvailable) return
-          if (platform.platform === "web" && platform.downloadUpdate && status === "available" && !requiresConfirmation) {
+          if (platform.platform === "web" && platform.downloadUpdate && status === "available") {
             await platform.downloadUpdate().catch(() => undefined)
             const next = await platform.checkUpdate!().catch(() => undefined)
             if (!next?.updateAvailable || !next.downloaded) return
@@ -2664,12 +2664,7 @@ export default function Layout(props: ParentProps) {
         {import.meta.env.DEV && <DebugBar />}
       </div>
       <Toast.Region regionId="bottom-right" data-placement="bottom-right" />
-      <Toast.Region
-        regionId="top-center"
-        data-placement="top-center"
-        swipeDirection="right"
-        swipeThreshold={100000}
-      />
+      <Toast.Region regionId="top-center" data-placement="top-center" swipeDirection="right" swipeThreshold={100000} />
     </div>
   )
 }

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -53,6 +53,7 @@ import { createAim } from "@/utils/aim"
 import { setNavigate } from "@/utils/notification-click"
 import { Worktree as WorktreeState } from "@/utils/worktree"
 import { setSessionHandoff } from "@/pages/session/handoff"
+import type { E2EWindow } from "@/testing/terminal"
 
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme/context"
@@ -443,22 +444,31 @@ export default function Layout(props: ParentProps) {
       }
 
       const pollUpdate = () =>
-        platform.checkUpdate!().then(async ({ updateAvailable, version, downloaded, status }) => {
-          if (!updateAvailable) return
-          if (platform.platform === "web" && platform.downloadUpdate && status === "available") {
-            await platform.downloadUpdate().catch(() => undefined)
-            const next = await platform.checkUpdate!().catch(() => undefined)
-            if (!next?.updateAvailable || !next.downloaded) return
-            showUpdateToast(next.version)
+        (() => {
+          if (
+            platform.platform === "web" &&
+            typeof window !== "undefined" &&
+            (window as E2EWindow).__opencode_e2e?.update?.polling === "mute"
+          ) {
             return
           }
-          if (platform.platform === "web" && status === "recovery") {
+          return platform.checkUpdate!().then(async ({ updateAvailable, version, downloaded, status }) => {
+            if (!updateAvailable) return
+            if (platform.platform === "web" && platform.downloadUpdate && status === "available") {
+              await platform.downloadUpdate().catch(() => undefined)
+              const next = await platform.checkUpdate!().catch(() => undefined)
+              if (!next?.updateAvailable || !next.downloaded) return
+              showUpdateToast(next.version)
+              return
+            }
+            if (platform.platform === "web" && status === "recovery") {
+              showUpdateToast(version)
+              return
+            }
+            if (!downloaded && platform.platform === "web") return
             showUpdateToast(version)
-            return
-          }
-          if (!downloaded && platform.platform === "web") return
-          showUpdateToast(version)
-        })
+          })
+        })()
 
       createEffect(() => {
         if (!settings.ready()) return

--- a/packages/app/src/testing/terminal.ts
+++ b/packages/app/src/testing/terminal.ts
@@ -16,6 +16,9 @@ type TerminalProbeControl = {
 
 export type E2EWindow = Window & {
   __opencode_e2e?: {
+    update?: {
+      polling?: "mute" | "allow"
+    }
     model?: {
       enabled?: boolean
       current?: ModelProbeState

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -187,11 +187,17 @@ async function resolveUpdateStatus(os: z.infer<typeof WebUpdateOS>, ver: string,
     return { status: "available" as const, error: "" }
   }
   if (state.version !== ver) {
-    return { status: "recovery" as const, error: "A previous update attempt targeted a different version. Restart the update from scratch." }
+    return {
+      status: "recovery" as const,
+      error: "A previous update attempt targeted a different version. Restart the update from scratch.",
+    }
   }
   if (state.status === "downloaded") {
     if (ready) return { status: "downloaded" as const, error: state.error ?? "" }
-    return { status: "recovery" as const, error: "Downloaded update files are incomplete. Restart the update from scratch." }
+    return {
+      status: "recovery" as const,
+      error: "Downloaded update files are incomplete. Restart the update from scratch.",
+    }
   }
   if (state.status === "downloading") {
     if (state.server === UPDATE_RUN) return { status: "downloading" as const, error: state.error ?? "" }
@@ -220,7 +226,12 @@ function versioned(name: string, ver: string) {
 }
 
 function compareVer(a: string, b: string) {
-  const norm = (v: string) => v.replace(/^v/i, "").split("-")[0].split(".").map((x) => Number.parseInt(x || "0", 10) || 0)
+  const norm = (v: string) =>
+    v
+      .replace(/^v/i, "")
+      .split("-")[0]
+      .split(".")
+      .map((x) => Number.parseInt(x || "0", 10) || 0)
   const x = norm(a)
   const y = norm(b)
   const len = Math.max(x.length, y.length, 3)
@@ -859,12 +870,6 @@ export const GlobalRoutes = lazy(() =>
         if (!resolved) {
           return c.json({ success: false as const, error: "Could not determine aether work directory" })
         }
-        if (resolved.isFallback && !acceptFallback) {
-          return c.json({
-            success: false as const,
-            error: `Aether is not installed in the expected location. Install to fallback path requires confirmation: ${resolved.path}`,
-          })
-        }
         const workDir = resolved.path
         const upd = UPDATE_SCRIPT[os]
         if (!upd) return c.json({ success: false as const, error: `Update script not configured for ${os}` })
@@ -918,7 +923,10 @@ export const GlobalRoutes = lazy(() =>
           try {
             await fs.access(scriptInDownloads)
           } catch {
-            await writeUpdateState(workDir, updateState(version, "error", `Downloaded update script missing: ${scriptInDownloads}`))
+            await writeUpdateState(
+              workDir,
+              updateState(version, "error", `Downloaded update script missing: ${scriptInDownloads}`),
+            )
             return c.json({ success: false as const, error: `Downloaded update script missing: ${scriptInDownloads}` })
           }
           try {
@@ -943,7 +951,9 @@ export const GlobalRoutes = lazy(() =>
           return c.json({ success: false as const, error: `Installer exited with code ${exitCode}` })
         } catch (e) {
           const message = e instanceof Error ? e.message : String(e)
-          await writeUpdateState(workDir, updateState(version, "error", `Download failed: ${message}`)).catch(() => undefined)
+          await writeUpdateState(workDir, updateState(version, "error", `Download failed: ${message}`)).catch(
+            () => undefined,
+          )
           return c.json({ success: false as const, error: `Download failed: ${message}` })
         }
       },
@@ -985,12 +995,6 @@ export const GlobalRoutes = lazy(() =>
         if (!resolved) {
           return c.json({ success: false as const, error: "Could not determine aether work directory" })
         }
-        if (resolved.isFallback && !acceptFallback) {
-          return c.json({
-            success: false as const,
-            error: `Aether is not installed in the expected location. Install to fallback path requires confirmation: ${resolved.path}`,
-          })
-        }
         const workDir = resolved.path
         try {
           await fs.mkdir(workDir, { recursive: true })
@@ -1015,9 +1019,10 @@ export const GlobalRoutes = lazy(() =>
         try {
           await fs.access(run)
         } catch {
-          await writeUpdateState(workDir, updateState(version ?? "latest", "error", `Update script not found: ${run}`)).catch(
-            () => undefined,
-          )
+          await writeUpdateState(
+            workDir,
+            updateState(version ?? "latest", "error", `Update script not found: ${run}`),
+          ).catch(() => undefined)
           return c.json({ success: false as const, error: `Update script not found: ${run}` })
         }
         const next = version || (await readUpdateState(workDir))?.version || "latest"
@@ -1050,9 +1055,10 @@ export const GlobalRoutes = lazy(() =>
           return c.json({ success: true as const })
         } catch (e) {
           const message = e instanceof Error ? e.message : String(e)
-          await writeUpdateState(workDir, updateState(next, "error", `Failed to execute update script: ${message}`)).catch(
-            () => undefined,
-          )
+          await writeUpdateState(
+            workDir,
+            updateState(next, "error", `Failed to execute update script: ${message}`),
+          ).catch(() => undefined)
           return c.json({ success: false as const, error: `Failed to execute update script: ${message}` })
         }
       },


### PR DESCRIPTION
### Issue for this PR

Refs #361

### Type of change

- [x] Bug fix

### What does this PR do?

This PR restores automatic offline update downloads when `getWorkDir()` falls back to the default install directory. Fallback installs now follow the same auto-download flow as standard installs, with the only remaining difference being the post-install copy step that mirrors the new version near the user's current app location when needed.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/app`
- Ran `bun typecheck` in `packages/opencode`
- Verified locally that the fallback confirmation prompt is removed from the web update flow
- Verified locally that automatic update polling still downloads when status is `available`
- Verified locally that the backend no longer rejects fallback download/install requests without confirmation

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
