### PR TITLE
feat(feishu): extract slash command routing as pure function for CI coverage

### DIFF
--- a/packages/opencode/src/feishu/manager.ts
+++ b/packages/opencode/src/feishu/manager.ts
@@ -54,6 +54,62 @@ function readPath(name: "config.json" | "sessions.json" | "hidden_projects.json"
   return existsSync(next) || !existsSync(prev) ? next : prev
 }
 
+export type SlashRoute =
+  | { action: "help"; full: boolean }
+  | { action: "command"; cmd: string; rest: string }
+  | { action: "stop" }
+  | { action: "compact" }
+  | { action: "busy_reply"; reason: "prompt_active" | "pending_question" | "pending_permission" }
+  | { action: "compact_no_session" }
+  | { action: "stop_idle" }
+  | { action: "question_reply" }
+  | { action: "permission_reply" }
+  | { action: "normal_busy"; reason: "prompt_active" | "pending_question" | "pending_permission" }
+  | { action: "start_prompt" }
+
+export interface SlashRoutingState {
+  activePrompt: boolean
+  pendingQuestion: boolean
+  pendingPermission: boolean
+  hasSession: boolean
+}
+
+export function classifySlashCommand(text: string, state: SlashRoutingState): SlashRoute {
+  const isSlash = text.startsWith("/")
+  const cmd = isSlash ? text.trim().split(/\s+/)[0].toLowerCase() : ""
+
+  if (cmd === "/h" || cmd === "/help") {
+    const full = text.trim().split(/\s+/)[1]?.toLowerCase() === "list"
+    return { action: "help", full }
+  }
+
+  if (isSlash && cmd !== "/stop" && cmd !== "/compact" && cmd !== "/c") {
+    const parts = text.trim().split(/\s+/)
+    const rest = parts.slice(1).join(" ")
+    return { action: "command", cmd, rest }
+  }
+
+  if (cmd === "/stop") {
+    if (!state.activePrompt && !state.pendingQuestion && !state.pendingPermission) {
+      return { action: "stop_idle" }
+    }
+    return { action: "stop" }
+  }
+
+  if (cmd === "/c" || cmd === "/compact") {
+    if (state.pendingQuestion) return { action: "busy_reply", reason: "pending_question" }
+    if (state.pendingPermission) return { action: "busy_reply", reason: "pending_permission" }
+    if (state.activePrompt) return { action: "busy_reply", reason: "prompt_active" }
+    if (!state.hasSession) return { action: "compact_no_session" }
+    return { action: "compact" }
+  }
+
+  if (state.pendingQuestion) return { action: "normal_busy", reason: "pending_question" }
+  if (state.pendingPermission) return { action: "normal_busy", reason: "pending_permission" }
+  if (state.activePrompt) return { action: "normal_busy", reason: "prompt_active" }
+  return { action: "start_prompt" }
+}
+
 function localISOString(d = new Date()): string {
   const offset = -d.getTimezoneOffset()
   const sign = offset >= 0 ? "+" : "-"
@@ -782,18 +838,22 @@ class FeishuManagerImpl {
       if (!text) return
       console.log("[feishu] text:", text, localISOString())
 
-      const isSlash = text.startsWith("/")
-      const parts = isSlash ? text.trim().split(/\s+/) : []
-      const cmd = isSlash ? text.trim().split(/\s+/)[0].toLowerCase() : ""
+      const routingState: SlashRoutingState = {
+        activePrompt: !!this._activePrompt.get(chatId),
+        pendingQuestion: chatId in this._pendingQuestions,
+        pendingPermission: chatId in this._pendingPermissions,
+        hasSession: chatId in this._chatSessions,
+      }
+      const route = classifySlashCommand(text, routingState)
 
-      if (cmd === "/h" || cmd === "/help") {
-        await this.replyText(messageId, parts[1]?.toLowerCase() === "list" ? HELP_LIST_TEXT : HELP_TEXT)
+      if (route.action === "help") {
+        await this.replyText(messageId, route.full ? HELP_LIST_TEXT : HELP_TEXT)
         return
       }
 
       await this.autoUnhide()
 
-      if (isSlash && cmd !== "/stop" && cmd !== "/compact" && cmd !== "/c") {
+      if (route.action === "command") {
         await this.handleCommand(text, messageId, chatId)
         return
       }
@@ -806,13 +866,13 @@ class FeishuManagerImpl {
         void this.saveHiddenDirs()
       }
 
-      if (cmd === "/stop") {
-        const hasPending = chatId in this._pendingQuestions || chatId in this._pendingPermissions
+      if (route.action === "stop_idle") {
+        await this.replyText(messageId, "没有任务在执行")
+        return
+      }
+
+      if (route.action === "stop") {
         const active = this._activePrompt.get(chatId)
-        if (!active && !hasPending) {
-          await this.replyText(messageId, "没有任务在执行")
-          return
-        }
         if (active) {
           try {
             await Instance.provide({
@@ -826,29 +886,26 @@ class FeishuManagerImpl {
         return
       }
 
-      if (cmd === "/c" || cmd === "/compact") {
-        const pendingQ = this._pendingQuestions[chatId]
-        if (pendingQ) {
-          await this.replyText(messageId, this.formatQuestionRequest(pendingQ))
-          return
-        }
-        const pendingP = this._pendingPermissions[chatId]
-        if (pendingP) {
-          await this.replyText(messageId, this.formatPermissionRequest(pendingP))
-          return
-        }
-        const active = this._activePrompt.get(chatId)
-        if (active) {
+      if (route.action === "busy_reply") {
+        if (route.reason === "pending_question") {
+          await this.replyText(messageId, this.formatQuestionRequest(this._pendingQuestions[chatId]))
+        } else if (route.reason === "pending_permission") {
+          await this.replyText(messageId, this.formatPermissionRequest(this._pendingPermissions[chatId]))
+        } else {
           await this.replyText(
             messageId,
             "当前会话正在生成回复，请等待当前对话结束后再发送；如需立即开始新问题，请先 /new 或切换 /session n。如需停止本会话请输入 /stop",
           )
-          return
         }
-        if (!(chatId in this._chatSessions)) {
-          await this.replyText(messageId, "没有任务在执行")
-          return
-        }
+        return
+      }
+
+      if (route.action === "compact_no_session") {
+        await this.replyText(messageId, "没有任务在执行")
+        return
+      }
+
+      if (route.action === "compact") {
         try {
           await this.cmdCompact(messageId, chatId)
         } catch (err) {
@@ -871,23 +928,17 @@ class FeishuManagerImpl {
         return
       }
 
-      const pendingQ = this._pendingQuestions[chatId]
-      if (pendingQ) {
-        await this.handleQuestionReply(chatId, messageId, text, pendingQ)
-        return
-      }
-      const pendingP = this._pendingPermissions[chatId]
-      if (pendingP) {
-        await this.handlePermissionReply(chatId, messageId, text, pendingP)
-        return
-      }
-
-      const active = this._activePrompt.get(chatId)
-      if (active) {
-        await this.replyText(
-          messageId,
-          "当前会话正在生成回复，请等待当前对话结束后再发送；如需立即开始新问题，请先 /new 或切换 /session n。如需停止本会话请输入 /stop",
-        )
+      if (route.action === "normal_busy") {
+        if (route.reason === "pending_question") {
+          await this.handleQuestionReply(chatId, messageId, text, this._pendingQuestions[chatId])
+        } else if (route.reason === "pending_permission") {
+          await this.handlePermissionReply(chatId, messageId, text, this._pendingPermissions[chatId])
+        } else {
+          await this.replyText(
+            messageId,
+            "当前会话正在生成回复，请等待当前对话结束后再发送；如需立即开始新问题，请先 /new 或切换 /session n。如需停止本会话请输入 /stop",
+          )
+        }
         return
       }
 

--- a/packages/opencode/test/feishu/slash-routing.test.ts
+++ b/packages/opencode/test/feishu/slash-routing.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, test } from "bun:test"
+import { classifySlashCommand, type SlashRoutingState, type SlashRoute } from "../../src/feishu/manager"
+
+const idle: SlashRoutingState = {
+  activePrompt: false,
+  pendingQuestion: false,
+  pendingPermission: false,
+  hasSession: true,
+}
+
+const busy: SlashRoutingState = {
+  activePrompt: true,
+  pendingQuestion: false,
+  pendingPermission: false,
+  hasSession: true,
+}
+
+const pendingQ: SlashRoutingState = {
+  activePrompt: false,
+  pendingQuestion: true,
+  pendingPermission: false,
+  hasSession: true,
+}
+
+const pendingP: SlashRoutingState = {
+  activePrompt: false,
+  pendingQuestion: false,
+  pendingPermission: true,
+  hasSession: true,
+}
+
+const busyAndPendingQ: SlashRoutingState = {
+  activePrompt: true,
+  pendingQuestion: true,
+  pendingPermission: false,
+  hasSession: true,
+}
+
+const noSession: SlashRoutingState = {
+  activePrompt: false,
+  pendingQuestion: false,
+  pendingPermission: false,
+  hasSession: false,
+}
+
+describe("classifySlashCommand — /help", () => {
+  test("/help → help, not full", () => {
+    expect(classifySlashCommand("/help", idle)).toEqual({ action: "help", full: false })
+  })
+
+  test("/help list → help, full", () => {
+    expect(classifySlashCommand("/help list", idle)).toEqual({ action: "help", full: true })
+  })
+
+  test("/h → help, not full", () => {
+    expect(classifySlashCommand("/h", idle)).toEqual({ action: "help", full: false })
+  })
+
+  test("/help不受busy/pending影响", () => {
+    expect(classifySlashCommand("/help", busy)).toEqual({ action: "help", full: false })
+    expect(classifySlashCommand("/h", pendingQ)).toEqual({ action: "help", full: false })
+    expect(classifySlashCommand("/help list", pendingP)).toEqual({ action: "help", full: true })
+  })
+})
+
+describe("classifySlashCommand — general commands (no busy check)", () => {
+  const commands = [
+    "/new",
+    "/n",
+    "/model",
+    "/model list",
+    "/m 1",
+    "/m l",
+    "/agent",
+    "/a build",
+    "/a 1",
+    "/project",
+    "/p l",
+    "/p 1",
+    "/session",
+    "/s l",
+    "/s 1",
+    "/variant",
+    "/variant 1",
+    "/autoaccept",
+    "/autoaccept 1",
+  ]
+
+  for (const cmd of commands) {
+    test(`${cmd} — idle → command`, () => {
+      const route = classifySlashCommand(cmd, idle)
+      expect(route.action).toBe("command")
+    })
+
+    test(`${cmd} — busy → still command (不受繁忙影响)`, () => {
+      const route = classifySlashCommand(cmd, busy)
+      expect(route.action).toBe("command")
+    })
+
+    test(`${cmd} — pendingQuestion → still command (不受pending影响)`, () => {
+      const route = classifySlashCommand(cmd, pendingQ)
+      expect(route.action).toBe("command")
+    })
+  }
+})
+
+describe("classifySlashCommand — /stop", () => {
+  test("/stop idle → stop_idle", () => {
+    expect(classifySlashCommand("/stop", idle)).toEqual({ action: "stop_idle" })
+  })
+
+  test("/stop noSession → stop_idle", () => {
+    expect(classifySlashCommand("/stop", noSession)).toEqual({ action: "stop_idle" })
+  })
+
+  test("/stop busy → stop", () => {
+    expect(classifySlashCommand("/stop", busy)).toEqual({ action: "stop" })
+  })
+
+  test("/stop pendingQuestion → stop", () => {
+    expect(classifySlashCommand("/stop", pendingQ)).toEqual({ action: "stop" })
+  })
+
+  test("/stop pendingPermission → stop", () => {
+    expect(classifySlashCommand("/stop", pendingP)).toEqual({ action: "stop" })
+  })
+
+  test("/stop busy+pendingQ → stop", () => {
+    expect(classifySlashCommand("/stop", busyAndPendingQ)).toEqual({ action: "stop" })
+  })
+})
+
+describe("classifySlashCommand — /compact", () => {
+  test("/compact idle → compact", () => {
+    expect(classifySlashCommand("/compact", idle)).toEqual({ action: "compact" })
+  })
+
+  test("/c idle → compact", () => {
+    expect(classifySlashCommand("/c", idle)).toEqual({ action: "compact" })
+  })
+
+  test("/compact busy → busy_reply, prompt_active", () => {
+    expect(classifySlashCommand("/compact", busy)).toEqual({ action: "busy_reply", reason: "prompt_active" })
+  })
+
+  test("/c busy → busy_reply, prompt_active", () => {
+    expect(classifySlashCommand("/c", busy)).toEqual({ action: "busy_reply", reason: "prompt_active" })
+  })
+
+  test("/compact pendingQuestion → busy_reply, pending_question", () => {
+    expect(classifySlashCommand("/compact", pendingQ)).toEqual({ action: "busy_reply", reason: "pending_question" })
+  })
+
+  test("/compact pendingPermission → busy_reply, pending_permission", () => {
+    expect(classifySlashCommand("/compact", pendingP)).toEqual({ action: "busy_reply", reason: "pending_permission" })
+  })
+
+  test("/compact noSession → compact_no_session", () => {
+    expect(classifySlashCommand("/compact", noSession)).toEqual({ action: "compact_no_session" })
+  })
+
+  test("/c noSession → compact_no_session", () => {
+    expect(classifySlashCommand("/c", noSession)).toEqual({ action: "compact_no_session" })
+  })
+})
+
+describe("classifySlashCommand — normal message (not slash)", () => {
+  test("normal text idle → start_prompt", () => {
+    expect(classifySlashCommand("hello", idle)).toEqual({ action: "start_prompt" })
+  })
+
+  test("normal text busy → normal_busy, prompt_active", () => {
+    expect(classifySlashCommand("hello", busy)).toEqual({ action: "normal_busy", reason: "prompt_active" })
+  })
+
+  test("normal text pendingQuestion → normal_busy, pending_question", () => {
+    expect(classifySlashCommand("hello", pendingQ)).toEqual({ action: "normal_busy", reason: "pending_question" })
+  })
+
+  test("normal text pendingPermission → normal_busy, pending_permission", () => {
+    expect(classifySlashCommand("hello", pendingP)).toEqual({ action: "normal_busy", reason: "pending_permission" })
+  })
+})
+
+describe("classifySlashCommand — command parsing", () => {
+  test("/new with extra spaces → command", () => {
+    const route = classifySlashCommand("/new  ", idle)
+    expect(route.action).toBe("command")
+    if (route.action === "command") {
+      expect(route.cmd).toBe("/new")
+      expect(route.rest).toBe("")
+    }
+  })
+
+  test("/model list → command with rest 'list'", () => {
+    const route = classifySlashCommand("/model list", idle)
+    expect(route.action).toBe("command")
+    if (route.action === "command") {
+      expect(route.cmd).toBe("/model")
+      expect(route.rest).toBe("list")
+    }
+  })
+
+  test("/a build → command with rest 'build'", () => {
+    const route = classifySlashCommand("/a build", idle)
+    expect(route.action).toBe("command")
+    if (route.action === "command") {
+      expect(route.cmd).toBe("/a")
+      expect(route.rest).toBe("build")
+    }
+  })
+})
+
+describe("classifySlashCommand — decision matrix summary", () => {
+  const matrix: { input: string; state: SlashRoutingState; expectedAction: SlashRoute["action"] }[] = [
+    { input: "/help", state: idle, expectedAction: "help" },
+    { input: "/help", state: busy, expectedAction: "help" },
+    { input: "/help", state: pendingQ, expectedAction: "help" },
+    { input: "/help", state: pendingP, expectedAction: "help" },
+    { input: "/new", state: idle, expectedAction: "command" },
+    { input: "/new", state: busy, expectedAction: "command" },
+    { input: "/new", state: pendingQ, expectedAction: "command" },
+    { input: "/new", state: pendingP, expectedAction: "command" },
+    { input: "/stop", state: idle, expectedAction: "stop_idle" },
+    { input: "/stop", state: busy, expectedAction: "stop" },
+    { input: "/stop", state: pendingQ, expectedAction: "stop" },
+    { input: "/stop", state: pendingP, expectedAction: "stop" },
+    { input: "/compact", state: idle, expectedAction: "compact" },
+    { input: "/compact", state: busy, expectedAction: "busy_reply" },
+    { input: "/compact", state: pendingQ, expectedAction: "busy_reply" },
+    { input: "/compact", state: pendingP, expectedAction: "busy_reply" },
+    { input: "/compact", state: noSession, expectedAction: "compact_no_session" },
+    { input: "/model", state: idle, expectedAction: "command" },
+    { input: "/model", state: busy, expectedAction: "command" },
+    { input: "/agent", state: idle, expectedAction: "command" },
+    { input: "/agent", state: busy, expectedAction: "command" },
+    { input: "/project", state: idle, expectedAction: "command" },
+    { input: "/project", state: busy, expectedAction: "command" },
+    { input: "/session", state: idle, expectedAction: "command" },
+    { input: "/session", state: busy, expectedAction: "command" },
+    { input: "/variant", state: idle, expectedAction: "command" },
+    { input: "/variant", state: busy, expectedAction: "command" },
+    { input: "/autoaccept", state: idle, expectedAction: "command" },
+    { input: "/autoaccept", state: busy, expectedAction: "command" },
+    { input: "普通文本", state: idle, expectedAction: "start_prompt" },
+    { input: "普通文本", state: busy, expectedAction: "normal_busy" },
+  ]
+
+  for (const { input, state, expectedAction } of matrix) {
+    test(`"${input}" → ${expectedAction}`, () => {
+      expect(classifySlashCommand(input, state).action).toBe(expectedAction)
+    })
+  }
+})


### PR DESCRIPTION
### Issue for this PR

Closes #433

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

将飞书端 `feishu/manager.ts` 的 `handleMessage` 中的 slash 命令路由决策逻辑（约 70 行 if/else）提取为纯函数 `classifySlashCommand(text, state)`。纯函数根据消息文本和会话状态（busy/pendingQuestion/pendingPermission/hasSession）返回 `SlashRoute` 联合类型，明确标注 11 种路由场景。`handleMessage` 改为先调用纯函数计算路由再执行副作用，行为与原实现完全一致。同时编写 113 个单元测试覆盖所有命令 × 所有会话状态的决策矩阵，确保 CI 能自动捕获未来路由逻辑的意外改动。

### How did you verify your code works?

- `bun typecheck` 从 `packages/opencode` 通过
- `bun test test/feishu/slash-routing.test.ts` 113 个测试全部通过
- 手动比对重构前后 handleMessage 的每个分支，确认行为一致

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR