### PR TITLE
feat: implement addPreferenceMethods with manual fetch

### DIFF
--- a/packages/app/src/utils/server.ts
+++ b/packages/app/src/utils/server.ts
@@ -108,7 +108,29 @@ export function createSdkForServer({
 }
 
 export function addPreferenceMethods(client: AppClient, baseUrl: string, auth?: Record<string, string>): AppClient {
-  void baseUrl
-  void auth
+  const headers: Record<string, string> = { "Content-Type": "application/json", ...auth }
+  const pref = {
+    get: (input: { sessionID: string }) =>
+      fetch(`${baseUrl}/session/${input.sessionID}/preference`, { headers })
+        .then((r) => r.json())
+        .then((data) => ({ data })),
+    update: (input: {
+      sessionID: string
+      agent?: string
+      model?: { providerID: string; modelID: string }
+      variant?: string
+      autoAccept?: boolean
+    }) => {
+      const { sessionID, ...body } = input
+      return fetch(`${baseUrl}/session/${sessionID}/preference`, {
+        method: "PATCH",
+        headers,
+        body: JSON.stringify(body),
+      })
+        .then((r) => r.json())
+        .then((data) => ({ data }))
+    },
+  }
+  Object.defineProperty(client.session, "preference", { value: pref, writable: true, configurable: true })
   return client
 }


### PR DESCRIPTION
### Issue for this PR

Closes #375

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Implement the `addPreferenceMethods` function in `packages/app/src/utils/server.ts` with manual `fetch` calls for session preference get/update operations. The previous implementation was a stub that voided parameters and returned the client unchanged. Using manual fetch bypasses the `throwOnError` response format mismatch in the SDK's auto-generated client methods.

### How did you verify your code works?

Ran `bun typecheck` in `packages/app` to verify type correctness. Verified the fetch calls match the existing API endpoints (`GET /session/{sessionID}/preference` and `PATCH /session/{sessionID}/preference`).

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR