### PR TITLE
fix(mobile): persist recent model and inherit session preference on creation

### DIFF
--- a/packages/opencode/src/mobile/base.ts
+++ b/packages/opencode/src/mobile/base.ts
@@ -371,6 +371,17 @@ export abstract class MobileManagerBase {
     })
   }
 
+  protected async inheritPreference(newSessionId: string, dir: string): Promise<void> {
+    const candidates = await Instance.provide({
+      directory: dir,
+      fn: () => [...Session.list({ directory: dir, roots: true, limit: 20 })].map((s) => s.id),
+    })
+    await Instance.provide({
+      directory: dir,
+      fn: () => SessionPreference.inheritFor(newSessionId, candidates),
+    })
+  }
+
   protected async currentSession(chatId: string, create?: boolean): Promise<string | undefined> {
     const pinned = this._chatSessions[chatId]
     if (pinned) return pinned
@@ -388,6 +399,7 @@ export abstract class MobileManagerBase {
       directory: dir,
       fn: () => Session.create({ title: `${this.platformName()}对话 - ${new Date().toISOString()}` }),
     })
+    await this.inheritPreference(session.id, dir)
     this._chatSessions[chatId] = session.id
     return session.id
   }
@@ -549,6 +561,7 @@ export abstract class MobileManagerBase {
           fn: () => Session.create({ title: `${this.platformName()}对话 - ${new Date().toISOString()}` }),
         })
         sessionId = session.id
+        await this.inheritPreference(session.id, effectiveDir)
         console.log(`[${this.adapter.platform}] session created:`, sessionId)
       }
       this._chatSessions[chatId] = sessionId
@@ -764,6 +777,7 @@ export abstract class MobileManagerBase {
       directory: dir,
       fn: () => Session.create({ title: `${this.platformName()}对话 - ${new Date().toISOString()}` }),
     })
+    await this.inheritPreference(session.id, dir)
     this._chatSessions[chatId] = session.id
     await this.saveSessionMap()
     await this.replyCmd(targetId, chatId, `✅ 已开启新对话\n💬 ${session.title}`)
@@ -1192,6 +1206,7 @@ export abstract class MobileManagerBase {
         return { sessionId: session.id, sessionTitle: session.title, created: true }
       },
     })
+    if (created) await this.inheritPreference(newSessionId, newDir)
     this._chatSessions[chatId] = newSessionId
     await this.saveSessionMap()
 
@@ -1239,6 +1254,7 @@ export abstract class MobileManagerBase {
         return { sessionId: session.id, sessionTitle: session.title, created: true }
       },
     })
+    if (created) await this.inheritPreference(newSessionId, newDir)
     this._chatSessions[chatId] = newSessionId
     await this.saveSessionMap()
 
@@ -1317,6 +1333,7 @@ export abstract class MobileManagerBase {
         directory: effectiveDir,
         fn: () => Session.create({ title: `${this.platformName()}对话 - ${new Date().toISOString()}` }),
       })
+      await this.inheritPreference(session.id, effectiveDir)
       this._chatSessions[chatId] = session.id
       await this.replyCmd(targetId, chatId, "📂 当前项目下还没有任何会话，已自动创建一个新会话并切换。")
       return

--- a/packages/opencode/src/session/preference.ts
+++ b/packages/opencode/src/session/preference.ts
@@ -97,6 +97,24 @@ export namespace SessionPreference {
     return merged
   }
 
+  export async function inheritFor(newSessionID: string, candidateIDs: string[]): Promise<void> {
+    const id = SessionID.make(newSessionID)
+    for (const cid of candidateIDs) {
+      const pref = store.get(cid)
+      if (pref?.model) {
+        const { sessionID: _, ...data } = pref
+        await update({ sessionID: id, ...data })
+        return
+      }
+    }
+    const { Provider } = await import("@/provider/provider")
+    const fallback = await Provider.defaultModel()
+    await update({
+      sessionID: id,
+      model: { providerID: ProviderID.make(fallback.providerID), modelID: ModelID.make(fallback.modelID) },
+    })
+  }
+
   export function remove(sessionID: string): void {
     store.delete(sessionID)
   }

--- a/packages/opencode/src/session/preference.ts
+++ b/packages/opencode/src/session/preference.ts
@@ -1,9 +1,12 @@
+import path from "path"
 import z from "zod"
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { SessionID } from "./schema"
 import { ModelID, ProviderID } from "@/provider/schema"
 import { Log } from "@/util/log"
+import { Global } from "@/global"
+import { Filesystem } from "@/util/filesystem"
 
 const log = Log.create({ service: "session.preference" })
 
@@ -87,6 +90,10 @@ export namespace SessionPreference {
       }
     }
 
+    if (modelChanged && merged.model) {
+      void persistRecentModel(merged.model.providerID, merged.model.modelID)
+    }
+
     return merged
   }
 
@@ -97,4 +104,16 @@ export namespace SessionPreference {
   export function clear(): void {
     store.clear()
   }
+}
+
+async function persistRecentModel(providerID: string, modelID: string): Promise<void> {
+  const filepath = path.join(Global.Path.state, "model.json")
+  const prev = await Filesystem.readJson<{ recent?: { providerID: string; modelID: string }[] }>(filepath)
+    .then((x) => (Array.isArray(x.recent) ? x.recent : []))
+    .catch(() => [])
+  const entry = { providerID, modelID }
+  const recent = [entry, ...prev.filter((r) => r.providerID !== providerID || r.modelID !== modelID)].slice(0, 5)
+  await Filesystem.writeJson(filepath, { recent }).catch((err) => {
+    log.error("persistRecentModel write failed", err)
+  })
 }


### PR DESCRIPTION
### Issue for this PR

Closes #454

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two changes that fix mobile sessions showing "—" as model and `defaultModel()` picking unsuitable intent-detect models:

1. **`preference.ts` — Persist recent model to `model.json`** — When `SessionPreference.update` changes the model, the new model is written into `Global.Path.state/model.json` as the head of a `recent` list (deduplicated, max 5 entries). `Provider.defaultModel()` already reads this file but the `recent` field was never written by backend code, so it always fell through to sort-based default which could pick `tongyi-intent-detect-v3`.

2. **`preference.ts` + `base.ts` — Inherit preference on session creation** — Added `SessionPreference.inheritFor(newSessionID, candidateIDs)` that copies model/agent/variant/autoAccept from the first candidate session that has a model. If no candidate has preference, falls back to `Provider.defaultModel()`. Added `inheritPreference()` helper in `MobileManagerBase` and applied it at all 6 mobile session creation points:
   - `cmdNew` (/n)
   - `startPrompt` new session
   - `currentSession` create
   - `cmdSession` auto-create
   - `switchToProject` create
   - `switchToNewProject` create

### How did you verify your code works?

- `bun typecheck` passes in `packages/opencode` (both commits)
- Code review confirms all 6 session creation paths now call `inheritPreference`
- `inheritFor` correctly iterates candidates and falls back to `Provider.defaultModel()`

### Screenshots / recordings

Not applicable — backend logic change with no UI impact beyond fixing the "—" display in mobile headers.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR