### PR TITLE
fix: move session tree sidebar toolbar to bottom

### DIFF
--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -885,8 +885,8 @@ export const dict = {
   "settings.general.row.followup.description": "选择跟进提示是立即引导还是在队列中等待",
   "settings.general.row.followup.option.queue": "排队",
   "settings.general.row.followup.option.steer": "引导",
-  "settings.general.row.branchesTab.title": "启用对话树",
-  "settings.general.row.branchesTab.description": "在会话列表侧栏中内联显示对话树视图",
+  "settings.general.row.branchesTab.title": "启用会话树",
+  "settings.general.row.branchesTab.description": "在会话列表侧栏中内联显示会话树视图",
   "settings.general.row.reviewBatch.title": "审查分页大小",
   "settings.general.row.reviewBatch.description":
     "设置审查栏每次加载多少个文件变更，“加载更多”也会按这个数量继续加载。",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -644,8 +644,8 @@ export const dict = {
   "settings.general.row.followup.description": "選擇後續追問提示是立即引導還是進入佇列等待",
   "settings.general.row.followup.option.queue": "佇列",
   "settings.general.row.followup.option.steer": "引導",
-  "settings.general.row.branchesTab.title": "啟用對話樹",
-  "settings.general.row.branchesTab.description": "在會話清單側欄中內聯顯示對話樹視圖",
+  "settings.general.row.branchesTab.title": "啟用會話樹",
+  "settings.general.row.branchesTab.description": "在會話清單側欄中內聯顯示會話樹視圖",
   "settings.general.row.reasoningSummaries.title": "顯示推理摘要",
   "settings.general.row.reasoningSummaries.description": "在時間軸中顯示模型推理摘要",
 

--- a/packages/app/src/pages/session/branch/sidebar-branch-view.tsx
+++ b/packages/app/src/pages/session/branch/sidebar-branch-view.tsx
@@ -203,130 +203,6 @@ export function SidebarBranchView(props: {
 
   return (
     <div class="overflow-hidden rounded-md border border-border-weaker-base bg-background-stronger">
-      <div class="border-b border-border-weaker-base px-2 py-1">
-        <button
-          type="button"
-          class="flex w-full items-center justify-between gap-2 text-left text-[11px] text-text-weak transition-colors hover:text-text-base"
-          onClick={() => setControlsOpen((value) => !value)}
-        >
-          <span>{zh() ? "对话树" : "Conversation tree"}</span>
-          <Icon name={controlsOpen() ? "chevron-down" : "chevron-right"} size="small" class="text-icon-weak" />
-        </button>
-
-        <Show when={controlsOpen()}>
-          <div class="mt-2 flex flex-wrap items-center gap-2">
-            <button
-              class="rounded-md border border-border-weak-base px-2 py-px text-[11px] text-text-weak transition-colors hover:bg-background-base"
-              onClick={() => setCompact((value) => !value)}
-            >
-              {compact() ? (zh() ? "完整" : "Full") : zh() ? "简略" : "Compact"}
-            </button>
-
-            <div class="flex overflow-hidden rounded-md border border-border-weak-base">
-              <button
-                class="px-2 py-px text-[11px] transition-colors"
-                classList={{
-                  "bg-background-base text-text-strong": orderMode() === "sequence",
-                  "text-text-weak hover:bg-background-base": orderMode() !== "sequence",
-                }}
-                onClick={() => settings.general.setBranchGraphOrderMode("sequence")}
-              >
-                {zh() ? "序列优先" : "Sequence"}
-              </button>
-              <button
-                class="border-l border-border-weak-base px-2 py-px text-[11px] transition-colors"
-                classList={{
-                  "bg-background-base text-text-strong": orderMode() === "time",
-                  "text-text-weak hover:bg-background-base": orderMode() !== "time",
-                }}
-                onClick={() => settings.general.setBranchGraphOrderMode("time")}
-              >
-                {zh() ? "时间优先" : "Time"}
-              </button>
-            </div>
-
-            <DropdownMenu placement="bottom-start">
-              <DropdownMenu.Trigger class="rounded-md border border-border-weak-base px-2 py-px text-[11px] text-text-weak transition-colors hover:bg-background-base">
-                {zh() ? "显示" : "Display"}
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Portal>
-                <DropdownMenu.Content class="min-w-40">
-                  <DropdownMenu.Group>
-                    <DropdownMenu.GroupLabel>{zh() ? "字号" : "Font size"}</DropdownMenu.GroupLabel>
-                    <DropdownMenu.RadioGroup
-                      value={fontSize()}
-                      onChange={(value) => {
-                        if (value === "xs" || value === "sm" || value === "md" || value === "lg" || value === "xl") {
-                          settings.general.setBranchGraphFontSize(value)
-                        }
-                      }}
-                    >
-                      <For
-                        each={[
-                          { value: "xs", label: zh() ? "特小" : "X-Small" },
-                          { value: "sm", label: zh() ? "小" : "Small" },
-                          { value: "md", label: zh() ? "标准" : "Default" },
-                          { value: "lg", label: zh() ? "大" : "Large" },
-                          { value: "xl", label: zh() ? "特大" : "X-Large" },
-                        ]}
-                      >
-                        {(item) => (
-                          <DropdownMenu.RadioItem value={item.value}>
-                            <DropdownMenu.ItemLabel>{item.label}</DropdownMenu.ItemLabel>
-                            <DropdownMenu.ItemIndicator>
-                              <Icon name="check-small" size="small" class="text-icon-weak" />
-                            </DropdownMenu.ItemIndicator>
-                          </DropdownMenu.RadioItem>
-                        )}
-                      </For>
-                    </DropdownMenu.RadioGroup>
-                  </DropdownMenu.Group>
-
-                  <DropdownMenu.Separator />
-
-                  <DropdownMenu.Group>
-                    <DropdownMenu.GroupLabel>{zh() ? "行距" : "Row spacing"}</DropdownMenu.GroupLabel>
-                    <DropdownMenu.RadioGroup
-                      value={rowDensity()}
-                      onChange={(value) => {
-                        if (
-                          value === "xcompact" ||
-                          value === "compact" ||
-                          value === "normal" ||
-                          value === "relaxed" ||
-                          value === "xrelaxed"
-                        ) {
-                          settings.general.setBranchGraphRowDensity(value)
-                        }
-                      }}
-                    >
-                      <For
-                        each={[
-                          { value: "xcompact", label: zh() ? "极紧凑" : "Ultra compact" },
-                          { value: "compact", label: zh() ? "紧凑" : "Compact" },
-                          { value: "normal", label: zh() ? "标准" : "Default" },
-                          { value: "relaxed", label: zh() ? "宽松" : "Relaxed" },
-                          { value: "xrelaxed", label: zh() ? "极宽松" : "Ultra relaxed" },
-                        ]}
-                      >
-                        {(item) => (
-                          <DropdownMenu.RadioItem value={item.value}>
-                            <DropdownMenu.ItemLabel>{item.label}</DropdownMenu.ItemLabel>
-                            <DropdownMenu.ItemIndicator>
-                              <Icon name="check-small" size="small" class="text-icon-weak" />
-                            </DropdownMenu.ItemIndicator>
-                          </DropdownMenu.RadioItem>
-                        )}
-                      </For>
-                    </DropdownMenu.RadioGroup>
-                  </DropdownMenu.Group>
-                </DropdownMenu.Content>
-              </DropdownMenu.Portal>
-            </DropdownMenu>
-          </div>
-        </Show>
-      </div>
-
       <div ref={scrollContainer} class="min-h-0 overflow-auto" style={{ "max-height": `${maxPanelHeight()}px` }}>
         <Switch>
           <Match when={graph()?.kind === "legacy"}>
@@ -377,6 +253,130 @@ export function SidebarBranchView(props: {
             </div>
           </Match>
         </Switch>
+      </div>
+
+      <Show when={controlsOpen()}>
+        <div class="flex flex-wrap items-center gap-2 border-t border-border-weaker-base px-2 py-2">
+          <button
+            class="rounded-md border border-border-weak-base px-2 py-px text-[11px] text-text-weak transition-colors hover:bg-background-base"
+            onClick={() => setCompact((value) => !value)}
+          >
+            {compact() ? (zh() ? "完整" : "Full") : zh() ? "简略" : "Compact"}
+          </button>
+
+          <div class="flex overflow-hidden rounded-md border border-border-weak-base">
+            <button
+              class="px-2 py-px text-[11px] transition-colors"
+              classList={{
+                "bg-background-base text-text-strong": orderMode() === "sequence",
+                "text-text-weak hover:bg-background-base": orderMode() !== "sequence",
+              }}
+              onClick={() => settings.general.setBranchGraphOrderMode("sequence")}
+            >
+              {zh() ? "序列优先" : "Sequence"}
+            </button>
+            <button
+              class="border-l border-border-weak-base px-2 py-px text-[11px] transition-colors"
+              classList={{
+                "bg-background-base text-text-strong": orderMode() === "time",
+                "text-text-weak hover:bg-background-base": orderMode() !== "time",
+              }}
+              onClick={() => settings.general.setBranchGraphOrderMode("time")}
+            >
+              {zh() ? "时间优先" : "Time"}
+            </button>
+          </div>
+
+          <DropdownMenu placement="top-start">
+            <DropdownMenu.Trigger class="rounded-md border border-border-weak-base px-2 py-px text-[11px] text-text-weak transition-colors hover:bg-background-base">
+              {zh() ? "显示" : "Display"}
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Portal>
+              <DropdownMenu.Content class="min-w-40">
+                <DropdownMenu.Group>
+                  <DropdownMenu.GroupLabel>{zh() ? "字号" : "Font size"}</DropdownMenu.GroupLabel>
+                  <DropdownMenu.RadioGroup
+                    value={fontSize()}
+                    onChange={(value) => {
+                      if (value === "xs" || value === "sm" || value === "md" || value === "lg" || value === "xl") {
+                        settings.general.setBranchGraphFontSize(value)
+                      }
+                    }}
+                  >
+                    <For
+                      each={[
+                        { value: "xs", label: zh() ? "特小" : "X-Small" },
+                        { value: "sm", label: zh() ? "小" : "Small" },
+                        { value: "md", label: zh() ? "标准" : "Default" },
+                        { value: "lg", label: zh() ? "大" : "Large" },
+                        { value: "xl", label: zh() ? "特大" : "X-Large" },
+                      ]}
+                    >
+                      {(item) => (
+                        <DropdownMenu.RadioItem value={item.value}>
+                          <DropdownMenu.ItemLabel>{item.label}</DropdownMenu.ItemLabel>
+                          <DropdownMenu.ItemIndicator>
+                            <Icon name="check-small" size="small" class="text-icon-weak" />
+                          </DropdownMenu.ItemIndicator>
+                        </DropdownMenu.RadioItem>
+                      )}
+                    </For>
+                  </DropdownMenu.RadioGroup>
+                </DropdownMenu.Group>
+
+                <DropdownMenu.Separator />
+
+                <DropdownMenu.Group>
+                  <DropdownMenu.GroupLabel>{zh() ? "行距" : "Row spacing"}</DropdownMenu.GroupLabel>
+                  <DropdownMenu.RadioGroup
+                    value={rowDensity()}
+                    onChange={(value) => {
+                      if (
+                        value === "xcompact" ||
+                        value === "compact" ||
+                        value === "normal" ||
+                        value === "relaxed" ||
+                        value === "xrelaxed"
+                      ) {
+                        settings.general.setBranchGraphRowDensity(value)
+                      }
+                    }}
+                  >
+                    <For
+                      each={[
+                        { value: "xcompact", label: zh() ? "极紧凑" : "Ultra compact" },
+                        { value: "compact", label: zh() ? "紧凑" : "Compact" },
+                        { value: "normal", label: zh() ? "标准" : "Default" },
+                        { value: "relaxed", label: zh() ? "宽松" : "Relaxed" },
+                        { value: "xrelaxed", label: zh() ? "极宽松" : "Ultra relaxed" },
+                      ]}
+                    >
+                      {(item) => (
+                        <DropdownMenu.RadioItem value={item.value}>
+                          <DropdownMenu.ItemLabel>{item.label}</DropdownMenu.ItemLabel>
+                          <DropdownMenu.ItemIndicator>
+                            <Icon name="check-small" size="small" class="text-icon-weak" />
+                          </DropdownMenu.ItemIndicator>
+                        </DropdownMenu.RadioItem>
+                      )}
+                    </For>
+                  </DropdownMenu.RadioGroup>
+                </DropdownMenu.Group>
+              </DropdownMenu.Content>
+            </DropdownMenu.Portal>
+          </DropdownMenu>
+        </div>
+      </Show>
+
+      <div class="border-t border-border-weaker-base px-2 py-1">
+        <button
+          type="button"
+          class="flex w-full items-center justify-between gap-2 text-left text-[11px] text-text-weak transition-colors hover:text-text-base"
+          onClick={() => setControlsOpen((value) => !value)}
+        >
+          <span>{zh() ? "会话树" : "Conversation tree"}</span>
+          <Icon name={controlsOpen() ? "chevron-down" : "chevron-right"} size="small" class="text-icon-weak" />
+        </button>
       </div>
 
       <div


### PR DESCRIPTION
### Issue for this PR

Closes #530

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Moves the inline session tree panel controls to the bottom of the sidebar panel.

Also updates the Chinese and Traditional Chinese labels from 对话树 / 對話樹 to 会话树 / 會話樹, and changes the display menu to open upward from the new toolbar position.

### How did you verify your code works?

- un turbo typecheck passed in the pre-push hook
- manually checked the updated sidebar layout after the UI change

### Screenshots / recordings

- Not attached

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR