### PR TITLE
fix: support removing provider config entries

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3163,7 +3163,7 @@
 
     "get-tsconfig": ["get-tsconfig@4.13.6", "https://registry.npmmirror.com/get-tsconfig/-/get-tsconfig-4.13.6.tgz", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
 
-    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#4af877d", {}, "anomalyco-ghostty-web-4af877d", "sha512-fbEK8mtr7ar4ySsF+JUGjhaZrane7dKphanN+SxHt5XXI6yLMAh/Hpf6sNCOyyVa2UlGCd7YpXG/T2v2RUAX+A=="],
+    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#20bd361", {}, "anomalyco-ghostty-web-20bd361", "sha512-dW0nwaiBBcun9y5WJSvm3HxDLe5o9V0xLCndQvWonRVubU8CS1PHxZpLffyPt1YujPWC13ez03aWxcuKBPYYGQ=="],
 
     "gifwrap": ["gifwrap@0.10.1", "https://registry.npmmirror.com/gifwrap/-/gifwrap-0.10.1.tgz", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw=="],
 

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1145,6 +1145,10 @@ export namespace Config {
         .record(z.string(), Provider)
         .optional()
         .describe("Custom provider configurations and model overrides"),
+      provider_remove: z
+        .array(z.string())
+        .optional()
+        .describe("Remove these provider configs entirely from the config file"),
       mcp: z
         .record(
           z.string(),
@@ -1381,7 +1385,10 @@ export namespace Config {
   export async function update(config: Info) {
     const filepath = path.join(Instance.directory, "config.json")
     const existing = await loadFile(filepath)
-    await Filesystem.writeJson(filepath, mergeDeep(existing, config))
+    const merged = mergeDeep(existing, config)
+    applyProviderReplace(merged, existing, config)
+    delete merged.provider_remove
+    await Filesystem.writeJson(filepath, merged)
     await Instance.dispose()
   }
 
@@ -1533,6 +1540,21 @@ export namespace Config {
     return !!value && typeof value === "object" && !Array.isArray(value)
   }
 
+  function applyProviderReplace(merged: Info, existing: Info, config: Info) {
+    if (!config.provider && !config.provider_remove) return
+    merged.provider = merged.provider ?? {}
+    if (config.provider) {
+      for (const [id, value] of Object.entries(config.provider)) {
+        merged.provider[id] = value
+      }
+    }
+    if (config.provider_remove) {
+      for (const id of config.provider_remove) {
+        delete merged.provider[id]
+      }
+    }
+  }
+
   function patchJsonc(input: string, patch: unknown, path: string[] = []): string {
     if (!isRecord(patch)) {
       const edits = modify(input, path, patch, {
@@ -1544,8 +1566,12 @@ export namespace Config {
       return applyEdits(input, edits)
     }
 
+    const fmt = { formattingOptions: { insertSpaces: true, tabSize: 2 } }
     return Object.entries(patch).reduce((result, [key, value]) => {
-      if (value === undefined) return result
+      if (value === undefined) {
+        const edits = modify(result, [...path, key], undefined, fmt)
+        return applyEdits(result, edits)
+      }
       return patchJsonc(result, value, [...path, key])
     }, input)
   }
@@ -1597,6 +1623,8 @@ export namespace Config {
     const next = await (async () => {
       if (!before) {
         const merged = mergeDeep(await global(), config)
+        applyProviderReplace(merged, await global(), config)
+        delete merged.provider_remove
         await Filesystem.writeJson(filepath, merged)
         return merged
       }
@@ -1604,13 +1632,28 @@ export namespace Config {
       if (!filepath.endsWith(".jsonc")) {
         const existing = parseConfig(before, filepath)
         const merged = mergeDeep(existing, config)
+        applyProviderReplace(merged, existing, config)
+        delete merged.provider_remove
         await Filesystem.writeJson(filepath, merged)
         return merged
       }
 
-      const updated = patchJsonc(before, config)
-      const merged = parseConfig(updated, filepath)
-      await Filesystem.write(filepath, updated)
+      const fmt = { formattingOptions: { insertSpaces: true, tabSize: 2 } }
+      let result = patchJsonc(before, { ...config, provider: undefined, provider_remove: undefined })
+      if (config.provider) {
+        for (const [id, value] of Object.entries(config.provider)) {
+          const edits = modify(result, ["provider", id], value, fmt)
+          result = applyEdits(result, edits)
+        }
+      }
+      if (config.provider_remove) {
+        for (const id of config.provider_remove) {
+          const edits = modify(result, ["provider", id], undefined, fmt)
+          result = applyEdits(result, edits)
+        }
+      }
+      const merged = parseConfig(result, filepath)
+      await Filesystem.write(filepath, result)
       return merged
     })()
 


### PR DESCRIPTION
### Issue for this PR

Closes #389

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Config updates were only deep-merging provider settings, which meant existing provider entries could be overwritten but never removed. This adds an explicit  path and applies it consistently for both JSON and JSONC config writes so stale provider definitions are actually deleted.

### How did you verify your code works?

-  bun.lock                               |  2 +-
 packages/opencode/src/config/config.ts | 53 ++++++++++++++++++++++++++++++----
 2 files changed, 49 insertions(+), 6 deletions(-) to confirm the PR only contains this fix commit
- • Packages in scope: @opencode-ai/app, @opencode-ai/console-app, @opencode-ai/console-core, @opencode-ai/console-function, @opencode-ai/console-mail, @opencode-ai/console-resource, @opencode-ai/desktop, @opencode-ai/desktop-electron, @opencode-ai/enterprise, @opencode-ai/function, @opencode-ai/plugin, @opencode-ai/script, @opencode-ai/sdk, @opencode-ai/slack, @opencode-ai/storybook, @opencode-ai/ui, @opencode-ai/util, @opencode-ai/web, aether
• Running typecheck in 19 packages
• Remote caching disabled
aether:typecheck: cache miss, executing 83ed20687e7483fb
@opencode-ai/enterprise:typecheck: cache miss, executing fca003fda9468da3
@opencode-ai/ui:typecheck: cache miss, executing d018c191b2655f95
@opencode-ai/plugin:typecheck: cache miss, executing 1deb636506570279
@opencode-ai/slack:typecheck: cache miss, executing d4dcb215be7e2132
@opencode-ai/console-function:typecheck: cache miss, executing 23b88a02e17f0c77
@opencode-ai/desktop-electron:typecheck: cache miss, executing bfff8d9c3943ef6b
@opencode-ai/console-core:typecheck: cache miss, executing 4bfe08f6be06aac2
@opencode-ai/app:typecheck: cache miss, executing f17698593ca70052
@opencode-ai/console-app:typecheck: cache miss, executing 0417c5f3d9217779
aether:typecheck: $ bun ../../node_modules/@typescript/native-preview/bin/tsgo.js --noEmit
@opencode-ai/enterprise:typecheck: $ tsgo --noEmit
@opencode-ai/ui:typecheck: $ tsgo --noEmit
@opencode-ai/slack:typecheck: $ tsgo --noEmit
@opencode-ai/plugin:typecheck: $ tsgo --noEmit
@opencode-ai/console-function:typecheck: $ tsgo --noEmit
@opencode-ai/desktop-electron:typecheck: $ tsgo -b
@opencode-ai/console-core:typecheck: $ tsgo --noEmit
@opencode-ai/app:typecheck: $ tsgo -b
@opencode-ai/console-app:typecheck: $ tsgo --noEmit
@opencode-ai/util:typecheck: cache miss, executing d9fd755c808eff8e
@opencode-ai/util:typecheck: $ tsc --noEmit
@opencode-ai/sdk:typecheck: cache miss, executing 267953fb76f92365
@opencode-ai/sdk:typecheck: $ tsgo --noEmit

 Tasks:    12 successful, 12 total
Cached:    0 cached, 12 total
  Time:    2.891s 

branch 'fix/provider-remove-pr' set up to track 'origin/fix/provider-remove-pr'. completed successfully and ran the repo typecheck hook

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR