### PR TITLE
test: stabilize Windows projects-close e2e

### DIFF
--- a/packages/app/e2e/ci-specs-serial.txt
+++ b/packages/app/e2e/ci-specs-serial.txt
@@ -2,6 +2,7 @@
 # during local verification.
 
 e2e/files/file-viewer.spec.ts
+e2e/projects/projects-close.spec.ts
 e2e/projects/workspace-new-session.spec.ts
 e2e/projects/workspaces.spec.ts
 e2e/prompt/prompt-async.spec.ts

--- a/packages/app/e2e/ci-specs.txt
+++ b/packages/app/e2e/ci-specs.txt
@@ -13,7 +13,6 @@ e2e/files/file-open.spec.ts
 e2e/files/file-tree.spec.ts
 e2e/models/models-visibility.spec.ts
 e2e/projects/project-edit.spec.ts
-e2e/projects/projects-close.spec.ts
 e2e/prompt/prompt-mention.spec.ts
 e2e/prompt/prompt-multiline.spec.ts
 e2e/prompt/prompt-slash-open.spec.ts

--- a/packages/app/e2e/projects/projects-close.spec.ts
+++ b/packages/app/e2e/projects/projects-close.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "../fixtures"
-import { createTestProject, cleanupTestProject, openSidebar, clickMenuItem, openProjectMenu } from "../actions"
+import { createTestProject, cleanupTestProject, openSidebar, clickMenuItem, openProjectMenu, waitSession } from "../actions"
 import { projectSwitchSelector } from "../selectors"
 import { dirSlug } from "../utils"
 
@@ -18,7 +18,7 @@ test("closing active project navigates to another open project", async ({ page, 
         await expect(otherButton).toBeVisible()
         await otherButton.click()
 
-        await expect(page).toHaveURL(new RegExp(`/${otherSlug}/session`))
+        await waitSession(page, { directory: other })
 
         const menu = await openProjectMenu(page, otherSlug)
 


### PR DESCRIPTION
### Issue for this PR

Closes #475

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Stabilizes the Windows `projects-close` app e2e test without changing application behavior.

The test now waits for the target project session to be ready with the existing `waitSession` helper instead of only checking the URL with the default expect timeout. The spec is also moved from the parallel CI allowlist to the serial e2e allowlist to reduce Windows CI contention.

### How did you verify your code works?

- `git diff --check -- packages/app/e2e/projects/projects-close.spec.ts packages/app/e2e/ci-specs.txt packages/app/e2e/ci-specs-serial.txt`
- Confirmed `e2e/projects/projects-close.spec.ts` appears only in `ci-specs-serial.txt`.
- Attempted `bun test:e2e:local e2e/projects/projects-close.spec.ts`, but the local dependency environment failed before Playwright started: `preload not found "@opentui/solid/preload"`.

### Screenshots / recordings

Not applicable.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
