### PR TITLE
fix: stale busy/spinner icon on sessions interrupted by forced process kill

### DIFF
--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -9,7 +9,16 @@ import type {
 } from "@opencode-ai/sdk/v2/client"
 import { showToast } from "@opencode-ai/ui/toast"
 import { getFilename } from "@opencode-ai/util/path"
-import { createContext, createMemo, getOwner, onCleanup, onMount, type ParentProps, untrack, useContext } from "solid-js"
+import {
+  createContext,
+  createMemo,
+  getOwner,
+  onCleanup,
+  onMount,
+  type ParentProps,
+  untrack,
+  useContext,
+} from "solid-js"
 import { createStore, produce, reconcile } from "solid-js/store"
 import { useLanguage } from "@/context/language"
 import { Persist, persisted } from "@/utils/persist"
@@ -21,7 +30,11 @@ import { createChildStoreManager } from "./global-sync/child-store"
 import { applyDirectoryEvent, applyGlobalEvent, cleanupDroppedSessionCaches } from "./global-sync/event-reducer"
 import { createRefreshQueue } from "./global-sync/queue"
 import { clearSessionPrefetchDirectory } from "./global-sync/session-prefetch"
-import { estimateRootSessionTotal, loadDescendantsForRoots, loadRootSessionsWithFallback } from "./global-sync/session-load"
+import {
+  estimateRootSessionTotal,
+  loadDescendantsForRoots,
+  loadRootSessionsWithFallback,
+} from "./global-sync/session-load"
 import { trimSessions } from "./global-sync/session-trim"
 import type { ProjectMeta } from "./global-sync/types"
 import { SESSION_RECENT_LIMIT } from "./global-sync/types"
@@ -118,7 +131,10 @@ function createGlobalSync() {
       cacheRecent()
       return
     }
-    setGlobalStore("recent", next.filter((item) => !isRoot(item.directory)))
+    setGlobalStore(
+      "recent",
+      next.filter((item) => !isRoot(item.directory)),
+    )
     cacheRecent()
   }
 
@@ -255,6 +271,9 @@ function createGlobalSync() {
         setStore("session", reconcile(next, { key: "id" }))
         cleanupDroppedSessionCaches(store, setStore, next, setSessionTodo)
       }
+      globalSDK.client.session.status().then((x) => {
+        setStore("session_status", reconcile(x.data!))
+      })
       children.unpin(directory)
       return
     }
@@ -276,7 +295,9 @@ function createGlobalSync() {
           tree: (query) => globalSDK.client.session.tree(query),
           children: (query) => globalSDK.client.session.children(query),
         })
-        const nonArchived = [...nonArchivedRoots, ...descendants].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+        const nonArchived = [...nonArchivedRoots, ...descendants].sort((a, b) =>
+          a.id < b.id ? -1 : a.id > b.id ? 1 : 0,
+        )
         const limit = store.limit
         // Preserve sessions that arrived via SSE while this API call was in-flight.
         // Without this, reconcile() would overwrite them since the API snapshot predates their creation.
@@ -296,6 +317,9 @@ function createGlobalSync() {
         )
         setStore("session", reconcile(sessions, { key: "id" }))
         cleanupDroppedSessionCaches(store, setStore, sessions, setSessionTodo)
+        globalSDK.client.session.status().then((x) => {
+          setStore("session_status", reconcile(x.data!))
+        })
         sessionMeta.set(directory, { limit })
       })
       .catch((err) => {

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -327,18 +327,14 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
   })
   const isWorking = createMemo(() => {
     if (hasPermissions()) return false
+    const status = sessionStore.session_status[props.session.id]
+    if (!status || status.type === "idle") return false
     const pending = (sessionStore.message[props.session.id] ?? []).findLast(
       (message) =>
         message.role === "assistant" &&
         typeof (message as { time?: { completed?: unknown } }).time?.completed !== "number",
     )
-    const status = sessionStore.session_status[props.session.id]
-    return (
-      pending !== undefined ||
-      status?.type === "busy" ||
-      status?.type === "retry" ||
-      (status !== undefined && status.type !== "idle")
-    )
+    return pending !== undefined || status.type === "busy" || status.type === "retry"
   })
 
   const tint = createMemo(() => {


### PR DESCRIPTION
### Issue for this PR

Closes #483

### Type of change

- [x] Bug fix

### What does this PR do?

When the process is forcibly killed, assistant messages never get `time.completed` written to the database. The sidebar's `isWorking` logic treated the local "pending message" heuristic (checking `time.completed`) as equal priority to the server-side `session_status`, so incomplete messages caused a permanent Spinner icon even though the session is idle.

Two changes:

1. **`sidebar-items.tsx` — `isWorking` now trusts server-side `session_status`**: If `session_status` is absent (undefined — the server default is idle) or explicitly `idle`, `isWorking` returns `false` immediately, bypassing the stale pending-message check. This is the core fix.

2. **`global-sync.tsx` — `loadSessions` reconciles `session_status` from the API**: Both the cached and non-cached paths now call `session.status()` and reconcile the result into the store. This corrects stale `busy` entries that may accumulate when SSE events are lost (e.g. during reconnection), reducing the time a user sees a stale Spinner.

### How did you verify your code works?

- Verified via `bun typecheck` on both `packages/app` and `packages/opencode`
- Confirmed the fix in the running app: a session whose assistant message lacked `time.completed` (due to forced process kill) no longer shows a Spinner icon in the sidebar

### Screenshots / recordings

Not applicable — the fix changes which icon is displayed (Spinner → +/-), no visual regression.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR