### PR TITLE
fix: use SDK native Preference and add SSE echo dedup to prevent dropdown snap-back

### DIFF
--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -3,7 +3,7 @@ import { createSimpleContext } from "@opencode-ai/ui/context"
 import { createGlobalEmitter } from "@solid-primitives/event-bus"
 import { batch, onCleanup } from "solid-js"
 import z from "zod"
-import { type AppClient, addPreferenceMethods, createSdkForServer } from "@/utils/server"
+import { type AppClient, createSdkForServer } from "@/utils/server"
 import { useLanguage } from "./language"
 import { usePlatform } from "./platform"
 import { useServer } from "./server"
@@ -220,16 +220,6 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       fetch: platform.fetch,
       throwOnError: true,
     })
-    addPreferenceMethods(
-      sdk,
-      server.current.http.url,
-      (() => {
-        if (!server.current.http.password) return
-        return {
-          Authorization: `Basic ${btoa(`${server.current.http.username ?? "opencode"}:${server.current.http.password}`)}`,
-        }
-      })(),
-    )
 
     return {
       url: currentServer.http.url,
@@ -238,20 +228,11 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       createClient(opts: Omit<Parameters<typeof createSdkForServer>[0], "server" | "fetch">) {
         const s = server.current
         if (!s) throw new Error(language.t("error.globalSDK.serverNotAvailable"))
-        const c = createSdkForServer({
+        return createSdkForServer({
           server: s.http,
           fetch: platform.fetch,
           ...opts,
         })
-        addPreferenceMethods(
-          c,
-          s.http.url,
-          (() => {
-            if (!s.http.password) return
-            return { Authorization: `Basic ${btoa(`${s.http.username ?? "opencode"}:${s.http.password}`)}` }
-          })(),
-        )
-        return c
       },
     }
   },

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -273,6 +273,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       setStore("draft", state)
     }
 
+    const sseEcho = new Set<string>()
+
     const syncPreferenceToServer = (session: string, state: State) => {
       if (!sdk.client.session.preference) return
       const body: Record<string, unknown> = {}
@@ -286,6 +288,10 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     createEffect(() => {
       const session = id()
       if (!session) return
+      if (sseEcho.has(session)) {
+        sseEcho.delete(session)
+        return
+      }
       const local = saved.session[session]
       if (local) {
         syncPreferenceToServer(session, local)
@@ -331,7 +337,20 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         if (pref.model) state.model = pref.model
         if (pref.variant) state.variant = pref.variant
         if (pref.autoAccept !== undefined) state.autoAccept = pref.autoAccept
+        const prev = saved.session[session]
+        const eq = (a?: string | null, b?: string | null) => (a ?? null) === (b ?? null)
+        if (
+          prev &&
+          eq(state.agent, prev.agent) &&
+          eq(state.variant, prev.variant) &&
+          state.autoAccept === prev.autoAccept
+        ) {
+          const sm = state.model
+          const pm = prev.model
+          if (sm === pm || (sm && pm && sm.providerID === pm.providerID && sm.modelID === pm.modelID)) return
+        }
         if (Object.keys(state).length > 0) {
+          sseEcho.add(session)
           setSaved("session", session, { ...(saved.session[session] ?? {}), ...state })
         }
       })

--- a/packages/app/src/utils/server.ts
+++ b/packages/app/src/utils/server.ts
@@ -2,7 +2,6 @@ import { createOpencodeClient } from "@opencode-ai/sdk/v2/client"
 import type { ServerConnection } from "@/context/server"
 
 type Base = ReturnType<typeof createOpencodeClient>
-type Req<T> = Promise<{ data?: T }>
 type Skill = {
   name: string
   description: string
@@ -18,24 +17,26 @@ type Kb = {
 export type AppClient = Base & {
   config: Base["config"] & {
     skills: {
-      list(): Req<Skill[]>
-      toggle(input: { name: string; enabled: boolean }): Req<{ ok: boolean }>
-      addDefaults(input?: { directory?: string }): Req<{ added: string[] }>
+      list(): Promise<{ data?: Skill[] }>
+      toggle(input: { name: string; enabled: boolean }): Promise<{ data?: { ok: boolean } }>
+      addDefaults(input?: { directory?: string }): Promise<{ data?: { added: string[] } }>
     }
   }
   file: Base["file"] & {
-    create(input: { path: string; type: "file" | "directory" }): Req<{ ok: boolean }>
-    delete(input: { path: string }): Req<{ ok: boolean }>
-    rename(input: { path: string; name: string }): Req<{ ok: boolean; path: string }>
-    write(input: { path: string; content: string }): Req<{ ok: boolean }>
-    summarize(input?: { directory?: string; maxDepth?: number; force?: boolean }): Req<{ count: number }>
-    open(input: { path: string; app?: string }): Req<{ ok: boolean }>
-    openInExplorer(input: { path: string }): Req<{ ok: boolean }>
-    pickFolder(): Req<{ path: string | null }>
-    addToGitignore(input: { path: string; type: "file" | "directory" }): Req<{
-      ok: boolean
-      created: boolean
-      alreadyExists: boolean
+    create(input: { path: string; type: "file" | "directory" }): Promise<{ data?: { ok: boolean } }>
+    delete(input: { path: string }): Promise<{ data?: { ok: boolean } }>
+    rename(input: { path: string; name: string }): Promise<{ data?: { ok: boolean; path: string } }>
+    write(input: { path: string; content: string }): Promise<{ data?: { ok: boolean } }>
+    summarize(input?: { directory?: string; maxDepth?: number; force?: boolean }): Promise<{ data?: { count: number } }>
+    open(input: { path: string; app?: string }): Promise<{ data?: { ok: boolean } }>
+    openInExplorer(input: { path: string }): Promise<{ data?: { ok: boolean } }>
+    pickFolder(): Promise<{ data?: { path: string | null } }>
+    addToGitignore(input: { path: string; type: "file" | "directory" }): Promise<{
+      data?: {
+        ok: boolean
+        created: boolean
+        alreadyExists: boolean
+      }
     }>
   }
   session: Base["session"] & {
@@ -58,29 +59,7 @@ export type AppClient = Base & {
       variant?: string
       knowledgeBase?: Kb
       parts: unknown[]
-    }): Req<unknown>
-    preference: {
-      get(input: { sessionID: string }): Req<{
-        sessionID: string
-        agent?: string
-        model?: { providerID: string; modelID: string }
-        variant?: string
-        autoAccept?: boolean
-      } | null>
-      update(input: {
-        sessionID: string
-        agent?: string
-        model?: { providerID: string; modelID: string }
-        variant?: string
-        autoAccept?: boolean
-      }): Req<{
-        sessionID: string
-        agent?: string
-        model?: { providerID: string; modelID: string }
-        variant?: string
-        autoAccept?: boolean
-      } | null>
-    }
+    }): Promise<{ data?: unknown }>
   }
 }
 
@@ -105,32 +84,4 @@ export function createSdkForServer({
       ...(config.headers ?? {}),
     },
   }) as unknown as AppClient
-}
-
-export function addPreferenceMethods(client: AppClient, baseUrl: string, auth?: Record<string, string>): AppClient {
-  const headers: Record<string, string> = { "Content-Type": "application/json", ...auth }
-  const pref = {
-    get: (input: { sessionID: string }) =>
-      fetch(`${baseUrl}/session/${input.sessionID}/preference`, { headers })
-        .then((r) => r.json())
-        .then((data) => ({ data })),
-    update: (input: {
-      sessionID: string
-      agent?: string
-      model?: { providerID: string; modelID: string }
-      variant?: string
-      autoAccept?: boolean
-    }) => {
-      const { sessionID, ...body } = input
-      return fetch(`${baseUrl}/session/${sessionID}/preference`, {
-        method: "PATCH",
-        headers,
-        body: JSON.stringify(body),
-      })
-        .then((r) => r.json())
-        .then((data) => ({ data }))
-    },
-  }
-  Object.defineProperty(client.session, "preference", { value: pref, writable: true, configurable: true })
-  return client
 }

--- a/packages/app/src/utils/server.ts
+++ b/packages/app/src/utils/server.ts
@@ -108,7 +108,29 @@ export function createSdkForServer({
 }
 
 export function addPreferenceMethods(client: AppClient, baseUrl: string, auth?: Record<string, string>): AppClient {
-  void baseUrl
-  void auth
+  const headers: Record<string, string> = { "Content-Type": "application/json", ...auth }
+  const pref = {
+    get: (input: { sessionID: string }) =>
+      fetch(`${baseUrl}/session/${input.sessionID}/preference`, { headers })
+        .then((r) => r.json())
+        .then((data) => ({ data })),
+    update: (input: {
+      sessionID: string
+      agent?: string
+      model?: { providerID: string; modelID: string }
+      variant?: string
+      autoAccept?: boolean
+    }) => {
+      const { sessionID, ...body } = input
+      return fetch(`${baseUrl}/session/${sessionID}/preference`, {
+        method: "PATCH",
+        headers,
+        body: JSON.stringify(body),
+      })
+        .then((r) => r.json())
+        .then((data) => ({ data }))
+    },
+  }
+  Object.defineProperty(client.session, "preference", { value: pref, writable: true, configurable: true })
   return client
 }


### PR DESCRIPTION
### Issue for this PR

Closes #377

### Type of change

- [x] Bug fix

### What does this PR do?

Two interrelated bugs are fixed:

1. **Remove `addPreferenceMethods` and let SDK native `Preference` class handle preference get/update directly.** The previous `addPreferenceMethods` used manual `fetch()` calls that bypassed the SDK client's configured headers (including `x-opencode-directory` and auth). Without `x-opencode-directory`, the server could not locate the correct workspace directory for the preference update. Removing this wrapper lets all SDK-configured headers propagate correctly through the native SDK methods.

2. **Add SSE echo dedup in `local.tsx` to prevent the `session.preference.updated` event from triggering an infinite reactive loop.** The server has no echo suppression — every preference PATCH broadcasts an SSE event back to the initiating client. This caused: SSE → `setSaved` → `createEffect` re-run → `syncPreferenceToServer` → PATCH → SSE → loop. The `List` component's `createEffect` fires `scrollIntoView` on each `props.current` change, causing the dropdown to snap back. Two dedup mechanisms are added:
   - A `sseEcho` Set flag: when SSE updates `saved`, the next preference effect run is skipped entirely
   - Deep comparison of incoming SSE state vs. current saved state: if identical (treating `undefined` and `null` as equivalent for `variant` fields), skip `setSaved` entirely

The `preference` type override in `AppClient` is also removed — SDK native `Preference.get()` with `throwOnError: true` returns `{ data, request, response }`, and `resp.data` access in `local.tsx` remains compatible.

Net result: -49 lines of code.

### How did you verify your code works?

- `bun typecheck` passes in `packages/app`
- Manually tested in browser: model selection dropdown scrolls and selects correctly without snapping back
- Thinking depth controls work correctly
- SSE preference sync works across multiple browser tabs

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR