### PR TITLE
fix: clear orphaned time.compacted and skip orphaned CompTriggers in revert and fork

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -717,9 +717,31 @@ export namespace Session {
         await SessionPreference.update({ sessionID: session.id, ...prefData })
       }
       const idMap = new Map<string, MessageID>()
+      const copyIDs = new Set<string>()
+      for (const msg of msgs) {
+        if (input.messageID && msg.info.id >= input.messageID) break
+        copyIDs.add(msg.info.id)
+      }
+      const completedCompactionTriggers = new Set<string>()
+      for (const msg of msgs) {
+        if (!copyIDs.has(msg.info.id)) continue
+        if (msg.info.role === "assistant" && msg.info.summary && msg.info.finish && !msg.info.error)
+          completedCompactionTriggers.add(msg.info.parentID)
+      }
+      const orphanedCompactionTriggers = new Set<string>()
+      for (const msg of msgs) {
+        if (!copyIDs.has(msg.info.id)) continue
+        if (
+          msg.info.role === "user" &&
+          msg.parts.some((part) => part.type === "compaction") &&
+          !completedCompactionTriggers.has(msg.info.id)
+        )
+          orphanedCompactionTriggers.add(msg.info.id)
+      }
 
       for (const msg of msgs) {
         if (input.messageID && msg.info.id >= input.messageID) break
+        if (orphanedCompactionTriggers.has(msg.info.id)) continue
         const newID = MessageID.ascending()
         idMap.set(msg.info.id, newID)
 
@@ -732,8 +754,16 @@ export namespace Session {
         })
 
         for (const part of msg.parts) {
+          const next =
+            part.type === "tool" && part.state.status === "completed" && part.state.time.compacted
+              ? (() => {
+                  const time = { ...part.state.time }
+                  delete time.compacted
+                  return { ...part, state: { ...part.state, time } }
+                })()
+              : part
           await updatePart({
-            ...part,
+            ...next,
             id: PartID.ascending(),
             messageID: cloned.id,
             sessionID: session.id,

--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -158,6 +158,37 @@ export namespace SessionRevert {
         messageID: msg.info.id,
       })
     }
+    const completedCompactionTriggers = new Set<string>()
+    for (const msg of preserve) {
+      if (msg.info.role === "assistant" && msg.info.summary && msg.info.finish && !msg.info.error)
+        completedCompactionTriggers.add(msg.info.parentID)
+    }
+    const orphanedCompactionTriggers: MessageV2.WithParts[] = []
+    for (const msg of preserve) {
+      if (
+        msg.info.role === "user" &&
+        msg.parts.some((part) => part.type === "compaction") &&
+        !completedCompactionTriggers.has(msg.info.id)
+      )
+        orphanedCompactionTriggers.push(msg)
+    }
+    for (const msg of orphanedCompactionTriggers) {
+      preserve.splice(preserve.indexOf(msg), 1)
+      SyncEvent.run(MessageV2.Event.Removed, {
+        sessionID: sessionID,
+        messageID: msg.info.id,
+      })
+      if (msg === target) target = undefined
+    }
+    for (const msg of preserve) {
+      for (const part of msg.parts) {
+        if (part.type === "tool" && part.state.status === "completed" && part.state.time.compacted) {
+          const time = { ...part.state.time }
+          delete time.compacted
+          await Session.updatePart({ ...part, state: { ...part.state, time } })
+        }
+      }
+    }
     if (session.revert.partID && target) {
       const partID = session.revert.partID
       const removeStart = target.parts.findIndex((part) => part.id === partID)


### PR DESCRIPTION
### Issue for this PR

Closes #555

### Type of change

- [x] Bug fix

### What does this PR do?

Revert 和 fork 在 compaction 之后操作时，会留下两种孤儿状态导致会话上下文污染：

1. **`time.compacted` 标志残留**：`prune()` 在工具输出上设置 `time.compacted` 是只写操作（永不清除）。当 CompSummary 消息被删除（revert）或未拷贝（fork）后，这些标志变成了孤儿——`toModelMessages()` 将输出渲染为 `[Old tool result content cleared]` 但没有 summary 文本解释做了什么，模型严重失忆。

   **修复**：在 revert cleanup 和 fork 克隆时，清除所有 `time.compacted` 标志（不可变 spread+delete 风格），恢复原始工具输出。被存活 CompSummary 覆盖的消息本来不会进入模型上下文（`filterCompacted` 会 break），清除无害。

2. **孤儿 CompTrigger**：CompTrigger 是纯合成消息（只有 CompactionPart），渲染为 `"What did we do so far?"`。如果其 CompSummary 不在同一范围（被删除/未拷贝），模型看到一个没有回答的问题。

   **修复**：检测孤儿 CompTrigger（没有 completed CompSummary 的 CompTrigger），revert 中删除它们并置 `target = undefined`，fork 中跳过不拷贝。

### How did you verify your code works?

- `bun typecheck` 通过（所有 19 个 package）
- 逻辑审查：遍历 revert/fork 所有边界场景（CompTrigger+CompSummary 同侧、CompTrigger 在 preserve 而 CompSummary 在 remove、target 是孤儿 CompTrigger 等），确认无遗漏

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR