### PR TITLE
fix: open login dialog directly from sidebar

### DIFF
--- a/packages/app/src/pages/layout/sidebar-shell.tsx
+++ b/packages/app/src/pages/layout/sidebar-shell.tsx
@@ -135,24 +135,15 @@ export const SidebarContent = (props: {
           <Show
             when={auth.isAuthenticated && auth.account}
             fallback={
-              <DropdownMenu>
-                <Tooltip placement={placement()} value={language.t("auth.account.loginOrRegister")}>
-                  <DropdownMenu.Trigger
-                    as={IconButton}
-                    icon="user"
-                    variant="ghost"
-                    size="large"
-                    aria-label={language.t("auth.login.submit")}
-                  />
-                </Tooltip>
-                <DropdownMenu.Portal>
-                  <DropdownMenu.Content class="mt-1">
-                    <DropdownMenu.Item onSelect={openLogin}>
-                      <DropdownMenu.ItemLabel>{language.t("auth.login.submit")}</DropdownMenu.ItemLabel>
-                    </DropdownMenu.Item>
-                  </DropdownMenu.Content>
-                </DropdownMenu.Portal>
-              </DropdownMenu>
+              <Tooltip placement={placement()} value={language.t("auth.login.submit")}>
+                <IconButton
+                  icon="user"
+                  variant="ghost"
+                  size="large"
+                  onClick={openLogin}
+                  aria-label={language.t("auth.login.submit")}
+                />
+              </Tooltip>
             }
           >
             {(account) => (


### PR DESCRIPTION
## Summary

- Remove the unnecessary dropdown menu step for unauthenticated users in the sidebar; clicking the user icon now opens the login dialog directly
- Update the tooltip text from "Login or Register" to "Login" to match the actual behavior