### PR TITLE
feat: increase sidebar default session limit from 5 to 10

### DIFF
--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -183,7 +183,7 @@ export function createChildStoreManager(input: {
             mcp: {},
             lsp: [],
             vcs: vcsStore.value,
-            limit: 5,
+            limit: 10,
             message: {},
             part: {},
             preference: {},

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -862,7 +862,7 @@ export const SortableWorkspace = (props: {
   const touch = createMediaQuery("(hover: none)")
   const showNew = createMemo(() => !loading() && (touch() || count() === 0 || (active() && !params.id)))
   const loadMore = async () => {
-    setWorkspaceStore("limit", (limit) => (limit ?? 0) + 5)
+    setWorkspaceStore("limit", (limit) => (limit ?? 0) + 10)
     await globalSync.project.loadSessions(props.directory)
   }
 
@@ -1032,7 +1032,7 @@ export const LocalWorkspace = (props: {
   const loading = createMemo(() => !booted() && count() === 0)
   const hasMore = createMemo(() => workspace().store.sessionTotal > count())
   const loadMore = async () => {
-    workspace().setStore("limit", (limit) => (limit ?? 0) + 5)
+    workspace().setStore("limit", (limit) => (limit ?? 0) + 10)
     await globalSync.project.loadSessions(props.project.worktree)
   }
 


### PR DESCRIPTION
### Issue for this PR

Closes #547

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

将侧边栏默认显示的会话数量从5改为10，同时"加载更多"的增量也从5改为10。涉及三处改动：
- `child-store.ts` — 初始 limit: 5 → 10
- `sidebar-workspace.tsx` — 两处 loadMore 增量 5 → 10

API 查询 limit 为 `store.limit + SESSION_RECENT_LIMIT`（55→60），仅多5行 SQLite，无实质开销增加。

### How did you verify your code works?

本地 dev server 验证侧边栏默认显示10条会话，点击加载更多每次增加10条。

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR