### PR TITLE
feat(server): configurable idle timeout & graceful shutdown

### DIFF
--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -720,6 +720,75 @@ export const SettingsGeneral: Component = () => {
     </div>
   )
 
+  const ServerSection = () => {
+    const idleOptions = createMemo(() => [
+      { value: "60", label: "1 min" },
+      { value: "300", label: "5 min" },
+      { value: "1800", label: "30 min" },
+      { value: "0", label: language.t("settings.general.row.idleTimeout.never") },
+    ])
+
+    const currentIdle = createMemo(() => {
+      const config = globalSync.data.config as Record<string, unknown>
+      const server =
+        typeof config.server === "object" && config.server ? (config.server as Record<string, unknown>) : {}
+      const val = String(typeof server.idleTimeout === "number" ? server.idleTimeout : 60)
+      return idleOptions().find((o) => o.value === val) ?? idleOptions()[0]
+    })
+
+    const onIdleChange = (option: { value: string } | undefined) => {
+      if (!option) return
+      const idleTimeout = Number(option.value)
+      const config = globalSync.data.config as Record<string, unknown>
+      const server =
+        typeof config.server === "object" && config.server ? (config.server as Record<string, unknown>) : {}
+      const before = typeof server.idleTimeout === "number" ? server.idleTimeout : 60
+      if (idleTimeout === before) return
+      globalSync.set("config", (prev: unknown) => ({
+        ...(prev as Record<string, unknown>),
+        server: { ...(((prev as Record<string, unknown>).server as Record<string, unknown>) ?? {}), idleTimeout },
+      }))
+      globalSync
+        .updateConfig({ server: { idleTimeout } } as Parameters<typeof globalSync.updateConfig>[0])
+        .catch((err: unknown) => {
+          globalSync.set("config", (prev: unknown) => ({
+            ...(prev as Record<string, unknown>),
+            server: {
+              ...(((prev as Record<string, unknown>).server as Record<string, unknown>) ?? {}),
+              idleTimeout: before,
+            },
+          }))
+          const message = err instanceof Error ? err.message : String(err)
+          showToast({ title: language.t("common.requestFailed"), description: message })
+        })
+    }
+
+    return (
+      <div class="flex flex-col gap-1">
+        <h3 class="text-14-medium text-text-strong pb-2">{language.t("settings.general.section.server")}</h3>
+        <SettingsList>
+          <SettingsRow
+            title={language.t("settings.general.row.idleTimeout.title")}
+            description={language.t("settings.general.row.idleTimeout.description")}
+          >
+            <Select
+              data-action="settings-idle-timeout"
+              options={idleOptions()}
+              current={currentIdle()}
+              value={(o) => o.value}
+              label={(o) => o.label}
+              onSelect={(o) => o && onIdleChange(o as { value: string })}
+              variant="secondary"
+              size="small"
+              triggerVariant="settings"
+              triggerStyle={{ "min-width": "180px" }}
+            />
+          </SettingsRow>
+        </SettingsList>
+      </div>
+    )
+  }
+
   const ProxySection = () => (
     <div class="flex flex-col gap-1">
       <h3 class="text-14-medium text-text-strong pb-2">{language.t("settings.general.section.network")}</h3>
@@ -835,6 +904,8 @@ export const SettingsGeneral: Component = () => {
         <NotificationsSection />
 
         <SoundsSection />
+
+        <ServerSection />
 
         <Show when={proxied()}>{(_) => <ProxySection />}</Show>
 

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -973,6 +973,11 @@ export const dict = {
   "settings.general.section.feed": "Feed",
   "settings.general.section.display": "Display",
   "settings.general.section.network": "Network",
+  "settings.general.section.server": "Server",
+  "settings.general.row.idleTimeout.title": "Auto-shutdown delay",
+  "settings.general.row.idleTimeout.description":
+    'How long to wait after all browser tabs close before shutting down the server. Set to "Never" to keep the server running permanently.',
+  "settings.general.row.idleTimeout.never": "Never",
   "settings.memory.title": "Memory",
   "settings.memory.description":
     "The main agent decides durable USER/MEMORY writes directly. Configure recall/reflection behavior and inspect read-only stores here.",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -863,6 +863,11 @@ export const dict = {
   "settings.general.section.feed": "动态",
   "settings.general.section.display": "显示",
   "settings.general.section.network": "网络",
+  "settings.general.section.server": "服务器",
+  "settings.general.row.idleTimeout.title": "自动关闭延迟",
+  "settings.general.row.idleTimeout.description":
+    '所有浏览器标签页关闭后，等待多长时间自动关闭服务器。选择"永不"可保持服务器始终运行。',
+  "settings.general.row.idleTimeout.never": "永不",
   "settings.general.row.defaultModel.title": "默认模型",
   "settings.general.row.defaultModel.description": "新对话未选择其他模型时使用的模型",
   "settings.general.row.defaultModel.none": "自动（提供商默认）",

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -8,6 +8,11 @@ import { networkInterfaces } from "os"
 import { Global } from "../../global"
 import nodePath from "path"
 import { Lease } from "../../server/lease"
+import { Instance } from "../../project/instance"
+import { FeishuManager } from "../../mobile/feishu"
+import { QQManager } from "../../mobile/qq"
+import { WeChatManager } from "../../mobile/wechat"
+import { Cron } from "../../cron"
 
 function getNetworkIPs() {
   const nets = networkInterfaces()
@@ -36,6 +41,22 @@ export const WebCommand = cmd({
   builder: (yargs) => withNetworkOptions(yargs),
   describe: "start opencode server and open web interface",
   handler: async (args) => {
+    async function gracefulShutdown(server: { stop: (close?: boolean) => Promise<void> }) {
+      const FORCE_EXIT_MS = 10_000
+      const timer = setTimeout(() => {
+        process.exit(0)
+      }, FORCE_EXIT_MS).unref()
+      await Promise.all([
+        Instance.disposeAll().catch(() => {}),
+        Cron.stop().catch(() => {}),
+        FeishuManager.stop().catch(() => {}),
+        QQManager.stop().catch(() => {}),
+        WeChatManager.stop().catch(() => {}),
+      ])
+      await server.stop(true).catch(() => {})
+      clearTimeout(timer)
+      process.exit(0)
+    }
     process.env.OPENCODE_EXPERIMENTAL_FILEWATCHER ??= "true"
     if (!Flag.OPENCODE_SERVER_PASSWORD) {
       UI.println(UI.Style.TEXT_WARNING_BOLD + "!  " + "OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
@@ -75,7 +96,7 @@ export const WebCommand = cmd({
                 return
               }
               clearInterval(connectionChecker)
-              process.exit(0)
+              void gracefulShutdown(server)
             }, IDLE_TIMEOUT_MS)
         }
       }, 1_000)

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -41,7 +41,7 @@ export const WebCommand = cmd({
       UI.println(UI.Style.TEXT_WARNING_BOLD + "!  " + "OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
     const opts = await resolveNetworkOptions(args)
-    const EXIT_GRACE_MS = 10_000
+    const IDLE_TIMEOUT_MS = (opts.idleTimeout ?? 60) * 1_000
     let sse = 0
     const server = Server.listen({
       ...opts,
@@ -53,30 +53,33 @@ export const WebCommand = cmd({
     // Auto-exit when all browser connections close (after at least one was open).
     // Polling server.pendingRequests is more reliable than SSE onAbort, because
     // Bun only detects TCP close when it next tries to write to the socket.
-    let everConnected = false
-    let exitTimer: ReturnType<typeof setTimeout> | null = null
-    const connectionChecker = setInterval(() => {
-      const active = (server as any).pendingRequests as number
-      if (active > 0 || sse > 0 || Lease.count() > 0) {
-        everConnected = true
-        if (exitTimer !== null) {
-          clearTimeout(exitTimer)
-          exitTimer = null
+    // Disable by setting idleTimeout to 0 (always-on daemon mode).
+    if (IDLE_TIMEOUT_MS > 0) {
+      let everConnected = false
+      let exitTimer: ReturnType<typeof setTimeout> | null = null
+      const connectionChecker = setInterval(() => {
+        const active = (server as any).pendingRequests as number
+        if (active > 0 || sse > 0 || Lease.count() > 0) {
+          everConnected = true
+          if (exitTimer !== null) {
+            clearTimeout(exitTimer)
+            exitTimer = null
+          }
+        } else if (everConnected) {
+          exitTimer =
+            exitTimer ??
+            setTimeout(() => {
+              const pending = (server as any).pendingRequests as number
+              if (pending > 0 || sse > 0 || Lease.count() > 0) {
+                exitTimer = null
+                return
+              }
+              clearInterval(connectionChecker)
+              process.exit(0)
+            }, IDLE_TIMEOUT_MS)
         }
-      } else if (everConnected) {
-        exitTimer =
-          exitTimer ??
-          setTimeout(() => {
-            const pending = (server as any).pendingRequests as number
-            if (pending > 0 || sse > 0 || Lease.count() > 0) {
-              exitTimer = null
-              return
-            }
-            clearInterval(connectionChecker)
-            process.exit(0)
-          }, EXIT_GRACE_MS)
-      }
-    }, 1_000)
+      }, 1_000)
+    }
     const portfile = nodePath.join(Global.Path.data, "serve-port")
     await Bun.write(portfile, String(server.port))
     UI.empty()

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -28,6 +28,10 @@ const options = {
     describe: "additional domains to allow for CORS",
     default: [] as string[],
   },
+  "idle-timeout": {
+    type: "number" as const,
+    describe: "seconds to wait after all browser connections close before exiting (default: 60, 0 to disable)",
+  },
 }
 
 export type NetworkOptions = InferredOptionTypes<typeof options>
@@ -43,6 +47,7 @@ export async function resolveNetworkOptions(args: NetworkOptions) {
   const mdnsExplicitlySet = process.argv.includes("--mdns")
   const mdnsDomainExplicitlySet = process.argv.includes("--mdns-domain")
   const corsExplicitlySet = process.argv.includes("--cors")
+  const idleTimeoutExplicitlySet = process.argv.includes("--idle-timeout")
 
   const mdns = mdnsExplicitlySet ? args.mdns : (config?.server?.mdns ?? args.mdns)
   const mdnsDomain = mdnsDomainExplicitlySet ? args["mdns-domain"] : (config?.server?.mdnsDomain ?? args["mdns-domain"])
@@ -55,6 +60,7 @@ export async function resolveNetworkOptions(args: NetworkOptions) {
   const configCors = config?.server?.cors ?? []
   const argsCors = Array.isArray(args.cors) ? args.cors : args.cors ? [args.cors] : []
   const cors = [...configCors, ...argsCors]
+  const idleTimeout = idleTimeoutExplicitlySet ? args["idle-timeout"] : (config?.server?.idleTimeout ?? 60)
 
-  return { hostname, port, mdns, mdnsDomain, cors }
+  return { hostname, port, mdns, mdnsDomain, cors, idleTimeout }
 }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1029,6 +1029,14 @@ export namespace Config {
       mdns: z.boolean().optional().describe("Enable mDNS service discovery"),
       mdnsDomain: z.string().optional().describe("Custom domain name for mDNS service (default: opencode.local)"),
       cors: z.array(z.string()).optional().describe("Additional domains to allow for CORS"),
+      idleTimeout: z
+        .number()
+        .int()
+        .min(0)
+        .optional()
+        .describe(
+          "Seconds to wait after all browser connections close before exiting (default: 60). Set to 0 to disable auto-exit.",
+        ),
     })
     .strict()
     .meta({
@@ -1277,7 +1285,10 @@ export namespace Config {
         .optional(),
       memory: z
         .object({
-          enabled: z.boolean().optional().describe("Enable memory tools, prompt recall, and memory reflection (default: true)"),
+          enabled: z
+            .boolean()
+            .optional()
+            .describe("Enable memory tools, prompt recall, and memory reflection (default: true)"),
           memory_reflection_model: z
             .object({
               providerID: z.string(),

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -962,7 +962,12 @@ export namespace Server {
 
     for (const signal of ["SIGINT", "SIGTERM"] as const) {
       process.on(signal, () => {
-        Promise.all([FeishuManager.stop(), QQManager.stop(), WeChatManager.stop()].map((p) => p.catch(() => {})))
+        setTimeout(() => process.exit(0), 10_000).unref()
+        Promise.all(
+          [Instance.disposeAll(), Cron.stop(), FeishuManager.stop(), QQManager.stop(), WeChatManager.stop()].map((p) =>
+            p.catch(() => {}),
+          ),
+        )
           .then(() => server.stop(true).catch(() => {}))
           .then(() => process.exit(0))
       })

--- a/packages/opencode/test/cli/tui/thread.test.ts
+++ b/packages/opencode/test/cli/tui/thread.test.ts
@@ -102,6 +102,8 @@ describe("tui thread", () => {
       "mdns-domain": "opencode.local",
       mdnsDomain: "opencode.local",
       cors: [],
+      "idle-timeout": undefined,
+      idleTimeout: undefined,
     }
     return TuiThreadCommand.handler(args)
   }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1233,6 +1233,10 @@ export type ServerConfig = {
    * Additional domains to allow for CORS
    */
   cors?: Array<string>
+  /**
+   * Seconds to wait after all browser connections close before exiting (default: 60). Set to 0 to disable auto-exit.
+   */
+  idleTimeout?: number
 }
 
 export type PermissionActionConfig = "ask" | "allow" | "deny"


### PR DESCRIPTION
### Issue for this PR

Closes #543

### Type of change

- [x] New feature
- [x] Bug fix (orphan child processes on exit)

### What does this PR do?

Two commits addressing the issue of zombie processes and port conflicts when using `aether web`:

**Commit 1: Configurable idle timeout** (`d9cd1d625`)
- Replaces the hardcoded 10s exit grace period with a configurable `idleTimeout` (default 60s)
- Configuration: CLI `--idle-timeout`, `opencode.json` `server.idleTimeout`, or web UI Settings > Server > Auto-shutdown delay
- `idleTimeout: 0` disables auto-exit (daemon mode)
- Adds `idleTimeout` field to `ServerConfig` in config schema, CLI options, and SDK types
- Adds a "Server" section in the web settings UI with a dropdown (1 min / 5 min / 30 min / Never)
- Adds i18n keys for en and zh

**Commit 2: Graceful shutdown with child process cleanup** (`82fd652d8`)
- Replaces bare `process.exit(0)` in idle timeout handler with `gracefulShutdown()` that:
  - Disposes all project instances → kills LSP child process trees (`taskkill /T /F` on Windows)
  - Stops cron scheduler
  - Stops mobile integrations (Feishu, QQ, WeChat)
  - Closes the HTTP server
  - Has a 10s force-exit timeout as safety net
- Fixes SIGINT/SIGTERM signal handlers in `server.ts` to also call `Instance.disposeAll()` and `Cron.stop()` with the same timeout protection

### How did you verify your code works?

- `bun typecheck` passes in both `packages/opencode` and `packages/app`
- Pre-push hook runs full typecheck across all 12 packages (all pass)

### Screenshots / recordings

Not applicable (config option in settings UI, no visual change beyond a new dropdown).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR