### PR TITLE
fix: tolerate missing darwin updater uv runtime

### DIFF
--- a/Update/update_darwin.command
+++ b/Update/update_darwin.command
@@ -453,12 +453,19 @@ done
 shopt -u nullglob
 
 chmod +x "$target/aether" "$target/Aether.command"
-uv="$(find "$target/wechat-bridge/runtime/uv" -name 'uv-*apple-darwin*/uv' -type f 2>/dev/null | head -1)"
+uv=""
+shopt -s nullglob
+for file in "$target"/wechat-bridge/runtime/uv/uv-*apple-darwin*/uv; do
+  [ -f "$file" ] || continue
+  uv="$file"
+  break
+done
+shopt -u nullglob
 if [ -f "$uv" ]; then
   chmod +x "$uv"
 fi
 xattr -cr "$target/aether" "$target/Aether.command" >/dev/null 2>&1 || true
-if [ -n "$uv" ] && [ -f "$uv" ]; then
+if [ -f "$uv" ]; then
   xattr -cr "$uv" >/dev/null 2>&1 || true
 fi
 printf "%s\n" "$ver" >"$target/.aether_web_version"


### PR DESCRIPTION
### Issue for this PR

Closes #460

### Type of change

- [x] Bug fix

### What does this PR do?

This PR fixes the macOS web updater so it no longer exits when the installed package does not contain `wechat-bridge/runtime/uv`. The previous implementation used a bare `find` under `set -euo pipefail`, which treated a missing optional `uv` directory as a fatal error and stopped the updater before mirror/launch steps could run. The update script now treats the `uv` path as optional and only applies permission/xattr changes when a matching file is actually present.

### How did you verify your code works?

- `cd packages/opencode && bun typecheck`
- `TMPDIR=... bun test test/server/web-update-script.test.ts --timeout 30000`
- The targeted test file passes on Linux for the runnable cases and skips the macOS/Windows cases as expected.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
