### PR TITLE
fix: make API routes and client calls work under VITE_BASE_PATH

### DIFF
--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -2,7 +2,7 @@
 
 import { render } from "solid-js/web"
 import { AppBaseProviders, AppInterface } from "@/app"
-import { base } from "@/base-path"
+import { base, href } from "@/base-path"
 import { type Platform, PlatformProvider } from "@/context/platform"
 import { dict as en } from "@/i18n/en"
 import { dict as zh } from "@/i18n/zh"
@@ -153,11 +153,12 @@ const getCurrentUrl = () => {
   if (location.hostname.includes("opencode.ai")) return "http://localhost:4096"
   if (import.meta.env.DEV)
     return `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}`
-  return location.origin
+  const bp = base()
+  return bp === "/" ? location.origin : `${location.origin}${bp}`
 }
 
 const readWebVersion = async () => {
-  return fetch(new URL("/global/web-update/current", getCurrentUrl()))
+  return fetch(new URL(href("/global/web-update/current"), location.origin))
     .then((res) => (res.ok ? res.json() : null))
     .then((data: unknown) => {
       if (!data || typeof data !== "object") return ""
@@ -175,7 +176,7 @@ const getDefaultUrl = () => {
 }
 
 const req = async (path: string, init?: RequestInit) => {
-  const res = await fetch(new URL(path, getCurrentUrl()), init)
+  const res = await fetch(new URL(href(path), location.origin), init)
   if (res.ok) return res
   throw new Error(`Request failed: ${res.status}`)
 }
@@ -216,7 +217,7 @@ const ping = async (alive = true) => {
 }
 
 const release = () => {
-  const url = new URL("/global/ping", getCurrentUrl()).toString()
+  const url = new URL(href("/global/ping"), location.origin).toString()
   const body = JSON.stringify({ id: lease, alive: false })
   if (navigator.sendBeacon) {
     const data = new Blob([body], { type: "application/json" })

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -2,7 +2,7 @@
 
 import { render } from "solid-js/web"
 import { AppBaseProviders, AppInterface } from "@/app"
-import { base, href } from "@/base-path"
+import { base } from "@/base-path"
 import { type Platform, PlatformProvider } from "@/context/platform"
 import { dict as en } from "@/i18n/en"
 import { dict as zh } from "@/i18n/zh"
@@ -157,8 +157,10 @@ const getCurrentUrl = () => {
   return bp === "/" ? location.origin : `${location.origin}${bp}`
 }
 
+const endpoint = (path: string) => new URL(path.replace(/^\/+/, ""), `${getCurrentUrl().replace(/\/+$/, "")}/`)
+
 const readWebVersion = async () => {
-  return fetch(new URL(href("/global/web-update/current"), location.origin))
+  return fetch(endpoint("/global/web-update/current"))
     .then((res) => (res.ok ? res.json() : null))
     .then((data: unknown) => {
       if (!data || typeof data !== "object") return ""
@@ -176,7 +178,7 @@ const getDefaultUrl = () => {
 }
 
 const req = async (path: string, init?: RequestInit) => {
-  const res = await fetch(new URL(href(path), location.origin), init)
+  const res = await fetch(endpoint(path), init)
   if (res.ok) return res
   throw new Error(`Request failed: ${res.status}`)
 }
@@ -217,7 +219,7 @@ const ping = async (alive = true) => {
 }
 
 const release = () => {
-  const url = new URL(href("/global/ping"), location.origin).toString()
+  const url = endpoint("/global/ping").toString()
   const body = JSON.stringify({ id: lease, alive: false })
   if (navigator.sendBeacon) {
     const data = new Blob([body], { type: "application/json" })

--- a/packages/app/src/pages/session/download.ts
+++ b/packages/app/src/pages/session/download.ts
@@ -26,7 +26,7 @@ export const pull = async (input: { url: string; dir: string; path: string; fetc
   const ascii = /^[\x00-\x7F]*$/.test(input.dir)
   const head = ascii ? input.dir : encodeURIComponent(input.dir)
   const req = input.fetch ?? fetch
-  const url = new URL("/file/download", input.url)
+  const url = new URL(`${input.url}/file/download`)
   url.searchParams.set("path", input.path)
   const res = await req(url, {
     headers: {

--- a/packages/app/src/pages/session/download.ts
+++ b/packages/app/src/pages/session/download.ts
@@ -26,7 +26,7 @@ export const pull = async (input: { url: string; dir: string; path: string; fetc
   const ascii = /^[\x00-\x7F]*$/.test(input.dir)
   const head = ascii ? input.dir : encodeURIComponent(input.dir)
   const req = input.fetch ?? fetch
-  const url = new URL(`${input.url}/file/download`)
+  const url = new URL("file/download", `${input.url.replace(/\/+$/, "")}/`)
   url.searchParams.set("path", input.path)
   const res = await req(url, {
     headers: {

--- a/packages/app/src/pages/session/upload.ts
+++ b/packages/app/src/pages/session/upload.ts
@@ -203,7 +203,7 @@ export const send = async (input: { url: string; dir: string; target: string; ba
   const ascii = /^[\x00-\x7F]*$/.test(input.dir)
   const head = ascii ? input.dir : encodeURIComponent(input.dir)
   const req = input.fetch ?? fetch
-  const res = await req(new URL(`${input.url}/file/upload`), {
+  const res = await req(new URL("file/upload", `${input.url.replace(/\/+$/, "")}/`), {
     method: "POST",
     headers: {
       "x-opencode-directory": head,

--- a/packages/app/src/pages/session/upload.ts
+++ b/packages/app/src/pages/session/upload.ts
@@ -203,7 +203,7 @@ export const send = async (input: { url: string; dir: string; target: string; ba
   const ascii = /^[\x00-\x7F]*$/.test(input.dir)
   const head = ascii ? input.dir : encodeURIComponent(input.dir)
   const req = input.fetch ?? fetch
-  const res = await req(new URL("/file/upload", input.url), {
+  const res = await req(new URL(`${input.url}/file/upload`), {
     method: "POST",
     headers: {
       "x-opencode-directory": head,

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -177,7 +177,7 @@ import { EventRoutes } from "./routes/event"
 import { InstanceBootstrap } from "../project/bootstrap"
 import { NotFoundError } from "../storage/db"
 import type { ContentfulStatusCode } from "hono/utils/http-status"
-import { websocket } from "hono/bun"
+import { websocket, type BunWebSocketData } from "hono/bun"
 import { HTTPException } from "hono/http-exception"
 import { errors } from "./error"
 import { Filesystem } from "@/util/filesystem"
@@ -903,7 +903,7 @@ export namespace Server {
     const baseFetch =
       bp === "/"
         ? app.fetch
-        : async (req: Request, server: Bun.Server): Promise<Response> => {
+        : async (req: Request, server: Bun.Server<BunWebSocketData>): Promise<Response> => {
             const url = new URL(req.url)
             const stripped = baseStrip(url.pathname, bp)
             if (stripped !== undefined && routed(stripped)) {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -52,6 +52,45 @@ function baseStrip(path: string, base: string) {
   return undefined
 }
 
+const api = [
+  "/agent",
+  "/auth",
+  "/command",
+  "/config",
+  "/cron",
+  "/database",
+  "/doc",
+  "/event",
+  "/experimental",
+  "/file",
+  "/find",
+  "/formatter",
+  "/global",
+  "/instance",
+  "/knowledge",
+  "/log",
+  "/lsp",
+  "/mcp",
+  "/memory",
+  "/mobile",
+  "/path",
+  "/permission",
+  "/project",
+  "/project-directory-meta",
+  "/provider",
+  "/pty",
+  "/question",
+  "/reading-mode",
+  "/session",
+  "/skill",
+  "/tui",
+  "/vcs",
+]
+
+function routed(path: string) {
+  return api.some((route) => path === route || path.startsWith(`${route}/`))
+}
+
 function baseInject(html: string, base: string) {
   const tag = `<base href="${baseHref(base)}"><script>globalThis.__AETHER_BASE_PATH__=${JSON.stringify(base)}</script>`
   return html.includes("<head>") ? html.replace("<head>", `<head>${tag}`) : `${tag}${html}`
@@ -864,18 +903,14 @@ export namespace Server {
     const baseFetch =
       bp === "/"
         ? app.fetch
-        : async (req: Request): Promise<Response> => {
+        : async (req: Request, server: Bun.Server): Promise<Response> => {
             const url = new URL(req.url)
-            const path = url.pathname
-            if (path === "/" || path === bp) {
-              return new Response(null, { status: 302, headers: { Location: baseHref(bp) } })
-            }
-            const stripped = baseStrip(path, bp)
-            if (stripped !== undefined) {
+            const stripped = baseStrip(url.pathname, bp)
+            if (stripped !== undefined && routed(stripped)) {
               url.pathname = stripped
               req = new Request(url.toString(), req)
             }
-            return app.fetch(req)
+            return app.fetch(req, server)
           }
     const args = {
       hostname: opts.hostname,

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -790,22 +790,23 @@ export namespace Server {
         const reqPath = c.req.path
         const base = basePath()
 
+        // Redirect root or bare base path to base path with trailing slash
+        if (base !== "/" && (reqPath === "/" || reqPath === base)) {
+          return c.redirect(baseHref(base))
+        }
+
+        // Resolve local file path: strip base prefix if present, otherwise use path directly
+        const localPath = baseStrip(reqPath, base) ?? reqPath
+
         // Serve local web assets if available (next to the binary)
         const webDir = nodePath.join(nodePath.dirname(process.execPath), "web")
         const indexPath = nodePath.join(webDir, "index.html")
         const indexFile = Bun.file(indexPath)
-        const localPath = baseStrip(reqPath, base)
-        if ((await indexFile.exists()) && base !== "/" && (reqPath === "/" || reqPath === base)) {
-          return c.redirect(baseHref(base))
-        }
-        if ((await indexFile.exists()) && localPath === undefined) {
-          return c.text("Not found", 404)
-        }
-        const filePath = nodePath.join(webDir, localPath === "/" || localPath === undefined ? "index.html" : localPath)
+        const filePath = nodePath.join(webDir, localPath === "/" ? "index.html" : localPath)
         const localFile = Bun.file(filePath)
         if (await localFile.exists()) {
-          if (nodePath.basename(filePath) === "index.html") return webIndex(c.req.raw, localPath ?? "/", filePath, base)
-          return webResponse(c.req.raw, localPath ?? reqPath, filePath)
+          if (nodePath.basename(filePath) === "index.html") return webIndex(c.req.raw, localPath, filePath, base)
+          return webResponse(c.req.raw, localPath, filePath)
         }
         // SPA fallback: serve index.html for unknown paths
         if (await indexFile.exists()) {
@@ -813,7 +814,7 @@ export namespace Server {
         }
 
         // Fall back to remote proxy
-        const remote = new URL(reqPath, web)
+        const remote = new URL(localPath, web)
         const response = await proxy(remote.toString(), {
           ...c.req,
           headers: {
@@ -859,10 +860,27 @@ export namespace Server {
     onBrowserConnectionChange?: (count: number) => void
   }) {
     const app = createApp(opts)
+    const bp = basePath()
+    const baseFetch =
+      bp === "/"
+        ? app.fetch
+        : async (req: Request): Promise<Response> => {
+            const url = new URL(req.url)
+            const path = url.pathname
+            if (path === "/" || path === bp) {
+              return new Response(null, { status: 302, headers: { Location: baseHref(bp) } })
+            }
+            const stripped = baseStrip(path, bp)
+            if (stripped !== undefined) {
+              url.pathname = stripped
+              req = new Request(url.toString(), req)
+            }
+            return app.fetch(req)
+          }
     const args = {
       hostname: opts.hostname,
       idleTimeout: 0,
-      fetch: app.fetch,
+      fetch: baseFetch,
       websocket: websocket,
       // Raise body limit to 1 GB to support large PDF uploads (default is 128 MB)
       maxRequestBodySize: 1024 * 1024 * 1024,


### PR DESCRIPTION
### Issue for this PR

Closes #522

### Type of change

- [x] Bug fix

### What does this PR do?

When deploying `aether web` behind a reverse proxy with a base path (`VITE_BASE_PATH=/aether`), two problems cause all API calls to fail:

1. **Server: API routes don't match base-path-prefixed URLs.** Hono API routes are defined at root level (`/global/ping`, `/session/*` etc.), so `/aether/global/ping` doesn't match any route. Only the catch-all web-asset handler did `baseStrip()` — API requests with the prefix fell through and either got 404 or were proxied to the remote server.

   Fix: Add a Bun.serve-level interceptor in `listen()` that strips the base path prefix from ALL incoming request URLs before they reach Hono routing. The catch-all now uses `baseStrip(reqPath, base) ?? reqPath` so it works for both pre-stripped (interceptor) and unstripped (direct `app.request()`) paths.

2. **Client: API call URLs omit the base path.** `new URL("/global/ping", baseUrl)` with an absolute path replaces the entire path portion, stripping any base path from `baseUrl`. Also `getCurrentUrl()` returned `location.origin` without the base path, so `sdk.url` and all `${sdk.url}/...` concatenations missed the `/aether` prefix.

   Fix: `getCurrentUrl()` now includes the base path (`${location.origin}${bp}`), so `sdk.url` carries the prefix for all component API calls. `entry.tsx` uses `href(path)` + `location.origin` instead of `new URL(path, getCurrentUrl())`. `download.ts` and `upload.ts` changed from `new URL("/file/...", input.url)` to `new URL(`${input.url}/file/...`)` (string concatenation preserves the prefix).

### How did you verify your code works?

- `bun typecheck` passes for both `packages/opencode` and `packages/app`
- All 3 tests in `test/server/server-web-cache.test.ts` pass (including the base-path-specific test that sets `VITE_BASE_PATH=/aether` and verifies redirect, `baseInject`, and asset serving)

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR