### PR TITLE
fix: prevent closing dialogs from leaking in the stack during handoff

### DIFF
--- a/packages/ui/src/context/dialog.tsx
+++ b/packages/ui/src/context/dialog.tsx
@@ -31,42 +31,27 @@ const Context = createContext<ReturnType<typeof init>>()
 function init() {
   // 改为对话框堆栈，支持多个对话框同时显示
   const [stack, setStack] = createSignal<Active[]>([])
-  const timer = { current: undefined as ReturnType<typeof setTimeout> | undefined }
-  const lock = { value: false }
+  const timers = new Map<string, ReturnType<typeof setTimeout>>()
 
   onCleanup(() => {
-    if (timer.current === undefined) return
-    clearTimeout(timer.current)
-    timer.current = undefined
+    for (const timer of timers.values()) clearTimeout(timer)
+    timers.clear()
   })
 
   const close = () => {
     const currentStack = stack()
     const current = currentStack[currentStack.length - 1]
-    if (!current || lock.value) return
-    lock.value = true
+    if (!current || timers.has(current.id)) return
     current.onClose?.()
     current.setClosing(true)
 
     const id = current.id
-    if (timer.current !== undefined) {
-      clearTimeout(timer.current)
-      timer.current = undefined
-    }
-
-    timer.current = setTimeout(() => {
-      timer.current = undefined
+    const timer = setTimeout(() => {
+      timers.delete(id)
       current.dispose()
-      // 只移除最顶层的对话框
-      setStack(prev => {
-        if (prev.length === 0) return prev
-        if (prev[prev.length - 1].id === id) {
-          return prev.slice(0, -1)
-        }
-        return prev
-      })
-      lock.value = false
+      setStack((prev) => prev.filter((item) => item.id !== id))
     }, 100)
+    timers.set(id, timer)
   }
 
   createEffect(() => {
@@ -85,11 +70,6 @@ function init() {
   })
 
   const show = (element: DialogElement, owner: Owner, onClose?: () => void, options?: DialogOptions) => {
-    if (timer.current !== undefined) {
-      clearTimeout(timer.current)
-      timer.current = undefined
-    }
-    lock.value = false
     const modal = options?.modal !== false
 
     const id = Math.random().toString(36).slice(2)

--- a/packages/ui/src/context/dialog.vitest.tsx
+++ b/packages/ui/src/context/dialog.vitest.tsx
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, test } from "vitest"
+import { render } from "solid-js/web"
+import { DialogProvider, useDialog } from "./dialog"
+
+const wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+function Second() {
+  const dialog = useDialog()
+  return (
+    <div data-dialog="second">
+      <button type="button" onClick={() => dialog.close()}>
+        close second
+      </button>
+    </div>
+  )
+}
+
+function First() {
+  const dialog = useDialog()
+  return (
+    <div data-dialog="first">
+      <button
+        type="button"
+        onClick={() => {
+          dialog.close()
+          dialog.show(() => <Second />)
+        }}
+      >
+        open second
+      </button>
+    </div>
+  )
+}
+
+function App() {
+  const dialog = useDialog()
+  return (
+    <>
+      <button type="button" onClick={() => dialog.show(() => <First />)}>
+        open first
+      </button>
+      <div data-state={dialog.active ? "open" : "closed"} />
+    </>
+  )
+}
+
+afterEach(() => {
+  document.body.innerHTML = ""
+})
+
+describe("dialog stack", () => {
+  test("removes a closing dialog even after another dialog is pushed on top", async () => {
+    const host = document.createElement("div")
+    document.body.append(host)
+    const off = render(
+      () => (
+        <DialogProvider>
+          <App />
+        </DialogProvider>
+      ),
+      host,
+    )
+
+    const open = document.querySelector("button")
+    open?.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+    await Promise.resolve()
+
+    const next = [...document.querySelectorAll("button")].find((item) => item.textContent === "open second")
+    next?.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+    await wait(150)
+
+    expect(document.querySelector('[data-dialog="second"]')).toBeTruthy()
+    expect(document.querySelector("[data-state]")?.getAttribute("data-state")).toBe("open")
+
+    const close = [...document.querySelectorAll("button")].find((item) => item.textContent === "close second")
+    close?.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+    await wait(150)
+
+    expect(document.querySelector("[data-state]")?.getAttribute("data-state")).toBe("closed")
+
+    off()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #490

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
The dialog stack used a single global close timer and only removed the top-most entry when the delay elapsed. If one dialog began closing and a new dialog was opened before the timeout fired, the old dialog could be pushed below the top of the stack and never be removed.
This change tracks pending close timers per dialog id and removes the closing dialog by id after the delay, so dialog handoff flows do not leave stale entries behind.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
Added vitest coverage for close-then-show handoff; bun run typecheck in packages/ui

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
