### PR TITLE
fix: auto-focus and auto-select rename input when context menu closes

### DIFF
--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -547,6 +547,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
                   ref={renameInputRef}
                   value={renameValue()}
                   class="text-14-regular text-text-strong min-w-0 flex-1 bg-transparent outline-none border-b border-border-base"
+                  onFocus={(e) => e.currentTarget.select()}
                   onInput={(e) => setRenameValue(e.currentTarget.value)}
                   onKeyDown={(e) => {
                     e.stopPropagation()
@@ -656,6 +657,8 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
           onCloseAutoFocus={(e) => {
             if (!renaming()) return
             e.preventDefault()
+            renameInputRef?.focus()
+            renameInputRef?.select()
           }}
         >
           <Show when={props.renameSession}>


### PR DESCRIPTION
### Issue for this PR

Closes #500

### Type of change

- [x] Bug fix

### What does this PR do?

When right-clicking a session in the sidebar and choosing "Rename", the rename input did not receive focus automatically and the existing text was not fully selected. The user had to manually click the input and select all text before typing a new name.

**Root cause**: `startRename` used `requestAnimationFrame` to call `focus()`/`select()`, but the Kobalte ContextMenu's FocusScope focus trap was still active at that point, intercepting the focus call and redirecting it back into the menu content.

**Fix** (two changes in `sidebar-items.tsx`):

1. **`onCloseAutoFocus`** — After `e.preventDefault()`, actively call `renameInputRef?.focus()` and `renameInputRef?.select()`. This handler fires inside the FocusScope cleanup `setTimeout(fn, 0)`, after SolidJS has synchronously removed the focus trap listeners, so the focus call is not intercepted.

2. **`onFocus` on the rename input** — Added `onFocus={(e) => e.currentTarget.select()}` as a safety net, ensuring text is always fully selected whenever the input receives focus (covers both the context-menu path and any other path that might trigger rename mode).

### How did you verify your code works?

- Ran `bun typecheck` in `packages/app` — no errors
- Used `agent-browser` to right-click a session → "Rename" → confirmed the input appears with `selectionStart=0, selectionEnd=4` (full text selected)
- Verified the fix works consistently across two consecutive rename attempts

### Screenshots / recordings

Not applicable — this is a focus/selection behavior fix that requires interactive testing.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR