### PR TITLE
feat(wechat): support stdin file transfer and auto-reconnect on session expiry

### DIFF
--- a/Aether-wechat-bridge/aether_wechat_agent.py
+++ b/Aether-wechat-bridge/aether_wechat_agent.py
@@ -65,8 +65,18 @@ except Exception:
     pass
 
 # SDK imports
-from wechat_agent_sdk import Agent, ChatRequest, ChatResponse, WeChatBot
-from wechat_agent_sdk.api.client import ILinkBotClient, DEFAULT_API_BASE
+from wechat_agent_sdk import (
+    Agent,
+    ChatRequest,
+    ChatResponse,
+    WeChatBot,
+    LoginRequiredError,
+)
+from wechat_agent_sdk.api.client import (
+    ILinkBotClient,
+    DEFAULT_API_BASE,
+    SessionExpiredError,
+)
 from wechat_agent_sdk.api.auth import login_with_qrcode
 from wechat_agent_sdk.account.storage import JsonFileStorage
 
@@ -1322,6 +1332,8 @@ class AetherAgent(Agent):
                 conv_id,
                 "--file",
                 filepath,
+                "--stdin",
+                "1",
                 "--token",
                 token,
                 "--base-url",
@@ -1331,6 +1343,11 @@ class AetherAgent(Agent):
                 "--context-token",
                 ctx,
             ]
+            try:
+                file_buf = Path(filepath).read_bytes()
+            except OSError as e:
+                logger.warning(f"[file] read failed in python: {filepath} -> {e}")
+                return False
             sub_env = (
                 {**os.environ, "BRIDGE_LOG": str(_log_file)}
                 if _log_file
@@ -1339,16 +1356,18 @@ class AetherAgent(Agent):
             out = await asyncio.to_thread(
                 subprocess.run,
                 cmd,
+                input=file_buf,
                 capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
                 timeout=120,
                 check=False,
                 env=sub_env,
             )
             if out.returncode != 0:
-                detail = (out.stderr or out.stdout or "unknown error").strip()
+                detail = (
+                    (out.stderr or out.stdout or b"unknown error")
+                    .decode("utf-8", errors="replace")
+                    .strip()
+                )
                 logger.warning(f"[file] send failed: {filepath} -> {detail}")
                 return False
             logger.info(f"[file] 已发送: {filepath}")
@@ -2313,7 +2332,7 @@ async def custom_login(client: ILinkBotClient, log=print) -> str:
 
 
 class CustomWeChatBot(WeChatBot):
-    """自定义 Bot，覆盖登录方法"""
+    """自定义 Bot，覆盖登录方法与 run 添加自动重连"""
 
     async def login(self, log=print) -> str:
         transport = self._transport
@@ -2321,10 +2340,8 @@ class CustomWeChatBot(WeChatBot):
         if stored_token:
             transport._client.token = stored_token
             log(f"[weixin] 使用已保存的 token")
-            # 通知 Aether 已连接
             print(f"[登录成功] user: unknown (已保存的账号)")
             sys.stdout.flush()
-            # 保存会话到文件
             if SESSION_FILE:
                 try:
                     session_data = {
@@ -2343,6 +2360,66 @@ class CustomWeChatBot(WeChatBot):
         token = await custom_login(transport._client, log=log)
         await transport._storage.save_token(transport.account_id, token)
         return token
+
+    async def run(self, log=print, auto_login=True) -> None:
+        if self._transport.needs_login:
+            if auto_login:
+                await self.login(log=log)
+            else:
+                raise LoginRequiredError("No token.")
+
+        while True:
+            await self._transport.connect()
+            await self._agent.on_start()
+            self._running = True
+            self._semaphore = asyncio.Semaphore(self._max_concurrent)
+            self._setup_message_sender()
+            log(f"[weixin] Bot 已启动 (account={self._transport.account_id})")
+
+            try:
+                async for raw_msg in self._transport.messages():
+                    if not self._running:
+                        return
+                    task = asyncio.create_task(self._handle_message_guarded(raw_msg))
+                    self._tasks.add(task)
+                    task.add_done_callback(self._tasks.discard)
+            except SessionExpiredError:
+                log("[weixin] 会话已过期，准备重新登录...")
+                if self._tasks:
+                    await asyncio.gather(*self._tasks, return_exceptions=True)
+                self._tasks.clear()
+                await self._agent.on_stop()
+                self._running = False
+                if SESSION_FILE:
+                    try:
+                        Path(SESSION_FILE).write_text(
+                            json.dumps(
+                                {"connected": False, "reason": "session_expired"},
+                                ensure_ascii=False,
+                            )
+                        )
+                    except Exception:
+                        pass
+                self._transport._client.token = ""
+                await self._transport._storage.save_token(
+                    self._transport.account_id, ""
+                )
+                await self._transport.disconnect()
+                log("[weixin] 正在重新登录...")
+                await self.login(log=log)
+                if hasattr(self._agent, "_wechat_client"):
+                    self._agent._wechat_client = self._transport._client
+                if hasattr(self._agent, "_bot_transport"):
+                    self._agent._bot_transport = self._transport
+                continue
+            except asyncio.CancelledError:
+                return
+            finally:
+                if self._running:
+                    if self._tasks:
+                        await asyncio.gather(*self._tasks, return_exceptions=True)
+                    self._tasks.clear()
+                    await self.stop()
 
 
 async def _resolve_default_directory(base_url: str) -> str:

--- a/Aether-wechat-bridge/send_file.ts
+++ b/Aether-wechat-bridge/send_file.ts
@@ -97,8 +97,7 @@ const post = async (url: string, body: unknown, token?: string) => {
   return raw ? JSON.parse(raw) : {}
 }
 
-const upload = async (opts: Record<string, string>, filePath: string) => {
-  const buf = await readFile(filePath)
+const upload = async (opts: Record<string, string>, filePath: string, buf: Buffer) => {
   const key = crypto.randomBytes(16)
   const filekey = crypto.randomBytes(16).toString("hex")
   const file = mediaType(filePath)
@@ -190,10 +189,22 @@ const send = async (opts: Record<string, string>, media: Awaited<ReturnType<type
   await post(`${req(opts, "base-url").replace(/\/$/, "")}/ilink/bot/sendmessage`, body, req(opts, "token"))
 }
 
+const readData = async (opts: Record<string, string>) => {
+  if (opts["stdin"] === "1") {
+    const chunks: Buffer[] = []
+    for await (const chunk of process.stdin) {
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk)
+    }
+    return Buffer.concat(chunks)
+  }
+  return await readFile(req(opts, "file"))
+}
+
 const main = async () => {
   const opts = parse()
   const filePath = path.resolve(req(opts, "file"))
-  const media = await upload(opts, filePath)
+  const buf = await readData(opts)
+  const media = await upload(opts, filePath, buf)
   await send(opts, media)
   process.stdout.write(JSON.stringify({ ok: true, filePath }) + "\n")
 }


### PR DESCRIPTION
### Issue for this PR

Closes #368

### Type of change

- [x] New feature
- [x] Refactor / code improvement

### What does this PR do?

1. **Stdin file transfer**: The Python caller now reads file bytes and passes them to `send_file.ts` via stdin (`--stdin 1`) instead of letting the subprocess read from disk itself. This gives the Python side early error handling when the file cannot be read and avoids path/permission issues.

2. **Auto-reconnect on session expiry**: Override `WeChatBot.run` to catch `SessionExpiredError`. On expiry, the bot clears the stale token, updates the session file, re-logs in, restores client/transport references on the agent, and resumes the message loop — no manual restart needed.

### How did you verify your code works?

- Manually tested file sending via stdin path and existing file-path path.
- Verified auto-reconnect behavior after session expiry.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR