### PR TITLE
feat: 统一模型可见性 — disabled_models 配置

### DIFF
--- a/packages/app/src/context/models.tsx
+++ b/packages/app/src/context/models.tsx
@@ -1,11 +1,10 @@
 import { createMemo } from "solid-js"
 import { createStore } from "solid-js/store"
-import { DateTime } from "luxon"
-import { filter, firstBy, flat, groupBy, mapValues, pipe, uniqueBy, values } from "remeda"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { useProviders } from "@/hooks/use-providers"
 import { useGlobalSync } from "@/context/global-sync"
 import { Persist, persisted } from "@/utils/persist"
+import { uniqueBy } from "remeda"
 
 export type ModelKey = { providerID: string; modelID: string }
 
@@ -50,47 +49,6 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       ),
     )
 
-    const release = createMemo(
-      () =>
-        new Map(
-          available().map((model) => {
-            const parsed = DateTime.fromISO(model.release_date)
-            return [modelKey({ providerID: model.provider.id, modelID: model.id }), parsed] as const
-          }),
-        ),
-    )
-
-    const latest = createMemo(() =>
-      pipe(
-        available(),
-        filter(
-          (x) =>
-            Math.abs(
-              (release().get(modelKey({ providerID: x.provider.id, modelID: x.id })) ?? DateTime.invalid("invalid"))
-                .diffNow()
-                .as("months"),
-            ) < 6,
-        ),
-        groupBy((x) => x.provider.id),
-        mapValues((models) =>
-          pipe(
-            models,
-            groupBy((x) => x.family),
-            values(),
-            (groups) =>
-              groups.flatMap((g) => {
-                const first = firstBy(g, [(x) => x.release_date, "desc"])
-                return first ? [{ modelID: first.id, providerID: first.provider.id }] : []
-              }),
-          ),
-        ),
-        values(),
-        flat(),
-      ),
-    )
-
-    const latestSet = createMemo(() => new Set(latest().map((x) => modelKey(x))))
-
     const disabledModelsSet = createMemo(() => {
       const list = globalSync.data.config.disabled_models ?? []
       return new Set(list)
@@ -116,11 +74,7 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
 
     const visible = (model: ModelKey) => {
       const id = disabledModelID(model)
-      if (disabledModelsSet().has(id) || disabledModelsSet().has(model.modelID)) return false
-      if (latestSet().has(modelKey(model))) return true
-      const date = release().get(modelKey(model))
-      if (!date?.isValid) return true
-      return false
+      return !disabledModelsSet().has(id) && !disabledModelsSet().has(model.modelID)
     }
 
     const setVisibility = (model: ModelKey, state: boolean) => {
@@ -159,7 +113,7 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
 
     const push = (model: ModelKey) => {
       const uniq = uniqueBy([model, ...store.recent], (x) => `${x.providerID}:${x.modelID}`)
-      if (uniq.length > RECENT_LIMIT) uniq.pop()
+      if (uniq.length > RECENT_LIMIT) uniq.length = RECENT_LIMIT
       setStore("recent", uniq)
     }
 

--- a/packages/app/src/context/models.tsx
+++ b/packages/app/src/context/models.tsx
@@ -4,12 +4,12 @@ import { DateTime } from "luxon"
 import { filter, firstBy, flat, groupBy, mapValues, pipe, uniqueBy, values } from "remeda"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { useProviders } from "@/hooks/use-providers"
+import { useGlobalSync } from "@/context/global-sync"
 import { Persist, persisted } from "@/utils/persist"
 
 export type ModelKey = { providerID: string; modelID: string }
 
-type Visibility = "show" | "hide"
-type User = ModelKey & { visibility: Visibility; favorite?: boolean }
+type User = ModelKey & { favorite?: boolean }
 type Store = {
   user: User[]
   recent: ModelKey[]
@@ -22,10 +22,15 @@ function modelKey(model: ModelKey) {
   return `${model.providerID}:${model.modelID}`
 }
 
+function disabledModelID(model: ModelKey) {
+  return `${model.providerID}/${model.modelID}`
+}
+
 export const { use: useModels, provider: ModelsProvider } = createSimpleContext({
   name: "Models",
   init: () => {
     const providers = useProviders()
+    const globalSync = useGlobalSync()
 
     const [store, setStore, _, ready] = persisted(
       Persist.global("model", ["model.v1"]),
@@ -86,9 +91,16 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
 
     const latestSet = createMemo(() => new Set(latest().map((x) => modelKey(x))))
 
-    const visibility = createMemo(() => {
-      const map = new Map<string, Visibility>()
-      for (const item of store.user) map.set(`${item.providerID}:${item.modelID}`, item.visibility)
+    const disabledModelsSet = createMemo(() => {
+      const list = globalSync.data.config.disabled_models ?? []
+      return new Set(list)
+    })
+
+    const favoritesSet = createMemo(() => {
+      const map = new Map<string, boolean>()
+      for (const item of store.user) {
+        if (item.favorite) map.set(`${item.providerID}:${item.modelID}`, true)
+      }
       return map
     })
 
@@ -102,29 +114,48 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
 
     const find = (key: ModelKey) => list().find((m) => m.id === key.modelID && m.provider.id === key.providerID)
 
-    function update(model: ModelKey, state: Visibility) {
-      const index = store.user.findIndex((x) => x.modelID === model.modelID && x.providerID === model.providerID)
-      if (index >= 0) {
-        setStore("user", index, (current) => ({ ...current, visibility: state }))
-        return
-      }
-      setStore("user", store.user.length, { ...model, visibility: state })
-    }
-
     const visible = (model: ModelKey) => {
-      const key = modelKey(model)
-      const state = visibility().get(key)
-      if (state === "hide") return false
-      if (state === "show") return true
-      if (latestSet().has(key)) return true
-      const date = release().get(key)
+      const id = disabledModelID(model)
+      if (disabledModelsSet().has(id) || disabledModelsSet().has(model.modelID)) return false
+      if (latestSet().has(modelKey(model))) return true
+      const date = release().get(modelKey(model))
       if (!date?.isValid) return true
       return false
     }
 
     const setVisibility = (model: ModelKey, state: boolean) => {
-      update(model, state ? "show" : "hide")
+      const id = disabledModelID(model)
+      const before = globalSync.data.config.disabled_models ?? []
+      const isCurrentlyDisabled = before.includes(id) || before.includes(model.modelID)
+      if (state && !isCurrentlyDisabled) return
+      if (!state && isCurrentlyDisabled) return
+      if (state) {
+        const next = before.filter((x) => x !== id && x !== model.modelID)
+        globalSync.set("config", "disabled_models", next)
+        globalSync.updateConfig({ disabled_models: next }).catch((err: unknown) => {
+          globalSync.set("config", "disabled_models", before)
+          console.error("Failed to enable model", err)
+        })
+      } else {
+        const next = [...before, id]
+        globalSync.set("config", "disabled_models", next)
+        globalSync.updateConfig({ disabled_models: next }).catch((err: unknown) => {
+          globalSync.set("config", "disabled_models", before)
+          console.error("Failed to disable model", err)
+        })
+      }
     }
+
+    const toggleFavorite = (model: ModelKey, state: boolean) => {
+      const index = store.user.findIndex((x) => x.modelID === model.modelID && x.providerID === model.providerID)
+      if (index >= 0) {
+        setStore("user", index, (current) => ({ ...current, favorite: state }))
+        return
+      }
+      setStore("user", store.user.length, { ...model, favorite: state })
+    }
+
+    const isFavorite = (model: ModelKey) => favoritesSet().get(modelKey(model)) ?? false
 
     const push = (model: ModelKey) => {
       const uniq = uniqueBy([model, ...store.recent], (x) => `${x.providerID}:${x.modelID}`)
@@ -150,6 +181,8 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       find,
       visible,
       setVisibility,
+      isFavorite,
+      toggleFavorite,
       recent: {
         list: createMemo(() => store.recent),
         push,

--- a/packages/opencode/src/cli/error.ts
+++ b/packages/opencode/src/cli/error.ts
@@ -8,7 +8,8 @@ export function FormatError(input: unknown) {
   if (MCP.Failed.isInstance(input))
     return `MCP server "${input.data.name}" failed. Note, opencode does not support MCP authentication yet.`
   if (Provider.ModelNotFoundError.isInstance(input)) {
-    const { providerID, modelID, suggestions } = input.data
+    const { providerID, modelID, suggestions, disabled } = input.data
+    if (disabled) return `Model disabled: ${providerID}/${modelID}. Enable it in Settings > Models.`
     return [
       `Model not found: ${providerID}/${modelID}`,
       ...(Array.isArray(suggestions) && suggestions.length ? ["Did you mean: " + suggestions.join(", ")] : []),

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -79,6 +79,9 @@ export namespace Config {
     if (target.instructions && source.instructions) {
       merged.instructions = Array.from(new Set([...target.instructions, ...source.instructions]))
     }
+    if (target.disabled_models && source.disabled_models) {
+      merged.disabled_models = Array.from(new Set([...target.disabled_models, ...source.disabled_models]))
+    }
     return merged
   }
 

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1152,6 +1152,10 @@ export namespace Config {
         .array(z.string())
         .optional()
         .describe("When set, ONLY these providers will be enabled. All other providers will be ignored"),
+      disabled_models: z
+        .array(z.string())
+        .optional()
+        .describe("Disable specific models in provider/model format, e.g. anthropic/claude-3-5-haiku"),
       model: ModelId.describe("Model to use in the format of provider/model, eg anthropic/claude-2").optional(),
       small_model: ModelId.describe(
         "Small model to use for tasks like title generation in the format of provider/model",

--- a/packages/opencode/src/mobile/base.ts
+++ b/packages/opencode/src/mobile/base.ts
@@ -336,6 +336,7 @@ export abstract class MobileManagerBase {
         const sortedIds = modelValues.map(([id]) => id)
         const defaultModelId = sortedIds[0]
         for (const [modelID, model] of modelValues) {
+          if ((model as any).disabled) continue
           entries.push({
             index,
             providerID,

--- a/packages/opencode/src/mobile/base.ts
+++ b/packages/opencode/src/mobile/base.ts
@@ -328,7 +328,10 @@ export abstract class MobileManagerBase {
 
   protected async buildModelList(): Promise<ModelEntry[]> {
     try {
-      const providers = await Provider.list()
+      const providers = await Instance.provide({
+        directory: this._initialDir,
+        fn: () => Provider.list(),
+      })
       const entries: ModelEntry[] = []
       let index = 1
       for (const [providerID, info] of Object.entries(providers)) {

--- a/packages/opencode/src/mobile/base.ts
+++ b/packages/opencode/src/mobile/base.ts
@@ -336,16 +336,15 @@ export abstract class MobileManagerBase {
       let index = 1
       for (const [providerID, info] of Object.entries(providers)) {
         const modelValues = Object.entries(info.models)
-        const sortedIds = modelValues.map(([id]) => id)
-        const defaultModelId = sortedIds[0]
+        const defaultModelId = modelValues.filter(([_, m]) => !m.disabled).map(([id]) => id)[0]
         for (const [modelID, model] of modelValues) {
-          if ((model as any).disabled) continue
+          if (model.disabled) continue
           entries.push({
             index,
             providerID,
             providerName: info.name || providerID,
             modelID,
-            name: (model as any).name || modelID,
+            name: model.name || modelID,
             isDefault: modelID === defaultModelId,
           })
           index++

--- a/packages/opencode/src/mobile/base.ts
+++ b/packages/opencode/src/mobile/base.ts
@@ -1720,6 +1720,7 @@ export abstract class MobileManagerBase {
     this._busUnsubs.push(() => GlobalBus.off("event", onPermission))
 
     this._globalBusListener = (event) => {
+      if (event.directory === "global") this._modelList = []
       const dir = event.directory ? this.normDir(event.directory) : null
       if (!dir || !(dir in this._hiddenDirs)) return
       delete this._hiddenDirs[dir]

--- a/packages/opencode/src/mobile/base.ts
+++ b/packages/opencode/src/mobile/base.ts
@@ -934,9 +934,7 @@ export abstract class MobileManagerBase {
 
   protected async cmdModel(targetId: string, scope: string, args: string[]): Promise<void> {
     const ctx = await this.commandCtx(scope)
-    if (this._modelList.length === 0) {
-      this._modelList = await this.buildModelList()
-    }
+    this._modelList = await this.buildModelList()
 
     if (args.length === 0) {
       await this.replyCmd(targetId, scope, this.formatModelList(ctx, false))
@@ -1720,7 +1718,6 @@ export abstract class MobileManagerBase {
     this._busUnsubs.push(() => GlobalBus.off("event", onPermission))
 
     this._globalBusListener = (event) => {
-      if (event.directory === "global") this._modelList = []
       const dir = event.directory ? this.normDir(event.directory) : null
       if (!dir || !(dir in this._hiddenDirs)) return
       delete this._hiddenDirs[dir]

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1241,8 +1241,7 @@ export namespace Provider {
           (configProvider?.whitelist && !configProvider.whitelist.includes(modelID))
         )
           delete provider.models[modelID]
-        if (disabledModels.has(`${providerID}/${modelID}`) || disabledModels.has(modelID))
-          delete provider.models[modelID]
+        if (disabledModels.has(`${providerID}/${modelID}`) || disabledModels.has(modelID)) model.disabled = true
 
         model.variants = mapValues(ProviderTransform.variants(model), (v) => v)
 
@@ -1468,6 +1467,7 @@ export namespace Provider {
       const suggestions = matches.map((m) => m.target)
       throw new ModelNotFoundError({ providerID, modelID, suggestions })
     }
+    if (info.disabled) throw new ModelNotFoundError({ providerID, modelID, suggestions: [] })
     return info
   }
 
@@ -1475,6 +1475,8 @@ export namespace Provider {
     const s = await state()
     const key = `${model.providerID}/${model.id}`
     if (s.models.has(key)) return s.models.get(key)!
+    if (s.providers[model.providerID]?.models[model.id]?.disabled)
+      throw new ModelNotFoundError({ providerID: model.providerID, modelID: model.id, suggestions: [] })
 
     const url = e2eURL()
     if (url) {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -979,6 +979,7 @@ export namespace Provider {
 
     const disabled = new Set(config.disabled_providers ?? [])
     const enabled = config.enabled_providers ? new Set(config.enabled_providers) : null
+    const disabledModels = new Set(config.disabled_models ?? [])
 
     function isProviderAllowed(providerID: ProviderID): boolean {
       if (enabled && !enabled.has(providerID)) return false
@@ -1238,6 +1239,8 @@ export namespace Provider {
           (configProvider?.blacklist && configProvider.blacklist.includes(modelID)) ||
           (configProvider?.whitelist && !configProvider.whitelist.includes(modelID))
         )
+          delete provider.models[modelID]
+        if (disabledModels.has(`${providerID}/${modelID}`) || disabledModels.has(modelID))
           delete provider.models[modelID]
 
         model.variants = mapValues(ProviderTransform.variants(model), (v) => v)

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1467,7 +1467,7 @@ export namespace Provider {
       const suggestions = matches.map((m) => m.target)
       throw new ModelNotFoundError({ providerID, modelID, suggestions })
     }
-    if (info.disabled) throw new ModelNotFoundError({ providerID, modelID, suggestions: [] })
+    if (info.disabled) throw new ModelNotFoundError({ providerID, modelID, suggestions: [], disabled: true })
     return info
   }
 
@@ -1476,7 +1476,7 @@ export namespace Provider {
     const key = `${model.providerID}/${model.id}`
     if (s.models.has(key)) return s.models.get(key)!
     if (s.providers[model.providerID]?.models[model.id]?.disabled)
-      throw new ModelNotFoundError({ providerID: model.providerID, modelID: model.id, suggestions: [] })
+      throw new ModelNotFoundError({ providerID: model.providerID, modelID: model.id, suggestions: [], disabled: true })
 
     const url = e2eURL()
     if (url) {
@@ -1610,12 +1610,14 @@ export namespace Provider {
       const provider = providers[entry.providerID]
       if (!provider) continue
       if (!provider.models[entry.modelID]) continue
+      if (provider.models[entry.modelID].disabled) continue
       return { providerID: entry.providerID, modelID: entry.modelID }
     }
 
     const provider = Object.values(providers).find((p) => !cfg.provider || Object.keys(cfg.provider).includes(p.id))
     if (!provider) throw new Error("no providers found")
-    const [model] = sort(Object.values(provider.models))
+    const enabled = Object.values(provider.models).filter((m) => !m.disabled)
+    const [model] = sort(enabled)
     if (!model) throw new Error("no models found")
     return {
       providerID: provider.id,
@@ -1637,6 +1639,7 @@ export namespace Provider {
       providerID: ProviderID.zod,
       modelID: ModelID.zod,
       suggestions: z.array(z.string()).optional(),
+      disabled: z.boolean().optional(),
     }),
   )
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -868,6 +868,7 @@ export namespace Provider {
         output: z.number(),
       }),
       status: z.enum(["alpha", "beta", "deprecated", "active"]),
+      disabled: z.boolean().optional(),
       options: z.record(z.string(), z.any()),
       headers: z.record(z.string(), z.string()),
       release_date: z.string(),

--- a/packages/opencode/src/server/routes/provider.ts
+++ b/packages/opencode/src/server/routes/provider.ts
@@ -235,14 +235,16 @@ export const ProviderRoutes = lazy(() =>
           connected,
         )
         for (const [providerID, provider] of Object.entries(providers)) {
-          for (const modelID of Object.keys(provider.models)) {
-            if (disabledModels.has(`${providerID}/${modelID}`) || disabledModels.has(modelID))
-              delete provider.models[modelID]
+          for (const [modelID, model] of Object.entries(provider.models)) {
+            if (disabledModels.has(`${providerID}/${modelID}`) || disabledModels.has(modelID)) model.disabled = true
           }
         }
         return c.json({
           all: Object.values(providers),
-          default: mapValues(providers, (item) => Provider.sort(Object.values(item.models))[0].id),
+          default: mapValues(providers, (item) => {
+            const enabled = Object.values(item.models).filter((m) => !m.disabled)
+            return enabled.length > 0 ? Provider.sort(enabled)[0].id : ""
+          }),
           connected: await Provider.connected(),
         })
       },

--- a/packages/opencode/src/server/routes/provider.ts
+++ b/packages/opencode/src/server/routes/provider.ts
@@ -219,6 +219,7 @@ export const ProviderRoutes = lazy(() =>
         const config = await Config.get()
         const disabled = new Set(config.disabled_providers ?? [])
         const enabled = config.enabled_providers ? new Set(config.enabled_providers) : undefined
+        const disabledModels = new Set(config.disabled_models ?? [])
 
         const allProviders = await ModelsDev.get()
         const filteredProviders: Record<string, (typeof allProviders)[string]> = {}
@@ -233,6 +234,12 @@ export const ProviderRoutes = lazy(() =>
           mapValues(filteredProviders, (x) => Provider.fromModelsDevProvider(x)),
           connected,
         )
+        for (const [providerID, provider] of Object.entries(providers)) {
+          for (const modelID of Object.keys(provider.models)) {
+            if (disabledModels.has(`${providerID}/${modelID}`) || disabledModels.has(modelID))
+              delete provider.models[modelID]
+          }
+        }
         return c.json({
           all: Object.values(providers),
           default: mapValues(providers, (item) => Provider.sort(Object.values(item.models))[0].id),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -367,11 +367,13 @@ export namespace SessionPrompt {
 
       const model = await Provider.getModel(lastUser.model.providerID, lastUser.model.modelID).catch((e) => {
         if (Provider.ModelNotFoundError.isInstance(e)) {
-          const hint = e.data.suggestions?.length ? ` Did you mean: ${e.data.suggestions.join(", ")}?` : ""
+          const msg = e.data.disabled
+            ? `Model disabled: ${e.data.providerID}/${e.data.modelID}. Enable it in Settings > Models.`
+            : `Model not found: ${e.data.providerID}/${e.data.modelID}.${e.data.suggestions?.length ? ` Did you mean: ${e.data.suggestions.join(", ")}?` : ""}`
           Bus.publish(Session.Event.Error, {
             sessionID,
             error: new NamedError.Unknown({
-              message: `Model not found: ${e.data.providerID}/${e.data.modelID}.${hint}`,
+              message: msg,
             }).toObject(),
           })
         }
@@ -1959,11 +1961,13 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       await Provider.getModel(taskModel.providerID, taskModel.modelID)
     } catch (e) {
       if (Provider.ModelNotFoundError.isInstance(e)) {
-        const { providerID, modelID, suggestions } = e.data
-        const hint = suggestions?.length ? ` Did you mean: ${suggestions.join(", ")}?` : ""
+        const { providerID, modelID, suggestions, disabled } = e.data
+        const msg = disabled
+          ? `Model disabled: ${providerID}/${modelID}. Enable it in Settings > Models.`
+          : `Model not found: ${providerID}/${modelID}.${suggestions?.length ? ` Did you mean: ${suggestions.join(", ")}?` : ""}`
         Bus.publish(Session.Event.Error, {
           sessionID: input.sessionID,
-          error: new NamedError.Unknown({ message: `Model not found: ${providerID}/${modelID}.${hint}` }).toObject(),
+          error: new NamedError.Unknown({ message: msg }).toObject(),
         })
       }
       throw e

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1246,6 +1246,10 @@ export type Config = {
    */
   enabled_providers?: Array<string>
   /**
+   * Disable specific models in provider/model format, e.g. anthropic/claude-3-5-haiku
+   */
+  disabled_models?: Array<string>
+  /**
    * Model to use in the format of provider/model, eg anthropic/claude-2
    */
   model?: string

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -3017,6 +3017,7 @@ export type ProviderListResponses = {
           }
           experimental?: boolean
           status?: "alpha" | "beta" | "deprecated"
+          disabled?: boolean
           options: {
             [key: string]: unknown
           }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1571,6 +1571,10 @@ export type Config = {
    */
   enabled_providers?: Array<string>
   /**
+   * Disable specific models in provider/model format, e.g. anthropic/claude-3-5-haiku
+   */
+  disabled_models?: Array<string>
+  /**
    * Model to use in the format of provider/model, eg anthropic/claude-2
    */
   model?: string

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1855,6 +1855,7 @@ export type Model = {
     [key: string]: string
   }
   release_date: string
+  disabled?: boolean
   variants?: {
     [key: string]: {
       [key: string]: unknown
@@ -5120,6 +5121,7 @@ export type ProviderListResponses = {
           }
           experimental?: boolean
           status?: "alpha" | "beta" | "deprecated"
+          disabled?: boolean
           options: {
             [key: string]: unknown
           }


### PR DESCRIPTION
## Summary

- 新增 `disabled_models` 配置字段，让 Web 端关闭的模型在移动端/subagent 也不可用
- Web "设置→模型" toggle 同步写入 server config，所有端实时生效
- disabled 模型在设置页可见（Switch OFF），可重新启用
- `Provider.getModel()`/`getLanguage()` 拒绝 disabled 模型，给出 "Model disabled" 提示
- Mobile `/m` 每次实时构建模型列表，不缓存

Closes #545

## Changes

| 文件 | 修改 |
|---|---|
| `config.ts` | `disabled_models` schema + mergeConfigConcatArrays 集合合并 |
| `provider.ts` | state 标记 disabled；getModel/getLanguage/defaultModel 拮绝/过滤；ModelNotFoundError.disabled 字段 |
| `provider route` | GET /provider 标记 disabled 不删除 |
| `mobile/base.ts` | Instance.provide 包裹 + 跳过 disabled + 实时重建 |
| `error.ts + prompt.ts` | "Model disabled" vs "Model not found" 区分 |
| `models.tsx` | visible() 简化为 disabledModelsSet 检查；setVisibility() 同步 server config |
| SDK types | Config.disabled_models + Model.disabled |