### PR TITLE
feat(chat): 支持通过对话树节点切换 AI 回复折叠

### DIFF
--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -42,6 +42,8 @@ type SessionView = {
   reviewOpen?: string[]
   pendingMessage?: string
   pendingMessageAt?: number
+  pendingToggle?: string
+  pendingToggleAt?: number
 }
 
 type TabHandoff = {
@@ -652,6 +654,49 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
             produce((draft) => {
               delete draft.pendingMessage
               delete draft.pendingMessageAt
+            }),
+          )
+
+          if (Date.now() - at > PENDING_MESSAGE_TTL_MS) return
+          return message
+        },
+      },
+      pendingToggle: {
+        set(sessionKey: string, messageID: string) {
+          const at = Date.now()
+          touch(sessionKey)
+          const current = store.sessionView[sessionKey]
+          if (!current) {
+            setStore("sessionView", sessionKey, {
+              scroll: {},
+              pendingToggle: messageID,
+              pendingToggleAt: at,
+            })
+            prune(usage.active ?? sessionKey)
+            return
+          }
+
+          setStore(
+            "sessionView",
+            sessionKey,
+            produce((draft) => {
+              draft.pendingToggle = messageID
+              draft.pendingToggleAt = at
+            }),
+          )
+        },
+        consume(sessionKey: string) {
+          const current = store.sessionView[sessionKey]
+          const message = current?.pendingToggle
+          const at = current?.pendingToggleAt
+          if (!message || !at) return
+
+          setStore(
+            "sessionView",
+            sessionKey,
+            produce((draft) => {
+              delete draft.pendingToggle
+              delete draft.pendingToggleAt
             }),
           )
 

--- a/packages/app/src/pages/session/branch/sidebar-branch-view.tsx
+++ b/packages/app/src/pages/session/branch/sidebar-branch-view.tsx
@@ -1,9 +1,10 @@
-import { useNavigate, useParams } from "@solidjs/router"
+import { useLocation, useNavigate, useParams } from "@solidjs/router"
 import type { SessionGraphResult } from "@opencode-ai/sdk/v2"
 import { DropdownMenu } from "@opencode-ai/ui/dropdown-menu"
 import { Icon } from "@opencode-ai/ui/icon"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { useLanguage } from "@/context/language"
+import { useLayout } from "@/context/layout"
 import { useSettings } from "@/context/settings"
 import { errorMessage as formatErrorMessage } from "@/pages/layout/helpers"
 import { For, Match, Show, Switch, createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js"
@@ -45,8 +46,10 @@ export function SidebarBranchView(props: {
   refreshKey?: string
 }) {
   const params = useParams()
+  const location = useLocation()
   const navigate = useNavigate()
   const globalSDK = useGlobalSDK()
+  const layout = useLayout()
   const settings = useSettings()
   const language = useLanguage()
   const zh = createMemo(() => language.locale() === "zh" || language.locale() === "zht")
@@ -190,7 +193,20 @@ export function SidebarBranchView(props: {
   const openNode = async (node: { sessionID: string; userMessageID?: string }) => {
     if (!params.dir || !node.sessionID) return
     const hash = node.userMessageID ? `#message-${node.userMessageID}` : ""
-    navigate(`/${params.dir}/session/${node.sessionID}${hash}`)
+    if (!node.userMessageID) {
+      navigate(`/${params.dir}/session/${node.sessionID}${hash}`)
+      return
+    }
+    if (props.currentSessionID !== node.sessionID || location.hash !== hash) {
+      navigate(`/${params.dir}/session/${node.sessionID}${hash}`)
+      return
+    }
+    if (!document.getElementById(`message-${node.userMessageID}`)) {
+      navigate(`/${params.dir}/session/${node.sessionID}${hash}`)
+      return
+    }
+    layout.pendingToggle.set(`${params.dir}/${node.sessionID}`, node.userMessageID)
+    return
   }
 
   const startResize = (event: PointerEvent) => {

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -22,6 +22,7 @@ import { shouldMarkBoundaryGesture, normalizeWheelDelta } from "@/pages/session/
 import { SessionContextUsage } from "@/components/session-context-usage"
 import { useI18n } from "@opencode-ai/ui/context"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { useLayout } from "@/context/layout"
 import { useLanguage } from "@/context/language"
 import { useSessionKey } from "@/pages/session/session-layout"
 import { useGlobalSDK } from "@/context/global-sdk"
@@ -230,6 +231,7 @@ export function MessageTimeline(props: {
   const sync = useSync()
   const settings = useSettings()
   const dialog = useDialog()
+  const layout = useLayout()
   const language = useLanguage()
   const uiI18n = useI18n()
   const { params, sessionKey } = useSessionKey()
@@ -396,6 +398,13 @@ export function MessageTimeline(props: {
   const allAssistantCollapsed = createMemo(() => {
     const ids = collapsibleTurnIDs()
     return ids.length > 0 && ids.every((messageID) => isAssistantCollapsed(messageID))
+  })
+  createEffect(() => {
+    const id = sessionID()
+    if (!id) return
+    const messageID = layout.pendingToggle.consume(sessionKey())
+    if (!messageID || !rendered().includes(messageID) || !collapsibleTurnIDs().includes(messageID)) return
+    setAssistantCollapsed(messageID, !isAssistantCollapsed(messageID))
   })
   const collapseAllAssistant = () => {
     const id = sessionID()


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

为对话树节点点击补充二次交互。现在第一次点击节点仍然会导航到对应的 session 和消息位置；当当前页面已经定位到同一条消息时，再次点击同一个对话树节点会切换这条 user turn 对应 assistant 回复的展开和收起。

实现上新增了一个轻量的 pendingToggle 意图通道，由对话树发出切换请求，message-timeline 复用现有的 assistant 折叠逻辑完成实际切换。没有改变 bud 节点或无 userMessageID 节点的行为，这些节点仍然只负责导航。

### How did you verify your code works?

- 在 packages/app 运行 bun typecheck
- 在 packages/ui 运行 bun typecheck
- push hook 自动运行 bun turbo typecheck 并通过
- 本地手动验证以下场景：
  - 第一次点击对话树节点正常导航
  - 已定位到目标消息后再次点击切换对应 AI 回复折叠
  - 再次点击可恢复展开
  - bud 节点和无 userMessageID 节点不触发折叠
  - 与 footer 折叠按钮、点击用户文本气泡折叠不冲突

### Screenshots / recordings

- 未附；已在本地手动验证 UI 行为

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR