### PR TITLE
fix: run file tree e2e serially in CI

### DIFF
--- a/packages/app/e2e/ci-specs-serial.txt
+++ b/packages/app/e2e/ci-specs-serial.txt
@@ -2,6 +2,7 @@
 # during local verification.
 
 e2e/files/file-viewer.spec.ts
+e2e/files/file-tree.spec.ts
 e2e/projects/projects-close.spec.ts
 e2e/projects/workspace-new-session.spec.ts
 e2e/projects/workspaces.spec.ts

--- a/packages/app/e2e/ci-specs.txt
+++ b/packages/app/e2e/ci-specs.txt
@@ -10,7 +10,6 @@ e2e/commands/input-focus.spec.ts
 e2e/commands/panels.spec.ts
 e2e/commands/tab-close.spec.ts
 e2e/files/file-open.spec.ts
-e2e/files/file-tree.spec.ts
 e2e/models/models-visibility.spec.ts
 e2e/projects/project-edit.spec.ts
 e2e/prompt/prompt-mention.spec.ts


### PR DESCRIPTION
### Issue for this PR

Closes #479

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Moves `e2e/files/file-tree.spec.ts` from the parallel app e2e CI allowlist to the serial e2e allowlist.

On Windows CI, this spec can hang while waiting for the root file tree to load because the shared e2e backend can get stuck under parallel load. Running this spec in the existing serial phase keeps the behavior covered while avoiding the concurrency-sensitive failure.

### How did you verify your code works?

- Ran `git diff --check`.

### Screenshots / recordings

Not applicable.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR