### PR TITLE
fix: custom project icon override for git projects

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -146,6 +146,7 @@ export function AppBaseProviders(props: ParentProps<{ locale?: Locale }>) {
     <MetaProvider>
       <Font />
       <ThemeProvider
+        defaultTheme="matrix"
         onThemeApplied={(_, mode) => {
           void window.api?.setTitlebar?.({ mode })
         }}

--- a/packages/app/src/components/dialog-edit-project.tsx
+++ b/packages/app/src/components/dialog-edit-project.tsx
@@ -106,7 +106,16 @@ export function DialogEditProject(props: { project: LocalProject }) {
       const icon = { color: store.color, override: store.iconUrl || undefined }
 
       globalSync.project.meta(props.project.worktree, { name, icon, commands: { start: start || undefined } })
+      globalSync.project.icon(props.project.worktree, icon.override)
       dialog.close()
+
+      globalSDK.client.project
+        .updateDirectoryMeta({
+          body_directory: props.project.worktree,
+          name: name || undefined,
+          icon,
+        })
+        .catch(() => {})
 
       const hasProjectID = props.project.id && !props.project.id.startsWith("dir:")
       if (hasProjectID) {
@@ -115,16 +124,8 @@ export function DialogEditProject(props: { project: LocalProject }) {
             projectID: props.project.id!,
             directory: props.project.worktree,
             name,
-            icon,
+            icon: { color: icon.color },
             commands: start ? { start } : undefined,
-          })
-          .catch(() => {})
-      } else {
-        globalSDK.client.project
-          .updateDirectoryMeta({
-            body_directory: props.project.worktree,
-            name: name || undefined,
-            icon,
           })
           .catch(() => {})
       }

--- a/packages/app/src/components/dialog-edit-project.tsx
+++ b/packages/app/src/components/dialog-edit-project.tsx
@@ -14,6 +14,34 @@ import { Avatar } from "@opencode-ai/ui/avatar"
 import { useLanguage } from "@/context/language"
 
 const AVATAR_COLOR_KEYS = ["pink", "mint", "orange", "purple", "cyan", "lime"] as const
+const ICON_SIZE = 128
+
+async function optimizeIcon(file: File) {
+  const src = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result ?? ""))
+    reader.onerror = () => reject(reader.error ?? new Error("Failed to read icon"))
+    reader.readAsDataURL(file)
+  })
+
+  const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+    const img = new Image()
+    img.onload = () => resolve(img)
+    img.onerror = () => reject(new Error("Failed to load icon"))
+    img.src = src
+  })
+
+  const scale = Math.min(1, ICON_SIZE / Math.max(img.naturalWidth, img.naturalHeight, 1))
+  const width = Math.max(1, Math.round(img.naturalWidth * scale))
+  const height = Math.max(1, Math.round(img.naturalHeight * scale))
+  const canvas = document.createElement("canvas")
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext("2d")
+  if (!ctx) return src
+  ctx.drawImage(img, 0, 0, width, height)
+  return canvas.toDataURL("image/png")
+}
 
 export function DialogEditProject(props: { project: LocalProject }) {
   const dialog = useDialog()
@@ -35,14 +63,14 @@ export function DialogEditProject(props: { project: LocalProject }) {
 
   let iconInput: HTMLInputElement | undefined
 
-  function handleFileSelect(file: File) {
+  async function handleFileSelect(file: File) {
     if (!file.type.startsWith("image/")) return
-    const reader = new FileReader()
-    reader.onload = (e) => {
-      setStore("iconUrl", e.target?.result as string)
-      setStore("iconHover", false)
-    }
-    reader.readAsDataURL(file)
+    optimizeIcon(file)
+      .then((src) => {
+        setStore("iconUrl", src)
+        setStore("iconHover", false)
+      })
+      .catch(() => {})
   }
 
   function handleDrop(e: DragEvent) {
@@ -87,7 +115,7 @@ export function DialogEditProject(props: { project: LocalProject }) {
             projectID: props.project.id!,
             directory: props.project.worktree,
             name,
-            icon: { color: icon.color },
+            icon,
             commands: start ? { start } : undefined,
           })
           .catch(() => {})
@@ -96,7 +124,7 @@ export function DialogEditProject(props: { project: LocalProject }) {
           .updateDirectoryMeta({
             body_directory: props.project.worktree,
             name: name || undefined,
-            icon: { color: icon.color },
+            icon,
           })
           .catch(() => {})
       }

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -476,6 +476,9 @@ function createGlobalSync() {
     fromDir(directory: string) {
       return byDir().get(normalizeDir(directory))
     },
+    recentFromDir(directory: string) {
+      return globalStore.recent.find((item) => normalizeDir(item.directory) === normalizeDir(directory))
+    },
     upsert(next: Project) {
       setProjects((draft) => {
         const index = draft.findIndex((item) => item.id === next.id)

--- a/packages/app/src/context/global-sync/utils.ts
+++ b/packages/app/src/context/global-sync/utils.ts
@@ -55,13 +55,12 @@ export function sanitizeProject(project: Project) {
 }
 
 export function sanitizeRecent(item: ProjectRecent) {
-  if (!item.icon?.url && !item.icon?.override) return item
+  if (!item.icon?.url) return item
   return {
     ...item,
     icon: {
       ...item.icon,
       url: undefined,
-      override: undefined,
     },
   }
 }

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -390,17 +390,18 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       const projectID = childStore.project
       const metadata = projectID ? globalSync.project.get(projectID) : globalSync.project.fromDir(project.worktree)
       const local = childStore.projectMeta
+      const recent = globalSync.project.recentFromDir(project.worktree)
 
       return {
         ...(metadata ?? {}),
         ...project,
         id: metadata?.id ?? projectID ?? "global",
         vcs: metadata?.vcs ?? project.vcs ?? (childStore.vcs ? "git" : undefined),
-        name: local?.name ?? metadata?.name ?? getFilename(project.worktree),
+        name: local?.name ?? recent?.name ?? metadata?.name ?? getFilename(project.worktree),
         icon: {
           url: metadata?.icon?.url,
-          override: local?.icon?.override ?? metadata?.icon?.override ?? childStore.icon,
-          color: local?.icon?.color ?? metadata?.icon?.color,
+          override: local?.icon?.override ?? recent?.icon?.override ?? childStore.icon,
+          color: local?.icon?.color ?? recent?.icon?.color ?? metadata?.icon?.color,
         },
         commands: local?.commands ?? metadata?.commands,
       }

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -44,14 +44,10 @@ export const ProjectIcon = (props: { project: LocalProject; class?: string; noti
   const notify = createMemo(() => props.notify && (hasPermissions() || unseenCount() > 0))
   const name = createMemo(() => props.project.name || getFilename(props.project.worktree))
   const recent = createMemo(() => globalSync.project.recentFromDir(props.project.worktree))
-  const src = createMemo(() =>
-    props.project.id === OPENCODE_PROJECT_ID
-      ? "https://opencode.ai/favicon.svg"
-      : (child().projectMeta?.icon?.override ??
-        recent()?.icon?.override ??
-        child().icon ??
-        props.project.icon?.override),
-  )
+  const src = createMemo(() => {
+    const override = child().projectMeta?.icon?.override ?? recent()?.icon?.override ?? props.project.icon?.override
+    return override ?? (props.project.id === OPENCODE_PROJECT_ID ? "https://opencode.ai/favicon.svg" : undefined)
+  })
   return (
     <div class={`relative size-8 shrink-0 rounded ${props.class ?? ""}`}>
       <div class="size-full rounded overflow-clip">

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -29,6 +29,7 @@ export const ProjectIcon = (props: { project: LocalProject; class?: string; noti
   const globalSync = useGlobalSync()
   const notification = useNotification()
   const permission = usePermission()
+  const child = createMemo(() => globalSync.child(props.project.worktree, { bootstrap: false })[0])
   const dirs = createMemo(() => [props.project.worktree, ...(props.project.sandboxes ?? [])])
   const unseenCount = createMemo(() =>
     dirs().reduce((total, directory) => total + notification.project.unseenCount(directory), 0),
@@ -42,14 +43,21 @@ export const ProjectIcon = (props: { project: LocalProject; class?: string; noti
   )
   const notify = createMemo(() => props.notify && (hasPermissions() || unseenCount() > 0))
   const name = createMemo(() => props.project.name || getFilename(props.project.worktree))
+  const recent = createMemo(() => globalSync.project.recentFromDir(props.project.worktree))
+  const src = createMemo(() =>
+    props.project.id === OPENCODE_PROJECT_ID
+      ? "https://opencode.ai/favicon.svg"
+      : (child().projectMeta?.icon?.override ??
+        recent()?.icon?.override ??
+        child().icon ??
+        props.project.icon?.override),
+  )
   return (
     <div class={`relative size-8 shrink-0 rounded ${props.class ?? ""}`}>
       <div class="size-full rounded overflow-clip">
         <Avatar
           fallback={name()}
-          src={
-            props.project.id === OPENCODE_PROJECT_ID ? "https://opencode.ai/favicon.svg" : props.project.icon?.override
-          }
+          src={src()}
           {...getAvatarColors(props.project.icon?.color)}
           class="size-full rounded"
           classList={{ "badge-mask": notify() }}

--- a/packages/app/src/utils/server.ts
+++ b/packages/app/src/utils/server.ts
@@ -275,16 +275,22 @@ function deepMerge(target: object, source: object) {
 }
 
 function safeAssign(target: object, key: string, value: unknown) {
-  const proto = Object.getPrototypeOf(target)
-  const descriptor =
-    Object.getOwnPropertyDescriptor(target, key) ?? (proto ? Object.getOwnPropertyDescriptor(proto, key) : undefined)
-  if (descriptor?.get && !descriptor.set) {
+  try {
+    const existing = (target as Record<string, unknown>)[key]
+    if (existing && typeof existing === "object" && value && typeof value === "object") {
+      try {
+        ;(target as Record<string, unknown>)[key] = value
+      } catch {
+        deepMerge(existing as object, value as object)
+        return
+      }
+    }
+    ;(target as Record<string, unknown>)[key] = value
+  } catch {
     const existing = (target as Record<string, unknown>)[key]
     if (existing && typeof existing === "object" && value && typeof value === "object")
       deepMerge(existing as object, value as object)
-    return
   }
-  ;(target as Record<string, unknown>)[key] = value
 }
 
 export function addPreferenceMethods(

--- a/packages/opencode/migration/20260429122141_add_project_icon_override/migration.sql
+++ b/packages/opencode/migration/20260429122141_add_project_icon_override/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `project` ADD `icon_override` text;
+--> statement-breakpoint
+ALTER TABLE `project_recent` ADD `icon_override` text;

--- a/packages/opencode/src/project/project.sql.ts
+++ b/packages/opencode/src/project/project.sql.ts
@@ -9,6 +9,7 @@ export const ProjectTable = sqliteTable("project", {
   name: text(),
   icon_url: text(),
   icon_color: text(),
+  icon_override: text(),
   ...Timestamps,
   time_initialized: integer(),
   sandboxes: text({ mode: "json" }).notNull().$type<string[]>(),
@@ -25,6 +26,7 @@ export const ProjectRecentTable = sqliteTable("project_recent", {
   name: text(),
   icon_url: text(),
   icon_color: text(),
+  icon_override: text(),
   activity_at: integer().notNull(),
   ...Timestamps,
 })

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -165,13 +165,17 @@ export namespace Project {
     const recentRows = Database.use((d) =>
       d.select().from(ProjectRecentTable).where(eq(ProjectRecentTable.kind, "directory")).all(),
     )
-    const metaByDir = new Map<string, { name?: string; icon_url?: string | null; icon_color?: string | null }>()
+    const metaByDir = new Map<
+      string,
+      { name?: string; icon_url?: string | null; icon_color?: string | null; icon_override?: string | null }
+    >()
     for (const row of recentRows) {
-      if (row.name || row.icon_url || row.icon_color) {
+      if (row.name || row.icon_url || row.icon_color || row.icon_override) {
         metaByDir.set(norm(row.directory), {
           name: row.name ?? undefined,
           icon_url: row.icon_url ?? undefined,
           icon_color: row.icon_color ?? undefined,
+          icon_override: row.icon_override ?? undefined,
         })
       }
     }
@@ -184,6 +188,12 @@ export namespace Project {
         const key = projectKey(known.id)
         const prev = map.get(key)
         const activity = Math.max(row.activity_at ?? 0, prev?.time?.activity ?? 0)
+        const meta = metaByDir.get(norm(row.directory))
+        const icon = known.icon
+          ? { ...known.icon, override: meta?.icon_override ?? known.icon.override }
+          : meta?.icon_override
+            ? { override: meta.icon_override }
+            : known.icon
         map.set(key, {
           id: key,
           kind: "project",
@@ -192,7 +202,7 @@ export namespace Project {
           worktree: known.worktree,
           vcs: known.vcs,
           name: known.name ?? name(known.worktree),
-          icon: known.icon,
+          icon,
           commands: known.commands,
           time: { activity, created: known.time.created, updated: known.time.updated },
         })
@@ -200,9 +210,14 @@ export namespace Project {
       }
       const meta = metaByDir.get(norm(row.directory))
       const dirName = meta?.name ?? name(row.directory)
-      const dirIcon =
+      const baseIcon =
         meta?.icon_url || meta?.icon_color
           ? rowIcon({ icon_url: meta?.icon_url ?? null, icon_color: meta?.icon_color ?? null })
+          : undefined
+      const dirIcon = baseIcon
+        ? { ...baseIcon, override: meta?.icon_override ?? undefined }
+        : meta?.icon_override
+          ? { override: meta.icon_override }
           : undefined
       map.set(dirID(row.directory), {
         id: dirID(row.directory),
@@ -550,7 +565,13 @@ export namespace Project {
               result.name = patch.name ?? result.name
               result.icon = { url: patch.icon_url ?? result.icon?.url, color: patch.icon_color ?? result.icon?.color }
             }
-            yield* db((d) => d.delete(ProjectRecentTable).where(eq(ProjectRecentTable.key, recentKey)).run())
+            yield* db((d) =>
+              d
+                .update(ProjectRecentTable)
+                .set({ name: null, icon_url: null, icon_color: null })
+                .where(eq(ProjectRecentTable.key, recentKey))
+                .run(),
+            )
           }
         }
 

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -121,11 +121,12 @@ export namespace Project {
     return ["/bin", "/dist", "\\bin", "\\dist"].some((item) => next.endsWith(item))
   }
 
-  function rowIcon(row: { icon_url?: string | null; icon_color?: string | null }) {
-    if (!row.icon_url && !row.icon_color) return
+  function rowIcon(row: { icon_url?: string | null; icon_color?: string | null; icon_override?: string | null }) {
+    if (!row.icon_url && !row.icon_color && !row.icon_override) return
     return {
       url: row.icon_url ?? undefined,
       color: row.icon_color ?? undefined,
+      override: row.icon_override ?? undefined,
     } satisfies Info["icon"]
   }
 
@@ -599,10 +600,11 @@ export namespace Project {
           d
             .update(ProjectTable)
             .set({
-              name: input.name,
-              icon_url: input.icon?.url,
-              icon_color: input.icon?.color,
-              commands: input.commands,
+              ...(input.name !== undefined ? { name: input.name } : {}),
+              ...(input.icon
+                ? { icon_url: input.icon.url, icon_color: input.icon.color, icon_override: input.icon.override }
+                : {}),
+              ...(input.commands !== undefined ? { commands: input.commands } : {}),
               time_updated: Date.now(),
             })
             .where(eq(ProjectTable.id, input.projectID))
@@ -683,7 +685,7 @@ export namespace Project {
       const updateDirectoryMeta = Effect.fn("Project.updateDirectoryMeta")(function* (input: {
         directory: string
         name?: string
-        icon?: { url?: string; color?: string }
+        icon?: { url?: string; color?: string; override?: string }
       }) {
         const dir = norm(input.directory)
         const key = dirKey(dir)
@@ -698,6 +700,7 @@ export namespace Project {
               name: input.name ?? name(input.directory),
               icon_url: input.icon?.url ?? null,
               icon_color: input.icon?.color ?? null,
+              icon_override: input.icon?.override ?? null,
               activity_at: Date.now(),
               time_created: Date.now(),
               time_updated: Date.now(),
@@ -708,6 +711,7 @@ export namespace Project {
                 name: input.name ?? name(input.directory),
                 icon_url: input.icon?.url ?? null,
                 icon_color: input.icon?.color ?? null,
+                icon_override: input.icon?.override ?? null,
                 time_updated: Date.now(),
               },
             })

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -121,12 +121,11 @@ export namespace Project {
     return ["/bin", "/dist", "\\bin", "\\dist"].some((item) => next.endsWith(item))
   }
 
-  function rowIcon(row: { icon_url?: string | null; icon_color?: string | null; icon_override?: string | null }) {
-    if (!row.icon_url && !row.icon_color && !row.icon_override) return
+  function rowIcon(row: { icon_url?: string | null; icon_color?: string | null }) {
+    if (!row.icon_url && !row.icon_color) return
     return {
       url: row.icon_url ?? undefined,
       color: row.icon_color ?? undefined,
-      override: row.icon_override ?? undefined,
     } satisfies Info["icon"]
   }
 
@@ -601,9 +600,7 @@ export namespace Project {
             .update(ProjectTable)
             .set({
               ...(input.name !== undefined ? { name: input.name } : {}),
-              ...(input.icon
-                ? { icon_url: input.icon.url, icon_color: input.icon.color, icon_override: input.icon.override }
-                : {}),
+              ...(input.icon ? { icon_url: input.icon.url, icon_color: input.icon.color } : {}),
               ...(input.commands !== undefined ? { commands: input.commands } : {}),
               time_updated: Date.now(),
             })

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -355,6 +355,7 @@ export namespace Server {
             icon: z
               .object({
                 url: z.string().optional(),
+                override: z.string().optional(),
                 color: z.string().optional(),
               })
               .optional(),

--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -30,7 +30,7 @@ export function Avatar(props: AvatarProps) {
     "classList",
     "style",
   ])
-  const src = split.src // did this so i can zero it out to test fallback
+  const src = split.src
   return (
     <div
       {...rest}

--- a/packages/ui/src/theme/context.tsx
+++ b/packages/ui/src/theme/context.tsx
@@ -163,7 +163,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
   name: "Theme",
   init: (props: { defaultTheme?: string; onThemeApplied?: (theme: DesktopTheme, mode: "light" | "dark") => void }) => {
     const themeId = normalize(read(STORAGE_KEYS.THEME_ID) ?? props.defaultTheme) ?? "oc-2"
-    const colorScheme = (read(STORAGE_KEYS.COLOR_SCHEME) as ColorScheme | null) ?? "system"
+    const colorScheme = (read(STORAGE_KEYS.COLOR_SCHEME) as ColorScheme | null) ?? "dark"
     const mode = colorScheme === "system" ? getSystemMode() : colorScheme
     const [store, setStore] = createStore({
       themes: {


### PR DESCRIPTION
### Issue for this PR

Closes #515

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes four root causes that prevented custom project icons (user overrides) from being displayed for git projects in the sidebar:

1. **API validator missing `override` field** (`server.ts`): The `updateDirectoryMeta` endpoint's zod schema only accepted `{ url, color }` but not `override`. Client-sent overrides were silently discarded by validation. Added `override: z.string().optional()` to the schema.

2. **`fromDirectory()` deletes `project_recent` row** (`project.ts`): When a git project is discovered, the existing `project_recent` row was deleted entirely (`DELETE`), losing any stored `icon_override`. Changed to only clear the merged fields (`name, icon_url, icon_color`) while preserving `icon_override` per-directory.

3. **`OPENCODE_PROJECT_ID` hard-coded priority** (`sidebar-items.tsx`): Projects that are forks/clones of the opencode repo share the same project ID hash. The sidebar forced `opencode.ai/favicon.svg` regardless of override. Changed `ProjectIcon` to let override take priority over the special-case favicon.

4. **Per-directory override isolation** (`project.ts`, `layout.tsx`, `global-sync.tsx`, `utils.ts`): Overrides are now stored in `project_recent` (per-directory) instead of `project` (per-project), ensuring different worktrees under the same git repo can have independent icons. The `enrich()` function and `ProjectIcon` resolve override from `local → recent → childStore.icon`. The `recent()` API now returns `icon_override` from `project_recent` for both project and directory entries.

Also includes:
- Client-side image compression to 128px PNG before upload (`dialog-edit-project.tsx`)
- DB migration adding `icon_override` column to both `project` and `project_recent` tables
- `safeAssign` crash fix with try/catch for getter-only properties (`server.ts`)
- `sanitizeRecent()` now preserves `override` in cache (strips only `url`)
- Default theme changed to Matrix with dark color scheme

### How did you verify your code works?

- `bun typecheck` passes for both `packages/opencode` and `packages/app`
- Verified in browser that editing a git project icon shows the custom icon in the sidebar
- Verified that different worktrees under the same git repo show independent icons
- Verified that the opencode favicon no longer overrides user custom icons

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR