### PR TITLE
fix: resolve SSE zombie connections on browser close

### DIFF
--- a/packages/opencode/src/control-plane/workspace-server/routes.ts
+++ b/packages/opencode/src/control-plane/workspace-server/routes.ts
@@ -7,26 +7,36 @@ export function WorkspaceServerRoutes() {
     c.header("X-Accel-Buffering", "no")
     c.header("X-Content-Type-Options", "nosniff")
     return streamSSE(c, async (stream) => {
+      let resolve!: () => void
+      let resolved = false
+      const finish = () => {
+        if (resolved) return
+        resolved = true
+        clearInterval(heartbeat)
+        GlobalBus.off("event", handler)
+        resolve()
+      }
       const send = async (event: unknown) => {
         await stream.writeSSE({
           data: JSON.stringify(event),
         })
       }
       const handler = async (event: { directory?: string; payload: unknown }) => {
-        await send(event.payload)
+        try {
+          await send(event.payload)
+        } catch {
+          finish()
+        }
       }
       GlobalBus.on("event", handler)
       await send({ type: "server.connected", properties: {} })
       const heartbeat = setInterval(() => {
-        void send({ type: "server.heartbeat", properties: {} })
+        send({ type: "server.heartbeat", properties: {} }).catch(finish)
       }, 10_000)
 
-      await new Promise<void>((resolve) => {
-        stream.onAbort(() => {
-          clearInterval(heartbeat)
-          GlobalBus.off("event", handler)
-          resolve()
-        })
+      await new Promise<void>((r) => {
+        resolve = r
+        stream.onAbort(finish)
       })
     })
   })

--- a/packages/opencode/src/server/routes/file.ts
+++ b/packages/opencode/src/server/routes/file.ts
@@ -1157,6 +1157,7 @@ export const FileRoutes = lazy(() =>
           let replayDone = false
           let cleanedUp = false
 
+          let resolve!: () => void
           const removeListener = () => {
             task.listeners.delete(listener)
           }
@@ -1165,6 +1166,10 @@ export const FileRoutes = lazy(() =>
             cleanedUp = true
             removeListener()
             if (hb) clearInterval(hb)
+          }
+          const finish = () => {
+            doCleanup(heartbeat)
+            resolve()
           }
 
           const listener = async (event: any) => {
@@ -1176,7 +1181,7 @@ export const FileRoutes = lazy(() =>
             try {
               await stream.writeSSE({ data: JSON.stringify(event) })
             } catch {
-              /* stream broken */
+              finish()
             }
           }
 
@@ -1194,7 +1199,7 @@ export const FileRoutes = lazy(() =>
             try {
               await stream.writeSSE({ data: JSON.stringify(event) })
             } catch {
-              /* stream broken */
+              finish()
             }
           }
 
@@ -1205,26 +1210,24 @@ export const FileRoutes = lazy(() =>
           }
 
           // 心跳保活
-          const heartbeat = setInterval(() => {
+          let heartbeat!: ReturnType<typeof setInterval>
+          heartbeat = setInterval(() => {
             stream
               .writeSSE({
                 data: JSON.stringify({ type: "heartbeat" }),
               })
-              .catch(() => doCleanup(heartbeat))
+              .catch(finish)
           }, 5_000)
 
-          await new Promise<void>((resolve) => {
-            stream.onAbort(() => {
-              doCleanup(heartbeat)
-              resolve()
-            })
+          await new Promise<void>((r) => {
+            resolve = r
+            stream.onAbort(finish)
 
             // 任务完成时也关闭
             const checkDone = setInterval(() => {
               if (task.status !== "running") {
                 clearInterval(checkDone)
-                doCleanup(heartbeat)
-                resolve()
+                finish()
               }
             }, 1000)
           })
@@ -1509,6 +1512,7 @@ export const FileRoutes = lazy(() =>
           const pendingEvents: any[] = []
           let replayDone = false
 
+          let resolve!: () => void
           let cleanedUp = false
           const removeListener = () => {
             task.listeners.delete(listener)
@@ -1519,6 +1523,10 @@ export const FileRoutes = lazy(() =>
             removeListener()
             if (hb) clearInterval(hb)
           }
+          const finish = () => {
+            doCleanup(heartbeat)
+            resolve()
+          }
 
           const listener = async (event: any) => {
             if (!replayDone) {
@@ -1528,7 +1536,7 @@ export const FileRoutes = lazy(() =>
             try {
               await stream.writeSSE({ data: JSON.stringify(event) })
             } catch {
-              /* stream broken */
+              finish()
             }
           }
 
@@ -1544,7 +1552,7 @@ export const FileRoutes = lazy(() =>
             try {
               await stream.writeSSE({ data: JSON.stringify(event) })
             } catch {
-              /* stream broken */
+              finish()
             }
           }
 
@@ -1553,25 +1561,23 @@ export const FileRoutes = lazy(() =>
             return
           }
 
-          const heartbeat = setInterval(() => {
+          let heartbeat!: ReturnType<typeof setInterval>
+          heartbeat = setInterval(() => {
             stream
               .writeSSE({
                 data: JSON.stringify({ type: "heartbeat" }),
               })
-              .catch(() => doCleanup(heartbeat))
+              .catch(finish)
           }, 5_000)
 
-          await new Promise<void>((resolve) => {
-            stream.onAbort(() => {
-              doCleanup(heartbeat)
-              resolve()
-            })
+          await new Promise<void>((r) => {
+            resolve = r
+            stream.onAbort(finish)
 
             const checkDone = setInterval(() => {
               if (task.status !== "running") {
                 clearInterval(checkDone)
-                doCleanup(heartbeat)
-                resolve()
+                finish()
               }
             }, 1000)
           })

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -757,7 +757,17 @@ export namespace Server {
               opts.onBrowserConnectionChange?.(sseConnectionCount)
             }
 
-            // Heartbeat every 3s: keeps proxy streams alive and detects browser close.
+            let resolve!: () => void
+            let resolved = false
+            const finish = () => {
+              if (resolved) return
+              resolved = true
+              clearInterval(heartbeat)
+              unsub()
+              onDisconnect()
+              resolve()
+              log.info("event disconnected")
+            }
             const heartbeat = setInterval(() => {
               stream
                 .writeSSE({
@@ -766,21 +776,12 @@ export namespace Server {
                     properties: {},
                   }),
                 })
-                .catch(() => {
-                  clearInterval(heartbeat)
-                  unsub()
-                  onDisconnect()
-                })
+                .catch(finish)
             }, 3_000)
 
-            await new Promise<void>((resolve) => {
-              stream.onAbort(() => {
-                clearInterval(heartbeat)
-                unsub()
-                resolve()
-                onDisconnect()
-                log.info("event disconnected")
-              })
+            await new Promise<void>((r) => {
+              resolve = r
+              stream.onAbort(finish)
             })
           })
         },


### PR DESCRIPTION
### Issue for this PR

Closes #524

### Type of change

- [x] Bug fix

### What does this PR do?

Four Promise-blocking SSE endpoints leave TCP connections stuck in `CLOSE_WAIT` when the browser disconnects. Bun's `stream.onAbort()` does not fire immediately on TCP close — it only triggers on the next write attempt. The heartbeat `writeSSE` is the sole fallback to detect dead connections, but its `.catch()` handler only cleaned up listeners/subscriptions **without resolving the blocking Promise**, leaving the `streamSSE` handler permanently suspended and the socket in `CLOSE_WAIT`.

This PR introduces a unified `finish()` function in each of the four affected endpoints that both cleans up resources and resolves the Promise. When a heartbeat write fails or `writeSSE` throws (indicating the client has disconnected), `finish()` is called, allowing the handler to return and Hono/Bun to close the underlying socket.

Affected endpoints:
1. `GET /event` in `packages/opencode/src/server/server.ts` — main event stream
2. `GET /file/pdf-to-markdown/progress` in `packages/opencode/src/server/routes/file.ts` — PDF conversion progress SSE
3. `GET /file/translate-markdown/progress` in `packages/opencode/src/server/routes/file.ts` — markdown translation progress SSE
4. `GET /event` in `packages/opencode/src/control-plane/workspace-server/routes.ts` — workspace event stream

### How did you verify your code works?

- `bun typecheck` passes for `packages/opencode`
- Observed that the previous code produced `CLOSE_WAIT` connections on port 19527 after closing the browser tab
- After the fix, connections properly close (TCP four-way handshake completes) when the heartbeat detects the disconnect

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR