### PR TITLE
feat: add optional downloadbeta upload workflow

### DIFF
--- a/.github/scripts/upload-downloadbeta.ts
+++ b/.github/scripts/upload-downloadbeta.ts
@@ -1,0 +1,169 @@
+type Item = {
+  archive: string
+  installer: string
+}
+
+type Link = {
+  url: string
+  contentType: string
+}
+
+type Platform = {
+  archive: Link
+  installer: Link
+}
+
+type Presign = {
+  ok: boolean
+  platforms: Record<string, Platform>
+}
+
+type Commit = {
+  ok: boolean
+  files?: Array<{
+    url?: string
+    latestUrl?: string
+    manifestUrl?: string
+    latestManifestUrl?: string
+    installerUrl?: string
+    latestInstallerUrl?: string
+  }>
+  ossWarnings?: unknown[]
+}
+
+const items = {
+  mac: {
+    archive: "dist/aether-darwin-arm64.dmg",
+    installer: "Update/update_darwin.command",
+  },
+  windows: {
+    archive: "dist/aether-windows-x64.zip",
+    installer: "Update/update_windows.bat",
+  },
+  linux: {
+    archive: "dist/aether-linux-x64.zip",
+    installer: "Update/update_linux.sh",
+  },
+} satisfies Record<string, Item>
+
+function fail(msg: string): never {
+  console.error(msg)
+  process.exit(1)
+}
+
+function env(key: string) {
+  return process.env[key]?.trim() || fail(`Missing ${key}`)
+}
+
+function url(root: string, path: string) {
+  return `${root.replace(/\/+$/, "")}${path}`
+}
+
+async function json(res: Response) {
+  return await res.json().catch(() => fail(`Invalid JSON response from ${res.url}: ${res.status}`))
+}
+
+function link(val: unknown): val is Link {
+  if (!val || typeof val !== "object") return false
+  if (!("url" in val) || typeof val.url !== "string" || !val.url) return false
+  if (!("contentType" in val) || typeof val.contentType !== "string" || !val.contentType) return false
+  return true
+}
+
+function platform(val: unknown): val is Platform {
+  if (!val || typeof val !== "object") return false
+  if (!("archive" in val) || !link(val.archive)) return false
+  if (!("installer" in val) || !link(val.installer)) return false
+  return true
+}
+
+function presign(val: unknown): val is Presign {
+  if (!val || typeof val !== "object") return false
+  if (!("ok" in val) || val.ok !== true) return false
+  if (!("platforms" in val) || !val.platforms || typeof val.platforms !== "object") return false
+  return Object.keys(items).every((key) => platform((val.platforms as Record<string, unknown>)[key]))
+}
+
+function commit(val: unknown): val is Commit {
+  if (!val || typeof val !== "object") return false
+  return "ok" in val && val.ok === true
+}
+
+function beta(val: unknown) {
+  if (typeof val !== "string") return false
+  if (!val) return false
+  return val.startsWith("/downloadbeta/")
+}
+
+function urls(file: NonNullable<Commit["files"]>[number]) {
+  return [
+    file.url,
+    file.latestUrl,
+    file.manifestUrl,
+    file.latestManifestUrl,
+    file.installerUrl,
+    file.latestInstallerUrl,
+  ].filter((x): x is string => typeof x === "string" && x.length > 0)
+}
+
+async function exists(item: Item) {
+  await Promise.all(
+    [item.archive, item.installer].map(async (file) => {
+      if (!(await Bun.file(file).exists())) fail(`Missing upload file: ${file}`)
+    }),
+  )
+}
+
+async function post(root: string, path: string, pass: string, body: Record<string, unknown>) {
+  const res = await fetch(url(root, path), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-download-admin-password": pass,
+    },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) fail(`Request failed: ${path} ${res.status}`)
+  return await json(res)
+}
+
+async function put(file: string, link: Link) {
+  const res = await fetch(link.url, {
+    method: "PUT",
+    headers: { "Content-Type": link.contentType },
+    body: Bun.file(file),
+  })
+  if (!res.ok) fail(`Upload failed: ${file} ${res.status}`)
+}
+
+const root = env("DOWNLOAD_BETA_BASE_URL")
+const pass = env("DOWNLOAD_ADMIN_PASSWORD")
+const ver = env("DOWNLOAD_BETA_VERSION")
+const body = Object.fromEntries(Object.keys(items).map((key) => [key, { version: ver }]))
+
+await Promise.all(Object.values(items).map(exists))
+
+const pre = await post(root, "/api/downloadbeta/admin/presign", pass, body)
+if (!presign(pre)) fail("Invalid presign response")
+
+await Promise.all(
+  Object.entries(items).flatMap(([key, item]) => [
+    put(item.archive, pre.platforms[key]!.archive),
+    put(item.installer, pre.platforms[key]!.installer),
+  ]),
+)
+
+const done = await post(root, "/api/downloadbeta/admin/commit", pass, {
+  ...body,
+  releaseDate: new Date().toISOString(),
+})
+
+if (!commit(done)) fail("Invalid commit response")
+if (Array.isArray(done.ossWarnings) && done.ossWarnings.length > 0) fail("Commit returned OSS warnings")
+if (!Array.isArray(done.files) || done.files.length < Object.keys(items).length) fail("Commit response is missing files")
+const links = done.files.map(urls)
+if (links.some((item) => item.length === 0) || !links.flat().every(beta)) {
+  fail("Commit response includes non-beta URLs")
+}
+
+console.log(`Uploaded ${ver} to downloadbeta`)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: false
         type: boolean
+      upload_downloadbeta:
+        description: "Upload web artifacts to downloadbeta"
+        required: false
+        default: false
+        type: boolean
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.version }}
 
@@ -235,6 +240,12 @@ jobs:
       - build-web-windows
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        if: inputs.upload_downloadbeta
+
+      - uses: ./.github/actions/setup-bun
+        if: inputs.upload_downloadbeta
+
       - uses: actions/download-artifact@v4
         with:
           pattern: release-*
@@ -254,3 +265,11 @@ jobs:
           fi
 
           gh release upload "${{ needs.release.outputs.tag }}" "${files[@]}" --clobber
+
+      - name: Upload web artifacts to downloadbeta
+        if: inputs.upload_downloadbeta
+        env:
+          DOWNLOAD_BETA_BASE_URL: ${{ vars.DOWNLOAD_BETA_BASE_URL }}
+          DOWNLOAD_ADMIN_PASSWORD: ${{ secrets.DOWNLOAD_ADMIN_PASSWORD }}
+          DOWNLOAD_BETA_VERSION: ${{ needs.release.outputs.version }}
+        run: bun .github/scripts/upload-downloadbeta.ts

--- a/docs/aether-download-admin-upload.md
+++ b/docs/aether-download-admin-upload.md
@@ -4,15 +4,16 @@
 
 ## 概览
 
-Aether 下载服务分为三个渠道：
+Aether 下载服务分为两个发布渠道：
 
 - **公开渠道** (`/download/`)：正式发布，支持版本化目录、manifest、OSS 推送
-- **私有测试渠道** (`/api/download2/`)：开发者测试产物，需鉴权，与公开渠道隔离
-- **手动安装渠道** (`/manual/`)：前端"手动安装"链接指向此渠道，仅存储 `latest` 安装包，无需鉴权
+- **测试版渠道** (`/downloadbeta/`)：测试发布，结构与公开渠道一致，但版本索引和 OSS 存储与公开渠道隔离
 
-每个渠道都有独立的管理员上传接口和独立的存储目录。
+信息站点中的"手动安装"下载链接不再维护独立 manual 包，直接指向公开渠道的 `/download/latest/<filename>`，由服务端解析到当前最新公开版本。
 
-**重要**：公开渠道和手动安装渠道要求配置 `DOWNLOAD_OSS_PUBLIC_BASE_URL`，下载时通过 302 重定向到 OSS。未配置时下载接口会返回错误。
+每个渠道都有独立的管理员 OSS 直传接口。
+
+**重要**：公开渠道和测试版渠道要求配置 `DOWNLOAD_OSS_PUBLIC_BASE_URL`，下载时通过 302 重定向到 OSS。未配置时下载接口会返回错误。
 
 当前支持的平台：
 
@@ -25,7 +26,8 @@ Aether 下载服务分为三个渠道：
 下载根路径：
 
 ```text
-https://aether.aiphys.cn/download
+https://aether.aiphys.cn/download       # 公开渠道
+https://aether.aiphys.cn/downloadbeta   # 测试版渠道
 ```
 
 管理员 OSS 直传接口（公开渠道）：
@@ -35,31 +37,14 @@ POST https://aether.aiphys.cn/api/download/admin/presign   # 获取预签名 URL
 POST https://aether.aiphys.cn/api/download/admin/commit     # 提交元数据，触发服务端处理
 ```
 
-管理员 OSS 直传接口（手动安装渠道）：
+管理员 OSS 直传接口（测试版渠道）：
 
 ```text
-POST https://aether.aiphys.cn/api/manual/admin/presign      # 获取预签名 URL
+POST https://aether.aiphys.cn/api/downloadbeta/admin/presign   # 获取预签名 URL
+POST https://aether.aiphys.cn/api/downloadbeta/admin/commit     # 提交元数据，触发服务端处理
 ```
 
-开发者私有测试下载接口：
-
-```text
-GET https://aether.aiphys.cn/api/download2/...
-```
-
-开发者私有测试上传接口：
-
-```text
-POST https://aether.aiphys.cn/api/download2/admin/upload
-```
-
-手动安装包下载接口：
-
-```text
-GET https://aether.aiphys.cn/manual/latest/<filename>
-```
-
-版本目录约定：
+公开渠道版本目录约定：
 
 - 最新通道：`/download/latest/`
 - 解析规则：`latest` 会解析到当前可用的最新公开版本，不限制大版本号
@@ -72,6 +57,19 @@ GET https://aether.aiphys.cn/manual/latest/<filename>
 - `/download/1.3.3/mac-arm64.yml`
 - `/download/1.3.3/aether-darwin-arm64.dmg`
 
+测试版渠道版本目录约定：
+
+- 最新通道：`/downloadbeta/latest/`
+- 解析规则：`latest` 会解析到当前可用的最新测试版，不影响公开渠道
+- 指定版本：`/downloadbeta/<version>/`
+
+例如：
+
+- `/downloadbeta/latest/mac-arm64.yml`
+- `/downloadbeta/latest/aether-darwin-arm64.dmg`
+- `/downloadbeta/1.3.3-beta.1/mac-arm64.yml`
+- `/downloadbeta/1.3.3-beta.1/aether-darwin-arm64.dmg`
+
 ## 公开渠道 OSS 直传上传
 
 服务端配置了 `ALIYUN_OSS_*` 环境变量后，大文件从客户端直传 OSS，不经过服务器中转，速度更快、节省服务器带宽。
@@ -80,7 +78,7 @@ GET https://aether.aiphys.cn/manual/latest/<filename>
 
 1. **presign** — 获取各平台文件的 OSS 预签名 PUT URL
 2. **upload** — 客户端并行直传文件到 OSS
-3. **commit** — 通知服务端完成本地写入、manifest 生成、版本记录等后续处理
+3. **commit** — 通知服务端计算校验信息、生成 manifest、更新版本记录
 
 ### Step 1: 获取预签名 URL
 
@@ -161,9 +159,9 @@ wait
 
 ```json
 {
-  "mac": { "version": "1.3.3", "hasInstaller": true },
-  "windows": { "version": "1.3.3", "hasInstaller": true },
-  "linux": { "version": "1.3.3", "hasInstaller": true },
+  "mac": { "version": "1.3.3" },
+  "windows": { "version": "1.3.3" },
+  "linux": { "version": "1.3.3" },
   "releaseDate": "2026-04-13T00:00:00.000Z"
 }
 ```
@@ -173,7 +171,6 @@ wait
 | 字段 | 必填 | 说明 |
 | --- | --- | --- |
 | `<platform>.version` | 是 | 该平台的版本号 |
-| `<platform>.hasInstaller` | 否 | 是否上传了安装脚本，默认 `false` |
 | `releaseDate` | 否 | ISO 时间字符串，不传由服务端生成 |
 
 响应格式与公开上传接口相同。
@@ -182,55 +179,59 @@ wait
 
 1. 从 OSS 下载各平台的安装包（走内网，速度快）
 2. 计算安装包的 `sha512` 和 `size`
-3. 生成 manifest 并写入本地和 OSS
-4. 将安装包和安装脚本写入本地 `downloads/{version}/` 和 `downloads/latest/`
-5. 更新 `downloads/latest-versions.json`
+3. 生成 manifest 并写入 OSS 的 `{version}/` 目录
+4. 更新 `downloads/latest-versions.json`
 
-## 手动安装渠道 OSS 直传上传
+服务端不会把安装包、版本安装脚本或 manifest 写入本地 `downloads/{version}/` 或 `downloads/latest/`。运行时唯一允许写入 `downloads/` 的文件是 `downloads/latest-versions.json`。
 
-手动安装渠道的文件直传到 OSS 后即生效，无需 commit 步骤（用户下载时直接 302 重定向到 OSS）。
+## 测试版渠道 OSS 直传上传
 
-流程分为两步：
+测试版渠道用于发布可被客户端自动更新读取的 beta 产物。接口协议与公开渠道一致，但存储、版本索引和下载路径必须与公开渠道隔离。
+下载成功统计也与公开渠道隔离：页面下载路由上报 `download_channel = 'download_beta'`，API 下载路由上报 `download_channel = 'api_download_beta'`。
+
+流程分为三步：
 
 1. **presign** — 获取各平台文件的 OSS 预签名 PUT URL
 2. **upload** — 客户端并行直传文件到 OSS
+3. **commit** — 通知服务端计算校验信息、生成 manifest、更新测试版版本记录
 
 ### Step 1: 获取预签名 URL
 
 - Method: `POST`
-- URL: `https://aether.aiphys.cn/api/manual/admin/presign`
+- URL: `https://aether.aiphys.cn/api/downloadbeta/admin/presign`
 - Content-Type: `application/json`
 - 鉴权：请求头 `x-download-admin-password`
 
-请求体示例：
+请求体与公开渠道相同：
 
 ```json
 {
-  "platforms": ["mac", "windows", "linux"]
+  "mac": { "version": "1.3.3-beta.1" },
+  "windows": { "version": "1.3.3-beta.1" },
+  "linux": { "version": "1.3.3-beta.1" }
 }
 ```
 
-响应示例：
+响应格式与公开渠道相同。测试版对象必须写入独立 OSS 前缀，建议使用 `beta/<version>/...`：
 
 ```json
 {
   "ok": true,
   "platforms": {
     "mac": {
-      "objectKey": "manual/latest/aether-darwin-arm64.dmg",
-      "url": "https://aether-asset.oss-cn-beijing.aliyuncs.com/manual/latest/aether-darwin-arm64.dmg?x-oss-signature-version=...",
-      "contentType": "application/x-apple-diskimage"
+      "archive": {
+        "objectKey": "beta/1.3.3-beta.1/aether-darwin-arm64.dmg",
+        "url": "https://aether-asset.oss-cn-beijing.aliyuncs.com/beta/1.3.3-beta.1/aether-darwin-arm64.dmg?x-oss-signature-version=...",
+        "contentType": "application/x-apple-diskimage"
+      },
+      "installer": {
+        "objectKey": "beta/1.3.3-beta.1/update_darwin.command",
+        "url": "https://aether-asset.oss-cn-beijing.aliyuncs.com/beta/1.3.3-beta.1/update_darwin.command?x-oss-signature-version=...",
+        "contentType": "text/x-shellscript; charset=utf-8"
+      }
     },
-    "windows": {
-      "objectKey": "manual/latest/aether-windows-x64.zip",
-      "url": "...",
-      "contentType": "application/zip"
-    },
-    "linux": {
-      "objectKey": "manual/latest/aether-linux-x64.zip",
-      "url": "...",
-      "contentType": "application/zip"
-    }
+    "windows": { ... },
+    "linux": { ... }
   },
   "expiresInSeconds": 1800
 }
@@ -238,88 +239,51 @@ wait
 
 ### Step 2: 直传文件到 OSS
 
-```bash
-curl -X PUT \
-  -H 'Content-Type: application/x-apple-diskimage' \
-  --data-binary @aether-darwin-arm64.dmg \
-  '<mac presigned url>' &
+上传方式与公开渠道相同，使用 presign 响应中的 URL 执行 PUT。
 
-curl -X PUT \
-  -H 'Content-Type: application/zip' \
-  --data-binary @aether-windows-x64.zip \
-  '<windows presigned url>' &
-
-curl -X PUT \
-  -H 'Content-Type: application/zip' \
-  --data-binary @aether-linux-x64.zip \
-  '<linux presigned url>' &
-
-wait
-```
-
-上传完成后，用户即可通过 `/manual/latest/<filename>` 下载。
-
-## 开发者私有测试上传接口
-
-该接口用于上传"仅供开发者测试"的最新产物，不会更新公开下载版本。
+### Step 3: 提交元数据
 
 - Method: `POST`
-- URL: `https://aether.aiphys.cn/api/download2/admin/upload`
-- Content-Type: `multipart/form-data`
-- 鉴权：请求头 `x-download-admin-password` 或表单字段 `password`
+- URL: `https://aether.aiphys.cn/api/downloadbeta/admin/commit`
+- Content-Type: `application/json`
+- 鉴权：请求头 `x-download-admin-password`
 
-写入行为：
+请求体与公开渠道相同：
 
-1. 只覆盖 `downloads2/latest/`
-2. 不写入 `downloads2/<version>/`
-3. 不影响公开 `/download/latest/...` 的版本解析结果
-4. 上传成功后应通过 `/api/download2/latest/...` 访问测试产物
-
-### 文件字段
-
-至少上传一个平台文件。每个已上传平台都必须带对应版本号。
-
-| 平台 | 文件字段 | 版本字段 | 发布文件名 |
-| --- | --- | --- | --- |
-| macOS | `macos` | `macVersion` | `aether-darwin-arm64.dmg` |
-| Windows | `windows` | `windowsVersion` | `aether-windows-x64.zip` |
-| Linux | `linux` | `linuxVersion` | `aether-linux-x64.zip` |
-
-### 可选安装脚本字段
-
-| 字段 | 含义 |
-| --- | --- |
-| `macInstaller` | macOS 可选更新脚本文件，发布为 `update_darwin.command` |
-| `winInstaller` | Windows 可选更新脚本文件，发布为 `update_windows.bat` |
-| `linuxInstaller` | Linux 可选更新脚本文件，发布为 `update_linux.sh` |
-
-### 上传示例
-
-```bash
-curl -X POST https://aether.aiphys.cn/api/download2/admin/upload \
-  -H 'x-download-admin-password: <your-password>' \
-  -F 'macVersion=1.4.1-dev' \
-  -F 'macos=@aether-darwin-arm64.dmg' \
-  -F 'macInstaller=@update_darwin.command'
+```json
+{
+  "mac": { "version": "1.3.3-beta.1" },
+  "windows": { "version": "1.3.3-beta.1" },
+  "linux": { "version": "1.3.3-beta.1" },
+  "releaseDate": "2026-04-13T00:00:00.000Z"
+}
 ```
 
-### 上传响应
+服务端处理流程：
 
-成功时返回的链接指向 `/api/download2/latest/...`，示例：
+1. 从 OSS 的 `beta/<version>/` 前缀读取各平台安装包
+2. 计算安装包的 `sha512` 和 `size`
+3. 生成 manifest 并写入 OSS 的 `beta/<version>/` 目录
+4. 更新测试版 latest 索引，建议使用 `downloads/beta-latest-versions.json` 或 OSS 内等价独立对象
+
+测试版 commit 响应中的下载链接必须指向 `/downloadbeta`，例如：
 
 ```json
 {
   "ok": true,
-  "releaseDate": "2026-04-08T10:00:00.000Z",
+  "releaseDate": "2026-04-13T00:00:00.000Z",
   "files": [
     {
       "platform": "mac",
-      "version": "1.4.1-dev",
-      "latestUrl": "/api/download2/latest/aether-darwin-arm64.dmg",
-      "latestManifestUrl": "/api/download2/latest/mac-arm64.yml",
+      "version": "1.3.3-beta.1",
+      "url": "/downloadbeta/1.3.3-beta.1/aether-darwin-arm64.dmg",
+      "latestUrl": "/downloadbeta/latest/aether-darwin-arm64.dmg",
+      "manifestUrl": "/downloadbeta/1.3.3-beta.1/mac-arm64.yml",
+      "latestManifestUrl": "/downloadbeta/latest/mac-arm64.yml",
       "sha512": "<base64-sha512>",
       "size": 93444053,
-      "latestInstallerUrl": "/api/download2/latest/update_darwin.command"
+      "installerUrl": "/downloadbeta/1.3.3-beta.1/update_darwin.command",
+      "latestInstallerUrl": "/downloadbeta/latest/update_darwin.command"
     }
   ]
 }
@@ -327,56 +291,34 @@ curl -X POST https://aether.aiphys.cn/api/download2/admin/upload \
 
 ## 手动安装包下载接口
 
-该接口供前端"手动安装"链接使用，无需鉴权。
+信息站点前端"手动安装"链接直接使用公开渠道最新安装包，无需维护独立 manual 对象。
 
 下载路径：
 
 ```text
-/manual/latest/aether-darwin-arm64.dmg
-/manual/latest/aether-windows-x64.zip
-/manual/latest/aether-linux-x64.zip
+/download/latest/aether-darwin-arm64.dmg
+/download/latest/aether-windows-x64.zip
+/download/latest/aether-linux-x64.zip
 ```
 
 说明：
 
+- `latest` 会按平台解析到当前最新公开版本
 - 通过 302 重定向到 OSS 公开地址
-- 下载成功后自动上报 analytics 事件（`download_channel = 'manual'`）
-
-## 开发者私有测试下载接口
-
-该接口仅供开发者测试未公开的 `latest` 产物使用，不对外开放。
-
-鉴权方式：
-
-- 请求头 `x-download-admin-password`
-- 或查询参数 `password`
-
-示例：
-
-```text
-/api/download2/latest/mac-arm64.yml
-/api/download2/latest/aether-darwin-arm64.dmg
-/api/download2/1.4.1/mac-arm64.yml
-```
-
-说明：
-
-- `/api/download2/latest/...` 直接读取 `downloads2/latest/`，与生产 `downloads/` 目录隔离
-- `/api/download2/<version>/...` 按 `downloads2/<version>/` 目录读取文件
+- 下载成功后按公开渠道上报 analytics 事件
 
 ## 下载接口
 
 ### 下载模式
 
-公开渠道和手动安装渠道要求配置 `DOWNLOAD_OSS_PUBLIC_BASE_URL`，通过 302 重定向到 OSS 对象地址。未配置时返回错误。
+公开渠道和测试版渠道要求配置 `DOWNLOAD_OSS_PUBLIC_BASE_URL`，通过 302 重定向到 OSS 对象地址。未配置时返回错误。
 
 例如：
 
 - `/download/latest/aether-darwin-arm64.dmg` 会先解析 `latest` 到具体版本（如 `1.4.1`），再重定向到 `https://<bucket-endpoint>/1.4.1/aether-darwin-arm64.dmg`
+- `/downloadbeta/latest/aether-darwin-arm64.dmg` 会先解析测试版 `latest` 到具体版本（如 `1.4.2-beta.1`），再重定向到 `https://<bucket-endpoint>/beta/1.4.2-beta.1/aether-darwin-arm64.dmg`
 - `/download/1.3.3/aether-windows-x64.zip` 会重定向到 `https://<bucket-endpoint>/1.3.3/aether-windows-x64.zip`
-- `/manual/latest/aether-darwin-arm64.dmg` 会重定向到 `https://<bucket-endpoint>/manual/latest/aether-darwin-arm64.dmg`
-
-私有测试渠道始终从本地文件系统读取，不经过 OSS 重定向。
+- `/downloadbeta/1.3.3-beta.1/aether-windows-x64.zip` 会重定向到 `https://<bucket-endpoint>/beta/1.3.3-beta.1/aether-windows-x64.zip`
 
 ### 最新通道
 
@@ -401,6 +343,18 @@ curl -X POST https://aether.aiphys.cn/api/download2/admin/upload \
 - 例如同时存在 `1.3.9`、`1.4.0`、`1.4.1` 时，`latest` 会解析到 `1.4.1`
 - 如果某个平台在最新版本下没有对应文件，则会继续向下寻找更早的可用版本
 
+测试版渠道使用相同文件名和解析规则，但根路径改为 `/downloadbeta`，且只读取测试版版本索引：
+
+- `/downloadbeta/latest/mac-arm64.yml`
+- `/downloadbeta/latest/windows-x64.yml`
+- `/downloadbeta/latest/linux-x64.yml`
+- `/downloadbeta/latest/aether-darwin-arm64.dmg`
+- `/downloadbeta/latest/update_darwin.command`
+- `/downloadbeta/latest/aether-windows-x64.zip`
+- `/downloadbeta/latest/update_windows.bat`
+- `/downloadbeta/latest/aether-linux-x64.zip`
+- `/downloadbeta/latest/update_linux.sh`
+
 ### 指定版本
 
 客户端也可以显式拉取某个版本：
@@ -418,6 +372,18 @@ curl -X POST https://aether.aiphys.cn/api/download2/admin/upload \
 - `/download/<version>/aether-linux-x64.zip`
 - `/download/<version>/update_linux.sh`
 
+测试版渠道的指定版本路径同样只需把根路径替换为 `/downloadbeta`：
+
+- `/downloadbeta/<version>/mac-arm64.yml`
+- `/downloadbeta/<version>/windows-x64.yml`
+- `/downloadbeta/<version>/linux-x64.yml`
+- `/downloadbeta/<version>/aether-darwin-arm64.dmg`
+- `/downloadbeta/<version>/update_darwin.command`
+- `/downloadbeta/<version>/aether-windows-x64.zip`
+- `/downloadbeta/<version>/update_windows.bat`
+- `/downloadbeta/<version>/aether-linux-x64.zip`
+- `/downloadbeta/<version>/update_linux.sh`
+
 ## macOS Manifest 协议
 
 mac 客户端应优先读取：
@@ -433,6 +399,20 @@ mac 客户端应优先读取：
 ```text
 /download/<version>/mac-arm64.yml
 ```
+
+测试版自动更新客户端应把本机 `Global.Path.config/update-config.jsonc` 配置为测试版下载根路径：
+
+```jsonc
+{
+  "updateBaseUrl": "https://aether.aiphys.cn/downloadbeta"
+}
+```
+
+各系统默认配置文件位置：
+
+- Windows: `C:\Users\<user>\.config\aether\update-config.jsonc`
+- macOS: `~/.config/aether/update-config.jsonc`
+- Linux: `~/.config/aether/update-config.jsonc`
 
 manifest 示例：
 
@@ -460,8 +440,8 @@ releaseDate: '2026-04-02T07:12:00.000Z'
 | `package.url` | 主安装包文件名，客户端应拼接到下载根路径或当前 manifest 所在目录 |
 | `package.sha512` | 主安装包的 Base64 SHA-512 |
 | `package.size` | 主安装包字节数 |
-| `installer.url` | 可选更新脚本文件名 |
-| `installer.size` | 可选更新脚本字节数 |
+| `installer.url` | 更新脚本文件名 |
+| `installer.size` | 更新脚本字节数 |
 | `files[0]` | 向后兼容字段，内容与 `package` 对应 |
 | `releaseDate` | 发布时间 |
 
@@ -504,7 +484,7 @@ OSS 上传失败时的响应示例：
   "ok": true,
   "releaseDate": "2026-04-02T07:12:00.000Z",
   "ossWarnings": [
-    { "objectKey": "1.3.3/aether-darwin-arm64.dmg", "error": "OSS upload failed: 403 ..." }
+    { "objectKey": "1.3.3/mac-arm64.yml", "error": "OSS upload failed: 403 ..." }
   ],
   "files": [...]
 }
@@ -514,7 +494,6 @@ OSS 上传失败时的响应示例：
 
 - `url` / `manifestUrl` 指向指定版本目录
 - `latestUrl` / `latestManifestUrl` 指向 `latest` 别名，服务端会解析到当前最新版本
-- `installerUrl` 与 `latestInstallerUrl` 在未上传对应平台安装脚本时为 `null`
 - `ossWarnings` 仅在部分文件上传失败时出现
 
 ## 错误响应
@@ -551,10 +530,10 @@ OSS 上传失败时的响应示例：
 
 ## 相关代码
 
-- [presign.ts](/root/aether-site/src/pages/api/download/admin/presign.ts)（公开渠道 OSS 直传预签名）
-- [commit.ts](/root/aether-site/src/pages/api/download/admin/commit.ts)（公开渠道 OSS 直传提交）
-- [presign.ts](/root/aether-site/src/pages/api/manual/admin/presign.ts)（手动安装渠道 OSS 直传预签名）
-- [upload.ts](/root/aether-site/src/pages/api/download2/admin/upload.ts)（私有测试渠道上传）
-- [download-upload.ts](/root/aether-site/src/lib/server/download-upload.ts)
-- [downloads.ts](/root/aether-site/src/lib/server/downloads.ts)
-- [oss.ts](/root/aether-site/src/lib/server/oss.ts)
+- [presign.ts](../src/pages/api/download/admin/presign.ts)（公开渠道 OSS 直传预签名）
+- [commit.ts](../src/pages/api/download/admin/commit.ts)（公开渠道 OSS 直传提交）
+- [presign.ts](../src/pages/api/downloadbeta/admin/presign.ts)（测试版渠道 OSS 直传预签名）
+- [commit.ts](../src/pages/api/downloadbeta/admin/commit.ts)（测试版渠道 OSS 直传提交）
+- [download-upload.ts](../src/lib/server/download-upload.ts)
+- [downloads.ts](../src/lib/server/downloads.ts)
+- [oss.ts](../src/lib/server/oss.ts)


### PR DESCRIPTION
### Issue for this PR

Closes #472

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds an optional `upload_downloadbeta` input to the `publish` workflow. When enabled, the publish job uploads the macOS arm64, Windows x64, and Linux x64 web artifacts to the isolated `/downloadbeta` admin API after all web packages have been built.

The upload script uses `DOWNLOAD_BETA_BASE_URL`, `DOWNLOAD_ADMIN_PASSWORD`, and the manually entered release version. It performs presign, parallel PUT uploads, commit, and response validation for beta-channel URLs only.

### How did you verify your code works?

- `git diff --check -- .github/workflows/publish.yml .github/scripts/upload-downloadbeta.ts docs/aether-download-admin-upload.md`
- `bun build .github/scripts/upload-downloadbeta.ts --target=bun --outfile /tmp/upload-downloadbeta.js`
- Ran the upload script with placeholder env vars to verify local artifact validation fails before any upload.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
