### PR TITLE
fix: prevent default port 4096 being occupied by zombie sockets

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -125,7 +125,10 @@ export namespace Server {
 
   export const Default = lazy(() => createApp({}))
 
-  export const createApp = (opts: { cors?: string[]; onBrowserConnectionChange?: (count: number) => void }): Hono<ServerEnv> => {
+  export const createApp = (opts: {
+    cors?: string[]
+    onBrowserConnectionChange?: (count: number) => void
+  }): Hono<ServerEnv> => {
     SessionPreference.clear()
     const app = new Hono<ServerEnv>()
     let sseConnectionCount = 0
@@ -135,7 +138,11 @@ export namespace Server {
         if (!input) return
         if (input.startsWith("http://localhost:")) return input
         if (input.startsWith("http://127.0.0.1:")) return input
-        if (input === "tauri://localhost" || input === "http://tauri.localhost" || input === "https://tauri.localhost") {
+        if (
+          input === "tauri://localhost" ||
+          input === "http://tauri.localhost" ||
+          input === "https://tauri.localhost"
+        ) {
           return input
         }
         if (/^https:\/\/([a-z0-9-]+\.)*opencode\.ai$/.test(input)) {
@@ -753,7 +760,7 @@ export namespace Server {
     } as const
     const tryServe = (port: number) => {
       try {
-        return Bun.serve({ ...args, port })
+        return Bun.serve({ ...args, port, reusePort: true })
       } catch {
         return undefined
       }
@@ -779,6 +786,15 @@ export namespace Server {
     server.stop = async (closeActiveConnections?: boolean) => {
       if (shouldPublishMDNS) MDNS.unpublish()
       return originalStop(closeActiveConnections)
+    }
+
+    for (const signal of ["SIGINT", "SIGTERM"] as const) {
+      process.on(signal, () => {
+        server
+          .stop(true)
+          .catch(() => {})
+          .then(() => process.exit(0))
+      })
     }
 
     return server


### PR DESCRIPTION
### Issue for this PR

Closes #431

### Type of change

- [x] Bug fix

### What does this PR do?

当 Aether 进程异常退出时，TCP socket 没有被正常关闭，导致默认端口 4096 被僵尸 socket 占用，后续启动只能 fallback 到随机端口。两个修复：

1. **`reusePort: true`**：`Bun.serve` 启用 `reusePort`，允许重新绑定仍有僵尸 socket 的端口（进程已死但 socket 未回收）。失败路径不变：绑定仍失败时行为与之前一致（fallback 随机端口或抛错）。
2. **SIGINT/SIGTERM 退出钩子**：进程收到终止信号时先调用 `server.stop(true)` 关闭所有活跃连接再退出，防止产生新的僵尸 socket。

### How did you verify your code works?

- `bun typecheck` 通过
- `reusePort` 不成功时 `tryServe` 的 catch 路径与之前行为完全一致，无新增风险

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR