### PR TITLE
feat(knowledge): 知识库改用后端聚合嵌入模型列表 + 白名单兜底

### DIFF
--- a/packages/app/src/components/knowledge-dialog.tsx
+++ b/packages/app/src/components/knowledge-dialog.tsx
@@ -11,9 +11,10 @@ import { useServer } from "@/context/server"
 import { useProviders } from "@/hooks/use-providers"
 import {
   inferKnowledgeProviderID,
-  labelEmbeddingModel,
+  labelResolvedEmbeddingModel,
   labelProvider,
-  listEmbeddingModels,
+  type ProviderConnection,
+  type ResolvedEmbeddingModel,
   toEmbeddingProvider,
 } from "@/utils/knowledge-embedding"
 import { DialogSelectDirectory } from "./dialog-select-directory"
@@ -34,7 +35,9 @@ export const KnowledgeDialog: Component = () => {
   const [editModel, setEditModel] = createSignal("")
   const [editApiKey, setEditApiKey] = createSignal("")
   const [editBaseURL, setEditBaseURL] = createSignal("")
+  const [editProviderType, setEditProviderType] = createSignal<"openai" | "local" | "custom">("local")
   const [editModelOptions, setEditModelOptions] = createSignal<string[]>([])
+  const [editResolvedModels, setEditResolvedModels] = createSignal<ResolvedEmbeddingModel[]>([])
   const [editLoadingModels, setEditLoadingModels] = createSignal(false)
   const [useManualEditModel, setUseManualEditModel] = createSignal(false)
   const [addPath, setAddPath] = createSignal("")
@@ -57,8 +60,10 @@ export const KnowledgeDialog: Component = () => {
   const [newModel, setNewModel] = createSignal("")
   const [newApiKey, setNewApiKey] = createSignal("")
   const [newBaseURL, setNewBaseURL] = createSignal("")
+  const [addProviderType, setAddProviderType] = createSignal<"openai" | "local" | "custom">("local")
 
   const [embeddingModelOptions, setEmbeddingModelOptions] = createSignal<string[]>([])
+  const [addResolvedModels, setAddResolvedModels] = createSignal<ResolvedEmbeddingModel[]>([])
   const [loadingModels, setLoadingModels] = createSignal(false)
   const [useManualModel, setUseManualModel] = createSignal(false)
   let addRun = 0
@@ -77,24 +82,23 @@ export const KnowledgeDialog: Component = () => {
       headers: { "Content-Type": "application/json", ...authHeader },
     })
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
-    return resp.json() as Promise<{ apiKey: string; baseURL: string; embeddingModels: string[] }>
+    return resp.json() as Promise<ProviderConnection>
   }
 
-  const setAddModels = (id: string, extra: string[] = [], pick?: string) => {
-    const list = Array.from(
-      new Set([
-        ...listEmbeddingModels(
-          id,
-          connected(),
-          knowledge.models(),
-        ),
-        ...extra,
-      ]),
-    )
-    setEmbeddingModelOptions(list)
+  const setAddModels = (id: string, extra: ResolvedEmbeddingModel[] = [], pick?: string) => {
+    const list =
+      id === "local"
+        ? knowledge
+            .models()
+            .filter((item) => item.provider === "local")
+            .map((item) => item.id)
+        : Array.from(new Set(extra.map((item) => item.id)))
+    const next = pick && !list.includes(pick) ? [pick, ...list] : list
+    setAddResolvedModels(extra)
+    setEmbeddingModelOptions(next)
 
     if (pick) {
-      if (list.includes(pick)) {
+      if (next.includes(pick)) {
         setUseManualModel(false)
         setNewModel(pick)
         return
@@ -104,9 +108,9 @@ export const KnowledgeDialog: Component = () => {
       return
     }
 
-    if (list.length > 0) {
+    if (next.length > 0) {
       setUseManualModel(false)
-      setNewModel(list[0]!)
+      setNewModel(next[0]!)
       return
     }
 
@@ -114,21 +118,20 @@ export const KnowledgeDialog: Component = () => {
     setNewModel("")
   }
 
-  const setEditModels = (id: string, extra: string[] = [], pick?: string) => {
-    const list = Array.from(
-      new Set([
-        ...listEmbeddingModels(
-          id,
-          connected(),
-          knowledge.models(),
-        ),
-        ...extra,
-      ]),
-    )
-    setEditModelOptions(list)
+  const setEditModels = (id: string, extra: ResolvedEmbeddingModel[] = [], pick?: string) => {
+    const list =
+      id === "local"
+        ? knowledge
+            .models()
+            .filter((item) => item.provider === "local")
+            .map((item) => item.id)
+        : Array.from(new Set(extra.map((item) => item.id)))
+    const next = pick && !list.includes(pick) ? [pick, ...list] : list
+    setEditResolvedModels(extra)
+    setEditModelOptions(next)
 
     if (pick) {
-      if (list.includes(pick)) {
+      if (next.includes(pick)) {
         setUseManualEditModel(false)
         setEditModel(pick)
         return
@@ -138,9 +141,9 @@ export const KnowledgeDialog: Component = () => {
       return
     }
 
-    if (list.length > 0) {
+    if (next.length > 0) {
       setUseManualEditModel(false)
-      setEditModel(list[0]!)
+      setEditModel(next[0]!)
       return
     }
 
@@ -152,6 +155,7 @@ export const KnowledgeDialog: Component = () => {
     if (!id) return
     const cur = ++addRun
     setSelectedProviderID(id)
+    setAddProviderType(id === "local" ? "local" : toEmbeddingProvider(id))
     setLoadingModels(id !== "local")
     setNewApiKey("")
     setNewBaseURL("")
@@ -164,6 +168,7 @@ export const KnowledgeDialog: Component = () => {
     try {
       const data = await fetchProviderConnection(id)
       if (cur !== addRun) return
+      setAddProviderType(data.embeddingProvider)
       if (data.baseURL) setNewBaseURL(data.baseURL)
       if (data.apiKey) setNewApiKey(data.apiKey)
       setAddModels(id, data.embeddingModels, pick)
@@ -178,6 +183,7 @@ export const KnowledgeDialog: Component = () => {
     if (!id) return
     const cur = ++editRun
     setEditProviderID(id)
+    setEditProviderType(id === "local" ? "local" : toEmbeddingProvider(id))
     setEditLoadingModels(id !== "local")
     setEditApiKey("")
     setEditBaseURL("")
@@ -190,6 +196,7 @@ export const KnowledgeDialog: Component = () => {
     try {
       const data = await fetchProviderConnection(id)
       if (cur !== editRun) return
+      setEditProviderType(data.embeddingProvider)
       if (data.baseURL) setEditBaseURL(data.baseURL)
       if (data.apiKey) setEditApiKey(data.apiKey)
       setEditModels(id, data.embeddingModels, pick)
@@ -240,7 +247,7 @@ export const KnowledgeDialog: Component = () => {
       setError("Please select or enter an embedding model")
       return
     }
-    if (toEmbeddingProvider(selectedProviderID()) === "custom" && !newBaseURL()) {
+    if (addProviderType() === "custom" && !newBaseURL()) {
       setError("Could not resolve provider API URL. Please check your provider configuration.")
       return
     }
@@ -251,7 +258,7 @@ export const KnowledgeDialog: Component = () => {
         path: newPath(),
         name: newName(),
         providerID: selectedProviderID(),
-        embeddingProvider: toEmbeddingProvider(selectedProviderID()),
+        embeddingProvider: addProviderType(),
         embeddingModel: newModel(),
         apiKey: newApiKey(),
         baseURL: newBaseURL(),
@@ -276,7 +283,10 @@ export const KnowledgeDialog: Component = () => {
         model: newModel(),
         apiKey: newApiKey(),
         baseURL: newBaseURL(),
-        dimensions: knowledge.models().find((item) => item.id === newModel())?.dimensions ?? 1536,
+        dimensions:
+          addResolvedModels().find((item) => item.id === newModel())?.dimensions ??
+          knowledge.models().find((item) => item.id === newModel())?.dimensions ??
+          1536,
       })
 
       if (result.errors && result.errors.length > 0) {
@@ -333,11 +343,7 @@ export const KnowledgeDialog: Component = () => {
     const kb = knowledge.knowledgeBases().find((item) => item.id === id)
     if (!kb) return
     setEditId(id)
-    const providerID = inferKnowledgeProviderID(
-      kb,
-      connected(),
-      knowledge.models(),
-    )
+    const providerID = inferKnowledgeProviderID(kb, connected(), knowledge.models())
     if (providerID) {
       await handleEditProviderSelect(providerID, kb.embeddingModel)
     } else {
@@ -381,11 +387,7 @@ export const KnowledgeDialog: Component = () => {
       setError("Please select or enter an embedding model")
       return
     }
-    if (toEmbeddingProvider(editProviderID()) === "openai" && !editApiKey()) {
-      setError("Please enter your OpenAI API key")
-      return
-    }
-    if (toEmbeddingProvider(editProviderID()) === "custom" && (!editApiKey() || !editBaseURL())) {
+    if (editProviderType() === "custom" && (!editApiKey() || !editBaseURL())) {
       setError("Please enter custom API URL and API Key")
       return
     }
@@ -393,7 +395,7 @@ export const KnowledgeDialog: Component = () => {
     setSyncing(true)
     try {
       await knowledge.updateEmbeddingConfig(id, {
-        embeddingProvider: toEmbeddingProvider(editProviderID()),
+        embeddingProvider: editProviderType(),
         embeddingModel: editModel(),
         apiKey: editApiKey(),
         baseURL: editBaseURL(),
@@ -586,6 +588,11 @@ export const KnowledgeDialog: Component = () => {
 
                           <div class="grid grid-cols-1 gap-2">
                             <label class="text-12-regular text-text-base">Embedding Model</label>
+                            <Show when={editProviderType() === "custom"}>
+                              <span class="text-12-regular text-text-weak">
+                                The current provider may not support these models. Check your provider docs.
+                              </span>
+                            </Show>
                             <Show when={editLoadingModels()}>
                               <span class="text-12-regular text-text-weak italic">Loading models...</span>
                             </Show>
@@ -597,7 +604,13 @@ export const KnowledgeDialog: Component = () => {
                                 label={(id) =>
                                   id === "__manual__"
                                     ? "Enter manually..."
-                                    : labelEmbeddingModel(id, editProviderID(), connected(), knowledge.models())
+                                    : labelResolvedEmbeddingModel(
+                                        id,
+                                        editResolvedModels(),
+                                        editProviderID(),
+                                        connected(),
+                                        knowledge.models(),
+                                      )
                                 }
                                 onSelect={(id) => {
                                   if (id === "__manual__") {
@@ -612,7 +625,9 @@ export const KnowledgeDialog: Component = () => {
                                 class="w-full"
                               />
                             </Show>
-                            <Show when={!editLoadingModels() && (editModelOptions().length === 0 || useManualEditModel())}>
+                            <Show
+                              when={!editLoadingModels() && (editModelOptions().length === 0 || useManualEditModel())}
+                            >
                               <input
                                 type="text"
                                 value={editModel()}
@@ -624,9 +639,7 @@ export const KnowledgeDialog: Component = () => {
 
                           <Show
                             when={
-                              !!editProviderID() &&
-                              (toEmbeddingProvider(editProviderID()) === "openai" ||
-                                toEmbeddingProvider(editProviderID()) === "custom")
+                              !!editProviderID() && (editProviderType() === "openai" || editProviderType() === "custom")
                             }
                           >
                             <div class="grid grid-cols-1 gap-2">
@@ -640,7 +653,7 @@ export const KnowledgeDialog: Component = () => {
                             </div>
                           </Show>
 
-                          <Show when={!!editProviderID() && toEmbeddingProvider(editProviderID()) === "custom"}>
+                          <Show when={!!editProviderID() && editProviderType() === "custom"}>
                             <div class="grid grid-cols-1 gap-2">
                               <label class="text-12-regular text-text-base">API URL</label>
                               <input
@@ -786,6 +799,11 @@ export const KnowledgeDialog: Component = () => {
             <Show when={selectedProviderID()}>
               <div class="flex flex-col gap-2">
                 <label class="text-13-medium text-text-strong">Embedding Model</label>
+                <Show when={addProviderType() === "custom"}>
+                  <span class="text-12-regular text-text-weak">
+                    The current provider may not support the models below. Check your provider documentation.
+                  </span>
+                </Show>
                 <Show when={loadingModels()}>
                   <span class="text-13-regular text-text-weak italic">Loading models...</span>
                 </Show>
@@ -797,7 +815,13 @@ export const KnowledgeDialog: Component = () => {
                     label={(id) =>
                       id === "__manual__"
                         ? "Enter manually..."
-                        : labelEmbeddingModel(id, selectedProviderID(), connected(), knowledge.models())
+                        : labelResolvedEmbeddingModel(
+                            id,
+                            addResolvedModels(),
+                            selectedProviderID(),
+                            connected(),
+                            knowledge.models(),
+                          )
                     }
                     onSelect={(id) => {
                       if (id === "__manual__") {

--- a/packages/app/src/components/settings-knowledge.tsx
+++ b/packages/app/src/components/settings-knowledge.tsx
@@ -8,9 +8,10 @@ import { useGlobalSDK } from "@/context/global-sdk"
 import { useServer } from "@/context/server"
 import { useProviders } from "@/hooks/use-providers"
 import {
-  labelEmbeddingModel,
+  labelResolvedEmbeddingModel,
   labelProvider,
-  listEmbeddingModels,
+  type ProviderConnection,
+  type ResolvedEmbeddingModel,
   toEmbeddingProvider,
 } from "@/utils/knowledge-embedding"
 import { DialogSelectDirectory } from "./dialog-select-directory"
@@ -33,10 +34,12 @@ export const SettingsKnowledge: Component = () => {
   const [newModel, setNewModel] = createSignal("")
   const [newApiKey, setNewApiKey] = createSignal("")
   const [newBaseURL, setNewBaseURL] = createSignal("")
+  const [newProviderType, setNewProviderType] = createSignal<"openai" | "local" | "custom">("local")
   const [newChunkSize, setNewChunkSize] = createSignal(500)
   const [newChunkOverlap, setNewChunkOverlap] = createSignal(50)
 
   const [embeddingModelOptions, setEmbeddingModelOptions] = createSignal<string[]>([])
+  const [resolvedModels, setResolvedModels] = createSignal<ResolvedEmbeddingModel[]>([])
   const [loadingModels, setLoadingModels] = createSignal(false)
   const [useManualModel, setUseManualModel] = createSignal(false)
   let run = 0
@@ -66,24 +69,23 @@ export const SettingsKnowledge: Component = () => {
       headers: { "Content-Type": "application/json", ...authHeader },
     })
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
-    return resp.json() as Promise<{ apiKey: string; baseURL: string; embeddingModels: string[] }>
+    return resp.json() as Promise<ProviderConnection>
   }
 
-  const setModels = (id: string, extra: string[] = [], pick?: string) => {
-    const list = Array.from(
-      new Set([
-        ...listEmbeddingModels(
-          id,
-          connected(),
-          knowledge.models(),
-        ),
-        ...extra,
-      ]),
-    )
-    setEmbeddingModelOptions(list)
+  const setModels = (id: string, extra: ResolvedEmbeddingModel[] = [], pick?: string) => {
+    const list =
+      id === "local"
+        ? knowledge
+            .models()
+            .filter((item) => item.provider === "local")
+            .map((item) => item.id)
+        : Array.from(new Set(extra.map((item) => item.id)))
+    const next = pick && !list.includes(pick) ? [pick, ...list] : list
+    setResolvedModels(extra)
+    setEmbeddingModelOptions(next)
 
     if (pick) {
-      if (list.includes(pick)) {
+      if (next.includes(pick)) {
         setUseManualModel(false)
         setNewModel(pick)
         return
@@ -93,9 +95,9 @@ export const SettingsKnowledge: Component = () => {
       return
     }
 
-    if (list.length > 0) {
+    if (next.length > 0) {
       setUseManualModel(false)
-      setNewModel(list[0]!)
+      setNewModel(next[0]!)
       return
     }
 
@@ -107,6 +109,7 @@ export const SettingsKnowledge: Component = () => {
     if (!id) return
     const cur = ++run
     setSelectedProviderID(id)
+    setNewProviderType(id === "local" ? "local" : toEmbeddingProvider(id))
     setLoadingModels(id !== "local")
     setNewApiKey("")
     setNewBaseURL("")
@@ -119,6 +122,7 @@ export const SettingsKnowledge: Component = () => {
     try {
       const data = await fetchProviderConnection(id)
       if (cur !== run) return
+      setNewProviderType(data.embeddingProvider)
       if (data.baseURL) setNewBaseURL(data.baseURL)
       if (data.apiKey) setNewApiKey(data.apiKey)
       setModels(id, data.embeddingModels, pick)
@@ -161,7 +165,7 @@ export const SettingsKnowledge: Component = () => {
       setError("Please select or enter an embedding model")
       return
     }
-    if (toEmbeddingProvider(selectedProviderID()) === "custom" && !newBaseURL()) {
+    if (newProviderType() === "custom" && !newBaseURL()) {
       setError("Could not resolve provider API URL. Please check your provider configuration.")
       return
     }
@@ -172,7 +176,7 @@ export const SettingsKnowledge: Component = () => {
         path: newPath(),
         name: newName(),
         providerID: selectedProviderID(),
-        embeddingProvider: toEmbeddingProvider(selectedProviderID()),
+        embeddingProvider: newProviderType(),
         embeddingModel: newModel(),
         apiKey: newApiKey(),
         baseURL: newBaseURL(),
@@ -203,7 +207,10 @@ export const SettingsKnowledge: Component = () => {
         model: newModel(),
         apiKey: newApiKey(),
         baseURL: newBaseURL(),
-        dimensions: knowledge.models().find((item) => item.id === newModel())?.dimensions ?? 1536,
+        dimensions:
+          resolvedModels().find((item) => item.id === newModel())?.dimensions ??
+          knowledge.models().find((item) => item.id === newModel())?.dimensions ??
+          1536,
       })
 
       setShowAddForm(false)
@@ -303,7 +310,10 @@ export const SettingsKnowledge: Component = () => {
                         <Button
                           variant="ghost"
                           size="small"
-                          onClick={(e: MouseEvent) => { e.stopPropagation(); handleSync(kb.id) }}
+                          onClick={(e: MouseEvent) => {
+                            e.stopPropagation()
+                            handleSync(kb.id)
+                          }}
                           disabled={isSyncing()}
                           class="h-7 px-2"
                         >
@@ -312,7 +322,10 @@ export const SettingsKnowledge: Component = () => {
                         <Button
                           variant="ghost"
                           size="small"
-                          onClick={(e: MouseEvent) => { e.stopPropagation(); handleRemove(kb.id) }}
+                          onClick={(e: MouseEvent) => {
+                            e.stopPropagation()
+                            handleRemove(kb.id)
+                          }}
                           class="h-7 px-2 text-text-error"
                         >
                           <Icon name="trash" class="size-3.5" />
@@ -397,9 +410,14 @@ export const SettingsKnowledge: Component = () => {
 
               {/* Embedding Model */}
               <Show when={selectedProviderID()}>
-                <div class="flex flex-wrap items-center justify-between gap-4 min-h-16 py-3 border-b border-border-weak-base">
-                  <div class="flex flex-col min-w-0 flex-1">
+                <div class="flex flex-col gap-3 py-3 border-b border-border-weak-base">
+                  <div class="flex flex-col min-w-0">
                     <span class="text-14-medium text-text-strong">Embedding Model</span>
+                    <Show when={newProviderType() === "custom"}>
+                      <span class="text-12-regular text-text-weak">
+                        The current provider may not support the models below. Check your provider documentation.
+                      </span>
+                    </Show>
                   </div>
                   <Show when={loadingModels()}>
                     <span class="text-13-regular text-text-weak italic">Loading models...</span>
@@ -412,11 +430,19 @@ export const SettingsKnowledge: Component = () => {
                       label={(id) =>
                         id === "__manual__"
                           ? "Enter manually..."
-                          : labelEmbeddingModel(id, selectedProviderID(), connected(), knowledge.models())
+                          : labelResolvedEmbeddingModel(
+                              id,
+                              resolvedModels(),
+                              selectedProviderID(),
+                              connected(),
+                              knowledge.models(),
+                            )
                       }
                       onSelect={(id) => {
-                        if (id === "__manual__") { setUseManualModel(true); setNewModel("") }
-                        else if (id) setNewModel(id)
+                        if (id === "__manual__") {
+                          setUseManualModel(true)
+                          setNewModel("")
+                        } else if (id) setNewModel(id)
                       }}
                       variant="secondary"
                       size="small"
@@ -479,7 +505,9 @@ export const SettingsKnowledge: Component = () => {
               <div class="flex justify-between items-center text-12-regular text-text-base">
                 <span>Processing documents...</span>
                 <div class="flex items-center gap-2">
-                  <span>{progress().current} / {progress().total}</span>
+                  <span>
+                    {progress().current} / {progress().total}
+                  </span>
                   <Button
                     variant="ghost"
                     size="small"

--- a/packages/app/src/utils/knowledge-embedding.ts
+++ b/packages/app/src/utils/knowledge-embedding.ts
@@ -8,6 +8,23 @@ type Model = {
   family?: string
 }
 
+export type ResolvedEmbeddingModel = {
+  id: string
+  name: string
+  dimensions?: number
+  provider?: string
+  source: "runtime" | "config" | "remote" | "whitelist"
+}
+
+export type ProviderConnection = {
+  providerID: string
+  name: string
+  embeddingProvider: "openai" | "custom"
+  apiKey: string
+  baseURL: string
+  embeddingModels: ResolvedEmbeddingModel[]
+}
+
 function trim(url?: string) {
   return (url ?? "").trim().replace(/\/+$/, "")
 }
@@ -52,6 +69,18 @@ export function labelEmbeddingModel(id: string, providerID: string, list: Provid
 
   const provider = list.find((item) => item.id === providerID)
   return provider?.models[id]?.name ?? id
+}
+
+export function labelResolvedEmbeddingModel(
+  id: string,
+  resolved: ResolvedEmbeddingModel[],
+  providerID: string,
+  list: Provider[],
+  local: EmbeddingModel[],
+) {
+  const match = resolved.find((item) => item.id === id)
+  if (match?.provider) return `${match.provider}/${match.id}`
+  return match?.name ?? labelEmbeddingModel(id, providerID, list, local)
 }
 
 export function hasEmbeddingModels(id: string, list: Provider[], local: EmbeddingModel[]) {

--- a/packages/opencode/src/server/routes/provider.ts
+++ b/packages/opencode/src/server/routes/provider.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono"
 import { describeRoute, validator, resolver } from "hono-openapi"
 import z from "zod"
+import { Auth, OAUTH_DUMMY_KEY } from "../../auth"
 import { Config } from "../../config/config"
 import { Provider } from "../../provider/provider"
 import { ModelsDev } from "../../provider/models"
@@ -12,6 +13,49 @@ import { lazy } from "../../util/lazy"
 import { Log } from "../../util/log"
 
 const log = Log.create({ service: "server" })
+
+const EMBEDDING_WHITELIST = [
+  { id: "text-embedding-3-small", dimensions: 1536, provider: "OpenAI" },
+  { id: "text-embedding-3-large", dimensions: 3072, provider: "OpenAI" },
+  { id: "text-embedding-v1", dimensions: 1536, provider: "OpenAI" },
+  { id: "text-embedding-v4", dimensions: 1024, provider: "Qwen" },
+  { id: "gemini-embedding-001", dimensions: 768, provider: "Google" },
+  { id: "gemini-embedding-2-preview", dimensions: 768, provider: "Google" },
+]
+
+const EmbeddingModel = z.object({
+  id: z.string(),
+  name: z.string(),
+  dimensions: z.number().int().optional(),
+  provider: z.string().optional(),
+  source: z.enum(["runtime", "config", "remote", "whitelist"]),
+})
+
+function trim(url?: string) {
+  return (url ?? "").trim().replace(/\/+$/, "")
+}
+
+function normalize(id: string, providerID: string) {
+  const prefix = `${providerID}/`
+  return id.startsWith(prefix) ? id.slice(prefix.length) : id
+}
+
+function embedding(...parts: Array<string | undefined>) {
+  return /(embed|embedding|bge|e5|gte)/i.test(parts.filter(Boolean).join(" "))
+}
+
+function model(
+  map: Map<string, z.infer<typeof EmbeddingModel>>,
+  providerID: string,
+  id?: string,
+  name?: string,
+  source?: z.infer<typeof EmbeddingModel>["source"],
+) {
+  if (!id || !source) return
+  const key = normalize(id, providerID)
+  if (!key || !embedding(key, name)) return
+  map.set(key, { id: key, name: name || key, source })
+}
 
 export const ProviderRoutes = lazy(() =>
   new Hono()
@@ -97,9 +141,12 @@ export const ProviderRoutes = lazy(() =>
               "application/json": {
                 schema: resolver(
                   z.object({
+                    providerID: z.string(),
+                    name: z.string(),
+                    embeddingProvider: z.union([z.literal("openai"), z.literal("custom")]),
                     apiKey: z.string(),
                     baseURL: z.string(),
-                    embeddingModels: z.array(z.string()),
+                    embeddingModels: z.array(EmbeddingModel),
                   }),
                 ),
               },
@@ -116,17 +163,38 @@ export const ProviderRoutes = lazy(() =>
       ),
       async (c) => {
         const { providerID } = c.req.valid("param")
+        const config = await Config.get()
         const providers = await Provider.list()
         const info = providers[providerID]
         if (!info) return c.json({ message: "Provider not found" } as any, 404)
 
-        const apiKey = (info.key ?? (info.options?.apiKey as string | undefined)) ?? ""
+        const auth = await Auth.get(providerID)
+        const cfg = config.provider?.[providerID]
+        const cfgOpts = cfg?.options as Record<string, unknown> | undefined
+        const cfgKey = typeof cfgOpts?.apiKey === "string" && cfgOpts.apiKey !== OAUTH_DUMMY_KEY ? cfgOpts.apiKey : ""
+        const authKey =
+          auth?.type === "api"
+            ? auth.key
+            : auth?.type === "oauth"
+              ? auth.access
+              : auth?.type === "wellknown"
+                ? auth.token
+                : ""
+        const apiKey = authKey || cfgKey || (info.key && info.key !== OAUTH_DUMMY_KEY ? info.key : "")
         const baseURL =
-          ((info.options?.baseURL ?? info.options?.endpoint) as string | undefined) ??
-          Object.values(info.models)[0]?.api.url ??
-          ""
+          trim(typeof cfgOpts?.baseURL === "string" ? cfgOpts.baseURL : undefined) ||
+          trim(typeof cfgOpts?.endpoint === "string" ? cfgOpts.endpoint : undefined) ||
+          trim((info.options?.baseURL ?? info.options?.endpoint) as string | undefined) ||
+          trim(Object.values(info.models)[0]?.api.url)
 
-        let embeddingModels: string[] = []
+        const embeddingModels = new Map<string, z.infer<typeof EmbeddingModel>>()
+        for (const item of Object.values(info.models)) {
+          model(embeddingModels, providerID, item.api.id || item.id, item.name || item.family || item.id, "runtime")
+        }
+        for (const [id, item] of Object.entries(cfg?.models ?? {})) {
+          model(embeddingModels, providerID, item.id ?? id, item.name ?? id, "config")
+        }
+
         if (apiKey && baseURL) {
           try {
             const controller = new AbortController()
@@ -136,18 +204,37 @@ export const ProviderRoutes = lazy(() =>
               signal: controller.signal,
             }).finally(() => clearTimeout(timeout))
             if (resp.ok) {
-              const data = (await resp.json()) as { data?: { id: string }[] }
+              const data = (await resp.json()) as { data?: { id?: string; name?: string; object?: string }[] }
               const list = data?.data ?? []
-              embeddingModels = list
-                .map((m) => m.id)
-                .filter((id) => id.toLowerCase().includes("embed"))
+              for (const item of list) {
+                model(embeddingModels, providerID, item.id, item.name ?? item.object ?? item.id, "remote")
+              }
             }
           } catch {
             // silently return empty list on timeout / network error
           }
         }
 
-        return c.json({ apiKey, baseURL, embeddingModels })
+        if (embeddingModels.size === 0) {
+          for (const wl of EMBEDDING_WHITELIST) {
+            embeddingModels.set(wl.id, {
+              id: wl.id,
+              name: wl.id,
+              dimensions: wl.dimensions,
+              provider: wl.provider,
+              source: "whitelist",
+            })
+          }
+        }
+
+        return c.json({
+          providerID,
+          name: info.name,
+          embeddingProvider: providerID === "openai" ? "openai" : "custom",
+          apiKey,
+          baseURL,
+          embeddingModels: [...embeddingModels.values()],
+        })
       },
     )
     .post(


### PR DESCRIPTION
### Issue for this PR

Closes #379

### Type of change

- [X] New feature
- [ ] Refactor / code improvement
- [ ] Bug fix
- [ ] Documentation

### What does this PR do?

本次 PR 重构了知识库嵌入模型的选择逻辑，核心变更如下：

**后端（`packages/opencode/src/server/routes/provider.ts`）**
- 重构 `/provider/:id/connection` 接口，从多维度提取嵌入模型：先检查 runtime models → config models → 远端 `/models` 探测
- 新增嵌入模型白名单常量 `EMBEDDING_WHITELIST`（包含 OpenAI、Qwen、Google 三家主流嵌入模型及对应维度）
- 当上述三种方式都未获取到模型时，自动用白名单兜底
- 返回结构化的模型列表，包含 `providerID`、`name`、`embeddingProvider`、`embeddingModels`（含 `id`、`name`、`dimensions`、`provider`、`source`）

**前端类型（`packages/app/src/utils/knowledge-embedding.ts`）**
- 新增 `ResolvedEmbeddingModel` 和 `ProviderConnection` 类型定义
- 新增 `labelResolvedEmbeddingModel()` 函数，下拉菜单显示 `提供商/模型名` 格式

**前端 UI（`settings-knowledge.tsx` + `knowledge-dialog.tsx`）**
- 知识库新建页和弹窗的嵌入模型选择不再依赖前端本地识别，改为使用后端返回的模型列表
- 保存配置时嵌入维度优先从后端返回值获取，确保维度正确
- 自定义提供商显示兼容性提示："The current provider may not support these models. Check your provider docs."

### 为什么这样改

经过排查发现，AIHubMix 等聚合代理的 `/models` 端点只返回聊天模型，不包含嵌入模型。但用户手动输入 `text-embedding-3-small` 等模型名是可以正常工作的。因此根本问题不是知识库执行链路，而是模型候选来源。本方案将候选来源从前端本地识别改为后端统一聚合，并用白名单兜底，是最稳定且最小改动量的方案。

### 如何验证

1. 启动后端和前端 dev 服务
2. 进入知识库设置页面
3. 选择已连接的 provider（如 openai 或自定义 provider）
4. 嵌入模型下拉菜单应显示白名单中的 6 个模型
5. 自定义 provider 应显示兼容性提示
6. 保存知识库后验证同步正常

### How did you verify your code works?

- 手动测试知识库新建/编辑页面的嵌入模型选择
- 验证白名单兜底逻辑正常工作
- 验证自定义提供商兼容性提示显示正常
- 验证保存知识库后同步功能正常

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR