### PR TITLE
feat(knowledge): 知识库改用后端聚合嵌入模型列表 + 白名单分级兜底

### DIFF
--- a/packages/opencode/src/server/routes/provider.ts
+++ b/packages/opencode/src/server/routes/provider.ts
@@ -32,6 +32,7 @@ const WHITELIST_BY_VENDOR: Record<string, typeof EMBEDDING_WHITELIST> = {
   qwen: [{ id: "text-embedding-v4", dimensions: 1024, provider: "Qwen" }],
   dashscope: [{ id: "text-embedding-v4", dimensions: 1024, provider: "Qwen" }],
   alibaba: [{ id: "text-embedding-v4", dimensions: 1024, provider: "Qwen" }],
+  "alibaba-cn": [{ id: "text-embedding-v4", dimensions: 1024, provider: "Qwen" }],
   google: [
     { id: "gemini-embedding-001", dimensions: 768, provider: "Google" },
     { id: "gemini-embedding-2-preview", dimensions: 768, provider: "Google" },


### PR DESCRIPTION
### Issue for this PR

Closes #418

### Type of change

- [X] New feature
- [ ] Bug fix
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

当前知识库嵌入模型选择依赖 `/models` 端点探测，但 AIHubMix 等聚合代理和多数内置提供商的 `/models` 端点不返回嵌入模型。用户手动输入模型名可以正常工作，说明问题在候选来源而非执行链路。

本次 PR 将候选来源从前端本地识别改为后端统一聚合：

**后端改动（`packages/opencode/src/server/routes/provider.ts`）**

- 重构 `/provider/:id/connection`，返回结构化模型列表（含 `providerID`、`name`、`embeddingProvider`、`apiKey`、`baseURL`、`embeddingModels`）
- 新增 `EMBEDDING_WHITELIST`，包含 OpenAI/Qwen/Google 共 6 个嵌入模型及对应维度
- 新增 `WHITELIST_BY_VENDOR`，按提供商 ID 映射对应的白名单子集。内置提供商无对应模型时列表为空，只有手动输入选项
- 自定义 provider 不在已知提供商列表中时，返回完整白名单
- 修复 provider 配置解析，支持从 Auth、Config、Provider runtime 多层级提取 apiKey 和 baseURL

**前端改动**

- `packages/app/src/utils/knowledge-embedding.ts`：新增 `ResolvedEmbeddingModel`、`ProviderConnection` 类型和 `labelResolvedEmbeddingModel()` 工具函数
- `packages/app/src/components/settings-knowledge.tsx` 和 `knowledge-dialog.tsx`：模型下拉改用后端返回的列表，不再调用前端 `listEmbeddingModels()`
- 自定义 provider 显示兼容性提示文案

### How did you verify your code works?

手动测试知识库新建和编辑页面的嵌入模型选择：
- 确认 `openai` 只显示 3 个 OpenAI 模型
- 确认 `google` 只显示 2 个 Gemini 模型
- 确认无嵌入模型的内置提供商只显示手动输入
- 确认自定义 provider 显示全部白名单模型
- 确认 `alibaba-cn` 显示 Qwen 嵌入模型
- 确认保存后知识库同步正常

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR