### PR TITLE
fix: prevent infinite updateConfig loop when selecting default/small model in settings

### DIFF
--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -167,24 +167,23 @@ export const SettingsGeneral: Component = () => {
           return
         }
 
-        const actions =
-          platform.update
-            ? [
-                {
-                  label: language.t("update.install"),
-                  onClick: install,
-                },
-                {
-                  label: language.t("toast.update.action.notYet"),
-                  onClick: "dismiss" as const,
-                },
-              ]
-            : [
-                {
-                  label: language.t("toast.update.action.notYet"),
-                  onClick: "dismiss" as const,
-                },
-              ]
+        const actions = platform.update
+          ? [
+              {
+                label: language.t("update.install"),
+                onClick: install,
+              },
+              {
+                label: language.t("toast.update.action.notYet"),
+                onClick: "dismiss" as const,
+              },
+            ]
+          : [
+              {
+                label: language.t("toast.update.action.notYet"),
+                onClick: "dismiss" as const,
+              },
+            ]
 
         showToast({
           persistent: true,
@@ -290,6 +289,7 @@ export const SettingsGeneral: Component = () => {
               if (!option) return
               const model = option.value || undefined
               const before = globalSync.data.config.model
+              if (model === before) return
               globalSync.set("config", "model", model)
               globalSync.updateConfig({ model }).catch((err: unknown) => {
                 globalSync.set("config", "model", before)
@@ -318,6 +318,7 @@ export const SettingsGeneral: Component = () => {
               if (!option) return
               const small_model = option.value || undefined
               const before = globalSync.data.config.small_model
+              if (small_model === before) return
               globalSync.set("config", "small_model", small_model)
               globalSync.updateConfig({ small_model }).catch((err: unknown) => {
                 globalSync.set("config", "small_model", before)


### PR DESCRIPTION
## Summary
- Fix the settings dropdown popover immediately closing when re-opening after a model selection
- Root cause: `bootstrap` replaced provider data after config update, triggering a reactive cascade that caused Kobalte's internal effect to re-fire `onSelectionChange` → `onSelect` → `updateConfig` loop, which called `close()` and dismissed the popover
- Fix: add early return guard in `onSelect` to skip `updateConfig` when selected value equals current config value

## Changes
- `packages/app/src/components/settings-general.tsx`: add `if (model === before) return` and `if (small_model === before) return` before the `updateConfig` call in the Default Model and Small Model Select callbacks