### PR TITLE
fix: keep mobile session map synced with most recent session

### DIFF
--- a/packages/opencode/src/mobile/base.ts
+++ b/packages/opencode/src/mobile/base.ts
@@ -283,6 +283,7 @@ export abstract class MobileManagerBase {
 
     const staleKeys: string[] = []
     const sessionToCanonicalScope: Record<string, string> = {}
+    const refreshed: { scope: string; newId: string }[] = []
     for (const [key, sessionId] of Object.entries(this.sessionMap)) {
       const canonical = sessionToCanonicalScope[sessionId]
       if (canonical) {
@@ -303,6 +304,14 @@ export abstract class MobileManagerBase {
         })
         if (found.time?.archived) {
           staleKeys.push(key)
+        } else {
+          const recent = await Instance.provide({
+            directory: dir,
+            fn: () => [...Session.list({ directory: dir, roots: true, limit: 1 })].filter((s) => !s.time?.archived),
+          })
+          if (recent[0] && recent[0].id !== sessionId) {
+            refreshed.push({ scope: key, newId: recent[0].id })
+          }
         }
       } catch {
         staleKeys.push(key)
@@ -311,7 +320,10 @@ export abstract class MobileManagerBase {
     for (const key of staleKeys) {
       delete this.sessionMap[key]
     }
-    if (staleKeys.length > 0) await this.saveSessionMap()
+    for (const { scope, newId } of refreshed) {
+      this.sessionMap[scope] = newId
+    }
+    if (staleKeys.length > 0 || refreshed.length > 0) await this.saveSessionMap()
 
     if (this._initialDir) {
       await Instance.provide({
@@ -462,26 +474,20 @@ export abstract class MobileManagerBase {
   }
 
   protected async currentSession(scope: string, create?: boolean): Promise<string | undefined> {
-    const pinned = this.sessionMap[scope]
-    if (pinned) {
-      try {
-        const found = await Instance.provide({
-          directory: this.effectiveDir(scope),
-          fn: () => Session.get(SessionID.make(pinned)),
-        })
-        if (!found.time?.archived) return pinned
-      } catch {
-        // pinned session not found in DB
-      }
-      delete this.sessionMap[scope]
-      await this.saveSessionMap()
-    }
     const dir = this.effectiveDir(scope)
     if (!dir) return
     const recent = await Instance.provide({
       directory: dir,
       fn: () => [...Session.list({ directory: dir, roots: true, limit: 10 })].filter((s) => !s.time?.archived),
     })
+    const pinned = this.sessionMap[scope]
+    if (pinned) {
+      const stillValid = recent.some((s) => s.id === pinned)
+      if (stillValid && recent[0]?.id === pinned) return pinned
+      if (!stillValid) {
+        delete this.sessionMap[scope]
+      }
+    }
     if (recent[0]) {
       this.sessionMap[scope] = recent[0].id
       await this.saveSessionMap()


### PR DESCRIPTION
### Issue for this PR

Closes #552

### Type of change

- [x] Bug fix

### What does this PR do?

In `initSessions`, refresh stale-but-not-archived mappings to point to the latest session. In `currentSession`, validate pinned session against the recent list and fall through to the latest when pinned is no longer the newest, avoiding a separate `Session.get` call.

### How did you verify your code works?

`bun typecheck` passes locally via pre-push hook.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR