### PR TITLE
feat: add Linux arm64 CD packaging and updates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,6 +80,16 @@ jobs:
               packages/desktop-electron/dist/*.rpm
               packages/desktop-electron/dist/latest*.yml
               packages/desktop-electron/dist/*.blockmap
+          - id: linux-arm64
+            host: ubuntu-24.04-arm
+            rust_target: aarch64-unknown-linux-gnu
+            flag: --linux --arm64
+            files: |
+              packages/desktop-electron/dist/*.AppImage
+              packages/desktop-electron/dist/*.deb
+              packages/desktop-electron/dist/*.rpm
+              packages/desktop-electron/dist/latest*.yml
+              packages/desktop-electron/dist/*.blockmap
     runs-on: ${{ matrix.host }}
     steps:
       - uses: actions/checkout@v4
@@ -123,6 +133,11 @@ jobs:
           OPENCODE_CHANNEL: prod
           CSC_IDENTITY_AUTO_DISCOVERY: false
 
+      - name: Rename Linux arm64 update metadata
+        if: matrix.id == 'linux-arm64'
+        run: mv dist/latest-linux.yml dist/latest-linux-arm64.yml
+        working-directory: packages/desktop-electron
+
       - uses: actions/upload-artifact@v4
         with:
           name: release-electron-${{ matrix.id }}
@@ -155,24 +170,34 @@ jobs:
   build-web-linux:
     if: github.repository == 'Science-Discovery/Aether'
     needs: release
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            host: ubuntu-24.04
+            yml: latest-web-linux.yml
+          - arch: arm64
+            host: ubuntu-24.04-arm
+            yml: latest-web-linux-arm64.yml
+    runs-on: ${{ matrix.host }}
     steps:
       - uses: actions/checkout@v4
 
       - uses: ./.github/actions/setup-bun
 
       - name: Package browser build for Linux
-        run: ./packing_scripts/release-linux-web.sh ${{ needs.release.outputs.version }}
+        run: ./packing_scripts/release-linux-web.sh ${{ needs.release.outputs.version }} ${{ matrix.arch }}
         env:
           OPENCODE_VERSION: ${{ needs.release.outputs.version }}
           OPENCODE_CHANNEL: prod
 
       - uses: actions/upload-artifact@v4
         with:
-          name: release-web-linux
+          name: release-web-linux-${{ matrix.arch }}
           path: |
-            packages/opencode/dist/aether-linux-x64.zip
-            packages/opencode/dist/latest-web-linux.yml
+            packages/opencode/dist/aether-linux-${{ matrix.arch }}.zip
+            packages/opencode/dist/${{ matrix.yml }}
           if-no-files-found: error
 
   build-web-windows:

--- a/Update/aether_linux_installer.md
+++ b/Update/aether_linux_installer.md
@@ -34,16 +34,18 @@
 最新版本：
 
 - `https://aether.aiphys.cn/download/latest/linux-x64.yml`
+- `https://aether.aiphys.cn/download/latest/linux-arm64.yml`
 - `https://aether.aiphys.cn/download/latest/windows-x64.yml`
 
 指定版本：
 
 - `https://aether.aiphys.cn/download/<version>/linux-x64.yml`
+- `https://aether.aiphys.cn/download/<version>/linux-arm64.yml`
 - `https://aether.aiphys.cn/download/<version>/windows-x64.yml`
 
 说明：
 
-- Linux 路径这里按与 Windows/macOS 相同的命名模式实现，当前假设平台标识为 `linux-x64`
+- Linux 路径按当前机器架构自动选择 `linux-x64` 或 `linux-arm64`，命名模式与 Windows/macOS 保持一致。
 
 示例：
 

--- a/Update/aether_linux_installer.sh
+++ b/Update/aether_linux_installer.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 base="https://aether.aiphys.cn/download"
-latest="latest/linux-x64.yml"
 default="$HOME/.local/share/applications/aether"
 mode="init"
 arg=""
@@ -22,6 +21,19 @@ sum_err=32
 run_err=33
 dir_err=40
 arg_err=50
+
+case "$(uname -m)" in
+  aarch64|arm64) arch="arm64" ;;
+  x86_64|amd64) arch="x64" ;;
+  *)
+    echo "Unsupported Linux architecture: $(uname -m)"
+    exit "$arg_err"
+    ;;
+esac
+
+plat="linux-$arch"
+pkg_base="aether-$plat"
+latest="latest/$plat.yml"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -80,7 +92,7 @@ keep="3"
 openssl_mode=""
 openssl_checked=0
 openssl_lib=""
-lib_roots="/usr/lib/x86_64-linux-gnu /usr/lib64 /usr/lib /lib/x86_64-linux-gnu /lib64 /lib"
+lib_roots="/usr/lib/$arch-linux-gnu /lib/$arch-linux-gnu /usr/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu /lib/aarch64-linux-gnu /usr/lib64 /usr/lib /lib64 /lib"
 
 lib_exact() {
   local name="$1"
@@ -241,7 +253,7 @@ cache_paths() {
   else
     pkg_ext=".$pkg_ext"
   fi
-  pkg_file="$dl/aether-linux-x64-$ver$pkg_ext"
+  pkg_file="$dl/$pkg_base-$ver$pkg_ext"
   ins_file=""
   if [ -n "$ins_url" ] && [ -n "$ins_name" ]; then
     ins_ext="${ins_name##*.}"
@@ -643,7 +655,7 @@ grab() {
   else
     pkg_ext=".$pkg_ext"
   fi
-  pkg_file="$dl/aether-linux-x64-$ver$pkg_ext"
+  pkg_file="$dl/$pkg_base-$ver$pkg_ext"
 
   need_pkg=1
   if [ -f "$pkg_file" ]; then
@@ -714,7 +726,7 @@ prune() {
   local arr n cut i list item
 
   shopt -s nullglob
-  arr=("$dl"/aether-linux-x64-*.*)
+  arr=("$dl"/"$pkg_base"-*.*)
   shopt -u nullglob
   n="${#arr[@]}"
   if [ "$n" -gt "$keep" ]; then
@@ -759,7 +771,7 @@ Usage:
 
 Remote manifests:
   $base/$latest
-  $base/1.2.3/linux-x64.yml
+  $base/1.2.3/$plat.yml
 
 Downloaders:
   curl (preferred), wget, or busybox wget
@@ -954,7 +966,7 @@ if [ "$mode" = "manual" ]; then
     echo "Work directory failed."
     exit "$dir_err"
   }
-  manifest_url="$base/$req/linux-x64.yml"
+  manifest_url="$base/$req/$plat.yml"
   if ! manifest "$manifest_url" version; then
     code="$?"
     if [ "$code" = "$miss" ]; then

--- a/Update/aether_linux_installer_devtest.sh
+++ b/Update/aether_linux_installer_devtest.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 base="https://aether.aiphys.cn/api/download2"
-latest="latest/linux-x64.yml"
 auth_name="x-download-admin-password"
 auth_value="ZkTi123456"
 default="$HOME/.local/share/applications/aether"
@@ -24,6 +23,19 @@ sum_err=32
 run_err=33
 dir_err=40
 arg_err=50
+
+case "$(uname -m)" in
+  aarch64|arm64) arch="arm64" ;;
+  x86_64|amd64) arch="x64" ;;
+  *)
+    echo "Unsupported Linux architecture: $(uname -m)"
+    exit "$arg_err"
+    ;;
+esac
+
+plat="linux-$arch"
+pkg_base="aether-$plat"
+latest="latest/$plat.yml"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -82,7 +94,7 @@ keep="3"
 openssl_mode=""
 openssl_checked=0
 openssl_lib=""
-lib_roots="/usr/lib/x86_64-linux-gnu /usr/lib64 /usr/lib /lib/x86_64-linux-gnu /lib64 /lib"
+lib_roots="/usr/lib/$arch-linux-gnu /lib/$arch-linux-gnu /usr/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu /lib/aarch64-linux-gnu /usr/lib64 /usr/lib /lib64 /lib"
 
 lib_exact() {
   local name="$1"
@@ -243,7 +255,7 @@ cache_paths() {
   else
     pkg_ext=".$pkg_ext"
   fi
-  pkg_file="$dl/aether-linux-x64-$ver$pkg_ext"
+  pkg_file="$dl/$pkg_base-$ver$pkg_ext"
   ins_file=""
   if [ -n "$ins_url" ] && [ -n "$ins_name" ]; then
     ins_ext="${ins_name##*.}"
@@ -641,7 +653,7 @@ grab() {
   else
     pkg_ext=".$pkg_ext"
   fi
-  pkg_file="$dl/aether-linux-x64-$ver$pkg_ext"
+  pkg_file="$dl/$pkg_base-$ver$pkg_ext"
 
   need_pkg=1
   if [ -f "$pkg_file" ]; then
@@ -712,7 +724,7 @@ prune() {
   local arr n cut i list item
 
   shopt -s nullglob
-  arr=("$dl"/aether-linux-x64-*.*)
+  arr=("$dl"/"$pkg_base"-*.*)
   shopt -u nullglob
   n="${#arr[@]}"
   if [ "$n" -gt "$keep" ]; then
@@ -757,7 +769,7 @@ Usage:
 
 Remote manifests:
   $base/$latest
-  $base/1.2.3/linux-x64.yml
+  $base/1.2.3/$plat.yml
 
 Downloaders:
   curl (preferred), wget, or busybox wget
@@ -952,7 +964,7 @@ if [ "$mode" = "manual" ]; then
     echo "Work directory failed."
     exit "$dir_err"
   }
-  manifest_url="$base/$req/linux-x64.yml"
+  manifest_url="$base/$req/$plat.yml"
   if ! manifest "$manifest_url" version; then
     code="$?"
     if [ "$code" = "$miss" ]; then

--- a/Update/aether_release_protocol.md
+++ b/Update/aether_release_protocol.md
@@ -47,6 +47,8 @@
   `https://aether.aiphys.cn/download/latest/mac-arm64.yml`
 - Linux x64
   `https://aether.aiphys.cn/download/latest/linux-x64.yml`
+- Linux arm64
+  `https://aether.aiphys.cn/download/latest/linux-arm64.yml`
 
 指定版本 manifest：
 
@@ -56,6 +58,8 @@
   `https://aether.aiphys.cn/download/<version>/mac-arm64.yml`
 - Linux x64
   `https://aether.aiphys.cn/download/<version>/linux-x64.yml`
+- Linux arm64
+  `https://aether.aiphys.cn/download/<version>/linux-arm64.yml`
 
 推荐的版本目录示例：
 
@@ -65,13 +69,16 @@ download/
     windows-x64.yml
     mac-arm64.yml
     linux-x64.yml
+    linux-arm64.yml
   1.2.3/
     windows-x64.yml
     mac-arm64.yml
     linux-x64.yml
+    linux-arm64.yml
     aether-1.2.3-windows-x64.zip
     aether-1.2.3-mac-arm64.zip
     aether-1.2.3-linux-x64.tar.gz
+    aether-1.2.3-linux-arm64.tar.gz
     install-windows.bat
     install-darwin.command
     install-linux.sh
@@ -379,11 +386,12 @@ Aether 调用安装入口脚本后，推荐按以下顺序处理：
   `mac-arm64`
 - Linux x64
   `linux-x64`
+- Linux arm64
+  `linux-arm64`
 
 如果未来新增平台，例如：
 
 - `mac-x64`
-- `linux-arm64`
 - `windows-arm64`
 
 可沿用同一目录结构和同一 manifest 协议。

--- a/Update/offline-update-regression-checklist.md
+++ b/Update/offline-update-regression-checklist.md
@@ -4,7 +4,7 @@ Short manual checks for desktop update recovery.
 
 ## Scope
 
-Cover offline web update behavior across Windows and Linux.
+Cover offline web update behavior across Windows and Linux x64/arm64.
 
 Focus on these regressions:
 
@@ -12,7 +12,7 @@ Focus on these regressions:
 - Partial downloads never enable install
 - In-progress manual download state survives while the same app/server process stays alive
 - Failed update or install offers a restart-from-scratch recovery path
-- Linux downloaded zip plus script installs and relaunches into the new version
+- Linux x64 and arm64 downloaded zip plus script installs and relaunches into the new version
 - Download completion requires matching package size and checksum from manifest metadata
 
 ## Environment/setup

--- a/Update/update_linux.sh
+++ b/Update/update_linux.sh
@@ -7,6 +7,17 @@ dl_err=31
 run_err=33
 arg_err=50
 
+case "$(uname -m)" in
+  aarch64|arm64) arch="arm64" ;;
+  x86_64|amd64) arch="x64" ;;
+  *)
+    echo "Unsupported Linux architecture: $(uname -m)"
+    exit "$arg_err"
+    ;;
+esac
+
+pkg_base="aether-linux-$arch"
+
 mode="install"
 arg=""
 tmp=""
@@ -48,7 +59,7 @@ Behavior:
   - Marks the latest installed version in .aether_web_version
 
 Package name pattern:
-  aether-linux-x64-<version>.*
+  $pkg_base-<version>.*
 
 Exit codes:
   0   install finished successfully
@@ -242,7 +253,7 @@ list_ssl() {
     if command -v ldconfig >/dev/null 2>&1; then
       ldconfig -p 2>/dev/null | awk '/libssl\.so\./{print $NF}'
     fi
-    for p in /lib /usr/lib /lib64 /usr/lib64 /usr/local/lib /usr/local/lib64 /lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu; do
+    for p in /lib /usr/lib /lib64 /usr/lib64 /usr/local/lib /usr/local/lib64 /lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu /lib/aarch64-linux-gnu /usr/lib/aarch64-linux-gnu; do
       [ -d "$p" ] || continue
       find "$p" -maxdepth 2 -type f -name 'libssl.so.*' 2>/dev/null
     done
@@ -254,7 +265,7 @@ list_crypto() {
     if command -v ldconfig >/dev/null 2>&1; then
       ldconfig -p 2>/dev/null | awk '/libcrypto\.so\./{print $NF}'
     fi
-    for p in /lib /usr/lib /lib64 /usr/lib64 /usr/local/lib /usr/local/lib64 /lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu; do
+    for p in /lib /usr/lib /lib64 /usr/lib64 /usr/local/lib /usr/local/lib64 /lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu /lib/aarch64-linux-gnu /usr/lib/aarch64-linux-gnu; do
       [ -d "$p" ] || continue
       find "$p" -maxdepth 2 -type f -name 'libcrypto.so.*' 2>/dev/null
     done
@@ -482,7 +493,7 @@ next="$work/.aether_$ver.next"
 echo "[0/4] Work directory: $work"
 
 shopt -s nullglob
-arr=("$dl"/aether-linux-x64-"$ver".*)
+arr=("$dl"/"$pkg_base"-"$ver".*)
 shopt -u nullglob
 if [ "${#arr[@]}" -eq 0 ]; then
   echo "[install] Package not found for version $ver in $dl"

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -58,11 +58,6 @@ const WebUpdateState = z.object({
 })
 
 const WEB_UPDATE_BASE_DEFAULT = "https://aether.aiphys.cn/download"
-const UPDATE_PKG_PREFIX: Record<string, string> = {
-  darwin: "aether-darwin",
-  linux: "aether-linux-x64",
-  windows: "aether-windows-x64",
-}
 const UPDATE_RUN = (() => {
   try {
     return crypto.randomUUID()
@@ -71,15 +66,15 @@ const UPDATE_RUN = (() => {
   }
 })()
 
-const INSTALLER_YML: Record<string, string> = {
+const INSTALLER_YML: Record<string, string | ((arch: string) => string)> = {
   darwin: "latest/mac-arm64.yml",
-  linux: "latest/linux-x64.yml",
+  linux: (arch) => `latest/linux-${arch}.yml`,
   windows: "latest/windows-x64.yml",
 }
 
-const UPDATE_YML: Record<string, string> = {
+const UPDATE_YML: Record<string, string | ((arch: string) => string)> = {
   darwin: "mac-arm64.yml",
-  linux: "linux-x64.yml",
+  linux: (arch) => `linux-${arch}.yml`,
   windows: "windows-x64.yml",
 }
 
@@ -190,10 +185,19 @@ function abs(url: string, val: string) {
   return `${url.slice(0, url.lastIndexOf("/"))}/${val}`
 }
 
+function arch() {
+  return process.arch === "arm64" ? "arm64" : "x64"
+}
+
+function yml(map: Record<string, string | ((arch: string) => string)>, os: z.infer<typeof WebUpdateOS>) {
+  const item = map[os]
+  return typeof item === "function" ? item(arch()) : item
+}
+
 async function manifestUrl(os: z.infer<typeof WebUpdateOS>, version?: string) {
   const base = await getUpdateBase()
-  if (!version) return `${base}/${INSTALLER_YML[os]}`
-  return `${base}/${version}/${UPDATE_YML[os]}`
+  if (!version) return `${base}/${yml(INSTALLER_YML, os)}`
+  return `${base}/${version}/${yml(UPDATE_YML, os)}`
 }
 
 function parseManifest(text: string) {
@@ -300,7 +304,7 @@ async function fetchManifest(os: z.infer<typeof WebUpdateOS>, version?: string) 
 
 function packageMatch(os: string, ver: string, name: string) {
   const ext = UPDATE_PKG_EXT[os] ?? ".dmg"
-  const prefix = UPDATE_PKG_PREFIX[os] ?? "aether"
+  const prefix = os === "linux" ? `aether-linux-${arch()}` : os === "windows" ? "aether-windows-x64" : "aether-darwin"
   return name.startsWith(prefix) && name.includes(ver) && name.toLowerCase().endsWith(ext)
 }
 
@@ -665,6 +669,8 @@ async function streamEvents(c: Context, subscribe: (q: AsyncQueue<string | null>
 
 export const WebUpdateTest = {
   fetchManifest,
+  manifestUrl,
+  packageMatch,
   parseManifest,
   readUpdateState,
   resetUpdate,

--- a/packages/opencode/test/server/web-update.test.ts
+++ b/packages/opencode/test/server/web-update.test.ts
@@ -25,6 +25,19 @@ async function sha(file: string) {
 }
 
 describe("web update helpers", () => {
+  test("linux arm64 uses arm64 manifests and packages", async () => {
+    const desc = Object.getOwnPropertyDescriptor(process, "arch")
+    Object.defineProperty(process, "arch", { value: "arm64" })
+    try {
+      expect((await WebUpdateTest.manifestUrl("linux")).endsWith("/latest/linux-arm64.yml")).toBe(true)
+      expect((await WebUpdateTest.manifestUrl("linux", "1.2.3")).endsWith("/1.2.3/linux-arm64.yml")).toBe(true)
+      expect(WebUpdateTest.packageMatch("linux", "1.2.3", "aether-linux-arm64-1.2.3.zip")).toBe(true)
+      expect(WebUpdateTest.packageMatch("linux", "1.2.3", "aether-linux-x64-1.2.3.zip")).toBe(false)
+    } finally {
+      if (desc) Object.defineProperty(process, "arch", desc)
+    }
+  })
+
   test("parseManifest reads package metadata from files list", () => {
     const data = WebUpdateTest.parseManifest(`version: 1.2.3
 files:

--- a/packing_scripts/release-linux-web.sh
+++ b/packing_scripts/release-linux-web.sh
@@ -4,30 +4,54 @@ set -euo pipefail
 root="$(cd "$(dirname "$0")/.." && pwd)"
 ver="${1:-$(cd "$root" && bun -e 'const p=await Bun.file("packages/opencode/package.json").json();console.log(p.version)')}"
 date="$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")"
+arch="${2:-}"
+
+if [ -z "$arch" ]; then
+  case "$(uname -m)" in
+    aarch64|arm64) arch="arm64" ;;
+    x86_64|amd64) arch="x64" ;;
+    *)
+      echo "Unsupported Linux architecture: $(uname -m)"
+      exit 1
+      ;;
+  esac
+fi
+
+case "$arch" in
+  arm64) uv="aarch64-unknown-linux-gnu" ;;
+  x64) uv="x86_64-unknown-linux-gnu" ;;
+  *)
+    echo "Unsupported Linux architecture: $arch"
+    exit 1
+    ;;
+esac
+
+pkg="aether-linux-$arch"
+yml="latest-web-linux"
+[ "$arch" = "x64" ] || yml="$yml-$arch"
 
 pushd "$root/packages/opencode" >/dev/null
 bun install
 bun run build -- --single
 
-src="dist/aether-linux-x64/bin"
+src="dist/$pkg/bin"
 if [ ! -d "$src" ]; then
-  echo "Missing $src. Run this on linux x64."
+  echo "Missing $src. Run this on linux $arch."
   exit 1
 fi
 
-uv="$src/wechat-bridge/runtime/uv"
+uv_dir="$src/wechat-bridge/runtime/uv"
 
-if [ -d "$uv" ]; then
-  for dir in "$uv"/*; do
+if [ -d "$uv_dir" ]; then
+  for dir in "$uv_dir"/*; do
     [ -d "$dir" ] || continue
     case "$(basename "$dir")" in
-      *x86_64-unknown-linux-gnu*) ;;
+      *"$uv"*) ;;
       *) rm -rf "$dir" ;;
     esac
   done
 fi
 
-pkg="aether-linux-x64"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 out="$tmp/$pkg"
@@ -52,17 +76,18 @@ if [ -f "$out/Aether.sh" ]; then
 fi
 
 cat >"$out/README_FIRST.txt" <<'EOF'
-Aether Web (Linux x64)
+Aether Web (Linux ARCH)
 
 Quick start
-1) Extract this ZIP and copy the folder aether-linux-x64 to a local path, for example: ~/Applications/Aether-Web
+1) Extract this ZIP and copy the folder PACKAGE to a local path, for example: ~/Applications/Aether-Web
 2) Open Terminal in that folder and run: ./Aether.sh
 
 Updates
 - Use Aether's in-app update flow to download and install newer versions.
 EOF
+sed -i "s/ARCH/$arch/g;s/PACKAGE/$pkg/g" "$out/README_FIRST.txt"
 
-zip="dist/aether-linux-x64.zip"
+zip="dist/$pkg.zip"
 zip_path="$PWD/$zip"
 rm -f "$zip"
 (cd "$tmp" && zip -r "$zip_path" "$pkg")
@@ -70,10 +95,10 @@ rm -f "$zip"
 sha="$(openssl dgst -sha512 -binary "$zip" | openssl base64 -A)"
 size="$(wc -c <"$zip" | tr -d '[:space:]')"
 
-cat >dist/latest-web-linux.yml <<EOF
+cat >"dist/$yml.yml" <<EOF
 version: $ver
 files:
-  - url: aether-linux-x64.zip
+  - url: $pkg.zip
     sha512: $sha
     size: $size
 releaseDate: '$date'
@@ -83,5 +108,5 @@ popd >/dev/null
 
 echo "Done"
 echo "Asset: packages/opencode/$zip"
-echo "YML:   packages/opencode/dist/latest-web-linux.yml"
+echo "YML:   packages/opencode/dist/$yml.yml"
 echo "Note:  ZIP includes folder $pkg and aether_linux_installer.sh"


### PR DESCRIPTION
### Issue for this PR

Closes #409

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds Linux arm64 support to the web CD and update flow.

This keeps the existing Linux x64 artifact names unchanged, adds an arm64 Linux web release matrix entry, and makes Linux installer/update code select architecture-specific manifests and package names. The web update backend now resolves Linux manifests and package matching from the running process architecture, so x64 continues using `linux-x64` and arm64 uses `linux-arm64`.

The release protocol and regression checklist are updated to document Linux x64/arm64 coverage.

### How did you verify your code works?

- `bash -n Update/aether_linux_installer.sh`
- `bash -n Update/update_linux.sh`
- `bash -n packing_scripts/release-linux-web.sh`
- `TMPDIR=/tmp/aether-owned-test bun test test/server/web-update.test.ts` from `packages/opencode`
- `bun typecheck` from `packages/opencode`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR