### PR TITLE
fix(app): always search files on @ mention, even for empty query

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -582,7 +582,6 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       const open = recent()
       const seen = new Set(open)
       const pinned: AtOption[] = open.map((path) => ({ type: "file", path, display: path, recent: true }))
-      if (!query.trim()) return [...agents, ...pinned]
       const paths = await files.searchFilesAndDirectories(query)
       const fileOptions: AtOption[] = paths
         .filter((path) => !seen.has(path))


### PR DESCRIPTION
### Issue for this PR

Closes #436

### Type of change

- [x] Bug fix

### What does this PR do?

Removes the `if (!query.trim()) return [...agents, ...pinned]` short-circuit in `prompt-input.tsx` that skips `files.searchFilesAndDirectories()` when the `@` mention query is empty. The backend `File.search` already supports empty queries (returns all project files), so the search should always be called. This makes the web app behavior consistent with the TUI autocomplete, which already does this correctly.

### How did you verify your code works?

- `bun typecheck` passes in `packages/app`
- `bun turbo typecheck` passes across all packages (pre-push hook)
- The backend `File.search` handler in `packages/opencode/src/file/index.ts` explicitly returns all project files when `query` is empty (`if (!query) return result.files.slice(0, limit)`)

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR