### PR TITLE
fix: auto-scroll conversation tree to bottom on expand and new conversation

### DIFF
--- a/packages/app/src/pages/session/branch/sidebar-branch-view.tsx
+++ b/packages/app/src/pages/session/branch/sidebar-branch-view.tsx
@@ -73,6 +73,7 @@ export function SidebarBranchView(props: {
   let activePointerID: number | undefined
   let dragStartY = 0
   let dragStartHeight = DEFAULT_PANEL_MAX_HEIGHT
+  let scrollContainer: HTMLDivElement | undefined
 
   const clampHeight = (height: number) => Math.max(MIN_PANEL_HEIGHT, Math.min(MAX_PANEL_HEIGHT, Math.round(height)))
 
@@ -176,6 +177,13 @@ export function SidebarBranchView(props: {
       graph: payload as ConversationGraph,
       compact: compact(),
       orderMode: orderMode() as ConversationGraphOrderMode,
+    })
+  })
+
+  createEffect(() => {
+    view()
+    queueMicrotask(() => {
+      if (scrollContainer) scrollContainer.scrollTop = scrollContainer.scrollHeight
     })
   })
 
@@ -319,7 +327,7 @@ export function SidebarBranchView(props: {
         </Show>
       </div>
 
-      <div class="min-h-0 overflow-auto" style={{ "max-height": `${maxPanelHeight()}px` }}>
+      <div ref={scrollContainer} class="min-h-0 overflow-auto" style={{ "max-height": `${maxPanelHeight()}px` }}>
         <Switch>
           <Match when={graph()?.kind === "legacy"}>
             <div class="flex h-full items-center justify-center px-4 text-center text-11-regular text-text-weak">


### PR DESCRIPTION
### Issue for this PR

Closes #441

### Type of change

- [x] Bug fix

### What does this PR do?

The conversation tree dropdown in the sidebar always stays scrolled to the top, even when expanding a session tree or when a new conversation branch is added. This makes it impossible to see the latest conversation without manually scrolling.

This PR adds a `createEffect` that tracks the conversation graph `view()` changes and uses `queueMicrotask` to set `scrollTop = scrollHeight` on the scroll container, ensuring the dropdown auto-scrolls to the bottom (latest conversation) whenever:
- The session tree is first expanded (component mounts)
- A new conversation/branch is added (view nodes update)

### How did you verify your code works?

- `bun typecheck` passes in `packages/app`
- Logic is straightforward: tracking reactive `view()` changes and setting scroll position

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR