### PR TITLE
fix: skip web update for local builds and fallback fetch update script

### DIFF
--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -319,6 +319,19 @@ async function readWebCurrentVersion() {
 
 async function webCheck(os: z.infer<typeof WebUpdateOS>) {
   const currentVersion = await readWebCurrentVersion()
+  if (Installation.isLocal()) {
+    return {
+      currentVersion,
+      remoteVersion: "",
+      updateAvailable: false,
+      downloaded: false,
+      status: "available" as const,
+      workDir: "",
+      workDirFallback: false,
+      updateError: undefined,
+      checkError: "Local build, skipping update check",
+    }
+  }
   const resolved = resolveWorkDir(os)
   const workDir = resolved?.path ?? ""
   const workDirFallback = resolved?.isFallback ?? false
@@ -866,6 +879,9 @@ export const GlobalRoutes = lazy(() =>
       ),
       async (c) => {
         const { os, version, acceptFallback, force } = c.req.valid("json")
+        if (Installation.isLocal()) {
+          return c.json({ success: false as const, error: "Local build, update is not available" })
+        }
         const resolved = resolveWorkDir(os)
         if (!resolved) {
           return c.json({ success: false as const, error: "Could not determine aether work directory" })
@@ -923,11 +939,35 @@ export const GlobalRoutes = lazy(() =>
           try {
             await fs.access(scriptInDownloads)
           } catch {
-            await writeUpdateState(
-              workDir,
-              updateState(version, "error", `Downloaded update script missing: ${scriptInDownloads}`),
-            )
-            return c.json({ success: false as const, error: `Downloaded update script missing: ${scriptInDownloads}` })
+            log.info("update script missing after installer, fetching as fallback")
+            try {
+              const ymlPath = INSTALLER_YML[os]
+              const manifestBase = `${WEB_UPDATE_BASE}/${ymlPath.substring(0, ymlPath.lastIndexOf("/") + 1)}`
+              const updUrl = `${manifestBase}${upd}`
+              const updRes = await fetch(updUrl)
+              if (!updRes.ok) throw new Error(`HTTP ${updRes.status}`)
+              const updBuf = Buffer.from(await updRes.arrayBuffer())
+              await fs.mkdir(dl, { recursive: true })
+              await fs.writeFile(scriptInDownloads, updBuf)
+              if (os !== "windows") {
+                await fs.chmod(scriptInDownloads, 0o755).catch(() => undefined)
+              }
+              log.info("update script fetched as fallback", { path: scriptInDownloads })
+            } catch (fallbackErr) {
+              const fallbackMsg = fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)
+              await writeUpdateState(
+                workDir,
+                updateState(
+                  version,
+                  "error",
+                  `Downloaded update script missing: ${scriptInDownloads} (fallback fetch also failed: ${fallbackMsg})`,
+                ),
+              )
+              return c.json({
+                success: false as const,
+                error: `Downloaded update script missing: ${scriptInDownloads} (fallback fetch also failed: ${fallbackMsg})`,
+              })
+            }
           }
           try {
             await fs.chmod(scriptInDownloads, 0o755)
@@ -991,6 +1031,9 @@ export const GlobalRoutes = lazy(() =>
       ),
       async (c) => {
         const { os, version, acceptFallback } = c.req.valid("json")
+        if (Installation.isLocal()) {
+          return c.json({ success: false as const, error: "Local build, update is not available" })
+        }
         const resolved = resolveWorkDir(os)
         if (!resolved) {
           return c.json({ success: false as const, error: "Could not determine aether work directory" })


### PR DESCRIPTION
### Issue for this PR

Closes #395

### Type of change

- [x] Bug fix

### What does this PR do?

Two fixes for the web auto-update system in `packages/opencode/src/server/routes/global.ts`:

1. **Gate local builds out of the update flow**: `Installation.isLocal()` returns true when `OPENCODE_VERSION` is `"local"` (bun dev mode). Previously the JS `compareVer` still parsed `"local"` as `[0,0,0]` and flagged an update available, but the Windows installer's PowerShell `[version]"local.0.0.0"` threw a FormatException, causing the installer to skip all downloads (exit 20). The server then found files missing, wrote an error state, and "重新开始更新" repeated the same failure — a dead loop. Now all three web-update endpoints (`check`, `download`, `install`) return early when `isLocal()` is true, preventing the update flow from ever starting.

2. **Fallback fetch for missing update script**: When the installer finishes but the versioned update script (e.g. `update_windows-0.5.3.bat`) is absent in the downloads directory (e.g. manifest lacks an `installer` section), the server now fetches it directly from the remote manifest base URL as a fallback before reporting an error. Only if this fallback also fails does it write an error state.

### How did you verify your code works?

- `bun typecheck` passes in `packages/opencode`
- Manually cleaned stale `web-update-state.json`, `update_windows-0.5.3.bat`, `last-result.yml` from `C:\Users\yqma\AppData\Local\Programs\aether\downloads` and `.aether_web_version` from the bun bin directory
- Verified that `Installation.VERSION = "local"` and `isLocal() = true` in dev mode
- Verified PowerShell `[version]"local.0.0.0"` throws FormatException, matching the observed installer behavior (exit 20, `last-result.yml` shows `status: 'up_to_date'`)

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR