### PR TITLE
fix: prepare install directories in init installers

### DIFF
--- a/Update/aether_darwin_installer.command
+++ b/Update/aether_darwin_installer.command
@@ -511,6 +511,13 @@ if [ "$mode" = "init" ]; then
     echo "工作目录处理失败。"
     fail "$dir_err"
   }
+  prep "$mirror" || {
+    res="dir_error"
+    result
+    echo
+    echo "安装目录处理失败。"
+    fail "$dir_err"
+  }
   manifest_url="$base/$latest"
   manifest "$manifest_url" latest || {
     res="meta_error"

--- a/Update/aether_linux_installer.sh
+++ b/Update/aether_linux_installer.sh
@@ -826,6 +826,13 @@ if [ "$mode" = "init" ]; then
     echo "Work directory failed."
     fail "$dir_err"
   }
+  prep "$mirror" || {
+    res="dir_error"
+    result
+    echo
+    echo "Install directory failed."
+    fail "$dir_err"
+  }
   manifest_url="$base/$latest"
   manifest "$manifest_url" latest || {
     res="meta_error"

--- a/Update/aether_windows_installer.bat
+++ b/Update/aether_windows_installer.bat
@@ -120,7 +120,8 @@ echo Work directory:
 echo   %WORK%
 echo Install directory:
 echo   %MIRROR%
-call :prep "%WORK%" || goto :dir_fail
+call :prep "%WORK%" || goto :work_dir_fail
+call :prep "%MIRROR%" || goto :mirror_dir_fail
 
 set "CUR="
 call :latest || goto :meta_fail
@@ -168,8 +169,8 @@ goto :done
 
 :auto
 call :work WORK
-call :prep "%WORK%" || goto :dir_fail
-call :latest || goto :meta_fail
+call :prep "%WORK%" || goto :work_dir_fail
+  call :latest || goto :meta_fail
 call :print_latest
 call :grab || goto :dl_fail
 set "RES=update_ready"
@@ -184,7 +185,7 @@ if "%ARG%"=="" (
 set "CUR="
 set "REQ=%ARG%"
 call :work WORK
-call :prep "%WORK%" || goto :dir_fail
+call :prep "%WORK%" || goto :work_dir_fail
 call :version "%REQ%"
 set "RC=%ERRORLEVEL%"
 if "%RC%"=="%MISS%" (
@@ -641,11 +642,19 @@ exit /b %RC%
 if /I "%MODE%"=="init" goto :done_err
 exit /b %RUN_ERR%
 
-:dir_fail
+:work_dir_fail
 set "RES=dir_error"
 call :result
 echo(
 echo Work directory failed.
+if /I "%MODE%"=="init" goto :done_err
+exit /b %DIR_ERR%
+
+:mirror_dir_fail
+set "RES=dir_error"
+call :result
+echo(
+echo Install directory failed.
 if /I "%MODE%"=="init" goto :done_err
 exit /b %DIR_ERR%
 

--- a/Update/update_darwin.command
+++ b/Update/update_darwin.command
@@ -236,13 +236,14 @@ stamp() {
 
 mirror_root() {
   if [ -n "${AETHER_MIRROR_ROOT:-}" ]; then
-    mkdir -p "${AETHER_MIRROR_ROOT}" || return 1
+    mkdir -p "${AETHER_MIRROR_ROOT}" 2>/dev/null || true
     cd "${AETHER_MIRROR_ROOT}" && pwd
     return 0
   fi
   local cur
   cur="${AETHER_CURRENT_DIR:-}"
   [ -n "$cur" ] || return 1
+  mkdir -p "$(dirname "$cur")" 2>/dev/null || true
   cd "$cur/.." && pwd
 }
 
@@ -252,8 +253,8 @@ in_work() {
   root="$1"
   [ -n "$cur" ] || return 1
   [ -n "$root" ] || return 1
-  cur="$(cd "$cur" 2>/dev/null && pwd)" || return 1
-  root="$(cd "$root" 2>/dev/null && pwd)" || return 1
+  cur="$(cd "$cur" && pwd)"
+  root="$(cd "$root" && pwd)"
   case "$cur" in
     "$root"|"$root"/*) return 0 ;;
   esac

--- a/Update/update_linux.sh
+++ b/Update/update_linux.sh
@@ -281,13 +281,14 @@ stamp() {
 
 mirror_root() {
   if [ -n "${AETHER_MIRROR_ROOT:-}" ]; then
-    mkdir -p "${AETHER_MIRROR_ROOT}" || return 1
+    mkdir -p "${AETHER_MIRROR_ROOT}" 2>/dev/null || true
     cd "${AETHER_MIRROR_ROOT}" && pwd
     return 0
   fi
   local cur
   cur="${AETHER_CURRENT_DIR:-}"
   [ -n "$cur" ] || return 1
+  mkdir -p "$(dirname "$cur")" 2>/dev/null || true
   cd "$cur/.." && pwd
 }
 
@@ -297,8 +298,8 @@ in_work() {
   root="$1"
   [ -n "$cur" ] || return 1
   [ -n "$root" ] || return 1
-  cur="$(cd "$cur" 2>/dev/null && pwd)" || return 1
-  root="$(cd "$root" 2>/dev/null && pwd)" || return 1
+  cur="$(cd "$cur" && pwd)"
+  root="$(cd "$root" && pwd)"
   case "$cur" in
     "$root"|"$root"/*) return 0 ;;
   esac


### PR DESCRIPTION
### Issue for this PR

Closes #505

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Prepares the install/mirror directory during init installs before downloading and running the platform update script.

This updates macOS, Linux, and Windows init installers to create or validate the target install directory early, and separates Windows work-directory failures from install-directory failures. The macOS and Linux update scripts also create the mirror root when resolving the mirror destination.

### How did you verify your code works?

- Ran `git diff --cached --check`
- Ran `bash -n` on the macOS and Linux installer/update scripts
- Ran a minimal Linux local install simulation with a test zip package to verify work and mirror version directories are created

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR