### PR TITLE
feat(mcp): add Wolfram MCP installer

### DIFF
--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -12,9 +12,10 @@ import { Instance } from "../../project/instance"
 import { Installation } from "../../installation"
 import path from "path"
 import { Global } from "../../global"
-import { modify, applyEdits } from "jsonc-parser"
+import { modify, applyEdits, parse as parseJsonc } from "jsonc-parser"
 import { Filesystem } from "../../util/filesystem"
 import { Bus } from "../../bus"
+import { WolframMCP } from "../../mcp/wolfram"
 
 function getAuthStatusIcon(status: MCP.AuthStatus): string {
   switch (status) {
@@ -59,6 +60,7 @@ export const McpCommand = cmd({
       .command(McpListCommand)
       .command(McpAuthCommand)
       .command(McpLogoutCommand)
+      .command(McpInstallCommand)
       .command(McpDebugCommand)
       .demandCommand(),
   async handler() {},
@@ -425,6 +427,13 @@ async function addMcpToConfig(name: string, mcpConfig: Config.Mcp, configPath: s
   return configPath
 }
 
+async function hasMcpInConfig(name: string, configPath: string) {
+  if (!(await Filesystem.exists(configPath))) return false
+  const data = parseJsonc(await Filesystem.readText(configPath)) as Record<string, unknown> | undefined
+  const mcp = data?.mcp
+  return !!mcp && typeof mcp === "object" && name in mcp
+}
+
 export const McpAddCommand = cmd({
   command: "add",
   describe: "add an MCP server",
@@ -584,6 +593,128 @@ export const McpAddCommand = cmd({
         }
 
         prompts.outro("MCP server added successfully")
+      },
+    })
+  },
+})
+
+export const McpInstallCommand = cmd({
+  command: "install",
+  describe: "install a known MCP server",
+  builder: (yargs) => yargs.command(McpInstallWolframCommand).demandCommand(),
+  async handler() {},
+})
+
+export const McpInstallWolframCommand = cmd({
+  command: "wolfram",
+  describe: "install the Wolfram Language MCP server",
+  builder: (yargs) =>
+    yargs
+      .option("project", {
+        describe: "Install into the current project config instead of global Aether config",
+        type: "boolean",
+        default: false,
+      })
+      .option("name", {
+        describe: "MCP server name",
+        type: "string",
+        default: WolframMCP.NAME,
+      })
+      .option("server", {
+        describe: "Wolfram AgentTools server preset",
+        type: "string",
+        default: WolframMCP.SERVER,
+      })
+      .option("binary", {
+        describe: "Path to wolfram or WolframKernel",
+        type: "string",
+      })
+      .option("timeout", {
+        describe: "MCP startup and tool timeout in milliseconds",
+        type: "number",
+        default: WolframMCP.TIMEOUT,
+      })
+      .option("overwrite", {
+        describe: "Replace an existing MCP entry with the same name",
+        type: "boolean",
+        default: false,
+      })
+      .option("paclet-install", {
+        describe: "Install or verify Wolfram/AgentTools with wolframscript",
+        type: "boolean",
+        default: true,
+      })
+      .option("connect", {
+        describe: "Connect once after writing the config to verify the server",
+        type: "boolean",
+        default: true,
+      }),
+  async handler(args) {
+    await Instance.provide({
+      directory: process.cwd(),
+      async fn() {
+        UI.empty()
+        prompts.intro("Install Wolfram MCP")
+
+        const name = typeof args.name === "string" && args.name.trim() ? args.name.trim() : WolframMCP.NAME
+        const server = typeof args.server === "string" && args.server.trim() ? args.server.trim() : WolframMCP.SERVER
+        const timeout =
+          typeof args.timeout === "number" && Number.isFinite(args.timeout) ? args.timeout : WolframMCP.TIMEOUT
+        const file = await resolveConfigPath(args.project ? Instance.worktree : Global.Path.config, !args.project)
+
+        if ((await hasMcpInConfig(name, file)) && !args.overwrite) {
+          prompts.log.warn(`MCP server "${name}" already exists in ${file}`)
+          prompts.outro("Use --overwrite to replace it")
+          return
+        }
+
+        if (args.pacletInstall !== false) {
+          const spinner = prompts.spinner()
+          spinner.start("Installing Wolfram/AgentTools...")
+          const paclet = await WolframMCP.installPaclet()
+          if (!paclet.ok) {
+            spinner.stop("Wolfram/AgentTools install failed", 1)
+            prompts.log.error(paclet.error ?? "Unknown error")
+            prompts.outro("Install stopped")
+            return
+          }
+          spinner.stop("Wolfram/AgentTools is available")
+        }
+
+        let cfg: Config.Mcp
+        try {
+          cfg = WolframMCP.config({
+            binary: typeof args.binary === "string" ? args.binary : undefined,
+            server,
+            timeout,
+          })
+        } catch (error) {
+          prompts.log.error(error instanceof Error ? error.message : String(error))
+          prompts.outro("Install stopped")
+          return
+        }
+
+        await addMcpToConfig(name, cfg, file)
+        prompts.log.success(`MCP server "${name}" written to ${file}`)
+
+        if (args.connect === false) {
+          prompts.outro("Wolfram MCP installed")
+          return
+        }
+
+        const spinner = prompts.spinner()
+        spinner.start("Connecting to Wolfram MCP...")
+        const result = await MCP.add(name, cfg)
+        const status = (result.status as Record<string, MCP.Status>)[name] ?? (result.status as MCP.Status)
+        if (status.status === "connected") {
+          spinner.stop("Wolfram MCP connected")
+          prompts.outro("Wolfram MCP installed")
+          return
+        }
+
+        spinner.stop("Wolfram MCP did not connect", 1)
+        prompts.log.warn(status.status === "failed" ? status.error : status.status)
+        prompts.outro("Config was written; run `aether mcp list` after checking Wolfram")
       },
     })
   },

--- a/packages/opencode/src/mcp/wolfram.ts
+++ b/packages/opencode/src/mcp/wolfram.ts
@@ -1,0 +1,117 @@
+import fs from "fs"
+import path from "path"
+import { Config } from "@/config/config"
+import { Process } from "@/util/process"
+import { which } from "@/util/which"
+
+export namespace WolframMCP {
+  export const NAME = "Wolfram"
+  export const SERVER = "WolframLanguage"
+  export const TIMEOUT = 60_000
+  export const START = 'PacletSymbol["Wolfram/AgentTools","Wolfram`AgentTools`StartMCPServer"][]'
+
+  export type Input = {
+    binary?: string
+    server?: string
+    timeout?: number
+  }
+
+  export type Paclet = {
+    ok: boolean
+    script?: string
+    error?: string
+  }
+
+  function executable(file: string | undefined) {
+    if (!file) return undefined
+    try {
+      fs.accessSync(file, fs.constants.X_OK)
+      return file
+    } catch {
+      return undefined
+    }
+  }
+
+  function sibling(file: string | undefined, name: string) {
+    if (!file) return undefined
+    return executable(path.join(path.dirname(file), name))
+  }
+
+  function versions(root: string, name: string) {
+    if (!fs.existsSync(root)) return [] as string[]
+    return fs
+      .readdirSync(root, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => executable(path.join(root, entry.name, "Executables", name)))
+      .filter((item): item is string => !!item)
+      .sort((a, b) => b.localeCompare(a))
+  }
+
+  export function findScript() {
+    return (
+      which("wolframscript") ??
+      executable("/usr/local/Wolfram/Mathematica/14.3/Executables/wolframscript") ??
+      executable("/usr/local/Wolfram/WolframEngine/14.3/Executables/wolframscript")
+    )
+  }
+
+  export function findBinary(input?: string) {
+    const script = findScript()
+    return (
+      executable(input) ??
+      which("wolfram") ??
+      which("WolframKernel") ??
+      sibling(script, "wolfram") ??
+      sibling(script, "WolframKernel") ??
+      versions("/usr/local/Wolfram/Mathematica", "wolfram")[0] ??
+      versions("/usr/local/Wolfram/WolframEngine", "wolfram")[0] ??
+      (process.platform === "darwin"
+        ? executable("/Applications/Mathematica.app/Contents/MacOS/WolframKernel")
+        : undefined)
+    )
+  }
+
+  export function config(input: Input = {}): Config.Mcp {
+    const binary = findBinary(input.binary)
+    if (!binary) throw new Error("Could not find a Wolfram executable. Install Mathematica or pass --binary.")
+    return {
+      type: "local",
+      command: [binary, "-run", START, "-noinit", "-noprompt"],
+      enabled: true,
+      timeout: input.timeout ?? TIMEOUT,
+      environment: {
+        MCP_SERVER_NAME: input.server ?? SERVER,
+        ...(process.env.WOLFRAM_USERBASE ? { WOLFRAM_USERBASE: process.env.WOLFRAM_USERBASE } : {}),
+      },
+    }
+  }
+
+  export async function installPaclet(): Promise<Paclet> {
+    const script = findScript()
+    if (!script) {
+      return {
+        ok: false,
+        error: "Could not find wolframscript. Install Wolfram/AgentTools manually or rerun with --no-paclet-install.",
+      }
+    }
+
+    const code = [
+      "$PrePrint = InputForm;",
+      'If[Length[PacletFind["Wolfram/AgentTools"]] == 0, PacletInstall["Wolfram/AgentTools"]];',
+      'If[Length[PacletFind["Wolfram/AgentTools"]] > 0, Print["ok"]; Exit[0], Print["missing"]; Exit[1]];',
+    ].join(" ")
+    const out = await Process.run([script, "-code", code], {
+      nothrow: true,
+      timeout: 120_000,
+    })
+    if (out.code === 0) return { ok: true, script }
+    return {
+      ok: false,
+      script,
+      error: (out.stderr.toString().trim() || out.stdout.toString().trim() || "Paclet installation failed").slice(
+        0,
+        2_000,
+      ),
+    }
+  }
+}

--- a/packages/opencode/test/mcp/wolfram.test.ts
+++ b/packages/opencode/test/mcp/wolfram.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { WolframMCP } from "../../src/mcp/wolfram"
+import { tmpdir } from "../fixture/fixture"
+
+test("builds WolframLanguage local MCP config", async () => {
+  await using tmp = await tmpdir()
+  const bin = path.join(tmp.path, "wolfram")
+  await fs.writeFile(bin, "")
+  await fs.chmod(bin, 0o755)
+
+  const cfg = WolframMCP.config({
+    binary: bin,
+    server: "WolframLanguage",
+    timeout: 12_345,
+  })
+
+  expect(cfg).toEqual({
+    type: "local",
+    command: [bin, "-run", WolframMCP.START, "-noinit", "-noprompt"],
+    enabled: true,
+    timeout: 12_345,
+    environment: {
+      MCP_SERVER_NAME: "WolframLanguage",
+    },
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #520

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a built-in Wolfram MCP installer for Aether.

This introduces `aether mcp install wolfram`, which can install or verify the `Wolfram/AgentTools` paclet, generate the local MCP config for the Wolfram Language server, write it to global or project config, and optionally connect once to verify the server starts.

The implementation keeps the Wolfram-specific logic in a dedicated helper module and wires it into the existing `mcp` CLI command tree. This PR intentionally does not add UI support yet.

### How did you verify your code works?

Locally verified with:

- `bun typecheck`
- `bun --cwd packages/ui test:unit`
- `bun --cwd packages/app test:unit`
- `OPENCODE_RIPGREP_PATH=$(command -v rg) OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER=true bun test --timeout 30000` from `packages/opencode`
- App E2E CI allowlist:
  - concurrent specs: 48 passed, 2 skipped
  - serial specs: 27 passed, 1 skipped
- Focused Wolfram MCP smoke:
  - `aether mcp install wolfram --overwrite --timeout 60000`
  - verified the configured MCP server connected successfully to local Wolfram/AgentTools

The push hook also reran `bun typecheck` successfully.

### Screenshots / recordings

N/A. This is a CLI-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR