### PR TITLE
feat(mobile): add QQ bot platform and fix mobile bridge issues

### DIFF
--- a/packages/app/src/components/dialog-mobile.tsx
+++ b/packages/app/src/components/dialog-mobile.tsx
@@ -304,69 +304,14 @@ export const DialogMobile: Component<Props> = (props) => {
                     </Collapsible>
                   </Show>
                   <Show when={p() === "qq"}>
-                    <Collapsible open={true} variant="ghost">
-                      <Collapsible.Trigger class="flex items-center gap-2 w-full px-2 py-1.5 rounded-md hover:bg-surface-muted cursor-pointer">
-                        <Collapsible.Arrow />
-                        <span class="text-13-medium text-text-strong">
-                          按以下步骤在QQ开放平台配置机器人【点击展开每步细节】
-                        </span>
-                      </Collapsible.Trigger>
-                      <Collapsible.Content class="flex flex-col gap-1">
-                        <Collapsible open={steps[1]} onOpenChange={(v) => setSteps(1, v)} variant="ghost">
-                          <Collapsible.Trigger class="flex items-center gap-2 w-full px-2 py-1.5 rounded-md hover:bg-surface-muted cursor-pointer">
-                            <Collapsible.Arrow />
-                            <span class="text-13-medium text-text-strong">第一步：注册并创建机器人</span>
-                          </Collapsible.Trigger>
-                          <Collapsible.Content class="px-2 pb-2">
-                            <ol class="text-13-regular text-text-weak list-decimal list-outside ml-4 space-y-1">
-                              <li>
-                                打开{" "}
-                                <a
-                                  href="https://q.qq.com"
-                                  target="_blank"
-                                  rel="noopener"
-                                  class="text-text-link underline"
-                                >
-                                  QQ开放平台
-                                </a>
-                                ，选择个人或企业入驻
-                              </li>
-                              <li>点击「创建机器人」，填写资料</li>
-                              <li>
-                                获取 <strong class="text-text-base">AppID</strong> 和{" "}
-                                <strong class="text-text-base">AppSecret</strong>
-                              </li>
-                            </ol>
-                          </Collapsible.Content>
-                        </Collapsible>
-                        <Collapsible open={steps[2]} onOpenChange={(v) => setSteps(2, v)} variant="ghost">
-                          <Collapsible.Trigger class="flex items-center gap-2 w-full px-2 py-1.5 rounded-md hover:bg-surface-muted cursor-pointer">
-                            <Collapsible.Arrow />
-                            <span class="text-13-medium text-text-strong">第二步：配置开发场景</span>
-                          </Collapsible.Trigger>
-                          <Collapsible.Content class="px-2 pb-2">
-                            <ol class="text-13-regular text-text-weak list-decimal list-outside ml-4 space-y-1">
-                              <li>在开发基础设置页面获取 AppID 和 AppSecret</li>
-                              <li>配置沙箱环境（测试群/频道/单聊）</li>
-                              <li>将机器人添加至沙箱群或沙箱频道进行测试</li>
-                            </ol>
-                          </Collapsible.Content>
-                        </Collapsible>
-                        <Collapsible open={steps[3]} onOpenChange={(v) => setSteps(3, v)} variant="ghost">
-                          <Collapsible.Trigger class="flex items-center gap-2 w-full px-2 py-1.5 rounded-md hover:bg-surface-muted cursor-pointer">
-                            <Collapsible.Arrow />
-                            <span class="text-13-medium text-text-strong">第三步：发布上线</span>
-                          </Collapsible.Trigger>
-                          <Collapsible.Content class="px-2 pb-2">
-                            <ol class="text-13-regular text-text-weak list-decimal list-outside ml-4 space-y-1">
-                              <li>填写自测报告并提交审核</li>
-                              <li>审核通过后手动上线</li>
-                              <li>用户可在QQ客户端添加机器人</li>
-                            </ol>
-                          </Collapsible.Content>
-                        </Collapsible>
-                      </Collapsible.Content>
-                    </Collapsible>
+                    <p class="text-13-regular text-text-weak">
+                      打开{" "}
+                      <a href="https://q.qq.com" target="_blank" rel="noopener" class="text-text-link underline">
+                        QQ开放平台
+                      </a>
+                      ，点击「机器人」{"->"}「创建QQ机器人」，获取 <strong class="text-text-base">AppID</strong> 和{" "}
+                      <strong class="text-text-base">AppSecret</strong>
+                    </p>
                   </Show>
                 </div>
               </div>

--- a/packages/app/src/components/dialog-mobile.tsx
+++ b/packages/app/src/components/dialog-mobile.tsx
@@ -426,7 +426,7 @@ export const DialogMobile: Component<Props> = (props) => {
                 <Show when={(p() === "feishu" || p() === "qq") && appId(p())}>
                   <p class="text-14-regular text-text-weak">App: {appId(p())!.slice(0, 16)}...</p>
                 </Show>
-                <Show when={user(p())}>
+                <Show when={user(p()) && user(p())!.name && user(p())!.name !== "Unknown"}>
                   <p class="text-14-regular text-text-weak">{user(p())!.name}</p>
                 </Show>
               </div>

--- a/packages/app/src/components/dialog-mobile.tsx
+++ b/packages/app/src/components/dialog-mobile.tsx
@@ -172,6 +172,7 @@ export const DialogMobile: Component<Props> = (props) => {
                       type="text"
                       value={inputAppId()}
                       onInput={(e) => setInputAppId(e.currentTarget.value)}
+                      autocomplete="off"
                       placeholder={p() === "qq" ? "10xxxxxx" : "cli_xxxxxxxx"}
                       class="w-full px-3 py-2 rounded-md border border-border-base bg-surface-base text-text-base text-13-regular focus:outline-none focus:border-border-focus"
                     />
@@ -182,6 +183,7 @@ export const DialogMobile: Component<Props> = (props) => {
                       type="password"
                       value={inputAppSecret()}
                       onInput={(e) => setInputAppSecret(e.currentTarget.value)}
+                      autocomplete="new-password"
                       placeholder="输入 App Secret"
                       class="w-full px-3 py-2 rounded-md border border-border-base bg-surface-base text-text-base text-13-regular focus:outline-none focus:border-border-focus"
                     />

--- a/packages/app/src/context/mobile.ts
+++ b/packages/app/src/context/mobile.ts
@@ -182,7 +182,11 @@ function connectSSE(p: MobilePlatform) {
               const cur = prev(p).status
               if (
                 s === "idle" &&
-                (cur === "loading" || cur === "reconnecting" || cur === "qrcode" || cur === "connected")
+                (cur === "loading" ||
+                  cur === "reconnecting" ||
+                  cur === "qrcode" ||
+                  cur === "connected" ||
+                  cur === "config")
               )
                 continue
               const u: Partial<PlatformState> = { status: s }

--- a/packages/app/src/context/mobile.ts
+++ b/packages/app/src/context/mobile.ts
@@ -191,6 +191,8 @@ function connectSSE(p: MobilePlatform) {
                 continue
               const u: Partial<PlatformState> = { status: s }
               if (props.message) u.loadingMsg = props.message
+              if (props.appId) u.appId = props.appId
+              if (props.user) u.user = props.user
               if (s === "connected") clearSseRetry(p)
               patch(p, u)
             }

--- a/packages/opencode/src/mobile/feishu.ts
+++ b/packages/opencode/src/mobile/feishu.ts
@@ -117,9 +117,9 @@ class FeishuAdapter implements MobileAdapter {
     try {
       const next = this.manager.file("config.json")
       const prev = this.manager.readPath("config.json")
-      const path = existsSync(next) || !existsSync(prev) ? next : prev
-      if (existsSync(path)) {
-        const data = await readFile(path, "utf-8")
+      const configPath = existsSync(next) || !existsSync(prev) ? next : prev
+      if (existsSync(configPath)) {
+        const data = await readFile(configPath, "utf-8")
         return JSON.parse(data)
       }
     } catch {}

--- a/packages/opencode/src/mobile/qq.ts
+++ b/packages/opencode/src/mobile/qq.ts
@@ -25,8 +25,16 @@ enum OpCode {
   Identify = 2,
   Resume = 6,
   Reconnect = 7,
+  InvalidSession = 9,
   Hello = 10,
   HeartbeatACK = 11,
+}
+
+type ChatType = "c2c" | "group"
+
+interface ChatInfo {
+  type: ChatType
+  openid: string
 }
 
 class QQAdapter implements MobileAdapter {
@@ -63,9 +71,20 @@ class QQAdapter implements MobileAdapter {
 
   async replyText(messageId: string, text: string): Promise<void> {
     if (!this._accessToken || !this._appId) return
+    const chatId = this.manager._currentChatId
+    const info = chatId ? this.manager._chatInfos[chatId] : undefined
+    if (!info) {
+      console.error("[qq] replyText: no chat info", chatId)
+      return
+    }
+
     try {
       const token = await this.getAccessToken()
-      await fetch(`https://api.sgroup.qq.com/v2/messages`, {
+      const url =
+        info.type === "c2c"
+          ? `https://api.sgroup.qq.com/v2/users/${info.openid}/messages`
+          : `https://api.sgroup.qq.com/v2/groups/${info.openid}/messages`
+      const resp = await fetch(url, {
         method: "POST",
         headers: { Authorization: `QQBot ${token}`, "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -74,6 +93,10 @@ class QQAdapter implements MobileAdapter {
           msg_id: messageId,
         }),
       })
+      if (!resp.ok) {
+        const body = await resp.text()
+        console.error("[qq] replyText failed:", resp.status, body)
+      }
     } catch (err) {
       console.error("[qq] reply error:", err)
     }
@@ -81,10 +104,14 @@ class QQAdapter implements MobileAdapter {
 
   async replyFile(messageId: string, filePath: string): Promise<void> {
     if (!this._accessToken || !this._appId) return
+    const chatId = this.manager._currentChatId
+    const info = chatId ? this.manager._chatInfos[chatId] : undefined
+    if (!info) return
+
     try {
       const { stat, readFile } = await import("fs/promises")
-      const info = await stat(filePath)
-      if (info.size > 30 * 1024 * 1024) return
+      const info2 = await stat(filePath)
+      if (info2.size > 30 * 1024 * 1024) return
       const filename = basename(filePath)
       const fileBuffer = await readFile(filePath)
       const token = await this.getAccessToken()
@@ -92,7 +119,11 @@ class QQAdapter implements MobileAdapter {
       const form = new FormData()
       form.append("file", new Blob([new Uint8Array(fileBuffer)]), filename)
 
-      const uploadResp = await fetch(`https://api.sgroup.qq.com/v2/files`, {
+      const uploadUrl =
+        info.type === "c2c"
+          ? `https://api.sgroup.qq.com/v2/users/${info.openid}/files`
+          : `https://api.sgroup.qq.com/v2/groups/${info.openid}/files`
+      const uploadResp = await fetch(uploadUrl, {
         method: "POST",
         headers: { Authorization: `QQBot ${token}` },
         body: form,
@@ -104,11 +135,15 @@ class QQAdapter implements MobileAdapter {
         return
       }
 
-      await fetch(`https://api.sgroup.qq.com/v2/messages`, {
+      const msgUrl =
+        info.type === "c2c"
+          ? `https://api.sgroup.qq.com/v2/users/${info.openid}/messages`
+          : `https://api.sgroup.qq.com/v2/groups/${info.openid}/messages`
+      await fetch(msgUrl, {
         method: "POST",
         headers: { Authorization: `QQBot ${token}`, "Content-Type": "application/json" },
         body: JSON.stringify({
-          msg_type: 3,
+          msg_type: 7,
           msg_id: messageId,
           media: { file_info: fileUuid },
         }),
@@ -148,12 +183,16 @@ class QQAdapter implements MobileAdapter {
 class QQManagerImpl extends MobileManagerBase {
   private ws: WebSocket | null = null
   public _qqSession: QQSession | null = null
+  public _chatInfos: Record<string, ChatInfo> = {}
+  public _currentChatId: string = ""
   private _heartbeat: ReturnType<typeof setInterval> | null = null
   private _heartbeatInterval: number = 30000
   private _sessionId: string = ""
+  private _lastSeq: number | null = null
   private _reconnect: ReturnType<typeof setTimeout> | null = null
   private _reconnectCount = 0
   private _lastConfig: QQConfig | null = null
+  private _identified = false
 
   private static readonly RECONNECT_MAX_MS = 300_000
 
@@ -221,7 +260,7 @@ class QQManagerImpl extends MobileManagerBase {
       const token = await this.qqAdapter.getAccessToken()
       console.log("[qq] access token obtained")
 
-      const gatewayResp = await fetch("https://api.sgroup.qq.com/websocket/", {
+      const gatewayResp = await fetch("https://api.sgroup.qq.com/gateway", {
         headers: { Authorization: `QQBot ${token}` },
       })
       const gatewayData = (await gatewayResp.json()) as any
@@ -230,23 +269,30 @@ class QQManagerImpl extends MobileManagerBase {
       console.log("[qq] gateway url:", wssUrl)
 
       this.ws = new WebSocket(wssUrl)
+      this._identified = false
+      this._lastSeq = null
 
       this.ws.addEventListener("open", () => {
         console.log("[qq] ws open", localISOString())
       })
 
       this.ws.addEventListener("message", (event) => {
-        const payload = JSON.parse(event.data as string)
-        this.handleWsMessage(payload)
+        try {
+          const payload = JSON.parse(event.data as string)
+          this.handleWsMessage(payload)
+        } catch (err) {
+          console.error("[qq] ws message parse error:", err)
+        }
       })
 
       this.ws.addEventListener("close", (event) => {
         console.log("[qq] ws close:", event.code, event.reason, localISOString())
-        this.onDisconnect(`ws_close_${event.code}`)
+        if (this._identified) this.onDisconnect(`ws_close_${event.code}`)
       })
 
       this.ws.addEventListener("error", () => {
-        this.onDisconnect("ws_error")
+        console.log("[qq] ws error", localISOString())
+        if (this._identified) this.onDisconnect("ws_error")
       })
 
       await this.waitForIdentify()
@@ -291,6 +337,8 @@ class QQManagerImpl extends MobileManagerBase {
             clearTimeout(timeout)
             this.ws!.removeEventListener("message", handleMessage)
             this._sessionId = payload.d?.session_id ?? ""
+            this._identified = true
+            if (payload.s) this._lastSeq = payload.s
             resolve()
           } else if (payload.op === OpCode.Hello) {
             this._heartbeatInterval = payload.d?.heartbeat_interval ?? 30000
@@ -305,6 +353,10 @@ class QQManagerImpl extends MobileManagerBase {
                 },
               }),
             )
+          } else if (payload.op === OpCode.InvalidSession) {
+            clearTimeout(timeout)
+            this.ws!.removeEventListener("message", handleMessage)
+            reject(new Error("QQ 鉴权失败 (Invalid Session)"))
           } else if (payload.op === OpCode.Reconnect) {
             clearTimeout(timeout)
             this.ws!.removeEventListener("message", handleMessage)
@@ -318,6 +370,8 @@ class QQManagerImpl extends MobileManagerBase {
   }
 
   private handleWsMessage(payload: any): void {
+    if (payload.s) this._lastSeq = payload.s
+
     switch (payload.op) {
       case OpCode.Dispatch:
         this.handleDispatch(payload)
@@ -328,6 +382,10 @@ class QQManagerImpl extends MobileManagerBase {
       case OpCode.Reconnect:
         console.log("[qq] reconnect requested", localISOString())
         this.onDisconnect("reconnect_requested")
+        break
+      case OpCode.InvalidSession:
+        console.log("[qq] invalid session", localISOString())
+        this.onDisconnect("invalid_session")
         break
       case OpCode.Hello:
         this._heartbeatInterval = payload.d?.heartbeat_interval ?? 30000
@@ -347,48 +405,51 @@ class QQManagerImpl extends MobileManagerBase {
   }
 
   private handleC2CMessage(data: any): void {
-    const content = data?.content ?? data?.event?.content ?? ""
-    const messageId = data?.id ?? data?.msg_id ?? ""
+    const content = data?.content ?? ""
+    const messageId = data?.id ?? ""
     const openId = data?.author?.user_openid ?? ""
 
-    if (!messageId || !content) return
-    if (!this.enqueueMessage(openId, messageId)) return
+    if (!messageId || !openId) return
 
     const text = content.trim()
     if (!text) return
 
     const chatId = `c2c_${openId}`
+    this._chatInfos[chatId] = { type: "c2c", openid: openId }
+
+    if (!this.enqueueMessage(chatId, messageId)) return
+
+    this._currentChatId = chatId
     const rootId = messageId
     void this.handleMessage(chatId, messageId, text, rootId)
   }
 
   private handleGroupMessage(data: any): void {
-    const content = data?.content ?? data?.event?.content ?? ""
-    const messageId = data?.id ?? data?.msg_id ?? ""
-    const groupOpenId = data?.group_openid ?? data?.event?.group_openid ?? ""
+    const content = data?.content ?? ""
+    const messageId = data?.id ?? ""
+    const groupOpenId = data?.group_openid ?? ""
 
-    if (!messageId || !content) return
+    if (!messageId || !groupOpenId) return
 
     let text = content.trim()
     text = text.replace(/@\S+\s*/g, "").trim()
     if (!text) return
 
-    if (!this.enqueueMessage(groupOpenId, messageId)) return
-
     const chatId = `group_${groupOpenId}`
+    this._chatInfos[chatId] = { type: "group", openid: groupOpenId }
+
+    if (!this.enqueueMessage(chatId, messageId)) return
+
+    this._currentChatId = chatId
     const rootId = messageId
     void this.handleMessage(chatId, messageId, text, rootId)
-  }
-
-  protected override replyTarget(chatId: string, messageId: string): string {
-    return messageId
   }
 
   private startWsHeartbeat(): void {
     this.stopWsHeartbeat()
     this._heartbeat = setInterval(() => {
       if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-        this.ws.send(JSON.stringify({ op: OpCode.Heartbeat, d: this._sessionId }))
+        this.ws.send(JSON.stringify({ op: OpCode.Heartbeat, d: this._lastSeq }))
       }
     }, this._heartbeatInterval)
   }
@@ -451,6 +512,7 @@ class QQManagerImpl extends MobileManagerBase {
     this._pendingPermissions = {}
     this._pendingConfirmCreate = {}
     this._activePrompt.clear()
+    this._chatInfos = {}
     if (!reset) return
     this._connectedModel = null
     this._chatDirs = {}

--- a/packages/opencode/src/mobile/qq.ts
+++ b/packages/opencode/src/mobile/qq.ts
@@ -158,9 +158,9 @@ class QQAdapter implements MobileAdapter {
     try {
       const next = this.manager.file("config.json")
       const prev = this.manager.readPath("config.json")
-      const path = existsSync(next) || !existsSync(prev) ? next : prev
-      if (existsSync(path)) {
-        const data = await readFile(path, "utf-8")
+      const configPath = existsSync(next) || !existsSync(prev) ? next : prev
+      if (existsSync(configPath)) {
+        const data = await readFile(configPath, "utf-8")
         return JSON.parse(data)
       }
     } catch {}

--- a/packages/opencode/src/mobile/route.ts
+++ b/packages/opencode/src/mobile/route.ts
@@ -193,28 +193,19 @@ export function createMobileRoutes(platform: "feishu" | "qq" | "wechat") {
           const q = new AsyncQueue<string | null>()
           let done = false
 
-          q.push(
-            JSON.stringify({
-              type: `${prefix}.status`,
-              properties: { status: manager.status },
-            }),
-          )
-
+          const initialProps: any = { status: manager.status }
           if (manager.status === "connected") {
             if (platform === "feishu" && FeishuManager.session?.appId) {
-              q.push(
-                JSON.stringify({ type: `${prefix}.connected`, properties: { appId: FeishuManager.session.appId } }),
-              )
+              initialProps.appId = FeishuManager.session.appId
             } else if (platform === "qq" && QQManager.session?.appId) {
-              q.push(JSON.stringify({ type: `${prefix}.connected`, properties: { appId: QQManager.session.appId } }))
+              initialProps.appId = QQManager.session.appId
             } else if (platform === "wechat") {
               const session = await WeChatManager.adapter.loadSession()
               const user = WeChatManager.session?.user || session?.user
-              if (user) {
-                q.push(JSON.stringify({ type: `${prefix}.connected`, properties: { user } }))
-              }
+              if (user) initialProps.user = user
             }
           }
+          q.push(JSON.stringify({ type: `${prefix}.status`, properties: initialProps }))
 
           if (platform === "wechat" && WeChatManager.status === "qrcode" && WeChatManager.qrcode) {
             q.push(JSON.stringify({ type: `${prefix}.qrcode`, properties: { image: WeChatManager.qrcode } }))


### PR DESCRIPTION
### Issue for this PR

Closes #452

### Type of change

- [x] New feature
- [x] Bug fix

### What does this PR do?

Adds QQ (腾讯QQ) official bot platform as a third mobile bridge alongside WeChat and Feishu, and fixes several related issues:

**New feature — QQ bot platform:**
- Backend: `QQAdapter` + `QQManagerImpl` in `qq.ts` implementing QQ's WebSocket gateway protocol (OpCode: Hello→Identify→Heartbeat→Dispatch), access token via `bots.qq.com/app/getAppAccessToken`, message sending via `/v2/users/{openid}/messages` (C2C) and `/v2/groups/{group_openid}/messages` (群聊)
- Frontend: QQ sidebar button (penguin icon, between WeChat and Feishu), QQ config dialog with AppID/AppSecret form, simplified one-line config instructions
- Route: `/mobile/qq` endpoint with SSE, status, start, stop
- Platform type: expanded `"feishu" | "wechat"` → `"feishu" | "qq" | "wechat"`

**Bug fixes:**
- SSE `.status` event now carries `appId`/`user` alongside status, preventing two rapid state patches that cause UI flicker (抖动)
- `autocomplete="off"` / `autocomplete="new-password"` on AppID/AppSecret inputs to prevent browser cross-platform credential autofill
- SSE `idle` status no longer overwrites frontend `config` state
- Wechat "Unknown" username hidden from connected dialog
- QQ gateway URL: use `/gateway` REST API instead of `/websocket/` endpoint
- QQ heartbeat: send last sequence number `s` (not session_id), per QQ official docs
- QQ message API: route to `/v2/users/{openid}/messages` or `/v2/groups/{group_openid}/messages` based on chat type
- Handle QQ OpCode 9 (Invalid Session)

### How did you verify your code works?

- `bun typecheck` passes for opencode, app, and ui packages
- QQ bot successfully connects via WebSocket gateway and receives C2C/group messages
- Manual testing: QQ config form, connection, message sending all work

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR