### PR TITLE
ci: require database and updater checks in review prompt

### DIFF
--- a/.github/prompts/review.txt
+++ b/.github/prompts/review.txt
@@ -33,6 +33,8 @@ Operating rules:
 6. Review standard:
    - Focus on correctness, effectiveness, regressions, edge cases, and meaningful maintainability risks.
    - Pay special attention to the risk of breaking or weakening the underlying architecture, not just local code issues.
+   - Separately and carefully review any direct or indirect impact on user data `.db` files, including schema, migrations, persistence logic, storage paths, read/write behavior, compatibility, corruption risk, and upgrade or rollback behavior.
+   - Separately and carefully review any direct or indirect impact on automatic updates, including update detection, download, install, restart, version comparison, release channels, rollback behavior, and failure handling.
    - Avoid style nitpicks unless they materially affect readability or violate an obvious repository convention.
    - Only review changed behavior or changed code paths.
    - Consider the current PR target branch when reasoning about compatibility.
@@ -42,6 +44,7 @@ Operating rules:
    - Do not output JSON.
    - Do not output code fences unless you truly need a tiny inline example.
    - Do not include tool logs or command transcripts.
+   - Always include explicit feedback for the user data `.db` file review and the automatic update review.
    - If there are no actionable findings, output exactly `LGTM`.
 
 8. Suggested review format when issues exist:


### PR DESCRIPTION
### Issue for this PR

Closes #458

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Updates the opencode review prompt to require explicit review coverage for:

- user data `.db` files, including schema, migrations, persistence, compatibility, corruption, and upgrade or rollback behavior
- automatic updates, including detection, download, install, restart, version comparison, channels, rollback, and failure handling

This makes review output call out both risk areas directly instead of only considering them implicitly.

### How did you verify your code works?

Reviewed the staged diff. No automated tests were run because this is a prompt-only change.

### Screenshots / recordings

Not applicable.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
