### PR TITLE
feat: support runtime base path for packaged web app

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -12,7 +12,7 @@
     <meta name="theme-color" content="#F8F7F7" />
     <meta name="theme-color" content="#131010" media="(prefers-color-scheme: dark)" />
     <meta property="og:image" content="/social-share.png" />
-    <meta property="twitter:image" content="/social-share.png" />
+    <meta property="twitter:image" content="./social-share.png" />
     <script id="oc-theme-preload-script" src="/oc-theme-preload.js"></script>
   </head>
   <body class="antialiased overscroll-none text-12-regular overflow-hidden">

--- a/packages/app/public/pdf-viewer-aether.css
+++ b/packages/app/public/pdf-viewer-aether.css
@@ -43,13 +43,13 @@ body.aether-pdf-viewer #aetherOpenReadingMode {
 }
 
 body.aether-pdf-viewer {
-  --aether-night-moon-icon: url("/pdfjs-ref/web/images/aether-night-mode-moon.svg");
-  --aether-night-sun-icon: url("/pdfjs-ref/web/images/aether-night-mode-sun.svg");
-  --aether-capture-region-icon: url("/pdfjs-ref/web/images/aether-capture-region.svg");
-  --aether-reading-settings-icon: url("/pdfjs-ref/web/images/secondaryToolbarButton-documentProperties.svg");
-  --aether-swap-right-icon: url("/pdfjs-ref/web/images/aether-swap-layout-right.svg");
-  --aether-swap-left-icon: url("/pdfjs-ref/web/images/aether-swap-layout-left.svg");
-  --aether-reading-mode-icon: url("/pdfjs-ref/web/images/aether-reading-mode.svg");
+  --aether-night-moon-icon: url("pdfjs-ref/web/images/aether-night-mode-moon.svg");
+  --aether-night-sun-icon: url("pdfjs-ref/web/images/aether-night-mode-sun.svg");
+  --aether-capture-region-icon: url("pdfjs-ref/web/images/aether-capture-region.svg");
+  --aether-reading-settings-icon: url("pdfjs-ref/web/images/secondaryToolbarButton-documentProperties.svg");
+  --aether-swap-right-icon: url("pdfjs-ref/web/images/aether-swap-layout-right.svg");
+  --aether-swap-left-icon: url("pdfjs-ref/web/images/aether-swap-layout-left.svg");
+  --aether-reading-mode-icon: url("pdfjs-ref/web/images/aether-reading-mode.svg");
   --main-color: var(--text-strong);
   --body-bg-color: var(--background-base);
   --progressBar-color: var(--border-selected);

--- a/packages/app/public/pdf-viewer-aether.js
+++ b/packages/app/public/pdf-viewer-aether.js
@@ -3,8 +3,8 @@
 (function () {
   const CHANNEL = "aether-pdf-viewer";
   const ORIGIN = window.location.origin;
-  const C_MAP_URL = "/pdfjs-ref/web/cmaps/";
-  const STANDARD_FONT_DATA_URL = "/pdfjs-ref/web/standard_fonts/";
+  const C_MAP_URL = "pdfjs-ref/web/cmaps/";
+  const STANDARD_FONT_DATA_URL = "pdfjs-ref/web/standard_fonts/";
   const RANGE_CHUNK_SIZE = 65536;
   const DEFAULT_SCALE = {
     full: "auto",
@@ -853,7 +853,7 @@
     "load",
     function () {
       applyTheme();
-      PDFViewerApplicationOptions.set("workerSrc", "/pdfjs-ref/build/pdf.worker.js");
+      PDFViewerApplicationOptions.set("workerSrc", "pdfjs-ref/build/pdf.worker.js");
       PDFViewerApplicationOptions.set("cMapUrl", C_MAP_URL);
       PDFViewerApplicationOptions.set("standardFontDataUrl", STANDARD_FONT_DATA_URL);
       PDFViewerApplication.initializedPromise.then(function () {

--- a/packages/app/public/pdf-viewer.html
+++ b/packages/app/public/pdf-viewer.html
@@ -25,15 +25,15 @@ See https://github.com/adobe-type-tools/cmap-resources
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="google" content="notranslate">
-    <script id="oc-theme-preload-script" src="/oc-theme-preload.js"></script>
+    <script id="oc-theme-preload-script" src="oc-theme-preload.js"></script>
     <title>Aether PDF Viewer</title>
 
-    <link rel="stylesheet" href="/pdfjs-ref/web/viewer.css">
-    <link rel="stylesheet" href="/pdf-viewer-aether.css">
-    <link rel="resource" type="application/l10n" href="/pdfjs-ref/web/locale/locale.properties">
-    <script src="/pdfjs-ref/build/pdf.js"></script>
-    <script src="/pdfjs-ref/web/viewer.js"></script>
-    <script src="/pdf-viewer-aether.js"></script>
+    <link rel="stylesheet" href="pdfjs-ref/web/viewer.css">
+    <link rel="stylesheet" href="pdf-viewer-aether.css">
+    <link rel="resource" type="application/l10n" href="pdfjs-ref/web/locale/locale.properties">
+    <script src="pdfjs-ref/build/pdf.js"></script>
+    <script src="pdfjs-ref/web/viewer.js"></script>
+    <script src="pdf-viewer-aether.js"></script>
 
   </head>
 

--- a/packages/app/src/base-path.ts
+++ b/packages/app/src/base-path.ts
@@ -1,0 +1,13 @@
+export function base() {
+  const env = import.meta.env as unknown as { VITE_BASE_PATH?: string }
+  const raw = (globalThis as { __AETHER_BASE_PATH__?: string }).__AETHER_BASE_PATH__ ?? env.VITE_BASE_PATH
+  if (!raw || raw === "." || raw === "./" || raw === "/") return "/"
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(raw)) return "/"
+  const path = raw.startsWith("/") ? raw : `/${raw}`
+  return path.replace(/\/+$/, "") || "/"
+}
+
+export function href(path: string) {
+  const root = base()
+  return root === "/" ? path : `${root}${path}`
+}

--- a/packages/app/src/components/pdf-viewer-shell-official.tsx
+++ b/packages/app/src/components/pdf-viewer-shell-official.tsx
@@ -1,4 +1,5 @@
 import { type Component, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
+import { href } from "@/base-path"
 import "./pdf-viewer-shell.css"
 
 type ViewerMode = "full" | "compact"
@@ -85,7 +86,7 @@ export const PdfViewerShell: Component<PdfViewerShellProps> = (props) => {
   let lastConfigKey = ""
   const [nightMode, setNightMode] = createSignal(sharedNightMode)
 
-  const viewerSrc = createMemo(() => "/pdf-viewer.html")
+  const viewerSrc = createMemo(() => href("/pdf-viewer.html"))
   const config = createMemo(() => ({
     src: props.src,
     authHeader: props.authHeader,

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -2,6 +2,7 @@
 
 import { render } from "solid-js/web"
 import { AppBaseProviders, AppInterface } from "@/app"
+import { base } from "@/base-path"
 import { type Platform, PlatformProvider } from "@/context/platform"
 import { dict as en } from "@/i18n/en"
 import { dict as zh } from "@/i18n/zh"
@@ -339,7 +340,7 @@ const boot = async () => {
             defaultServer={ServerConnection.Key.make(getDefaultUrl())}
             servers={[server]}
             disableHealthCheck
-            basePath={import.meta.env.VITE_BASE_PATH}
+            basePath={base()}
           />
         </AppBaseProviders>
       </PlatformProvider>

--- a/packages/app/vite.js
+++ b/packages/app/vite.js
@@ -37,6 +37,7 @@ function stripGitBashPrefix(path) {
 function readBasePath() {
   const raw = process.env.VITE_BASE_PATH
   if (!raw) return "/"
+  if (raw === "." || raw === "./") return "./"
   if (/^[A-Za-z]:[\\/]/.test(raw)) {
     const recovered = stripGitBashPrefix(raw)
     if (recovered) {
@@ -51,6 +52,11 @@ function readBasePath() {
   return raw.startsWith("/") ? raw : `/${raw}`
 }
 
+function readRouterBase(base) {
+  if (base === "./") return "/"
+  return base
+}
+
 const theme = fileURLToPath(new URL("./public/oc-theme-preload.js", import.meta.url))
 
 /**
@@ -62,10 +68,11 @@ export default [
     config() {
       const port = readServePort()
       const basePath = readBasePath()
+      const routerBase = readRouterBase(basePath)
       const env = port ? { VITE_OPENCODE_SERVER_PORT: port } : {}
       if (port) console.log(`[opencode] auto-detected backend port: ${port}`)
-      if (basePath !== "/") console.log(`[opencode] base path: ${basePath}`)
-      env.VITE_BASE_PATH = basePath
+      if (routerBase !== "/") console.log(`[opencode] base path: ${routerBase}`)
+      env.VITE_BASE_PATH = routerBase
       return {
         base: basePath,
         define: Object.fromEntries(Object.entries(env).map(([k, v]) => [`import.meta.env.${k}`, JSON.stringify(v)])),

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -170,13 +170,20 @@ pkgRaw.version = Script.version
 await Bun.write(pkgPath, JSON.stringify(pkgRaw, null, 2) + "\n")
 
 // Build web app (packages/app) and embed alongside binary
+const base = process.env.VITE_BASE_PATH
 try {
   if (!skipWeb) {
     console.log("building web app...")
+    process.env.VITE_BASE_PATH = "./"
     await $`bun run --cwd ${path.resolve(dir, "../../packages/app")} build`
     console.log("web app built")
   }
 } finally {
+  if (base === undefined) {
+    delete process.env.VITE_BASE_PATH
+  } else {
+    process.env.VITE_BASE_PATH = base
+  }
   // Restore original version in package.json to avoid dirtying the working tree
   pkgRaw.version = originalVersion
   await Bun.write(pkgPath, JSON.stringify(pkgRaw, null, 2) + "\n")

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -31,6 +31,32 @@ function hashed(path: string) {
   return path.startsWith("/assets/") && /-[A-Za-z0-9_-]{8,}\./.test(nodePath.basename(path))
 }
 
+function basePath() {
+  const raw = process.env.VITE_BASE_PATH?.trim()
+  if (!raw) return "/"
+  if (raw === "." || raw === "./") return "/"
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(raw)) return "/"
+  if (/[?#\s"'<>]/.test(raw)) return "/"
+  const base = raw.startsWith("/") ? raw : `/${raw}`
+  return base.replace(/\/+$/, "") || "/"
+}
+
+function baseHref(base: string) {
+  return base === "/" ? "/" : `${base}/`
+}
+
+function baseStrip(path: string, base: string) {
+  if (base === "/") return path
+  if (path === base || path === `${base}/`) return "/"
+  if (path.startsWith(`${base}/`)) return path.slice(base.length)
+  return undefined
+}
+
+function baseInject(html: string, base: string) {
+  const tag = `<base href="${baseHref(base)}"><script>globalThis.__AETHER_BASE_PATH__=${JSON.stringify(base)}</script>`
+  return html.includes("<head>") ? html.replace("<head>", `<head>${tag}`) : `${tag}${html}`
+}
+
 async function webHeaders(reqPath: string, filePath: string) {
   const stat = await Bun.file(filePath).stat()
   return {
@@ -51,6 +77,25 @@ async function webResponse(req: Request, reqPath: string, filePath: string) {
     })
   }
   return new Response(file, { headers })
+}
+
+async function webIndex(req: Request, reqPath: string, filePath: string, base: string) {
+  const file = Bun.file(filePath)
+  const stat = await file.stat()
+  const html = baseInject(await file.text(), base)
+  const headers = {
+    "content-type": getMimeType(filePath),
+    "cache-control": WEB_REVALIDATE,
+    etag: webEtag(new TextEncoder().encode(html).byteLength, stat.mtimeMs),
+    "last-modified": stat.mtime.toUTCString(),
+  }
+  if (req.headers.get("if-none-match") === headers.etag) {
+    return new Response(null, {
+      status: 304,
+      headers,
+    })
+  }
+  return new Response(html, { headers })
 }
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
@@ -741,19 +786,28 @@ export namespace Server {
       )
       .all("/*", async (c) => {
         const reqPath = c.req.path
+        const base = basePath()
 
         // Serve local web assets if available (next to the binary)
         const webDir = nodePath.join(nodePath.dirname(process.execPath), "web")
-        const localFilePath = nodePath.join(webDir, reqPath === "/" ? "index.html" : reqPath)
-        const localFile = Bun.file(localFilePath)
-        if (await localFile.exists()) {
-          return webResponse(c.req.raw, reqPath, localFilePath)
-        }
-        // SPA fallback: serve index.html for unknown paths
         const indexPath = nodePath.join(webDir, "index.html")
         const indexFile = Bun.file(indexPath)
+        const localPath = baseStrip(reqPath, base)
+        if ((await indexFile.exists()) && base !== "/" && (reqPath === "/" || reqPath === base)) {
+          return c.redirect(baseHref(base))
+        }
+        if ((await indexFile.exists()) && localPath === undefined) {
+          return c.text("Not found", 404)
+        }
+        const filePath = nodePath.join(webDir, localPath === "/" || localPath === undefined ? "index.html" : localPath)
+        const localFile = Bun.file(filePath)
+        if (await localFile.exists()) {
+          if (nodePath.basename(filePath) === "index.html") return webIndex(c.req.raw, localPath ?? "/", filePath, base)
+          return webResponse(c.req.raw, localPath ?? reqPath, filePath)
+        }
+        // SPA fallback: serve index.html for unknown paths
         if (await indexFile.exists()) {
-          return webResponse(c.req.raw, "/", indexPath)
+          return webIndex(c.req.raw, "/", indexPath, base)
         }
 
         // Fall back to remote proxy

--- a/packages/opencode/test/server/server-web-cache.test.ts
+++ b/packages/opencode/test/server/server-web-cache.test.ts
@@ -54,4 +54,43 @@ describe("web cache headers", () => {
       Object.defineProperty(process, "execPath", { value: old, configurable: true })
     }
   })
+
+  test("serves local web assets under runtime base path", async () => {
+    await using tmp = await tmpdir()
+    const root = path.join(tmp.path, "bin", "web")
+    await mkdir(path.join(root, "assets"), { recursive: true })
+    await writeFile(path.join(root, "index.html"), "<!doctype html><html><head></head><body></body></html>")
+    await writeFile(path.join(root, "assets", "index-ABCDEFGH.js"), "console.log('ok')")
+
+    const old = process.execPath
+    const env = process.env.VITE_BASE_PATH
+    Object.defineProperty(process, "execPath", { value: path.join(tmp.path, "bin", "aether"), configurable: true })
+    process.env.VITE_BASE_PATH = "/aether"
+
+    try {
+      const app = Server.createApp({})
+      const res = await app.request("/")
+      expect(res.status).toBe(302)
+      expect(res.headers.get("location")).toBe("/aether/")
+
+      const index = await app.request("/aether/")
+      expect(index.status).toBe(200)
+      expect(await index.text()).toContain(`globalThis.__AETHER_BASE_PATH__="/aether"`)
+
+      const asset = await app.request("/aether/assets/index-ABCDEFGH.js")
+      expect(asset.status).toBe(200)
+      expect(asset.headers.get("cache-control")).toBe("public, max-age=31536000, immutable")
+
+      const route = await app.request("/aether/session/test")
+      expect(route.status).toBe(200)
+      expect(await route.text()).toContain(`<base href="/aether/">`)
+    } finally {
+      Object.defineProperty(process, "execPath", { value: old, configurable: true })
+      if (env === undefined) {
+        delete process.env.VITE_BASE_PATH
+      } else {
+        process.env.VITE_BASE_PATH = env
+      }
+    }
+  })
 })

--- a/packing_scripts/release-linux-web.sh
+++ b/packing_scripts/release-linux-web.sh
@@ -81,6 +81,7 @@ Aether Web (Linux ARCH)
 Quick start
 1) Extract this ZIP and copy the folder PACKAGE to a local path, for example: ~/Applications/Aether-Web
 2) Open Terminal in that folder and run: ./Aether.sh
+3) Optional base path: VITE_BASE_PATH=/aether ./Aether.sh
 
 Updates
 - Use Aether's in-app update flow to download and install newer versions.


### PR DESCRIPTION
### Issue for this PR

Closes #513

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds runtime base path support for packaged Aether Web builds.

The embedded web build now uses relative asset paths for packaged single-binary builds, while the server reads `VITE_BASE_PATH` at runtime and serves local web assets under that prefix. The app reads the injected runtime base path for router setup, and PDF viewer assets were changed to avoid root-absolute references so they continue to load under a non-root base path.

Linux package documentation now includes an example:

```sh
VITE_BASE_PATH=/aether ./Aether.sh
```

Default launches without `VITE_BASE_PATH` continue to use `/`.

### How did you verify your code works?

- `bun typecheck` from `packages/app`
- `bun typecheck` from `packages/opencode`
- `env TMPDIR=/tmp/aether-codex-test bun test test/server/server-web-cache.test.ts` from `packages/opencode`
- `env VITE_BASE_PATH=./ bun run --cwd packages/app build`
- `bun turbo typecheck` via pre-push hook

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR