### PR TITLE
feat: enable conversation tree by default

### DIFF
--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -53,7 +53,7 @@ const defaultSettings: Settings = {
     releaseNotes: true,
     followup: "steer",
     reviewBatch: 10,
-    branchesTab: false,
+    branchesTab: true,
     branchGraphFontSize: "md",
     branchGraphRowDensity: "normal",
     branchGraphOrderMode: "sequence",


### PR DESCRIPTION
### Issue for this PR

Closes #405

### Type of change

- [x] New feature

### What does this PR do?

Changes the `branchesTab` default value from `false` to `true` in `packages/app/src/context/settings.tsx`, so the conversation tree is shown inline in the session list sidebar by default. Users no longer need to manually enable it in settings.

### How did you verify your code works?

- `bun turbo typecheck` passes

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR