### PR TITLE
feat: support configurable base path via VITE_BASE_PATH

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -61,9 +61,7 @@ const SessionRoute = () => (
   </SessionProviders>
 )
 
-const ReadingSessionRoute = () => (
-  <ReadingSession />
-)
+const ReadingSessionRoute = () => <ReadingSession />
 
 const SessionIndexRoute = () => <Navigate href="session" />
 
@@ -295,7 +293,9 @@ export function AppInterface(props: {
   servers?: Array<ServerConnection.Any>
   router?: Component<BaseRouterProps>
   disableHealthCheck?: boolean
+  basePath?: string
 }) {
+  const routerBase = props.basePath && props.basePath !== "/" ? props.basePath : undefined
   return (
     <ServerProvider defaultServer={props.defaultServer} servers={props.servers}>
       <ConnectionGate disableHealthCheck={props.disableHealthCheck}>
@@ -304,6 +304,7 @@ export function AppInterface(props: {
             <GlobalSyncProvider>
               <Dynamic
                 component={props.router ?? Router}
+                base={routerBase}
                 root={(routerProps) => <RouterRoot appChildren={props.children}>{routerProps.children}</RouterRoot>}
               >
                 <Route path="/" component={HomeRoute} />

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -403,6 +403,7 @@ const boot = async () => {
             defaultServer={ServerConnection.Key.make(getDefaultUrl())}
             servers={[server]}
             disableHealthCheck
+            basePath={import.meta.env.VITE_BASE_PATH}
           />
         </AppBaseProviders>
       </PlatformProvider>

--- a/packages/app/vite.js
+++ b/packages/app/vite.js
@@ -22,6 +22,35 @@ function readServePort() {
   return undefined
 }
 
+function stripGitBashPrefix(path) {
+  const idx = path.indexOf("/Git/")
+  if (idx !== -1) return "/" + path.slice(idx + 5)
+  const idx2 = path.indexOf("\\Git\\")
+  if (idx2 !== -1) return "/" + path.slice(idx2 + 5)
+  const idx3 = path.indexOf("/msys/")
+  if (idx3 !== -1) return "/" + path.slice(idx3 + 6)
+  const idx4 = path.indexOf("\\msys\\")
+  if (idx4 !== -1) return "/" + path.slice(idx4 + 6)
+  return null
+}
+
+function readBasePath() {
+  const raw = process.env.VITE_BASE_PATH
+  if (!raw) return "/"
+  if (/^[A-Za-z]:[\\/]/.test(raw)) {
+    const recovered = stripGitBashPrefix(raw)
+    if (recovered) {
+      console.warn(`[opencode] detected Git Bash path translation, corrected: "${raw}" → "${recovered}"`)
+      return recovered
+    }
+    console.error(
+      `[opencode] VITE_BASE_PATH "${raw}" is a Windows path, likely from Git Bash translation. Run from cmd.exe or set MSYS_NO_PATHCONV=1, or pass base path without leading slash: --basepath my/base/path`,
+    )
+    return "/"
+  }
+  return raw.startsWith("/") ? raw : `/${raw}`
+}
+
 const theme = fileURLToPath(new URL("./public/oc-theme-preload.js", import.meta.url))
 
 /**
@@ -32,9 +61,13 @@ export default [
     name: "opencode-desktop:config",
     config() {
       const port = readServePort()
+      const basePath = readBasePath()
       const env = port ? { VITE_OPENCODE_SERVER_PORT: port } : {}
       if (port) console.log(`[opencode] auto-detected backend port: ${port}`)
+      if (basePath !== "/") console.log(`[opencode] base path: ${basePath}`)
+      env.VITE_BASE_PATH = basePath
       return {
+        base: basePath,
         define: Object.fromEntries(Object.entries(env).map(([k, v]) => [`import.meta.env.${k}`, JSON.stringify(v)])),
         resolve: {
           alias: {
@@ -50,9 +83,10 @@ export default [
   },
   {
     name: "opencode-desktop:theme-preload",
+    enforce: "pre",
     transformIndexHtml(html) {
       return html.replace(
-        '<script id="oc-theme-preload-script" src="/oc-theme-preload.js"></script>',
+        /<script\s+id="oc-theme-preload-script"\s+src="[^"]*oc-theme-preload\.js"[^>]*><\/script>/,
         `<script id="oc-theme-preload-script">${readFileSync(theme, "utf8")}</script>`,
       )
     },
@@ -60,4 +94,3 @@ export default [
   tailwindcss(),
   solidPlugin(),
 ]
-


### PR DESCRIPTION
### Issue for this PR

Closes #493

### Type of change

- [x] New feature

### What does this PR do?

Adds support for a configurable base path via the `VITE_BASE_PATH` environment variable, enabling the web app to be served under a sub-path (e.g., `/my/base/path`) when deployed behind a reverse proxy.

Changes across 3 files in `packages/app`:

1. **vite.js** — Added `readBasePath()` that reads `VITE_BASE_PATH` from env, sets Vite's `base` config, and defines `import.meta.env.VITE_BASE_PATH` for client access. Also detects Git Bash path translation on Windows (where `/my/base/path` becomes `C:/Program Files/Git/my/base/path`) and auto-corrects it. Updated the theme-preload plugin to use regex matching so it works regardless of base path transformation order.

2. **app.tsx** — Added `basePath` prop to `AppInterface` and passes it as the `base` prop to the SolidJS Router, making client-side routing work correctly under the sub-path.

3. **entry.tsx** — Reads `import.meta.env.VITE_BASE_PATH` and passes it to `AppInterface`.

When `VITE_BASE_PATH` is not set (default), everything works exactly as before with root path `/`.

### How did you verify your code works?

- Started the dev servers with `VITE_BASE_PATH=/my/base/path` and verified:
  - Vite correctly serves the app at `http://localhost:4444/my/base/path/` (HTTP 200)
  - Asset URLs in HTML are prefixed with `/my/base/path/` (favicon, entry script, etc.)
  - The theme-preload script is correctly inlined regardless of base path
- Used `agent-browser` to navigate to the home page, click a project, and confirmed the session URL is `http://localhost:4444/my/base/path/<dir>/session/<id>` as expected
- Tested Git Bash path translation recovery: set `VITE_BASE_PATH` to a Windows path and confirmed it auto-corrects to the intended base path with a warning log
- Verified that without `VITE_BASE_PATH`, the app works identically to before (root path `/`)
- Verified that `--basepath my/base/path` (without leading slash) works correctly in both cmd.exe and Git Bash
- All typechecks pass (`bun turbo typecheck`)

### Screenshots / recordings

Not applicable — the UI renders identically; the change is in URL structure.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
