### PR TITLE
feat(chat): 增加 AI 回复折叠并默认聚焦最新一轮

### DIFF
--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -1,5 +1,5 @@
 import { For, createEffect, createMemo, on, onCleanup, Show, Index, type JSX, createSignal } from "solid-js"
-import { createStore, produce } from "solid-js/store"
+import { createStore, produce, reconcile } from "solid-js/store"
 import { useNavigate } from "@solidjs/router"
 import { useMutation } from "@tanstack/solid-query"
 import { Button } from "@opencode-ai/ui/button"
@@ -20,6 +20,7 @@ import { getFilename } from "@opencode-ai/util/path"
 import { Popover as KobaltePopover } from "@kobalte/core/popover"
 import { shouldMarkBoundaryGesture, normalizeWheelDelta } from "@/pages/session/message-gesture"
 import { SessionContextUsage } from "@/components/session-context-usage"
+import { useI18n } from "@opencode-ai/ui/context"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useLanguage } from "@/context/language"
 import { useSessionKey } from "@/pages/session/session-layout"
@@ -230,8 +231,16 @@ export function MessageTimeline(props: {
   const settings = useSettings()
   const dialog = useDialog()
   const language = useLanguage()
+  const uiI18n = useI18n()
   const { params, sessionKey } = useSessionKey()
   const platform = usePlatform()
+  const [assistantCollapse, setAssistantCollapse] = createStore({
+    bySession: {} as Record<string, Record<string, true>>,
+  })
+  const [entry, setEntry] = createStore({
+    session: "",
+    done: false,
+  })
 
   const rendered = createMemo(() => props.renderedUserMessages.map((message) => message.id))
   const sessionID = createMemo(() => params.id)
@@ -239,6 +248,11 @@ export function MessageTimeline(props: {
     const id = sessionID()
     if (!id) return emptyMessages
     return sync.data.message[id] ?? emptyMessages
+  })
+  const loaded = createMemo(() => {
+    const id = sessionID()
+    if (!id) return false
+    return Object.prototype.hasOwnProperty.call(sync.data.message, id)
   })
   const pending = createMemo(() =>
     sessionMessages().findLast(
@@ -297,6 +311,79 @@ export function MessageTimeline(props: {
   const shareEnabled = createMemo(() => sync.data.config.share !== "disabled")
   const parentID = createMemo(() => info()?.parentID)
   const showHeader = createMemo(() => !!(titleValue() || parentID()))
+  const collapsibleTurnIDs = createMemo(() => {
+    const visible = new Set(rendered())
+    const pending = new Set(
+      sessionMessages()
+        .filter((item): item is AssistantMessage => item.role === "assistant" && typeof item.time.completed !== "number")
+        .map((item) => item.parentID)
+        .filter((item): item is string => !!item),
+    )
+    const seen = new Set<string>()
+    return sessionMessages().flatMap((item) => {
+      if (item.role !== "assistant") return []
+      const pid = item.parentID
+      if (!pid || pending.has(pid) || !visible.has(pid) || seen.has(pid)) return []
+      seen.add(pid)
+      return [pid]
+    })
+  })
+  createEffect(
+    on(sessionID, (id) => {
+      setEntry({ session: id ?? "", done: false })
+      if (!id) return
+      setAssistantCollapse("bySession", id, reconcile({}))
+    }),
+  )
+  createEffect(() => {
+    const id = sessionID()
+    if (!id || !loaded() || entry.session !== id || entry.done) return
+    const ids = collapsibleTurnIDs()
+    const tail = ids[ids.length - 1]
+    setAssistantCollapse(
+      "bySession",
+      id,
+      reconcile(Object.fromEntries(ids.filter((item) => item !== tail).map((item) => [item, true] as const))),
+    )
+    setEntry("done", true)
+  })
+  const collapsedTurnMap = createMemo(() => {
+    const id = sessionID()
+    if (!id) return {}
+    return assistantCollapse.bySession[id] ?? {}
+  })
+  const isAssistantCollapsed = (messageID: string) => !!collapsedTurnMap()[messageID]
+  const setAssistantCollapsed = (messageID: string, value: boolean) => {
+    const id = sessionID()
+    if (!id) return
+    const current = assistantCollapse.bySession[id] ?? {}
+    if (value) {
+      setAssistantCollapse("bySession", id, reconcile({ ...current, [messageID]: true }))
+      return
+    }
+    if (!current[messageID]) return
+    const next = { ...current }
+    delete next[messageID]
+    setAssistantCollapse("bySession", id, reconcile(next))
+  }
+  const allAssistantCollapsed = createMemo(() => {
+    const ids = collapsibleTurnIDs()
+    return ids.length > 0 && ids.every((messageID) => isAssistantCollapsed(messageID))
+  })
+  const collapseAllAssistant = () => {
+    const id = sessionID()
+    if (!id) return
+    setAssistantCollapse(
+      "bySession",
+      id,
+      reconcile(Object.fromEntries(collapsibleTurnIDs().map((messageID) => [messageID, true] as const))),
+    )
+  }
+  const expandAllAssistant = () => {
+    const id = sessionID()
+    if (!id) return
+    setAssistantCollapse("bySession", id, reconcile({}))
+  }
   const stageCfg = { init: 1, batch: 3 }
   const staging = createTimelineStaging({
     sessionKey,
@@ -787,6 +874,24 @@ export function MessageTimeline(props: {
                                   </DropdownMenu.ItemLabel>
                                 </DropdownMenu.Item>
                               </Show>
+                              <Show when={collapsibleTurnIDs().length > 0}>
+                                <DropdownMenu.Item
+                                  onSelect={() => {
+                                    setTitle("menuOpen", false)
+                                    if (allAssistantCollapsed()) {
+                                      expandAllAssistant()
+                                      return
+                                    }
+                                    collapseAllAssistant()
+                                  }}
+                                >
+                                  <DropdownMenu.ItemLabel>
+                                    {allAssistantCollapsed()
+                                      ? uiI18n.t("ui.sessionReview.expandAll")
+                                      : uiI18n.t("ui.sessionReview.collapseAll")}
+                                  </DropdownMenu.ItemLabel>
+                                </DropdownMenu.Item>
+                              </Show>
                               <DropdownMenu.Item onSelect={() => void archiveSession(id())}>
                                 <DropdownMenu.ItemLabel>{language.t("common.archive")}</DropdownMenu.ItemLabel>
                               </DropdownMenu.Item>
@@ -948,11 +1053,15 @@ export function MessageTimeline(props: {
                     <div
                       id={props.anchor(messageID)}
                       data-message-id={messageID}
+                      data-assistant-collapsed={isAssistantCollapsed(messageID) ? "true" : undefined}
                       classList={{
                         "min-w-0 w-full max-w-full": true,
                         "md:max-w-200 2xl:max-w-[1000px]": props.centered,
                       }}
-                      style={{ "content-visibility": "auto", "contain-intrinsic-size": "auto 500px" }}
+                      style={{
+                        "content-visibility": "auto",
+                        "contain-intrinsic-size": isAssistantCollapsed(messageID) ? "auto 20px" : "auto 500px",
+                      }}
                     >
                       <Show when={commentCount() > 0}>
                         <div class="w-full px-4 md:px-5 pb-2">
@@ -999,6 +1108,8 @@ export function MessageTimeline(props: {
                         messageID={messageID}
                         messages={sessionMessages()}
                         actions={props.actions}
+                        assistantCollapsed={isAssistantCollapsed(messageID)}
+                        onAssistantCollapsedChange={(collapsed) => setAssistantCollapsed(messageID, collapsed)}
                         active={active()}
                         status={active() ? sessionStatus() : undefined}
                         showReasoningSummaries={settings.general.showReasoningSummaries()}

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -221,7 +221,9 @@
     display: flex;
     align-items: center;
     justify-content: flex-start;
-    gap: 10px;
+    gap: 6px;
+    width: fit-content;
+    max-width: 100%;
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.15s ease;
@@ -235,6 +237,15 @@
 
   [data-slot="text-part-meta"] {
     user-select: none;
+    flex: 0 1 auto;
+    min-width: 0;
+  }
+
+  [data-slot="text-part-actions"] {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex: 0 0 auto;
   }
 
   [data-slot="text-part-copy-wrapper"][data-interrupted] {

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -135,6 +135,7 @@ export interface MessageProps {
   actions?: UserActions
   showAssistantCopyPartID?: string | null
   showReasoningSummaries?: boolean
+  onUserBubbleClick?: JSX.EventHandlerUnion<HTMLDivElement, MouseEvent>
 }
 
 export type SessionAction = (input: { sessionID: string; messageID: string }) => Promise<void> | void
@@ -151,6 +152,8 @@ export interface MessagePartProps {
   defaultOpen?: boolean
   showAssistantCopyPartID?: string | null
   turnDurationMs?: number
+  onAssistantCollapse?: () => void
+  canCollapseAssistant?: boolean
 }
 
 export type PartComponent = Component<MessagePartProps>
@@ -563,6 +566,8 @@ export function AssistantParts(props: {
   showReasoningSummaries?: boolean
   shellToolDefaultOpen?: boolean
   editToolDefaultOpen?: boolean
+  onAssistantCollapse?: () => void
+  canCollapseAssistant?: boolean
 }) {
   const data = useData()
   const emptyParts: PartType[] = []
@@ -643,6 +648,8 @@ export function AssistantParts(props: {
                         message={message()!}
                         showAssistantCopyPartID={props.showAssistantCopyPartID}
                         turnDurationMs={props.turnDurationMs}
+                        onAssistantCollapse={props.onAssistantCollapse}
+                        canCollapseAssistant={props.canCollapseAssistant}
                         defaultOpen={partDefaultOpen(item()!, props.shellToolDefaultOpen, props.editToolDefaultOpen)}
                       />
                     </Show>
@@ -766,7 +773,12 @@ export function Message(props: MessageProps) {
     <Switch>
       <Match when={props.message.role === "user" && props.message}>
         {(userMessage) => (
-          <UserMessageDisplay message={userMessage() as UserMessage} parts={props.parts} actions={props.actions} />
+          <UserMessageDisplay
+            message={userMessage() as UserMessage}
+            parts={props.parts}
+            actions={props.actions}
+            onBubbleClick={props.onUserBubbleClick}
+          />
         )}
       </Match>
       <Match when={props.message.role === "assistant" && props.message}>
@@ -957,7 +969,12 @@ function ContextToolGroup(props: { parts: ToolPart[]; busy?: boolean }) {
   )
 }
 
-export function UserMessageDisplay(props: { message: UserMessage; parts: PartType[]; actions?: UserActions }) {
+export function UserMessageDisplay(props: {
+  message: UserMessage
+  parts: PartType[]
+  actions?: UserActions
+  onBubbleClick?: JSX.EventHandlerUnion<HTMLDivElement, MouseEvent>
+}) {
   const data = useData()
   const dialog = useDialog()
   const i18n = useI18n()
@@ -1078,7 +1095,7 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
       <Show when={text()}>
         <>
           <div data-slot="user-message-body">
-            <div data-slot="user-message-text">
+            <div data-slot="user-message-text" onClick={props.onBubbleClick}>
               <HighlightedText text={text()} references={inlineFiles()} agents={agents()} />
             </div>
           </div>
@@ -1209,6 +1226,8 @@ export function Part(props: MessagePartProps) {
         defaultOpen={props.defaultOpen}
         showAssistantCopyPartID={props.showAssistantCopyPartID}
         turnDurationMs={props.turnDurationMs}
+        onAssistantCollapse={props.onAssistantCollapse}
+        canCollapseAssistant={props.canCollapseAssistant}
       />
     </Show>
   )
@@ -1459,6 +1478,9 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
     if (typeof props.showAssistantCopyPartID === "string") return props.showAssistantCopyPartID === part().id
     return isLastTextPart()
   })
+  const showAssistantCollapseControl = createMemo(
+    () => props.message.role === "assistant" && !!props.onAssistantCollapse && !!props.canCollapseAssistant,
+  )
   const [copied, setCopied] = createSignal(false)
 
   const handleCopy = async () => {
@@ -1482,25 +1504,42 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
         </div>
         <Show when={showCopy()}>
           <div data-slot="text-part-copy-wrapper" data-interrupted={interrupted() ? "" : undefined}>
-            <Tooltip
-              value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
-              placement="top"
-              gutter={4}
-            >
-              <IconButton
-                icon={copied() ? "check" : "copy"}
-                size="normal"
-                variant="ghost"
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={handleCopy}
-                aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
-              />
-            </Tooltip>
             <Show when={meta()}>
               <span data-slot="text-part-meta" class="text-12-regular text-text-weak cursor-default">
                 {meta()}
               </span>
             </Show>
+            <div data-slot="text-part-actions">
+              <Tooltip
+                value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
+                placement="top"
+                gutter={4}
+              >
+                <IconButton
+                  icon={copied() ? "check" : "copy"}
+                  size="normal"
+                  variant="ghost"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={handleCopy}
+                  aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
+                />
+              </Tooltip>
+              <Show when={showAssistantCollapseControl()}>
+                <Tooltip value={i18n.t("ui.message.collapse")} placement="top" gutter={4}>
+                  <IconButton
+                    icon="collapse"
+                    size="normal"
+                    variant="ghost"
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      props.onAssistantCollapse?.()
+                    }}
+                    aria-label={i18n.t("ui.message.collapse")}
+                  />
+                </Tooltip>
+              </Show>
+            </div>
           </div>
         </Show>
       </div>

--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -7,6 +7,10 @@
   align-items: flex-start;
   justify-content: flex-start;
 
+  &[data-assistant-collapsed] {
+    height: auto;
+  }
+
   [data-slot="session-turn-content"] {
     flex-grow: 1;
     width: 100%;
@@ -14,6 +18,11 @@
     min-width: 0;
     overflow-y: auto;
     scrollbar-width: none;
+
+    &[data-assistant-collapsed] {
+      height: auto;
+      overflow: visible;
+    }
   }
 
   [data-slot="session-turn-content"]::-webkit-scrollbar {
@@ -28,6 +37,10 @@
     min-width: 0;
     gap: 18px;
     overflow-anchor: none;
+  }
+
+  [data-slot="session-turn-message-container"][data-assistant-collapsed] {
+    gap: 2px;
   }
 
   [data-slot="session-turn-message-content"] {
@@ -85,6 +98,21 @@
     flex-direction: column;
     align-self: stretch;
     gap: 12px;
+  }
+
+  [data-slot="session-turn-assistant-toggle"] {
+    width: 100%;
+    min-width: 0;
+    appearance: none;
+    border: 0;
+    background: transparent;
+    padding: 0;
+    text-align: left;
+    cursor: pointer;
+
+    [data-slot="compaction-part-divider"] {
+      padding: 1px 0;
+    }
   }
 
   [data-slot="session-turn-diffs"] {
@@ -228,5 +256,14 @@
 }
 
 [data-slot="session-turn-list"] {
-  gap: 48px;
+  gap: 0;
+
+  > * + * {
+    margin-top: 48px;
+  }
+
+  > * + *[data-assistant-collapsed],
+  > *[data-assistant-collapsed] + * {
+    margin-top: 8px;
+  }
 }

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -85,6 +85,17 @@ function list<T>(value: T[] | undefined | null, fallback: T[]) {
   return fallback
 }
 
+function skip(target: EventTarget | null) {
+  if (!(target instanceof Element)) return false
+  return !!target.closest("button, a, input, textarea, select, [role='button'], [data-clickable]")
+}
+
+function picked() {
+  const sel = window.getSelection?.()
+  if (!sel) return false
+  return sel.type === "Range" && sel.toString().trim().length > 0
+}
+
 const hidden = new Set(["todowrite"])
 
 function partState(part: PartType, showReasoningSummaries: boolean) {
@@ -158,6 +169,8 @@ export function SessionTurn(
     editToolDefaultOpen?: boolean
     active?: boolean
     status?: SessionStatus
+    assistantCollapsed?: boolean
+    onAssistantCollapsedChange?: (collapsed: boolean) => void
     onUserInteracted?: () => void
     classes?: {
       root?: string
@@ -378,6 +391,15 @@ export function SessionTurn(
     if (showReasoningSummaries()) return assistantVisible() === 0
     return true
   })
+  const assistantCollapsed = createMemo(() => props.assistantCollapsed ?? false)
+  const canCollapseAssistant = createMemo(() => assistantMessages().length > 0 && !working())
+  const assistantExpandLabel = createMemo(() => i18n.t("ui.message.expand"))
+  const collapseAssistant = () => props.onAssistantCollapsedChange?.(true)
+  const toggleAssistant = (event: MouseEvent) => {
+    if (event.button !== 0 || !canCollapseAssistant() || !props.onAssistantCollapsedChange) return
+    if (skip(event.target) || picked()) return
+    props.onAssistantCollapsedChange(!assistantCollapsed())
+  }
 
   const autoScroll = createAutoScroll({
     working,
@@ -386,11 +408,16 @@ export function SessionTurn(
   })
 
   return (
-    <div data-component="session-turn" class={props.classes?.root}>
+    <div
+      data-component="session-turn"
+      data-assistant-collapsed={assistantCollapsed() ? "true" : undefined}
+      class={props.classes?.root}
+    >
       <div
         ref={autoScroll.scrollRef}
         onScroll={autoScroll.handleScroll}
         data-slot="session-turn-content"
+        data-assistant-collapsed={assistantCollapsed() ? "true" : undefined}
         class={props.classes?.content}
       >
         <div onClick={autoScroll.handleInteraction}>
@@ -399,18 +426,41 @@ export function SessionTurn(
               ref={autoScroll.contentRef}
               data-message={message()!.id}
               data-slot="session-turn-message-container"
+              data-assistant-collapsed={assistantCollapsed() ? "true" : undefined}
               class={props.classes?.container}
             >
               <div data-slot="session-turn-message-content" aria-live="off">
-                <Message message={message()!} parts={parts()} actions={props.actions} />
+                <Message
+                  message={message()!}
+                  parts={parts()}
+                  actions={props.actions}
+                  onUserBubbleClick={toggleAssistant}
+                />
               </div>
-              <Show when={divider()}>
+              <Show when={divider() && !assistantCollapsed()}>
                 <div data-slot="session-turn-compaction">
                   <MessageDivider label={divider()} />
                 </div>
               </Show>
+              <Show when={assistantCollapsed() && canCollapseAssistant()}>
+                <button
+                  type="button"
+                  data-slot="session-turn-assistant-toggle"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    props.onAssistantCollapsedChange?.(false)
+                  }}
+                  aria-label={assistantExpandLabel()}
+                >
+                  <MessageDivider label={assistantExpandLabel()} />
+                </button>
+              </Show>
               <Show when={assistantMessages().length > 0}>
-                <div data-slot="session-turn-assistant-content" aria-hidden={working()}>
+                <div
+                  data-slot="session-turn-assistant-content"
+                  aria-hidden={working()}
+                  hidden={assistantCollapsed()}
+                >
                   <AssistantParts
                     messages={assistantMessages()}
                     showAssistantCopyPartID={assistantCopyPartID()}
@@ -419,10 +469,12 @@ export function SessionTurn(
                     showReasoningSummaries={showReasoningSummaries()}
                     shellToolDefaultOpen={props.shellToolDefaultOpen}
                     editToolDefaultOpen={props.editToolDefaultOpen}
+                    canCollapseAssistant={canCollapseAssistant()}
+                    onAssistantCollapse={collapseAssistant}
                   />
                 </div>
               </Show>
-              <Show when={showThinking()}>
+              <Show when={showThinking() && !assistantCollapsed()}>
                 <div data-slot="session-turn-thinking">
                   <TextShimmer text={i18n.t("ui.sessionTurn.status.thinking")} />
                   <Show when={!showReasoningSummaries()}>
@@ -436,7 +488,7 @@ export function SessionTurn(
                 </div>
               </Show>
               <SessionRetry status={status()} show={active()} />
-              <Show when={edited() > 0 && !working()}>
+              <Show when={edited() > 0 && !working() && !assistantCollapsed()}>
                 <div data-slot="session-turn-diffs">
                   <Collapsible open={open()} onOpenChange={(value) => setState("open", value)} variant="ghost">
                     <Collapsible.Trigger>
@@ -534,7 +586,7 @@ export function SessionTurn(
                   </Collapsible>
                 </div>
               </Show>
-              <Show when={error()}>
+              <Show when={error() && !assistantCollapsed()}>
                 <Card variant="error" class="error-card">
                   {errorText()}
                 </Card>


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

为会话里的 assistant 回复增加折叠能力。现在可以通过 assistant 文本 footer 的按钮或点击用户文本气泡来切换对应回复的展开/收起，也支持会话级的全部收起和全部展开。

为了改善超长历史对话的打开体验，进入或切换到一个会话时会默认收起历史 assistant 回复，只保留最新一轮展开。当前停留期间的新消息保持展开，用户手动展开或收起的状态不会被自动覆盖到本轮查看中。

### How did you verify your code works?

- 在 packages/app 运行 un typecheck
- 在 packages/ui 运行 un typecheck
- push hook 自动运行 un turbo typecheck 并通过
- 本地手动验证单条折叠/展开、批量折叠/展开、点击用户文本气泡切换，以及切换会话后默认只展开最新一轮

### Screenshots / recordings

- <img width="2560" height="1194" alt="image" src="https://github.com/user-attachments/assets/022981e1-d065-4dae-83fa-da017f5397d9" />；已在本地手动验证 UI 行为

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR