### PR TITLE
fix: correct Windows project path display in sidebar

### DIFF
--- a/packages/app/src/components/dialog-select-file.tsx
+++ b/packages/app/src/components/dialog-select-file.tsx
@@ -5,7 +5,7 @@ import { Icon } from "@opencode-ai/ui/icon"
 import { Keybind } from "@opencode-ai/ui/keybind"
 import { List } from "@opencode-ai/ui/list"
 import { base64Encode } from "@opencode-ai/util/encode"
-import { getDirectory, getFilename } from "@opencode-ai/util/path"
+import { displayPath, getDirectory, getFilename } from "@opencode-ai/util/path"
 import { useNavigate } from "@solidjs/router"
 import { createMemo, createSignal, Match, onCleanup, Show, Switch } from "solid-js"
 import { formatKeybind, useCommand, type CommandOption } from "@/context/command"
@@ -300,7 +300,7 @@ export function DialogSelectFile(props: { mode?: DialogSelectFileMode; onOpenFil
         : language.t("workspace.type.sandbox")
     const [store] = globalSync.child(directory, { bootstrap: false })
     const home = homedir()
-    const path = home ? directory.replace(home, "~") : directory
+    const path = displayPath(directory, home)
     const name = store.vcs?.branch ?? getFilename(directory)
     return `${kind} : ${name || path}`
   }

--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -13,6 +13,7 @@ import { DialogNewProject } from "@/components/dialog-new-project"
 import { DialogSelectServer } from "@/components/dialog-select-server"
 import { useServer } from "@/context/server"
 import { useGlobalSync } from "@/context/global-sync"
+import { displayPath } from "@opencode-ai/util/path"
 import { useLanguage } from "@/context/language"
 
 export default function Home() {
@@ -124,7 +125,7 @@ export default function Home() {
                     class="text-14-mono text-left justify-between px-3"
                     onClick={() => openProject(item.directory)}
                   >
-                    {item.directory.replace(homedir(), "~")}
+                    {displayPath(item.directory, homedir())}
                     <div class="text-14-regular text-text-weak">
                       {DateTime.fromMillis(item.time.activity).toRelative()}
                     </div>

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -23,7 +23,7 @@ import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { DropdownMenu } from "@opencode-ai/ui/dropdown-menu"
 import { Dialog } from "@opencode-ai/ui/dialog"
-import { getFilename } from "@opencode-ai/util/path"
+import { displayPath, getFilename } from "@opencode-ai/util/path"
 import { Session, type Message } from "@opencode-ai/sdk/v2/client"
 import { type UpdateAction, usePlatform } from "@/context/platform"
 import { useSettings } from "@/context/settings"
@@ -2351,7 +2351,7 @@ export default function Layout(props: ParentProps) {
       if (!item) return false
       return item.vcs === "git" || layout.sidebar.workspaces(item.worktree)()
     })
-    const homedir = createMemo(() => globalSync.data.path.home)
+    const projectDisplayPath = createMemo(() => displayPath(worktree(), globalSync.data.path.home))
 
     return (
       <div
@@ -2407,16 +2407,14 @@ export default function Layout(props: ParentProps) {
                     <Tooltip
                       placement="bottom"
                       gutter={2}
-                      value={worktree()}
+                      value={worktree().replace(/\\/g, "/")}
                       class="shrink-0"
                       contentStyle={{
                         "max-width": "640px",
                         transform: "translate3d(52px, 0, 0)",
                       }}
                     >
-                      <span class="text-12-regular text-text-base truncate select-text">
-                        {worktree().replace(homedir(), "~")}
-                      </span>
+                      <span class="text-12-regular text-text-base truncate select-text">{projectDisplayPath()}</span>
                     </Tooltip>
                   </div>
 

--- a/packages/opencode/src/cli/cmd/tui/context/directory.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/directory.ts
@@ -2,11 +2,17 @@ import { createMemo } from "solid-js"
 import { useSync } from "./sync"
 import { Global } from "@/global"
 
+function tuiDisplayPath(directory: string, home: string) {
+  const normDir = directory.replace(/\\/g, "/")
+  const normHome = home.replace(/\\/g, "/")
+  return normDir.startsWith(normHome) ? "~" + normDir.slice(normHome.length) : normDir
+}
+
 export function useDirectory() {
   const sync = useSync()
   return createMemo(() => {
     const directory = sync.data.path.directory || process.cwd()
-    const result = directory.replace(Global.Path.home, "~")
+    const result = tuiDisplayPath(directory, Global.Path.home)
     if (sync.data.vcs?.branch) return result + ":" + sync.data.vcs.branch
     return result
   })

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -400,7 +400,7 @@ export namespace Server {
         }),
         async (c) => {
           return c.json({
-            home: process.platform === "win32" ? "/" : Global.Path.home,
+            home: Global.Path.home,
             state: Global.Path.state,
             config: Global.Path.config,
             worktree: Instance.worktree,

--- a/packages/util/src/path.ts
+++ b/packages/util/src/path.ts
@@ -1,3 +1,9 @@
+export function displayPath(directory: string, home: string) {
+  const normDir = directory.replace(/\\/g, "/")
+  const normHome = home.replace(/\\/g, "/")
+  return normDir.startsWith(normHome) ? "~" + normDir.slice(normHome.length) : normDir
+}
+
 export function getFilename(path: string | undefined) {
   if (!path) return ""
   const trimmed = path.replace(/[\/\\]+$/, "")


### PR DESCRIPTION
### Issue for this PR

Closes #498

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes the incorrect project path display on Windows in the sidebar and other locations. The root cause had two parts:

1. **Backend**: On Windows, `path.home` was hardcoded to `"/"` instead of the actual home directory, causing the frontend's naive `.replace(homedir(), "~")` to replace the first `/` in any path with `~` (e.g. `E:/文字材料/AI工作区` → `E:~文字材料/AI工作区`). Fixed by always returning `Global.Path.home`.

2. **Frontend**: `String.replace` with a literal home directory string fails on Windows because `\` vs `/` separator mismatches prevent matching. Fixed by introducing a `displayPath(directory, home)` utility that normalizes both paths to `/` before comparison, and only substitutes `~` when the directory actually starts with the home path.

Changes:
- `packages/opencode/src/server/server.ts` — Return real `Global.Path.home` on Windows instead of `"/"`
- `packages/util/src/path.ts` — New `displayPath()` utility for cross-platform path display
- `packages/app/src/pages/layout.tsx` — Use `displayPath()` for sidebar project path
- `packages/app/src/pages/home.tsx` — Use `displayPath()` for recent project list
- `packages/app/src/components/dialog-select-file.tsx` — Use `displayPath()` for workspace labels
- `packages/opencode/src/cli/cmd/tui/context/directory.ts` — Use equivalent `tuiDisplayPath()` for TUI display

### How did you verify your code works?

- All packages typecheck passes (`bun typecheck` in app, opencode, util)
- Verified on Windows with `agent-browser`: sidebar shows `E:/文字材料/AI工作区` correctly (no `~` corruption)

### Screenshots / recordings

Before: `E:~文字材料/AI工作区` (incorrect `~` after drive letter)
After: `E:/文字材料/AI工作区` (correct forward-slash display)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR