### PR TITLE
fix: Windows :abs SRC env var, macOS CRLF, update retry toast, and script audit fixes

### DIFF
--- a/Update/.gitattributes
+++ b/Update/.gitattributes
@@ -1,0 +1,5 @@
+*.command text eol=lf
+*.sh text eol=lf
+*.bat text eol=crlf
+*.md text eol=lf
+.gitattributes text eol=lf

--- a/Update/aether_darwin_installer.command
+++ b/Update/aether_darwin_installer.command
@@ -368,11 +368,11 @@ grab() {
   fi
 
   if [ "$need_pkg" = "1" ]; then
-    echo "Downloading package:"
+    echo "正在下载安装包："
     echo "  $pkg_url"
     fetch_file "$pkg_url" "$pkg_file" || return "$dl_err"
   else
-    echo "Using cached package:"
+    echo "使用缓存的安装包："
     echo "  $pkg_file"
   fi
 
@@ -396,11 +396,11 @@ grab() {
     fi
 
     if [ "$need_ins" = "1" ]; then
-      echo "Downloading installer:"
+      echo "正在下载安装脚本："
       echo "  $ins_url"
       fetch_file "$ins_url" "$ins_file" || return "$dl_err"
     else
-      echo "Using cached installer:"
+      echo "使用缓存的安装脚本："
       echo "  $ins_file"
     fi
     chmod +x "$ins_file" 2>/dev/null || true
@@ -534,13 +534,13 @@ if [ "$mode" = "init" ]; then
     exit "$latest_ok"
   fi
   if cached_ready; then
-    echo "Using cached package:"
+    echo "使用缓存的安装包："
     echo "  $pkg_file"
-    echo "Using cached installer:"
+    echo "使用缓存的安装脚本："
     echo "  $ins_file"
   else
     grab || {
-      code="$?"
+      code=$?
       res="download_error"
       [ "$code" = "$sum_err" ] && res="checksum_error"
       result

--- a/Update/aether_linux_installer.sh
+++ b/Update/aether_linux_installer.sh
@@ -853,7 +853,7 @@ if [ "$mode" = "init" ]; then
     echo "  $ins_file"
   else
     grab || {
-      code="$?"
+      code=$?
       res="download_error"
       [ "$code" = "$sum_err" ] && res="checksum_error"
       result
@@ -915,7 +915,7 @@ if [ "$mode" = "auto" ]; then
   }
   echo "Latest version: $ver"
   grab || {
-    code="$?"
+    code=$?
     res="download_error"
     [ "$code" = "$sum_err" ] && res="checksum_error"
     result
@@ -949,7 +949,7 @@ if [ "$mode" = "manual" ]; then
   }
   manifest_url="$base/$req/$plat.yml"
   if ! manifest "$manifest_url" version; then
-    code="$?"
+    code=$?
     if [ "$code" = "$miss" ]; then
       ver="$req"
       res="version_missing"
@@ -965,7 +965,7 @@ if [ "$mode" = "manual" ]; then
   echo "Requested version: $req"
   echo "Resolved version:  $ver"
   grab || {
-    code="$?"
+    code=$?
     res="download_error"
     [ "$code" = "$sum_err" ] && res="checksum_error"
     result

--- a/Update/aether_windows_installer.bat
+++ b/Update/aether_windows_installer.bat
@@ -109,7 +109,7 @@ exit /b 0
 
 :init
 echo Aether Windows Installer
-echo.
+echo(
 set "WORK=%WORK_DEFAULT%"
 if defined PATH_ARG (
   call :normalize "%PATH_ARG%" MIRROR
@@ -380,9 +380,9 @@ if not exist "%INS_FILE%" exit /b 1
 exit /b 0
 
 :print_latest
-echo.
+echo(
 echo Latest version: %VER%
-echo.
+echo(
 exit /b 0
 
 :print_versions
@@ -391,19 +391,19 @@ echo Remote version: %~2
 exit /b 0
 
 :print_uptodate
-echo.
+echo(
 call :print_versions "%~1" "%~2"
 echo Already up to date.
 exit /b 0
 
 :print_downloaded
-echo.
+echo(
 echo Download finished.
 echo Version:   %VER%
 echo Package:   %PKG_FILE%
 echo Installer: %INS_FILE%
 echo Result:    %RES_FILE%
-echo.
+echo(
 exit /b 0
 
 :print_cached
@@ -436,15 +436,18 @@ echo Resolved version:  %~2
 exit /b 0
 
 :abs
+set "SRC=%~2"
 set "VAL=%~3"
 if not defined VAL (
   set "%~1="
+  set "SRC="
   exit /b 0
 )
 set "ABS_URL="
 for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$src=$env:SRC; $val=$env:VAL; if([string]::IsNullOrEmpty($val)){  } else { try { ([Uri]::new(([Uri]$src), $val)).AbsoluteUri } catch {  } }"`) do set "ABS_URL=%%i"
 set "%~1=%ABS_URL%"
 set "ABS_URL="
+set "SRC="
 exit /b 0
 
 :fetch_meta
@@ -571,27 +574,27 @@ exit /b 0
 
 :help
 echo Aether Windows Installer
-echo.
+echo(
 echo Usage:
 echo   %~nx0 [--no-pause] [--path ^<dir^>] init
 echo   %~nx0 [--no-pause] auto ^<current-version^>
 echo   %~nx0 [--no-pause] manual ^<target-version^>
-echo.
+echo(
 echo init mode:
 echo   --path specifies the install target directory (default %DEFAULT%)
 echo   Work directory is fixed at %WORK_DEFAULT%
 echo   Downloads, installs, and mirrors to the target directory
-echo.
+echo(
 echo auto mode:
 echo   Called by the main app; work directory via AETHER_WORK_DIR
-echo.
+echo(
 echo Remote manifests:
 echo   %BASE%/%LATEST%
 echo   %BASE%/1.2.3/windows-x64.yml
-echo.
+echo(
 echo Result file:
 echo   work_dir\downloads\last-result.yml
-echo.
+echo(
 echo Exit codes:
 echo   0   init finished successfully
 echo   10  latest update downloaded and ready
@@ -615,7 +618,7 @@ exit /b %ARG_ERR%
 :meta_fail
 set "RES=meta_error"
 call :result
-echo.
+echo(
 echo Manifest check failed.
 if /I "%MODE%"=="init" goto :done_err
 exit /b %META_ERR%
@@ -625,7 +628,7 @@ set "RC=%ERRORLEVEL%"
 set "RES=download_error"
 if "%RC%"=="%SUM_ERR%" set "RES=checksum_error"
 call :result
-echo.
+echo(
 if "%RC%"=="%SUM_ERR%" (
   echo Checksum verification failed.
 ) else (
@@ -641,7 +644,7 @@ exit /b %RUN_ERR%
 :dir_fail
 set "RES=dir_error"
 call :result
-echo.
+echo(
 echo Work directory failed.
 if /I "%MODE%"=="init" goto :done_err
 exit /b %DIR_ERR%
@@ -656,6 +659,6 @@ exit /b 0
 
 :hold
 if not defined HOLD exit /b 0
-echo.
+echo(
 powershell -NoProfile -Command "& { if(-not [Environment]::UserInteractive){ exit 0 }; try { Write-Host 'Press Esc to close...'; while(([Console]::ReadKey($true)).Key -ne 'Escape') {} } catch { exit 0 } }"
 exit /b 0

--- a/Update/aether_windows_installer_beta.bat
+++ b/Update/aether_windows_installer_beta.bat
@@ -436,15 +436,18 @@ echo Resolved version:  %~2
 exit /b 0
 
 :abs
+set "SRC=%~2"
 set "VAL=%~3"
 if not defined VAL (
   set "%~1="
+  set "SRC="
   exit /b 0
 )
 set "ABS_URL="
 for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$src=$env:SRC; $val=$env:VAL; if([string]::IsNullOrEmpty($val)){  } else { try { ([Uri]::new(([Uri]$src), $val)).AbsoluteUri } catch {  } }"`) do set "ABS_URL=%%i"
 set "%~1=%ABS_URL%"
 set "ABS_URL="
+set "SRC="
 exit /b 0
 
 :fetch_meta

--- a/Update/update_darwin.command
+++ b/Update/update_darwin.command
@@ -271,18 +271,16 @@ mirror_target() {
   printf "%s" "$root/aether_${ver}_$now"
 }
 
-write_launch() {
-  local final target
-  final="$1"
 build_app() {
-    local dir app bin cmd
-    dir="$1"
-    app="$dir/Aether.app"
-    bin="$app/Contents/MacOS/Aether"
-    cmd="$final/Aether.command"
-    rm -rf "$app"
-    mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
-    cat >"$bin" <<EOF
+  local dest final app bin cmd
+  dest="$1"
+  final="$2"
+  app="$dest/Aether.app"
+  bin="$app/Contents/MacOS/Aether"
+  cmd="$final/Aether.command"
+  rm -rf "$app"
+  mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
+  cat >"$bin" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -303,8 +301,8 @@ fi
 echo "Launch target not found: $cmd"
 exit 1
 EOF
-    chmod +x "$bin"
-    cat >"$app/Contents/Info.plist" <<'EOF'
+  chmod +x "$bin"
+  cat >"$app/Contents/Info.plist" <<'EOF'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -328,20 +326,23 @@ EOF
 </dict>
 </plist>
 EOF
-    xattr -cr "$app" >/dev/null 2>&1 || true
-  }
+  xattr -cr "$app" >/dev/null 2>&1 || true
+}
 
-  target="/Applications"
-  if build_app "$target" 2>/dev/null; then
-    launch="$target/Aether.app"
+write_launch() {
+  local final dest
+  final="$1"
+  dest="/Applications"
+  if build_app "$dest" "$final" 2>/dev/null; then
+    launch="$dest/Aether.app"
     launch_note="从 app 启动器中运行Aether。"
     return 0
   fi
 
-  target="$HOME/Applications"
-  mkdir -p "$target"
-  build_app "$target"
-  launch="$target/Aether.app"
+  dest="$HOME/Applications"
+  mkdir -p "$dest"
+  build_app "$dest" "$final"
+  launch="$dest/Aether.app"
   launch_note="无法写入 /Applications，已回退到 $launch。手动复制该 App 到 /Applications后，从 app 启动器中运行Aether，或在\"$HOME/Applications\"文件夹中双击Aether.app运行。"
 }
 
@@ -452,12 +453,12 @@ done
 shopt -u nullglob
 
 chmod +x "$target/aether" "$target/Aether.command"
-uv="$target/wechat-bridge/runtime/uv/uv-0.6.14-aarch64-apple-darwin/uv"
+uv="$(find "$target/wechat-bridge/runtime/uv" -name 'uv-*apple-darwin*/uv' -type f 2>/dev/null | head -1)"
 if [ -f "$uv" ]; then
   chmod +x "$uv"
 fi
 xattr -cr "$target/aether" "$target/Aether.command" >/dev/null 2>&1 || true
-if [ -f "$uv" ]; then
+if [ -n "$uv" ] && [ -f "$uv" ]; then
   xattr -cr "$uv" >/dev/null 2>&1 || true
 fi
 printf "%s\n" "$ver" >"$target/.aether_web_version"

--- a/Update/update_linux.sh
+++ b/Update/update_linux.sh
@@ -566,7 +566,11 @@ if [ "$mirror_only" != "1" ] && [ "${#arr[@]}" -eq 0 ]; then
   fail "[install] Package not found for version $ver in $dl"
 fi
 
-pkg="${arr[0]:-}"
+pkg=""
+for f in "${arr[@]}"; do
+  case "$f" in *.zip) pkg="$f"; break ;; esac
+done
+[ -n "$pkg" ] || pkg="${arr[0]:-}"
 tmp="$(mktemp -d "${TMPDIR:-/tmp}/aether-install.XXXXXX")"
 ex="$tmp/extract"
 mkdir -p "$ex" || fail "[install] Failed to prepare extract directory"

--- a/Update/update_windows.bat
+++ b/Update/update_windows.bat
@@ -73,7 +73,7 @@ set "SRC_FILE=%TMP%\src.txt"
 call :clean_tmp
 if "%MIRROR_ONLY%"=="1" (
   if not exist "%TARGET%" (
-set "MSG=Installed version directory not found for mirror retry: %TARGET%"
+    set "MSG=Installed version directory not found for mirror retry: %TARGET%"
     call :write_result "failed" "recover" "!MSG!"
     echo !MSG!
     goto :fail
@@ -118,7 +118,7 @@ echo [2/4] Extracting and installing to: %TARGET%
 )
 
 :post_install
-echo %VER%>"%TARGET%\.aether_web_version"
+>"%TARGET%\.aether_web_version" echo(%VER%
 if exist "%WORK%\.aether_web_version" del /f /q "%WORK%\.aether_web_version" >nul 2>nul
 
 if exist "%WORK%\current" rmdir "%WORK%\current" >nul 2>nul
@@ -137,7 +137,7 @@ if errorlevel 1 (
 ) else (
   set "COPY_NOTE=Current app already runs inside WorkDir; skipped mirror."
 )
-if not errorlevel 1 if defined MIRROR set "START=%MIRROR%"
+if defined MIRROR set "START=%MIRROR%"
 if defined MIRROR call :prune_mirror
 if not defined START set "START=%TARGET%"
 call :write_launch "%START%"

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -453,15 +453,22 @@ export default function Layout(props: ParentProps) {
         })
       }
 
-      const run = (next?: UpdateAction) => {
+      const run = async (next?: UpdateAction) => {
         const task = next === "mirror" ? platform.retryUpdateMirror?.() : platform.recoverUpdate?.()
         if (!task) return
         dismissToast()
-        showPromiseToast(task, {
+        const promiseId = showPromiseToast(task, {
           loading: language.t(next === "mirror" ? "update.retryingMirror" : "update.recovering"),
           success: () => language.t("update.installHint"),
-          error: (err) => messageOf(err),
+          error: () => "",
         })
+        try {
+          await task
+        } catch (err) {
+          toaster.dismiss(promiseId)
+          const data = await platform.checkUpdate?.()
+          showErrorToast(err, data?.version, next)
+        }
       }
 
       const showErrorToast = (err: unknown, version?: string, next?: UpdateAction) => {

--- a/packages/opencode/src/server/web-update.ts
+++ b/packages/opencode/src/server/web-update.ts
@@ -667,7 +667,7 @@ async function fetchInstallerScript(os: string): Promise<string | null> {
       return null
     }
     const text = await res.text()
-    const patched = patchInstallerScript(os, text)
+    const patched = patchInstallerScript(os, os === "windows" ? text : text.replace(/\r\n?/g, "\n"))
     await fs.writeFile(dest, patched)
     if (os !== "windows") {
       await fs.chmod(dest, 0o755).catch(() => undefined)


### PR DESCRIPTION
### Issue for this PR

Closes #443

### Type of change

- [x] Bug fix

### What does this PR do?

修复自动更新系统中三个相互关联的 bug 和一系列审计发现的低级别问题：

1. **Windows installer `:abs` 子程序缺少 `SRC` 环境变量** — `aether_windows_installer.bat` 的 `:abs` 用 PowerShell `$env:SRC` 做 URL 解析，但从未将第二个参数 `%~2` 赋值给 `SRC`，导致 `PKG_URL`/`INS_URL` 全为空，产生 "ECHO is off"、curl blank argument、script missing 等错误。修复：在 `:abs` 开头加 `set "SRC=%~2"`。beta 版 installer 同样修复。

2. **macOS/Linux 脚本 CRLF 行尾符** — `core.autocrlf=true` 导致 checkout 时所有文件变 CRLF，`.command`/`.sh` 在 macOS bash 中无法执行。三层修复：添加 `Update/.gitattributes`（`.command`/`.sh` 强制 LF，`.bat` 强制 CRLF）；本地文件行尾符全部修正；`fetchInstallerScript` 对非 Windows 脚本 strip `\r`。

3. **更新重试失败后 Toast 不再弹出** — `layout.tsx` 的 `run()` 用 `showPromiseToast` 显示恢复进度，失败后只显示不可交互的错误消息，没有重试按钮。修复：失败后 dismiss promise toast，重新调用 `showErrorToast`（带重试按钮）。

**Low-severity audit fixes**: `echo.`→`echo(`、`>file echo(%VER%` 防止 ECHO-is-off、移除 fragile errorlevel 检查、darwin `build_app` 从 `write_launch` 中提取为独立函数（消除变量名冲突）、darwin 中英混合消息统一翻译、darwin 硬编码 uv 版本路径改为 `find` 动态发现、linux glob 优先 `.zip`、`code="$?"`→`code=$?`。

### How did you verify your code works?

- `bun test` 16 tests 全部通过
- `bun typecheck` opencode + app 两个包通过
- Python E2E 模拟测试：mock HTTP server 模拟远端，测试了 installer auto 模式（exit 10）、update script 完整安装（exit 0）、checksum mismatch 失败（exit 32）、manifest 404 失败（exit 30）、重试成功（exit 10）→ 全部通过

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR