### PR TITLE
fix: align web updater source selection and installed version fallback

### DIFF
--- a/Update/aether_darwin_installer.command
+++ b/Update/aether_darwin_installer.command
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-base="https://aether.aiphys.cn/download"
+base="${AETHER_UPDATE_BASE:-https://aether.aiphys.cn/download}"
 latest="latest/mac-arm64.yml"
 default="$HOME/Applications/aether"
 mode="init"

--- a/Update/aether_linux_installer.sh
+++ b/Update/aether_linux_installer.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-base="https://aether.aiphys.cn/download"
+base="${AETHER_UPDATE_BASE:-https://aether.aiphys.cn/download}"
 default="$HOME/.local/share/applications/aether"
 mode="init"
 arg=""

--- a/Update/aether_windows_installer.bat
+++ b/Update/aether_windows_installer.bat
@@ -2,7 +2,7 @@
 chcp 65001 >nul
 setlocal EnableExtensions EnableDelayedExpansion
 
-set "BASE=https://aether.aiphys.cn/download"
+if defined AETHER_UPDATE_BASE (set "BASE=%AETHER_UPDATE_BASE%") else (set "BASE=https://aether.aiphys.cn/download")
 set "LATEST=latest/windows-x64.yml"
 if not defined LOCALAPPDATA set "LOCALAPPDATA=%USERPROFILE%\AppData\Local"
 set "DEFAULT=%LOCALAPPDATA%\Programs\aether"

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -496,8 +496,9 @@ async function fetchInstallerScript(os: string): Promise<string | null> {
       log.error("failed to fetch installer script", { url, status: res.status })
       return null
     }
-    const buf = Buffer.from(await res.arrayBuffer())
-    await fs.writeFile(dest, buf)
+    const text = await res.text()
+    const patched = patchInstallerScript(os, text)
+    await fs.writeFile(dest, patched)
     if (os !== "windows") {
       await fs.chmod(dest, 0o755).catch(() => undefined)
     }
@@ -508,8 +509,41 @@ async function fetchInstallerScript(os: string): Promise<string | null> {
   }
 }
 
+function patchInstallerScript(os: string, text: string): string {
+  if (os === "windows") {
+    return text.replace(
+      /set\s+"BASE=(https:\/\/[^\s"]+)"/,
+      'if defined AETHER_UPDATE_BASE (set "BASE=%AETHER_UPDATE_BASE%") else (set "BASE=$1")',
+    )
+  }
+  return text.replace(/base="(https:\/\/[^\s"]+)"/, 'base="${AETHER_UPDATE_BASE:-$1}"')
+}
+
 function getAppRoot(): string {
   return path.dirname(process.execPath)
+}
+
+async function detectInstalledVersion(): Promise<string> {
+  const work = getWorkDir()
+  if (!work) return ""
+  try {
+    const entries = await fs.readdir(work)
+    const dirs = entries.filter((x) => /^aether[-_]/i.test(x) && /^aether[-_]\d+\.\d+\.\d+/.test(x))
+    let best = ""
+    for (const dir of dirs) {
+      const verFile = path.join(work, dir, ".aether_web_version")
+      const ver = await fs
+        .readFile(verFile, "utf-8")
+        .then((x) => x.trim())
+        .catch(() => "")
+      const v = ver || dir.replace(/^aether[-_]/i, "")
+      if (!v) continue
+      if (compareVer(v, best) > 0) best = v
+    }
+    return best
+  } catch {
+    return ""
+  }
 }
 
 async function readWebCurrentVersion() {
@@ -522,7 +556,8 @@ async function readWebCurrentVersion() {
 
   const cached = await read()
   if (cached) return normalizeVersion(cached)
-  const fallback = normalizeVersion(Installation.VERSION)
+  const detected = await detectInstalledVersion()
+  const fallback = normalizeVersion(detected || Installation.VERSION)
   await fs.writeFile(file, `${fallback}\n`, "utf-8").catch(() => undefined)
   const next = await read()
   return next ? normalizeVersion(next) : fallback
@@ -1126,12 +1161,13 @@ export const GlobalRoutes = lazy(() =>
               package_size: meta.package_size,
             }),
           )
+          const updateBase = await getUpdateBase()
           const exitCode = await new Promise<number>((resolve, reject) => {
             const cmd = os === "windows" ? "cmd" : "bash"
             const cmdArgs = os === "windows" ? ["/c", scriptPath, "auto", cur] : [scriptPath, "auto", cur]
             const child = spawn(cmd, cmdArgs, {
               cwd: workDir,
-              env: { ...process.env, AETHER_WORK_DIR: workDir },
+              env: { ...process.env, AETHER_WORK_DIR: workDir, AETHER_UPDATE_BASE: updateBase },
               windowsHide: os === "windows",
             })
             child.on("close", (code: number | null) => resolve(code ?? 1))

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -431,21 +431,26 @@ function versioned(name: string, ver: string) {
   return `${name.slice(0, idx)}-${ver}${name.slice(idx)}`
 }
 
+function normalizeVersion(v: string): string {
+  const parts = v
+    .replace(/^v/i, "")
+    .split("-")[0]
+    .split(".")
+    .map((x) => Number.parseInt(x || "0", 10) || 0)
+  while (parts.length < 4) parts.push(0)
+  return parts.slice(0, 4).join(".")
+}
+
 function compareVer(a: string, b: string) {
   const norm = (v: string) =>
-    v
-      .replace(/^v/i, "")
-      .split("-")[0]
+    normalizeVersion(v)
       .split(".")
       .map((x) => Number.parseInt(x || "0", 10) || 0)
   const x = norm(a)
   const y = norm(b)
-  const len = Math.max(x.length, y.length, 3)
-  for (let i = 0; i < len; i++) {
-    const p = x[i] ?? 0
-    const q = y[i] ?? 0
-    if (p < q) return -1
-    if (p > q) return 1
+  for (let i = 0; i < 4; i++) {
+    if (x[i] < y[i]) return -1
+    if (x[i] > y[i]) return 1
   }
   return 0
 }
@@ -516,11 +521,11 @@ async function readWebCurrentVersion() {
       .catch(() => "")
 
   const cached = await read()
-  if (cached) return cached
-  const fallback = Installation.VERSION
+  if (cached) return normalizeVersion(cached)
+  const fallback = normalizeVersion(Installation.VERSION)
   await fs.writeFile(file, `${fallback}\n`, "utf-8").catch(() => undefined)
   const next = await read()
-  return next || fallback
+  return next ? normalizeVersion(next) : fallback
 }
 
 async function webCheck(os: z.infer<typeof WebUpdateOS>) {


### PR DESCRIPTION
### Issue for this PR

Closes #429

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes two web auto-update failures.

First, the server and installer can now use the same configured update base URL, including non-default sources such as `downloadbeta`, so update checks and downloaded files stay on the same release channel.
Second, when `.aether_web_version` is missing, the server now detects the highest installed Aether version from the local install directories instead of falling back to `local` and reporting `0.0.0.0`.

To make the update base fix work even before remote installer scripts are refreshed, the server patches downloaded installer scripts locally so they honor `AETHER_UPDATE_BASE`.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/opencode`
- Ran `bun test test/server/web-update.test.ts` in `packages/opencode`
- Traced the update flow against real manifests from `download` and `downloadbeta`
- Verified the local failure case using the downloaded files and persisted `web-update-state.json`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
