### PR TITLE
fix: remove dead project.icon_override column and fix safeAssign redundant path

### DIFF
--- a/packages/app/src/utils/server.ts
+++ b/packages/app/src/utils/server.ts
@@ -280,6 +280,7 @@ function safeAssign(target: object, key: string, value: unknown) {
     if (existing && typeof existing === "object" && value && typeof value === "object") {
       try {
         ;(target as Record<string, unknown>)[key] = value
+        return
       } catch {
         deepMerge(existing as object, value as object)
         return

--- a/packages/opencode/migration/20260429122141_add_project_icon_override/migration.sql
+++ b/packages/opencode/migration/20260429122141_add_project_icon_override/migration.sql
@@ -1,3 +1,1 @@
-ALTER TABLE `project` ADD `icon_override` text;
---> statement-breakpoint
 ALTER TABLE `project_recent` ADD `icon_override` text;

--- a/packages/opencode/src/project/project.sql.ts
+++ b/packages/opencode/src/project/project.sql.ts
@@ -9,7 +9,6 @@ export const ProjectTable = sqliteTable("project", {
   name: text(),
   icon_url: text(),
   icon_color: text(),
-  icon_override: text(),
   ...Timestamps,
   time_initialized: integer(),
   sandboxes: text({ mode: "json" }).notNull().$type<string[]>(),


### PR DESCRIPTION
### Issue for this PR

Follow-up to #516 (addressing review feedback)

### Type of change

- [ ] Bug fix
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two cleanups from the review of #516:

1. **Remove dead `project.icon_override` column**: The migration and schema added `icon_override` to both `project` and `project_recent` tables, but only `project_recent` is ever written to. The `project.icon_override` column is dead schema that could confuse future contributors. Removed it from the migration SQL and from `ProjectTable` in `project.sql.ts`.

2. **Fix `safeAssign` redundant assignment path**: When the inner try block successfully assigns a value for getter-only properties, it fell through to the outer `(target)[key] = value` line, performing the same assignment twice. Added a `return` after the inner try block to avoid the double write.

### How did you verify your code works?

- `bun typecheck` passes for both `packages/opencode` and `packages/app`
- The icon override mechanism still works correctly (override is only stored in `project_recent`, not `project`)

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR