### PR TITLE
fix: avoid GitLab Duo config test discovery

### DIFF
--- a/packages/opencode/test/provider/gitlab-duo.test.ts
+++ b/packages/opencode/test/provider/gitlab-duo.test.ts
@@ -54,7 +54,7 @@ test("GitLab Duo: config instanceUrl option sets baseURL", async () => {
   await Instance.provide({
     directory: tmp.path,
     init: async () => {
-      Env.set("GITLAB_TOKEN", "test-token")
+      Env.set("GITLAB_TOKEN", "")
       Env.set("GITLAB_INSTANCE_URL", "https://gitlab.example.com")
     },
     fn: async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #486

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This updates the GitLab Duo `instanceUrl` config test so it does not set a fake `GITLAB_TOKEN`.

The test only needs to verify that `GITLAB_INSTANCE_URL` is reflected in provider options. Setting a fake token makes the provider look connected and can trigger GitLab workflow model discovery during `Provider.list()`. On macOS CI, that discovery path can hang against the fake `https://gitlab.example.com` instance until the 30000ms Bun test timeout.

Clearing the token keeps the test focused on config handling and avoids the external discovery path.

### How did you verify your code works?

Attempted to run:

```text
bun test test/provider/gitlab-duo.test.ts --test-name-pattern "config instanceUrl option sets baseURL" --timeout 30000
```

The local run did not reach the test body because this environment is missing `drizzle-orm/bun-sqlite/migrator` and has a stale `/tmp/aether-test-data-2` permission issue.

### Screenshots / recordings

Not applicable.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
