### PR TITLE
fix: re-enable auto-update for local builds

### DIFF
--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -521,19 +521,6 @@ async function readWebCurrentVersion() {
 
 async function webCheck(os: z.infer<typeof WebUpdateOS>) {
   const currentVersion = await readWebCurrentVersion()
-  if (Installation.isLocal()) {
-    return {
-      currentVersion,
-      remoteVersion: "",
-      updateAvailable: false,
-      downloaded: false,
-      status: "available" as const,
-      workDir: "",
-      workDirFallback: false,
-      updateError: undefined,
-      checkError: "Local build, skipping update check",
-    }
-  }
   const resolved = resolveWorkDir(os)
   const workDir = resolved?.path ?? ""
   const workDirFallback = resolved?.isFallback ?? false
@@ -1079,9 +1066,6 @@ export const GlobalRoutes = lazy(() =>
       ),
       async (c) => {
         const { os, version, acceptFallback, force } = c.req.valid("json")
-        if (Installation.isLocal()) {
-          return c.json({ success: false as const, error: "Local build, update is not available" })
-        }
         const resolved = resolveWorkDir(os)
         if (!resolved) {
           return c.json({ success: false as const, error: "Could not determine aether work directory" })
@@ -1231,9 +1215,6 @@ export const GlobalRoutes = lazy(() =>
       ),
       async (c) => {
         const { os, version, acceptFallback } = c.req.valid("json")
-        if (Installation.isLocal()) {
-          return c.json({ success: false as const, error: "Local build, update is not available" })
-        }
         const resolved = resolveWorkDir(os)
         if (!resolved) {
           return c.json({ success: false as const, error: "Could not determine aether work directory" })


### PR DESCRIPTION
### Issue for this PR

Reverts the `isLocal()` gating from #398 (partial revert — no fallback logic changes).

### Type of change

- [x] Bug fix

### What does this PR do?

Removes the three `Installation.isLocal()` early-return gates in `packages/opencode/src/server/routes/global.ts` that were added in #398:

1. **`webCheck()`** — removed the block that returned `updateAvailable: false` with `checkError: "Local build, skipping update check"`
2. **`/web-update/download`** — removed the block that returned `{ success: false, error: "Local build, update is not available" }`
3. **`/web-update/install`** — removed the block that returned `{ success: false, error: "Local build, update is not available" }`

These gates prevented local (dev) builds from entering the auto-update flow entirely. After this PR, local builds will once again go through the normal update check → download → install pipeline, the same as any production build.

No fallback fetch logic is touched (as requested).

### How did you verify your code works?

- `bun typecheck` passes in `packages/opencode`
- Turbo monorepo typecheck passes (all 12 packages)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR