### PR TITLE
fix(chat): 收起后续加载的历史 AI 回复

### DIFF
--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -240,6 +240,8 @@ export function MessageTimeline(props: {
   const [entry, setEntry] = createStore({
     session: "",
     done: false,
+    mode: {} as Record<string, "default" | "open" | "closed">,
+    prev: {} as Record<string, string[]>,
   })
 
   const rendered = createMemo(() => props.renderedUserMessages.map((message) => message.id))
@@ -332,6 +334,8 @@ export function MessageTimeline(props: {
     on(sessionID, (id) => {
       setEntry({ session: id ?? "", done: false })
       if (!id) return
+      setEntry("mode", id, "default")
+      setEntry("prev", id, [])
       setAssistantCollapse("bySession", id, reconcile({}))
     }),
   )
@@ -345,7 +349,30 @@ export function MessageTimeline(props: {
       id,
       reconcile(Object.fromEntries(ids.filter((item) => item !== tail).map((item) => [item, true] as const))),
     )
+    setEntry("prev", id, rendered().slice())
     setEntry("done", true)
+  })
+  createEffect(() => {
+    const id = sessionID()
+    if (!id || !loaded() || entry.session !== id || !entry.done) return
+    const prev = entry.prev[id] ?? []
+    const next = rendered()
+    if (prev.length === next.length && prev.every((item, idx) => item === next[idx])) return
+    setEntry("prev", id, next.slice())
+    if (next.length <= prev.length) return
+    const off = next.length - prev.length
+    if (!prev.every((item, idx) => item === next[idx + off])) return
+    const mode = entry.mode[id] ?? "default"
+    if (mode === "open") return
+    const seen = new Set(collapsibleTurnIDs())
+    const add = next.slice(0, off).filter((item) => seen.has(item))
+    if (add.length === 0) return
+    const curr = assistantCollapse.bySession[id] ?? {}
+    setAssistantCollapse(
+      "bySession",
+      id,
+      reconcile({ ...curr, ...Object.fromEntries(add.map((item) => [item, true] as const)) }),
+    )
   })
   const collapsedTurnMap = createMemo(() => {
     const id = sessionID()
@@ -373,6 +400,7 @@ export function MessageTimeline(props: {
   const collapseAllAssistant = () => {
     const id = sessionID()
     if (!id) return
+    setEntry("mode", id, "closed")
     setAssistantCollapse(
       "bySession",
       id,
@@ -382,6 +410,7 @@ export function MessageTimeline(props: {
   const expandAllAssistant = () => {
     const id = sessionID()
     if (!id) return
+    setEntry("mode", id, "open")
     setAssistantCollapse("bySession", id, reconcile({}))
   }
   const stageCfg = { init: 1, batch: 3 }


### PR DESCRIPTION
### Issue for this PR

Closes #512 

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

修复长会话里 AI 回复默认收起只作用于初始加载窗口的问题。之前进入会话时只会对当前 
enderedUserMessages 做一次初始化，后续通过 Load earlier 或向上滚动回填出来的更老历史消息不会再走默认收起，所以这些消息会保持展开。

这次改动在 message-timeline.tsx 里增加了当前查看期的渲染窗口跟踪和批量模式状态。进入会话时仍然默认只展开最新一轮；同一会话内如果后续是向前 prepend 更老历史消息，就只对这批新增历史消息按当前模式增量处理，不会重置已经在窗口里的消息状态。这样既能保证长会话后续加载出来的历史消息也默认收起，也不会覆盖用户当前查看期里的手动展开/收起操作。

同时把 Expand all / Collapse all 的语义补全到当前查看期的后续历史加载场景：如果用户已经选择全部展开或全部收起，后续再加载出来的历史消息也会保持一致行为。

### How did you verify your code works?

- 在 packages/app 运行 un typecheck
- 在 packages/ui 运行 un typecheck
- push hook 自动运行 un turbo typecheck 并通过
- 本地手动验证以下场景：
  - 进入长会话时默认只展开最新一轮
  - 点击 Load earlier 后新加载的旧消息会自动收起
  - 向上滚动触发历史回填后，新加载的旧消息会自动收起
  - 当前聊天时新生成的消息仍默认展开
  - Expand all / Collapse all 后再加载更老历史时，行为与当前模式保持一致

### Screenshots / recordings

- 未附；已在本地手动验证 UI 行为

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR