### PR TITLE
fix: align conversation tree dots with session toggle button

### DIFF
--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -500,7 +500,7 @@ const SessionTreeNodes = (props: {
           />
         </div>
         <Show when={expanded() && conversationTreeEnabled() && hasBranchView()}>
-          <div class="pl-8 pr-2 pb-2">
+          <div class="pl-2 pr-2 pb-2">
             <SidebarBranchView
               sessionID={graphSessionID()}
               currentSessionID={props.currentSessionID() ?? nodeProps.session.id}

--- a/packages/app/src/pages/session/branch/conversation-graph-list.tsx
+++ b/packages/app/src/pages/session/branch/conversation-graph-list.tsx
@@ -31,7 +31,7 @@ export function ConversationGraphList(props: {
 }) {
   const language = useLanguage()
   const laneGap = 18
-  const railPadding = 18
+  const railPadding = 12
   const railWidth = createMemo(() => railPadding * 2 + Math.max(0, props.laneCount - 1) * laneGap + 16)
   const height = createMemo(() => Math.max(props.rowHeight, props.nodes.length * props.rowHeight))
 


### PR DESCRIPTION
### Issue for this PR

Closes #502

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes the left alignment of the conversation tree (SidebarBranchView) when expanded under a session in the sidebar.

- Reduced the tree container's left padding from  (32px) to  (8px) in .
- Reduced the SVG rail's left padding from  to  in .

These two changes align the first indicator dot's center (12px rail padding + 8px container padding = 20px) with the session toggle button's center (12px half of size-6 + 8px container padding = 20px).

### How did you verify your code works?

Used  to measure the positions before and after the change:
- Before:  (misaligned)
- After:  (aligned)

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR