### PR TITLE
fix: isolate truncate fresh-process test from package preload

### DIFF
--- a/packages/opencode/test/tool/truncation.test.ts
+++ b/packages/opencode/test/tool/truncation.test.ts
@@ -128,8 +128,11 @@ describe("Truncate", () => {
     })
 
     test("loads truncate effect in a fresh process", async () => {
-      const out = await Process.run([process.execPath, "run", path.join(ROOT, "src", "tool", "truncate.ts")], {
+      const cfg = path.join(ROOT, "..", "..", "bunfig.toml")
+      const out = await Process.run([process.execPath, "--config", cfg, "run", path.join(ROOT, "src", "tool", "truncate.ts")], {
+        abort: AbortSignal.timeout(15_000),
         cwd: ROOT,
+        timeout: 1_000,
       })
 
       expect(out.code).toBe(0)


### PR DESCRIPTION
### Issue for this PR

Closes #477

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Updates the truncate fresh-process test so it uses the repository-root Bun config instead of the `packages/opencode` Bun config.

The test is meant to verify that `src/tool/truncate.ts` can load in a fresh process. Running from `packages/opencode` also loaded the package-level OpenTUI preload, which is unrelated to truncate and can keep the macOS CI child process alive. The test now avoids that preload and adds an abort timeout for the child process.

### How did you verify your code works?

Ran:

`env TMPDIR=/tmp/aether-codex-test-tmp bun test --timeout 30000 test/tool/truncation.test.ts`

Result: 14 pass, 0 fail.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR