### PR TITLE
feat: auto-create .aether directory on project bootstrap

### DIFF
--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -1,3 +1,5 @@
+import fs from "fs/promises"
+import path from "path"
 import { Plugin } from "../plugin"
 import { Format } from "../format"
 import { LSP } from "../lsp"
@@ -12,9 +14,12 @@ import { Command } from "../command"
 import { Instance } from "./instance"
 import { Log } from "@/util/log"
 import { ShareNext } from "@/share/share-next"
+import { PROJECT } from "@/persist/naming"
 
 export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
+  const root = Instance.worktree === "/" ? Instance.directory : Instance.worktree
+  await fs.mkdir(path.join(root, PROJECT), { recursive: true })
   await Plugin.init()
   ShareNext.init()
   Format.init()

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -18,7 +18,7 @@ import { PROJECT } from "@/persist/naming"
 
 export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
-  const root = Instance.worktree === "/" ? Instance.directory : Instance.worktree
+  const root = Instance.project.worktree === "/" ? Instance.directory : Instance.project.worktree
   await fs.mkdir(path.join(root, PROJECT), { recursive: true })
   await Plugin.init()
   ShareNext.init()

--- a/packages/opencode/test/project/bootstrap.test.ts
+++ b/packages/opencode/test/project/bootstrap.test.ts
@@ -1,0 +1,46 @@
+import fs from "fs/promises"
+import { describe, expect, test } from "bun:test"
+import { Instance } from "../../src/project/instance"
+import { InstanceBootstrap } from "../../src/project/bootstrap"
+import { PROJECT } from "../../src/persist/naming"
+import { tmpdir } from "../fixture/fixture"
+import { Log } from "../../src/util/log"
+import path from "path"
+
+Log.init({ print: false })
+
+describe("InstanceBootstrap creates .aether directory", () => {
+  test("creates .aether in git project root", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const aetherDir = path.join(tmp.path, PROJECT)
+    expect(await fs.stat(aetherDir).catch(() => null)).toBeNull()
+
+    await Instance.provide({ directory: tmp.path, init: InstanceBootstrap, fn: async () => {} })
+
+    expect(await fs.stat(aetherDir).then(() => true).catch(() => false)).toBe(true)
+  })
+
+  test("creates .aether in non-git directory", async () => {
+    await using tmp = await tmpdir()
+
+    const aetherDir = path.join(tmp.path, PROJECT)
+    expect(await fs.stat(aetherDir).catch(() => null)).toBeNull()
+
+    await Instance.provide({ directory: tmp.path, init: InstanceBootstrap, fn: async () => {} })
+
+    expect(await fs.stat(aetherDir).then(() => true).catch(() => false)).toBe(true)
+  })
+
+  test("does not fail when .aether already exists", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const aetherDir = path.join(tmp.path, PROJECT)
+    await fs.mkdir(aetherDir, { recursive: true })
+    expect(await fs.stat(aetherDir).then(() => true).catch(() => false)).toBe(true)
+
+    await Instance.provide({ directory: tmp.path, init: InstanceBootstrap, fn: async () => {} })
+
+    expect(await fs.stat(aetherDir).then(() => true).catch(() => false)).toBe(true)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #414

### Type of change

- [x] New feature

### What does this PR do?

When a project is opened (instance bootstrapped), automatically creates the `.aether` directory in the project root if it doesn't already exist. This ensures all subsystems (skills, config, knowledge base) have a consistent starting state.

Implementation details:
- Added 2 lines in `InstanceBootstrap()` (bootstrap.ts) — uses `PROJECT` constant from `naming.ts`, not a hardcoded path
- For git projects, creates `.aether` at the worktree root; for non-git directories, at `Instance.directory`
- Uses `fs.mkdir` with `{ recursive: true }` — idempotent, no error if directory already exists

### How did you verify your code works?

- `bun typecheck` passes (pre-commit hook confirmed all 12 packages typecheck)
- 3 new unit tests in `bootstrap.test.ts` pass:
  - Creates `.aether` in git project root
  - Creates `.aether` in non-git directory
  - No failure when `.aether` already exists
- All 30 existing project tests still pass

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR