### PR TITLE
fix: stabilize workspace e2e project bootstrap

### DIFF
--- a/packages/app/e2e/actions.ts
+++ b/packages/app/e2e/actions.ts
@@ -1003,6 +1003,7 @@ export async function setWorkspacesEnabled(page: Page, projectSlug: string, enab
     const menu = await openProjectMenu(page, projectSlug)
     const toggle = menu.locator(projectWorkspacesToggleSelector(projectSlug)).first()
     await expect(toggle).toBeVisible()
+    await expect(toggle).toBeEnabled()
     return toggle.click({ force: true, timeout })
   }
 

--- a/packages/app/e2e/ci-specs-serial.txt
+++ b/packages/app/e2e/ci-specs-serial.txt
@@ -2,8 +2,11 @@
 # during local verification.
 
 e2e/files/file-viewer.spec.ts
+e2e/projects/workspace-new-session.spec.ts
+e2e/projects/workspaces.spec.ts
 e2e/prompt/prompt-async.spec.ts
 e2e/prompt/prompt-history.spec.ts
 e2e/prompt/prompt.spec.ts
 e2e/terminal/terminal-init.spec.ts
+e2e/terminal/terminal-tabs.spec.ts
 e2e/terminal/terminal-reconnect.spec.ts

--- a/packages/app/e2e/ci-specs-serial.txt
+++ b/packages/app/e2e/ci-specs-serial.txt
@@ -6,6 +6,7 @@ e2e/projects/workspace-new-session.spec.ts
 e2e/projects/workspaces.spec.ts
 e2e/prompt/prompt-async.spec.ts
 e2e/prompt/prompt-history.spec.ts
+e2e/prompt/prompt-shell.spec.ts
 e2e/prompt/prompt.spec.ts
 e2e/terminal/terminal-init.spec.ts
 e2e/terminal/terminal-tabs.spec.ts

--- a/packages/app/e2e/ci-specs.txt
+++ b/packages/app/e2e/ci-specs.txt
@@ -14,8 +14,6 @@ e2e/files/file-tree.spec.ts
 e2e/models/models-visibility.spec.ts
 e2e/projects/project-edit.spec.ts
 e2e/projects/projects-close.spec.ts
-e2e/projects/workspace-new-session.spec.ts
-e2e/projects/workspaces.spec.ts
 e2e/prompt/prompt-mention.spec.ts
 e2e/prompt/prompt-multiline.spec.ts
 e2e/prompt/prompt-shell.spec.ts
@@ -29,6 +27,5 @@ e2e/settings/settings-models.spec.ts
 e2e/settings/settings.spec.ts
 e2e/sidebar/sidebar.spec.ts
 e2e/status/status-popover.spec.ts
-e2e/terminal/terminal-tabs.spec.ts
 e2e/terminal/terminal.spec.ts
 e2e/thinking-level.spec.ts

--- a/packages/app/e2e/ci-specs.txt
+++ b/packages/app/e2e/ci-specs.txt
@@ -16,7 +16,6 @@ e2e/projects/project-edit.spec.ts
 e2e/projects/projects-close.spec.ts
 e2e/prompt/prompt-mention.spec.ts
 e2e/prompt/prompt-multiline.spec.ts
-e2e/prompt/prompt-shell.spec.ts
 e2e/prompt/prompt-slash-open.spec.ts
 e2e/prompt/prompt-slash-share.spec.ts
 e2e/prompt/prompt-slash-terminal.spec.ts

--- a/packages/app/e2e/projects/workspace-new-session.spec.ts
+++ b/packages/app/e2e/projects/workspace-new-session.spec.ts
@@ -9,15 +9,11 @@ import {
   waitSessionSaved,
   waitSlug,
 } from "../actions"
-import { promptSelector, workspaceItemSelector, workspaceNewSessionSelector } from "../selectors"
+import { promptSelector, workspaceItemSelector } from "../selectors"
 import { createSdk } from "../utils"
 
 function item(space: { slug: string; raw: string }) {
   return `${workspaceItemSelector(space.slug)}, ${workspaceItemSelector(space.raw)}`
-}
-
-function button(space: { slug: string; raw: string }) {
-  return `${workspaceNewSessionSelector(space.slug)}, ${workspaceNewSessionSelector(space.raw)}`
 }
 
 async function waitStableSession(page: Page, timeout = 15_000) {
@@ -65,11 +61,20 @@ async function openWorkspaceNewSession(page: Page, space: { slug: string; raw: s
   await waitWorkspaceReady(page, space)
 
   const row = page.locator(item(space)).first()
+  await expect(row).toBeVisible()
   await row.hover()
 
-  const next = page.locator(button(space)).first()
+  const next = row.locator('[data-action="workspace-new-session"]').first()
   await expect(next).toBeVisible()
-  await next.click({ force: true })
+  await expect
+    .poll(() =>
+      next.evaluate((node) => {
+        const style = getComputedStyle(node)
+        return `${style.pointerEvents}:${style.opacity}`
+      }),
+    )
+    .toBe("auto:1")
+  await next.click()
 
   await waitDir(page, space.directory)
   await expect(page.locator(promptSelector).first()).toBeVisible({ timeout: 45_000 })

--- a/packages/app/e2e/prompt/prompt-mention.spec.ts
+++ b/packages/app/e2e/prompt/prompt-mention.spec.ts
@@ -4,15 +4,16 @@ import { promptSelector } from "../selectors"
 test("smoke @mention inserts file pill token", async ({ page, gotoSession }) => {
   await gotoSession()
 
-  await page.locator(promptSelector).click()
+  const prompt = page.locator(promptSelector)
+  await prompt.click()
   const sep = process.platform === "win32" ? "\\" : "/"
   const file = ["packages", "app", "package.json"].join(sep)
   const filePattern = /packages[\\/]+app[\\/]+\s*package\.json/
 
-  await page.keyboard.type(`@${file}`)
+  await prompt.fill(`@${file}`)
 
   const suggestion = page.getByRole("button", { name: filePattern }).first()
-  await expect(suggestion).toBeVisible()
+  await expect(suggestion).toBeVisible({ timeout: 30_000 })
   await suggestion.hover()
 
   await page.keyboard.press("Tab")
@@ -22,5 +23,5 @@ test("smoke @mention inserts file pill token", async ({ page, gotoSession }) => 
   await expect(pill).toHaveAttribute("data-path", filePattern)
 
   await page.keyboard.type(" ok")
-  await expect(page.locator(promptSelector)).toContainText("ok")
+  await expect(prompt).toContainText("ok")
 })

--- a/packages/app/e2e/prompt/prompt-shell.spec.ts
+++ b/packages/app/e2e/prompt/prompt-shell.spec.ts
@@ -1,8 +1,6 @@
 import type { ToolPart } from "@opencode-ai/sdk/v2/client"
 import { test, expect } from "../fixtures"
-import { sessionIDFromUrl } from "../actions"
 import { promptSelector } from "../selectors"
-import { createSdk } from "../utils"
 
 const isBash = (part: unknown): part is ToolPart => {
   if (!part || typeof part !== "object") return false
@@ -11,52 +9,36 @@ const isBash = (part: unknown): part is ToolPart => {
   return "state" in part
 }
 
-test("shell mode runs a command in the project directory", async ({ page, withProject }) => {
+test("shell mode runs a command in the project directory", async ({ page, project }) => {
   test.setTimeout(120_000)
 
-  await withProject(async ({ directory, gotoSession, trackSession }) => {
-    const sdk = createSdk(directory)
-    const prompt = page.locator(promptSelector)
-    const cmd = process.platform === "win32" ? "dir" : "ls"
+  const cmd = process.platform === "win32" ? "dir" : "ls"
 
-    await gotoSession()
-    await prompt.click()
-    await page.keyboard.type("!")
-    await expect(prompt).toHaveAttribute("aria-label", /enter shell command/i)
+  await project.open()
+  const id = await project.shell(cmd)
 
-    await page.keyboard.type(cmd)
-    await page.keyboard.press("Enter")
+  await expect
+    .poll(
+      async () => {
+        const list = await project.sdk.session.messages({ sessionID: id, limit: 50 }).then((x) => x.data ?? [])
+        const msg = list.findLast(
+          (item) => item.info.role === "assistant" && "path" in item.info && item.info.path.cwd === project.directory,
+        )
+        if (!msg) return
 
-    await expect(page).toHaveURL(/\/session\/[^/?#]+/, { timeout: 30_000 })
+        const part = msg.parts
+          .filter(isBash)
+          .find((item) => item.state.input?.command === cmd && item.state.status === "completed")
 
-    const id = sessionIDFromUrl(page.url())
-    if (!id) throw new Error(`Failed to parse session id from url: ${page.url()}`)
-    trackSession(id, directory)
+        if (!part || part.state.status !== "completed") return
+        const output = typeof part.state.metadata?.output === "string" ? part.state.metadata.output : part.state.output
+        if (!output.includes("README.md")) return
 
-    await expect
-      .poll(
-        async () => {
-          const list = await sdk.session.messages({ sessionID: id, limit: 50 }).then((x) => x.data ?? [])
-          const msg = list.findLast(
-            (item) => item.info.role === "assistant" && "path" in item.info && item.info.path.cwd === directory,
-          )
-          if (!msg) return
+        return { cwd: project.directory, output }
+      },
+      { timeout: 90_000 },
+    )
+    .toEqual(expect.objectContaining({ cwd: project.directory, output: expect.stringContaining("README.md") }))
 
-          const part = msg.parts
-            .filter(isBash)
-            .find((item) => item.state.input?.command === cmd && item.state.status === "completed")
-
-          if (!part || part.state.status !== "completed") return
-          const output =
-            typeof part.state.metadata?.output === "string" ? part.state.metadata.output : part.state.output
-          if (!output.includes("README.md")) return
-
-          return { cwd: directory, output }
-        },
-        { timeout: 90_000 },
-      )
-      .toEqual(expect.objectContaining({ cwd: directory, output: expect.stringContaining("README.md") }))
-
-    await expect(prompt).toHaveText("")
-  })
+  await expect(page.locator(promptSelector)).toHaveText("")
 })

--- a/packages/app/script/e2e-local.ts
+++ b/packages/app/script/e2e-local.ts
@@ -90,6 +90,7 @@ let seed: ReturnType<typeof Bun.spawn> | undefined
 let runner: ReturnType<typeof Bun.spawn> | undefined
 let server: { stop: (close?: boolean) => Promise<void> | void } | undefined
 let inst: { Instance: { disposeAll: () => Promise<void> | void } } | undefined
+let db: { Database: { close: () => void } } | undefined
 let cleaned = false
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
@@ -110,11 +111,19 @@ async function terminate(proc: ReturnType<typeof Bun.spawn> | undefined, label: 
   await Promise.race([proc.exited.catch(() => undefined), sleep(2_000)])
 }
 
-async function bound(job: Promise<unknown> | unknown, label: string, ms = 10_000) {
+async function bound(job: () => Promise<unknown> | unknown, label: string, ms = 10_000) {
   return await Promise.race([
-    Promise.resolve(job),
+    Promise.resolve()
+      .then(job)
+      .then(() => true)
+      .catch((error) => {
+        console.warn(`e2e-local cleanup failed: ${label}`)
+        console.warn(error)
+        return false
+      }),
     sleep(ms).then(() => {
       console.warn(`e2e-local cleanup timeout: ${label} exceeded ${ms}ms`)
+      return false
     }),
   ])
 }
@@ -125,13 +134,24 @@ const cleanup = async () => {
 
   await Promise.allSettled([terminate(runner, "runner"), terminate(seed, "seed")])
 
-  await Promise.allSettled([
-    inst ? bound(inst.Instance.disposeAll(), "Instance.disposeAll()") : undefined,
-    server ? bound(server.stop(true), "server.stop(true)") : undefined,
-  ])
+  const stopped = server ? await bound(() => server.stop(true), "server.stop(true)", 30_000) : true
+  const disposed = inst ? await bound(() => inst.Instance.disposeAll(), "Instance.disposeAll()", 30_000) : true
+  const closed = db ? await bound(() => db.Database.close(), "Database.close()") : true
 
-  if (!keepSandbox) {
-    await bound(fs.rm(sandbox, { recursive: true, force: true }), "fs.rm(sandbox)")
+  if (!keepSandbox && stopped && disposed && closed) {
+    await bound(
+      () =>
+        fs.rm(sandbox, {
+          recursive: true,
+          force: true,
+          maxRetries: process.platform === "win32" ? 10 : 3,
+          retryDelay: process.platform === "win32" ? 500 : 100,
+        }),
+      "fs.rm(sandbox)",
+      30_000,
+    )
+  } else if (!keepSandbox) {
+    console.warn("e2e-local cleanup skipped sandbox removal because teardown did not finish")
   }
 }
 
@@ -187,6 +207,7 @@ try {
 
     const servermod = await import("../../opencode/src/server/server")
     inst = await import("../../opencode/src/project/instance")
+    db = await import("../../opencode/src/storage/db")
     server = await servermod.Server.listen({ port: serverPort, hostname: "127.0.0.1" })
     console.log(`opencode server listening on http://127.0.0.1:${serverPort}`)
 

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -385,8 +385,8 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       return available[Math.floor(Math.random() * available.length)]
     }
 
-    function enrich(project: { worktree: string; expanded: boolean }) {
-      const [childStore] = globalSync.child(project.worktree, { bootstrap: false })
+    function enrich(project: LocalProject) {
+      const [childStore] = globalSync.child(project.worktree, { bootstrap: true })
       const projectID = childStore.project
       const metadata = projectID ? globalSync.project.get(projectID) : globalSync.project.fromDir(project.worktree)
       const local = childStore.projectMeta
@@ -395,6 +395,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         ...(metadata ?? {}),
         ...project,
         id: metadata?.id ?? projectID ?? "global",
+        vcs: metadata?.vcs ?? project.vcs ?? (childStore.vcs ? "git" : undefined),
         name: local?.name ?? metadata?.name ?? getFilename(project.worktree),
         icon: {
           url: metadata?.icon?.url,

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -342,6 +342,41 @@ export namespace Config {
     }
   }
 
+  function project(dir: string) {
+    const base = path.basename(dir)
+    return base === PROJECT || base === LEGACY_PROJECT
+  }
+
+  async function declared(dir: string) {
+    for (const file of [...configFiles(CFG), ...configFiles(LEGACY_CFG)]) {
+      const loc = path.join(dir, file)
+      const text = await ConfigPaths.readFile(loc).catch(() => undefined)
+      if (!text) continue
+
+      const cfg = await ConfigPaths.parseText(text, loc).catch(() => undefined)
+      if (!cfg || typeof cfg !== "object" || Array.isArray(cfg)) continue
+
+      const plugin = (cfg as { plugin?: unknown }).plugin
+      if (!Array.isArray(plugin)) continue
+      if (plugin.some((item) => typeof item === "string" && item.trim())) return true
+    }
+    return false
+  }
+
+  async function consumer(dir: string, pkg: string) {
+    if (await Filesystem.exists(pkg)) return true
+
+    const hits = Glob.scanSync("{plugin,plugins,tool,tools}/*.{js,ts}", {
+      cwd: dir,
+      absolute: true,
+      dot: true,
+      symlink: true,
+    })
+    if (hits.length) return true
+
+    return declared(dir)
+  }
+
   export async function needsInstall(dir: string) {
     // Some config dirs may be read-only.
     // Installing deps there will fail; skip installation in that case.
@@ -351,11 +386,16 @@ export namespace Config {
       return false
     }
 
+    const pkg = path.join(dir, "package.json")
+    const pkgExists = await Filesystem.exists(pkg)
+    if (project(dir) && !pkgExists && !(await consumer(dir, pkg))) {
+      log.debug("config dir has no dependency consumers, skipping dependency install", { dir })
+      return false
+    }
+
     const nodeModules = path.join(dir, "node_modules")
     if (!existsSync(nodeModules)) return true
 
-    const pkg = path.join(dir, "package.json")
-    const pkgExists = await Filesystem.exists(pkg)
     if (!pkgExists) return true
 
     const parsed = await Filesystem.readJson<{ dependencies?: Record<string, string> }>(pkg).catch(() => null)

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -986,7 +986,7 @@ export namespace File {
         const { cache } = yield* InstanceState.get(state)
 
         return yield* Effect.promise(async () => {
-          const query = input.query.trim()
+          const query = input.query.trim().replaceAll("\\", "/")
           const limit = input.limit ?? 100
           const kind = input.type ?? (input.dirs === false ? "file" : "all")
           log.info("search", { query, kind })

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -1003,7 +1003,13 @@ export namespace File {
             kind === "file" ? result.files : kind === "directory" ? result.dirs : [...result.files, ...result.dirs]
 
           const searchLimit = kind === "directory" && !preferHidden ? limit * 20 : limit
-          const sorted = fuzzysort.go(query, items, { limit: searchLimit }).map((item) => item.target)
+          const sorted = fuzzysort
+            .go(
+              query,
+              items.map((item) => ({ item, path: item.replaceAll("\\", "/") })),
+              { limit: searchLimit, key: "path" },
+            )
+            .map((item) => item.obj.item)
           const output = kind === "directory" ? sortHiddenLast(sorted, preferHidden).slice(0, limit) : sorted
 
           log.info("search", { query, kind, results: output.length })

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -11,6 +11,7 @@ import { Global } from "../../src/global"
 import { ProjectID } from "../../src/project/schema"
 import { Filesystem } from "../../src/util/filesystem"
 import { BunProc } from "../../src/bun"
+import { PROJECT } from "../../src/persist/naming"
 
 // Get managed config directory from environment (set in preload.ts)
 const managedConfigDir = process.env.OPENCODE_TEST_MANAGED_CONFIG_DIR!
@@ -836,6 +837,32 @@ test("does not try to install dependencies in read-only OPENCODE_CONFIG_DIR", as
     if (prev === undefined) delete process.env.OPENCODE_CONFIG_DIR
     else process.env.OPENCODE_CONFIG_DIR = prev
   }
+})
+
+test("skips dependency install for empty project config dir", async () => {
+  await using tmp = await tmpdir<string>({
+    init: async (dir) => {
+      const cfg = path.join(dir, PROJECT)
+      await fs.mkdir(cfg, { recursive: true })
+      return cfg
+    },
+  })
+
+  expect(await Config.needsInstall(tmp.extra)).toBe(false)
+  expect(await Filesystem.exists(path.join(tmp.extra, "package.json"))).toBe(false)
+})
+
+test("installs dependencies for project config local plugins", async () => {
+  await using tmp = await tmpdir<string>({
+    init: async (dir) => {
+      const cfg = path.join(dir, PROJECT)
+      await fs.mkdir(path.join(cfg, "plugin"), { recursive: true })
+      await Filesystem.write(path.join(cfg, "plugin", "test.ts"), "export default async () => ({})\n")
+      return cfg
+    },
+  })
+
+  expect(await Config.needsInstall(tmp.extra)).toBe(true)
 })
 
 test("installs dependencies in writable OPENCODE_CONFIG_DIR", async () => {

--- a/packages/opencode/test/file/index.test.ts
+++ b/packages/opencode/test/file/index.test.ts
@@ -740,6 +740,22 @@ describe("file/index Filesystem patterns", () => {
       })
     })
 
+    test("normalizes windows separators in query", async () => {
+      await using tmp = await setupSearchableRepo()
+      await fs.mkdir(path.join(tmp.path, "packages", "app"), { recursive: true })
+      await fs.writeFile(path.join(tmp.path, "packages", "app", "package.json"), "{}", "utf-8")
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          await File.init()
+
+          const result = await File.search({ query: "packages\\app\\package.json", type: "file" })
+          expect(result.map((file) => file.replaceAll("\\", "/"))).toContain("packages/app/package.json")
+        },
+      })
+    })
+
     test("type filter returns only files", async () => {
       await using tmp = await setupSearchableRepo()
 

--- a/packages/opencode/test/pty/pty-output-isolation.test.ts
+++ b/packages/opencode/test/pty/pty-output-isolation.test.ts
@@ -4,6 +4,15 @@ import { Pty } from "../../src/pty"
 import { tmpdir } from "../fixture/fixture"
 import { setTimeout as sleep } from "node:timers/promises"
 
+const wait = async (fn: () => boolean, ms = 5000) => {
+  const end = Date.now() + ms
+  while (Date.now() < end) {
+    if (fn()) return
+    await sleep(25)
+  }
+  throw new Error("timeout waiting for pty output")
+}
+
 describe("pty", () => {
   test("does not leak output when websocket objects are reused", async () => {
     await using dir = await tmpdir({ git: true })
@@ -29,21 +38,21 @@ describe("pty", () => {
           }
 
           // Connect "a" first with ws.
-          Pty.connect(a.id, ws as any)
+          await Pty.connect(a.id, ws as any)
 
           // Now "reuse" the same ws object for another connection.
           ws.data = { events: { connection: "b" } }
           ws.send = (data: unknown) => {
             outB.push(typeof data === "string" ? data : Buffer.from(data as Uint8Array).toString("utf8"))
           }
-          Pty.connect(b.id, ws as any)
+          await Pty.connect(b.id, ws as any)
 
           // Clear connect metadata writes.
           outA.length = 0
           outB.length = 0
 
           // Output from a must never show up in b.
-          Pty.write(a.id, "AAA\n")
+          await Pty.write(a.id, "AAA\n")
           await sleep(100)
 
           expect(outB.join("")).not.toContain("AAA")
@@ -78,7 +87,7 @@ describe("pty", () => {
           }
 
           // Connect "a" first.
-          Pty.connect(a.id, ws as any)
+          await Pty.connect(a.id, ws as any)
           outA.length = 0
 
           // Simulate Bun reusing the same websocket object for another
@@ -88,7 +97,7 @@ describe("pty", () => {
             outB.push(typeof data === "string" ? data : Buffer.from(data as Uint8Array).toString("utf8"))
           }
 
-          Pty.write(a.id, "AAA\n")
+          await Pty.write(a.id, "AAA\n")
           await sleep(100)
 
           expect(outB.join("")).not.toContain("AAA")
@@ -121,15 +130,15 @@ describe("pty", () => {
             },
           }
 
-          Pty.connect(a.id, ws as any)
+          await Pty.connect(a.id, ws as any)
           out.length = 0
 
           // Mutating fields on ws.data should not look like a new
           // connection lifecycle when the object identity stays stable.
           ctx.connId = 2
 
-          Pty.write(a.id, "AAA\n")
-          await sleep(100)
+          await Pty.write(a.id, "AAA\n")
+          await wait(() => out.join("").includes("AAA"))
 
           expect(out.join("")).toContain("AAA")
         } finally {


### PR DESCRIPTION
### Issue for this PR

Closes #438

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes workspace e2e instability where an opened git project could be read from the app project list/sidebar before its directory bootstrap had populated git metadata.

This PR makes project enrichment bootstrap the project worktree when needed, preserves git detection from the child store, skips dependency installation for empty auto-created project config directories, and waits for the workspace toggle to become enabled before clicking it in e2e helpers.

### How did you verify your code works?

- `bun test test/config/config.test.ts --timeout 30000` from `packages/opencode`
- `bun typecheck` from `packages/opencode`
- `bun typecheck` from `packages/app`
- `bun test:e2e:local e2e/projects/workspaces.spec.ts e2e/projects/workspace-new-session.spec.ts` from `packages/app`
- `bun --cwd packages/ui test:unit`
- `bun --cwd packages/app test:unit`
- Full app e2e linux workflow-equivalent main specs from `packages/app`: `64 passed, 1 flaky, 3 skipped`
- Full app e2e linux workflow-equivalent serial specs from `packages/app`: `10 passed`

Note: `opencode unit (linux)` workflow-equivalent was run locally and failed in unrelated local environment/timeout cases.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR