### PR TITLE
fix: run session e2e spec serially

### DIFF
--- a/packages/app/e2e/ci-specs-serial.txt
+++ b/packages/app/e2e/ci-specs-serial.txt
@@ -8,6 +8,7 @@ e2e/prompt/prompt-async.spec.ts
 e2e/prompt/prompt-history.spec.ts
 e2e/prompt/prompt-shell.spec.ts
 e2e/prompt/prompt.spec.ts
+e2e/session/session.spec.ts
 e2e/terminal/terminal-init.spec.ts
 e2e/terminal/terminal-tabs.spec.ts
 e2e/terminal/terminal-reconnect.spec.ts

--- a/packages/app/e2e/ci-specs.txt
+++ b/packages/app/e2e/ci-specs.txt
@@ -21,7 +21,6 @@ e2e/prompt/prompt-slash-share.spec.ts
 e2e/prompt/prompt-slash-terminal.spec.ts
 e2e/session/session-child-navigation.spec.ts
 e2e/session/session-undo-redo.spec.ts
-e2e/session/session.spec.ts
 e2e/settings/settings-models.spec.ts
 e2e/settings/settings.spec.ts
 e2e/sidebar/sidebar.spec.ts


### PR DESCRIPTION
### Issue for this PR

Closes #461

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Moves `e2e/session/session.spec.ts` from the parallel app e2e CI spec list to the serial spec list.

This spec has shown Windows CI concurrency sensitivity around session setup, async seeding, navigation, and cleanup. Running it with the existing serial e2e group avoids sharing pressure from the parallel batch without changing the session rename UI or app behavior.

### How did you verify your code works?

Verified the spec appears only in `packages/app/e2e/ci-specs-serial.txt` after the change.

Full Windows e2e was not run locally; this failure is specific to the GitHub Actions Windows runner.

### Screenshots / recordings

Not applicable.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
