### PR TITLE
fix: refine CI workflow triggers and protected files

### DIFF
--- a/.github/cicd-protected-files.txt
+++ b/.github/cicd-protected-files.txt
@@ -5,6 +5,9 @@
 .github/cicd-admins.txt
 .github/cicd-protected-files.txt
 
+# CI/CD documentation
+docs/ci-guide.md
+
 # GitHub workflows
 .github/publish-python-sdk.yml
 .github/workflows/cicd-guard.yml
@@ -34,6 +37,7 @@
 .github/pull_request_template.md
 .github/prompts/review.txt
 .github/scripts/extract-opencode-comment.mjs
+.github/scripts/upload-downloadbeta.ts
 .github/TEAM_MEMBERS
 .github/VOUCHED.td
 
@@ -48,6 +52,12 @@ packing_scripts/release-mac-web.sh
 packing_scripts/release-windows-web.bat
 packages/app/happydom.ts
 packages/app/package.json
+packages/app/script/e2e-local.ts
+packages/app/script/vitest.ts
+packages/app/src/test/setup.ts
+packages/ui/package.json
+packages/ui/script/vitest.ts
+packages/ui/src/test/setup.ts
 packages/desktop-electron/electron-builder.config.ts
 packages/desktop-electron/package.json
 packages/desktop-electron/scripts/copy-icons.ts
@@ -59,10 +69,16 @@ script/duplicate-pr.ts
 script/generate.ts
 script/github/close-issues.ts
 
+# UI unit tests called by .github/workflows/test.yml
+packages/ui/src/components/message-file.test.ts
+packages/ui/src/components/scroll-view.test.ts
+packages/ui/src/components/session-review.vitest.tsx
+
 # App unit tests called by .github/workflows/test.yml
 packages/app/src/addons/serialize.test.ts
 packages/app/src/components/dialog-custom-provider.test.ts
 packages/app/src/components/file-tree.test.ts
+packages/app/src/components/file-tree.vitest.tsx
 packages/app/src/components/pick-folder.test.ts
 packages/app/src/components/prompt-input/attachments.test.ts
 packages/app/src/components/prompt-input/build-request-parts.test.ts
@@ -70,6 +86,7 @@ packages/app/src/components/prompt-input/editor-dom.test.ts
 packages/app/src/components/prompt-input/history.test.ts
 packages/app/src/components/prompt-input/placeholder.test.ts
 packages/app/src/components/prompt-input/submit.test.ts
+packages/app/src/components/settings-cron.vitest.tsx
 packages/app/src/components/session/session-context-breakdown.test.ts
 packages/app/src/components/session/session-context-metrics.test.ts
 packages/app/src/components/titlebar-history.test.ts
@@ -103,6 +120,8 @@ packages/app/src/pages/session/file-tab-state.test.ts
 packages/app/src/pages/session/helpers.test.ts
 packages/app/src/pages/session/message-gesture.test.ts
 packages/app/src/pages/session/session-model-helpers.test.ts
+packages/app/src/pages/session/session-side-panel-state.test.ts
+packages/app/src/pages/session/session-side-panel.vitest.tsx
 packages/app/src/pages/session/terminal-panel.test.ts
 packages/app/src/pages/session/upload.test.ts
 packages/app/src/pages/session/use-session-hash-scroll.test.ts
@@ -118,6 +137,52 @@ packages/app/src/utils/server-health.test.ts
 packages/app/src/utils/terminal-writer.test.ts
 packages/app/src/utils/uuid.test.ts
 packages/app/src/utils/worktree.test.ts
+
+# App E2E tests called by .github/workflows/test.yml
+packages/app/e2e/actions.ts
+packages/app/e2e/app/home.spec.ts
+packages/app/e2e/app/navigation.spec.ts
+packages/app/e2e/app/palette.spec.ts
+packages/app/e2e/app/server-default.spec.ts
+packages/app/e2e/app/session.spec.ts
+packages/app/e2e/backend.ts
+packages/app/e2e/ci-specs-serial.txt
+packages/app/e2e/ci-specs.txt
+packages/app/e2e/commands/input-focus.spec.ts
+packages/app/e2e/commands/panels.spec.ts
+packages/app/e2e/commands/tab-close.spec.ts
+packages/app/e2e/files/file-open.spec.ts
+packages/app/e2e/files/file-tree.spec.ts
+packages/app/e2e/files/file-viewer.spec.ts
+packages/app/e2e/fixtures.ts
+packages/app/e2e/models/models-visibility.spec.ts
+packages/app/e2e/projects/project-edit.spec.ts
+packages/app/e2e/projects/projects-close.spec.ts
+packages/app/e2e/projects/workspace-new-session.spec.ts
+packages/app/e2e/projects/workspaces.spec.ts
+packages/app/e2e/prompt/prompt-async.spec.ts
+packages/app/e2e/prompt/prompt-history.spec.ts
+packages/app/e2e/prompt/prompt-mention.spec.ts
+packages/app/e2e/prompt/prompt-multiline.spec.ts
+packages/app/e2e/prompt/prompt-shell.spec.ts
+packages/app/e2e/prompt/prompt-slash-open.spec.ts
+packages/app/e2e/prompt/prompt-slash-share.spec.ts
+packages/app/e2e/prompt/prompt-slash-terminal.spec.ts
+packages/app/e2e/prompt/prompt.spec.ts
+packages/app/e2e/selectors.ts
+packages/app/e2e/session/session-child-navigation.spec.ts
+packages/app/e2e/session/session-undo-redo.spec.ts
+packages/app/e2e/session/session.spec.ts
+packages/app/e2e/settings/settings-models.spec.ts
+packages/app/e2e/settings/settings.spec.ts
+packages/app/e2e/sidebar/sidebar.spec.ts
+packages/app/e2e/status/status-popover.spec.ts
+packages/app/e2e/terminal/terminal-init.spec.ts
+packages/app/e2e/terminal/terminal-reconnect.spec.ts
+packages/app/e2e/terminal/terminal-tabs.spec.ts
+packages/app/e2e/terminal/terminal.spec.ts
+packages/app/e2e/thinking-level.spec.ts
+packages/app/e2e/utils.ts
 
 # Opencode unit tests called by .github/workflows/test.yml
 packages/opencode/src/pdf-converter/util.test.ts
@@ -149,6 +214,7 @@ packages/opencode/test/control-plane/session-proxy-middleware.test.ts
 packages/opencode/test/control-plane/sse.test.ts
 packages/opencode/test/control-plane/workspace-server-sse.test.ts
 packages/opencode/test/control-plane/workspace-sync.test.ts
+packages/opencode/test/cron/cron.test.ts
 packages/opencode/test/effect/cross-spawn-spawner.test.ts
 packages/opencode/test/effect/instance-state.test.ts
 packages/opencode/test/effect/run-service.test.ts
@@ -178,8 +244,10 @@ packages/opencode/test/patch/patch.test.ts
 packages/opencode/test/permission-task.test.ts
 packages/opencode/test/permission/arity.test.ts
 packages/opencode/test/permission/next.test.ts
+packages/opencode/test/persist/migrate.test.ts
 packages/opencode/test/plugin/auth-override.test.ts
 packages/opencode/test/plugin/codex.test.ts
+packages/opencode/test/project/bootstrap.test.ts
 packages/opencode/test/project/migrate-global.test.ts
 packages/opencode/test/project/project.test.ts
 packages/opencode/test/project/state.test.ts
@@ -198,20 +266,27 @@ packages/opencode/test/question/question.test.ts
 packages/opencode/test/server/file-download.test.ts
 packages/opencode/test/server/global-session-list.test.ts
 packages/opencode/test/server/project-init-git.test.ts
+packages/opencode/test/server/server-web-cache.test.ts
+packages/opencode/test/server/session-graph.test.ts
 packages/opencode/test/server/session-list.test.ts
 packages/opencode/test/server/session-messages.test.ts
 packages/opencode/test/server/session-select.test.ts
+packages/opencode/test/server/session-tree.test.ts
+packages/opencode/test/server/web-update-script.test.ts
+packages/opencode/test/server/web-update.test.ts
 packages/opencode/test/session/compaction.test.ts
 packages/opencode/test/session/instruction.test.ts
 packages/opencode/test/session/llm.test.ts
 packages/opencode/test/session/message-v2.test.ts
 packages/opencode/test/session/messages-pagination.test.ts
+packages/opencode/test/session/preference.test.ts
 packages/opencode/test/session/prompt.test.ts
 packages/opencode/test/session/retry.test.ts
 packages/opencode/test/session/revert-compact.test.ts
 packages/opencode/test/session/session.test.ts
 packages/opencode/test/session/structured-output-integration.test.ts
 packages/opencode/test/session/structured-output.test.ts
+packages/opencode/test/session/summary.test.ts
 packages/opencode/test/session/system.test.ts
 packages/opencode/test/share/share-next.test.ts
 packages/opencode/test/skill/discovery.test.ts
@@ -248,4 +323,3 @@ packages/opencode/test/util/process.test.ts
 packages/opencode/test/util/timeout.test.ts
 packages/opencode/test/util/which.test.ts
 packages/opencode/test/util/wildcard.test.ts
-

--- a/.github/workflows/cicd-guard.yml
+++ b/.github/workflows/cicd-guard.yml
@@ -2,7 +2,7 @@ name: cicd-guard
 
 on:
   pull_request_target:
-    branches: [dev]
+    branches: [main, beta, dev]
     types: [opened, reopened, synchronize, ready_for_review]
 
 concurrency:

--- a/.github/workflows/nix-eval.yml
+++ b/.github/workflows/nix-eval.yml
@@ -2,9 +2,9 @@ name: nix-eval
 
 on:
   push:
-    branches: [dev]
+    branches: [main, beta, dev]
   pull_request:
-    branches: [dev]
+    branches: [main, beta, dev]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/nix-hashes.yml
+++ b/.github/workflows/nix-hashes.yml
@@ -5,17 +5,6 @@ permissions:
 
 on:
   workflow_dispatch:
-  push:
-    branches: [dev, beta]
-    paths:
-      - "bun.lock"
-      - "package.json"
-      - "packages/*/package.json"
-      - "flake.lock"
-      - "nix/node_modules.nix"
-      - "nix/scripts/**"
-      - "patches/**"
-      - ".github/workflows/nix-hashes.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -2,7 +2,7 @@ name: storybook
 
 on:
   push:
-    branches: [dev]
+    branches: [main, beta, dev]
     paths:
       - ".github/workflows/storybook.yml"
       - "package.json"
@@ -10,7 +10,7 @@ on:
       - "packages/storybook/**"
       - "packages/ui/**"
   pull_request:
-    branches: [dev]
+    branches: [main, beta, dev]
     paths:
       - ".github/workflows/storybook.yml"
       - "package.json"

--- a/docs/ci-guide.md
+++ b/docs/ci-guide.md
@@ -149,10 +149,10 @@
   - Repository variables：无
   - Repository secrets：无
   - 可选但常见的仓库配置：
-    - 如果希望把它作为合并门禁，需要在 `dev` 分支保护规则里把对应 check 设为 required
+    - 如果希望把它作为合并门禁，需要在对应目标分支保护规则里把对应 check 设为 required
 - 触发（当前）：
-  - `push` 到 `dev`
-  - `pull_request` 到 `dev`
+  - `push` 到 `main`、`beta`、`dev`
+  - `pull_request` 到 `main`、`beta`、`dev`
   - `workflow_dispatch`
   - 仅在 `packages/storybook/**`、`packages/ui/**`、锁文件或 workflow 本身变化时触发
 - 主要内容：
@@ -179,10 +179,10 @@
   - Repository variables：无
   - Repository secrets：无
   - 可选但常见的仓库配置：
-    - 如果希望把它作为合并门禁，需要在 `dev` 分支保护规则里把对应 check 设为 required
+    - 如果希望把它作为合并门禁，需要在对应目标分支保护规则里把对应 check 设为 required
 - 触发（当前）：
-  - `push` 到 `dev`
-  - `pull_request` 到 `dev`
+  - `push` 到 `main`、`beta`、`dev`
+  - `pull_request` 到 `main`、`beta`、`dev`
   - `workflow_dispatch`
 - 主要内容：
   - workflow 配置了基于 `workflow + ref` 的并发组，新 run 会取消旧 run
@@ -484,8 +484,6 @@
     - 该 App 至少需要仓库 `Contents: Read and write` 权限，才能把更新后的 `nix/hashes.json` 推回分支
 - 触发：
   - `workflow_dispatch`
-  - `push` 到 `dev`、`beta`
-  - 仅在 `bun.lock`、`package.json`、`flake.lock`、`nix/**`、`patches/**` 等变化时触发
 - 主要内容：
   - 在四个平台 runner 上分别计算 `node_modules` 哈希
   - 上传 hash artifact
@@ -494,8 +492,40 @@
 - 作用：
   - 维护 Nix 构建所需的依赖哈希
   - 保证多平台可复现构建
+- 备注：
+  - 当前已关闭 `push` 自动触发，只能在 GitHub Actions 页面手动运行
+  - 手动运行后仍会尝试自动提交并推送 `nix/hashes.json`，因此 GitHub App 变量、密钥和写权限仍然是必需前置条件
 
 ### 4. 仓库治理与社区流程
+
+#### `cicd-guard.yml`
+
+- 类型：PR 治理 / CI/CD 保护
+- 状态：活跃
+- 所需 GitHub 配置：
+  - 仓库设置：
+    - 必须启用 GitHub Actions
+    - 因 workflow 需要评论 PR 并把违规 PR 标红，`Settings -> Actions -> General -> Workflow permissions` 需要设为 `Read and write permissions`
+    - 如果组织限制了可用 action，需要放行 `actions/checkout@v4`、`actions/github-script@v8`
+  - Repository variables：无
+  - Repository secrets：无自定义项；使用系统自带 `GITHUB_TOKEN`
+  - 仓库内前置对象：
+    - `.github/cicd-admins.txt` 维护允许修改 CI/CD 相关文件的 GitHub 用户名
+    - `.github/cicd-protected-files.txt` 维护受保护文件列表
+- 触发（当前）：
+  - `pull_request_target` 到 `main`、`beta`、`dev`
+  - PR 事件类型为 `opened`、`reopened`、`synchronize`、`ready_for_review`
+- 主要内容：
+  - checkout 目标分支上的 guard 配置文件，而不是 PR 分支中的配置文件
+  - 读取 `.github/cicd-admins.txt`，如果 PR 作者在管理员名单中则直接放行
+  - 读取 `.github/cicd-protected-files.txt`，再通过 GitHub API 获取 PR 变更文件
+  - 如果非管理员 PR 修改了受保护文件：
+    - 创建或更新带 `<!-- cicd-guard -->` 标记的提醒评论
+    - 将 workflow 标为失败，阻止该 PR 悄悄修改 CI/CD 关键配置
+  - 如果未命中受保护文件，或此前违规后来修复，则清理旧的 guard 评论
+- 作用：
+  - 防止普通 PR 直接修改 workflow、复用 action、CI/CD 保护名单等敏感自动化配置
+  - 当前保护范围已覆盖面向 `main`、`beta`、`dev` 的 PR
 
 #### `duplicate-issues.yml`
 


### PR DESCRIPTION
### Issue for this PR

Closes #488

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Updates CI/CD workflow behavior and guard coverage:

- makes `nix-hashes` manual-only so unused Nix hash maintenance no longer fails automatically on branch pushes when GitHub App credentials are unavailable
- expands `storybook`, `nix-eval`, and `cicd-guard` coverage to `main`, `beta`, and `dev`
- updates `docs/ci-guide.md` to match the workflow changes and document `cicd-guard`
- expands `.github/cicd-protected-files.txt` to include CI/CD docs, publish helpers, test runners, current unit tests, and E2E specs/helpers exercised by CI

### How did you verify your code works?

- Reviewed staged workflow diffs.
- Checked `test.yml` test entrypoints against `.github/cicd-protected-files.txt`.
- Verified no missing protected entries for currently executed unit/Vitest tests.
- Verified no missing protected entries for E2E specs listed in `packages/app/e2e/ci-specs.txt` and `packages/app/e2e/ci-specs-serial.txt`.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
