### PR TITLE
feat: show each working directory independently in sidebar with per-directory name/icon overrides

### DIFF
--- a/packages/app/src/components/dialog-edit-project.tsx
+++ b/packages/app/src/components/dialog-edit-project.tsx
@@ -6,7 +6,6 @@ import { useMutation } from "@tanstack/solid-query"
 import { Icon } from "@opencode-ai/ui/icon"
 import { createMemo, For, Show } from "solid-js"
 import { createStore } from "solid-js/store"
-import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { type LocalProject, getAvatarColors } from "@/context/layout"
 import { getFilename } from "@opencode-ai/util/path"
@@ -17,7 +16,6 @@ const AVATAR_COLOR_KEYS = ["pink", "mint", "orange", "purple", "cyan", "lime"] a
 
 export function DialogEditProject(props: { project: LocalProject }) {
   const dialog = useDialog()
-  const globalSDK = useGlobalSDK()
   const globalSync = useGlobalSync()
   const language = useLanguage()
 
@@ -75,19 +73,6 @@ export function DialogEditProject(props: { project: LocalProject }) {
     mutationFn: async () => {
       const name = store.name.trim() === folderName() ? "" : store.name.trim()
       const start = store.startup.trim()
-
-      if (props.project.id && props.project.id !== "global") {
-        await globalSDK.client.project.update({
-          projectID: props.project.id,
-          directory: props.project.worktree,
-          name,
-          icon: { color: store.color, override: store.iconUrl },
-          commands: { start },
-        })
-        globalSync.project.icon(props.project.worktree, store.iconUrl || undefined)
-        dialog.close()
-        return
-      }
 
       globalSync.project.meta(props.project.worktree, {
         name,

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -5,6 +5,7 @@ import { useGlobalSync } from "./global-sync"
 import { useGlobalSDK } from "./global-sdk"
 import { useServer } from "./server"
 import { usePlatform } from "./platform"
+import { getFilename } from "@opencode-ai/util/path"
 import { Project } from "@opencode-ai/sdk/v2"
 import { Persist, persisted, removePersisted } from "@/utils/persist"
 import { decode64 } from "@/utils/base64"
@@ -388,93 +389,21 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       const [childStore] = globalSync.child(project.worktree, { bootstrap: false })
       const projectID = childStore.project
       const metadata = projectID ? globalSync.project.get(projectID) : globalSync.project.fromDir(project.worktree)
-
       const local = childStore.projectMeta
-      const localOverride =
-        local?.name !== undefined ||
-        local?.commands?.start !== undefined ||
-        local?.icon?.override !== undefined ||
-        local?.icon?.color !== undefined
-
-      const base = {
-        ...(metadata ?? {}),
-        ...project,
-        icon: {
-          url: metadata?.icon?.url,
-          override: metadata?.icon?.override ?? childStore.icon,
-          color: metadata?.icon?.color,
-        },
-      }
-
-      const isGlobal = projectID === "global" || (metadata?.id === undefined && localOverride)
-      if (!isGlobal) return base
 
       return {
-        ...base,
-        id: base.id ?? "global",
-        name: local?.name,
-        commands: local?.commands,
+        ...(metadata ?? {}),
+        ...project,
+        id: metadata?.id ?? projectID ?? "global",
+        name: local?.name ?? metadata?.name ?? getFilename(project.worktree),
         icon: {
-          url: base.icon?.url,
-          override: local?.icon?.override,
-          color: local?.icon?.color,
+          url: metadata?.icon?.url,
+          override: local?.icon?.override ?? metadata?.icon?.override ?? childStore.icon,
+          color: local?.icon?.color ?? metadata?.icon?.color,
         },
+        commands: local?.commands ?? metadata?.commands,
       }
     }
-
-    const roots = createMemo(() => {
-      const map = new Map<string, string>()
-      for (const project of globalSync.project.list()) {
-        const sandboxes = project.sandboxes ?? []
-        for (const sandbox of sandboxes) {
-          map.set(sandbox, project.worktree)
-        }
-      }
-      return map
-    })
-
-    const rootFor = (directory: string) => {
-      const map = roots()
-      if (map.size === 0) return directory
-
-      const visited = new Set<string>()
-      const chain = [directory]
-
-      while (chain.length) {
-        const current = chain[chain.length - 1]
-        if (!current) return directory
-
-        const next = map.get(current)
-        if (!next) return current
-
-        if (visited.has(next)) return directory
-        visited.add(next)
-        chain.push(next)
-      }
-
-      return directory
-    }
-
-    createEffect(() => {
-      const projects = server.projects.list()
-      const seen = new Set(projects.map((project) => project.worktree))
-
-      batch(() => {
-        for (const project of projects) {
-          const root = rootFor(project.worktree)
-          if (root === project.worktree) continue
-
-          server.projects.close(project.worktree)
-
-          if (!seen.has(root)) {
-            server.projects.open(root)
-            seen.add(root)
-          }
-
-          if (project.expanded) server.projects.expand(root)
-        }
-      })
-    })
 
     const enriched = createMemo(() => server.projects.list().map(enrich))
     const list = createMemo(() => {
@@ -564,10 +493,9 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       projects: {
         list,
         open(directory: string) {
-          const root = rootFor(directory)
-          if (server.projects.list().find((x) => x.worktree === root)) return
-          globalSync.project.loadSessions(root)
-          server.projects.open(root)
+          if (server.projects.list().find((x) => x.worktree === directory)) return
+          globalSync.project.loadSessions(directory)
+          server.projects.open(directory)
         },
         close(directory: string) {
           server.projects.close(directory)


### PR DESCRIPTION
### Issue for this PR

Closes #407

### Type of change

- [x] New feature

### What does this PR do?

Removes the sandbox-merging effect (`roots/rootFor`) so each working directory appears as its own sidebar tile, and makes `projectMeta` override `name/icon.color/icon.override` for **all** projects (not just global ones). This allows directories sharing the same git repo to display independently with customizable per-directory names and icons.

Key changes (2 files only):
- `context/layout.tsx`: Simplify `enrich()` so projectMeta overrides apply universally with proper fallback chain (`local → metadata → filename`). Remove the `roots/rootFor/createEffect` merging logic that collapsed directories into one tile. Fix `projects.open()` to open the directory directly instead of redirecting to the repo root.
- `dialog-edit-project.tsx`: Remove the server-side `project.update` call; unify to projectMeta-only path so every directory (regardless of projectID) can be renamed/recolored locally.

**Not changed**: All sandbox-based project lookups in `pages/layout.tsx`, `sidebar-project.tsx`, `sidebar-items.tsx`, `dialog-select-file.tsx`, `session-header.tsx`, and `bootstrap.ts` are preserved. The `sandboxes` field still flows through `enrich()` from server metadata, so workspace membership (sidebar workspace items, project selection, workspace actions) continues to work correctly.

### How did you verify your code works?

Typecheck passes (`bun turbo typecheck` — all 12 packages succeed). The previous version of this PR failed `app e2e (linux)` because it also removed the sandbox relationship queries; this version preserves them and only removes the tile-merging effect and the dual-path edit dialog logic.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR