### PR TITLE
fix: create missing unix update mirror roots

### DIFF
--- a/Update/update_darwin.command
+++ b/Update/update_darwin.command
@@ -236,6 +236,7 @@ stamp() {
 
 mirror_root() {
   if [ -n "${AETHER_MIRROR_ROOT:-}" ]; then
+    mkdir -p "${AETHER_MIRROR_ROOT}" || return 1
     cd "${AETHER_MIRROR_ROOT}" && pwd
     return 0
   fi
@@ -251,8 +252,8 @@ in_work() {
   root="$1"
   [ -n "$cur" ] || return 1
   [ -n "$root" ] || return 1
-  cur="$(cd "$cur" && pwd)"
-  root="$(cd "$root" && pwd)"
+  cur="$(cd "$cur" 2>/dev/null && pwd)" || return 1
+  root="$(cd "$root" 2>/dev/null && pwd)" || return 1
   case "$cur" in
     "$root"|"$root"/*) return 0 ;;
   esac

--- a/Update/update_linux.sh
+++ b/Update/update_linux.sh
@@ -281,6 +281,7 @@ stamp() {
 
 mirror_root() {
   if [ -n "${AETHER_MIRROR_ROOT:-}" ]; then
+    mkdir -p "${AETHER_MIRROR_ROOT}" || return 1
     cd "${AETHER_MIRROR_ROOT}" && pwd
     return 0
   fi
@@ -296,8 +297,8 @@ in_work() {
   root="$1"
   [ -n "$cur" ] || return 1
   [ -n "$root" ] || return 1
-  cur="$(cd "$cur" && pwd)"
-  root="$(cd "$root" && pwd)"
+  cur="$(cd "$cur" 2>/dev/null && pwd)" || return 1
+  root="$(cd "$root" 2>/dev/null && pwd)" || return 1
   case "$cur" in
     "$root"|"$root"/*) return 0 ;;
   esac


### PR DESCRIPTION
### Issue for this PR

Closes #495

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Ensures the Linux and macOS update scripts create `AETHER_MIRROR_ROOT` before resolving it with `cd`.

This fixes first-time init installs where the internal work directory exists, but the final install target root, such as `~/.local/share/applications/aether` or `~/Applications/aether`, does not exist yet.

The change also makes `in_work` return false silently when the current or root directory does not exist, avoiding misleading `cd: ... No such file or directory` output during normal first-install mirror handling.

### How did you verify your code works?

- Ran `bash -n Update/update_linux.sh`
- Ran `bash -n Update/update_darwin.command`
- Ran a local Linux reproduction using a temporary fake package and a missing `AETHER_MIRROR_ROOT`; the script created the target root and completed the mirror install.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
