### PR TITLE
fix: use fixed Aether default port 19527 with 5-candidate fallback

### DIFF
--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -334,6 +334,24 @@ async function getSidecarPort() {
     if (!Number.isNaN(parsed)) return parsed
   }
 
+  const AETHER_PORT = 19527
+  const tryPort = (port: number) =>
+    new Promise<number | null>((resolve) => {
+      const server = createServer()
+      server.on("error", () => {
+        server.close()
+        resolve(null)
+      })
+      server.listen(port, "127.0.0.1", () => {
+        server.close(() => resolve(port))
+      })
+    })
+
+  for (let i = 0; i < 5; i++) {
+    const port = await tryPort(AETHER_PORT + i)
+    if (port !== null) return port
+  }
+
   return await new Promise<number>((resolve, reject) => {
     const server = createServer()
     server.on("error", reject)

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -278,7 +278,7 @@ export const RunCommand = cmd({
       })
       .option("attach", {
         type: "string",
-        describe: "attach to a running opencode server (e.g., http://localhost:4096)",
+        describe: "attach to a running opencode server (e.g., http://localhost:19527)",
       })
       .option("password", {
         alias: ["p"],

--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -13,7 +13,7 @@ export const AttachCommand = cmd({
     yargs
       .positional("url", {
         type: "string",
-        describe: "http://localhost:4096",
+        describe: "http://localhost:19527",
         demandOption: true,
       })
       .option("dir", {

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -62,7 +62,7 @@ export namespace Plugin {
             const { Server } = await import("../server/server")
 
             const client = createOpencodeClient({
-              baseUrl: "http://localhost:4096",
+              baseUrl: "http://localhost:19527",
               directory: ctx.directory,
               headers: Flag.OPENCODE_SERVER_PASSWORD
                 ? {
@@ -78,7 +78,7 @@ export namespace Plugin {
               worktree: ctx.worktree,
               directory: ctx.directory,
               get serverUrl(): URL {
-                return Server.url ?? new URL("http://localhost:4096")
+                return Server.url ?? new URL("http://localhost:19527")
               },
               $: Bun.$,
             }

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -758,6 +758,7 @@ export namespace Server {
       // Raise body limit to 1 GB to support large PDF uploads (default is 128 MB)
       maxRequestBodySize: 1024 * 1024 * 1024,
     } as const
+    const AETHER_PORT = 19527
     const tryServe = (port: number) => {
       try {
         return Bun.serve({ ...args, port, reusePort: true })
@@ -765,7 +766,15 @@ export namespace Server {
         return undefined
       }
     }
-    const server = opts.port === 0 ? (tryServe(4096) ?? tryServe(0)) : tryServe(opts.port)
+    const server =
+      opts.port === 0
+        ? (tryServe(AETHER_PORT) ??
+          tryServe(AETHER_PORT + 1) ??
+          tryServe(AETHER_PORT + 2) ??
+          tryServe(AETHER_PORT + 3) ??
+          tryServe(AETHER_PORT + 4) ??
+          tryServe(0))
+        : tryServe(opts.port)
     if (!server) throw new Error(`Failed to start server on port ${opts.port}`)
 
     url = new URL(`http://${opts.hostname}:${server.port}`)


### PR DESCRIPTION
### Issue for this PR

Closes #456

### Type of change

- [x] Bug fix

### What does this PR do?

Aether server startup binds to a random port every time because:
1. Electron `getSidecarPort()` uses `listen(0)` to get a random port, then passes it to the sidecar, bypassing the `tryServe(4096)` fallback
2. On Windows, zombie sockets from dead processes occupy port 4096, and `reusePort` (SO_REUSEADDR) doesn't help, causing `tryServe(4096)` to fail
3. Port 4096 conflicts with upstream opencode which uses it as default

This PR fixes it by:
- Defining `AETHER_PORT = 19527` (distinct from opencode's 4096, unlikely to conflict with common services)
- Trying 5 consecutive fixed ports (19527→19531) before falling back to random, in both `server.ts` and Electron `getSidecarPort()`
- Updating all hardcoded `localhost:4096` fallback URLs/descriptions to `localhost:19527`

The port is now almost always predictable (19527 normally, 19528-19531 if occupied), with graceful fallback only when all 5 are unavailable.

### How did you verify your code works?

- Ran `bun typecheck` on both `packages/opencode` and `packages/desktop-electron` — both pass
- Started `bun run --conditions=browser ./src/index.ts serve` without `--port` — server consistently binds to 19527 across multiple restarts
- Verified health check via `curl http://127.0.0.1:19527/global/health` returns `{"healthy":true}`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR