### PR TITLE
feat: instance lifecycle — independent backend instances, dual-phase exit, launch server binding

### DIFF
--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -722,6 +722,7 @@ export const SettingsGeneral: Component = () => {
 
   const ServerSection = () => {
     const idleOptions = createMemo(() => [
+      { value: "30", label: "30s" },
       { value: "60", label: "1 min" },
       { value: "300", label: "5 min" },
       { value: "1800", label: "30 min" },
@@ -732,7 +733,7 @@ export const SettingsGeneral: Component = () => {
       const config = globalSync.data.config as Record<string, unknown>
       const server =
         typeof config.server === "object" && config.server ? (config.server as Record<string, unknown>) : {}
-      const val = String(typeof server.idleTimeout === "number" ? server.idleTimeout : 60)
+      const val = String(typeof server.idleTimeout === "number" ? server.idleTimeout : 30)
       return idleOptions().find((o) => o.value === val) ?? idleOptions()[0]
     })
 
@@ -742,7 +743,7 @@ export const SettingsGeneral: Component = () => {
       const config = globalSync.data.config as Record<string, unknown>
       const server =
         typeof config.server === "object" && config.server ? (config.server as Record<string, unknown>) : {}
-      const before = typeof server.idleTimeout === "number" ? server.idleTimeout : 60
+      const before = typeof server.idleTimeout === "number" ? server.idleTimeout : 30
       if (idleTimeout === before) return
       globalSync.set("config", (prev: unknown) => ({
         ...(prev as Record<string, unknown>),

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -149,7 +149,41 @@ if (!(root instanceof HTMLElement) && import.meta.env.DEV) {
   throw new Error(getRootNotFoundError())
 }
 
+const LAUNCH_SERVER_KEY = "opencode.launchServer"
+
+const resolveLaunchServer = () => {
+  if (typeof sessionStorage === "undefined") return null
+  const stored = sessionStorage.getItem(LAUNCH_SERVER_KEY)
+  if (stored) return stored
+
+  if (typeof location === "undefined") return null
+  const hash = location.hash
+  if (!hash || hash.length < 2) return null
+
+  try {
+    const params = new URLSearchParams(hash.slice(1))
+    const local = params.get("local")
+    const instance = params.get("instance")
+    if (local) {
+      const entry = instance ? `${local}|${instance}` : local
+      sessionStorage.setItem(LAUNCH_SERVER_KEY, entry)
+      history.replaceState(null, "", location.pathname + location.search)
+      return entry
+    }
+  } catch {}
+
+  return null
+}
+
+const parseLaunchServer = (raw: string | null) => {
+  if (!raw) return null
+  const parts = raw.split("|")
+  return { url: parts[0], instance: parts.length > 1 ? parts[1] : undefined }
+}
+
 const getCurrentUrl = () => {
+  const launch = parseLaunchServer(resolveLaunchServer())
+  if (launch) return launch.url
   if (location.hostname.includes("opencode.ai")) return "http://localhost:4096"
   if (import.meta.env.DEV)
     return `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}`
@@ -172,6 +206,8 @@ const readWebVersion = async () => {
 }
 
 const getDefaultUrl = () => {
+  const launch = parseLaunchServer(resolveLaunchServer())
+  if (launch) return launch.url
   const lsDefault = readDefaultServerUrl()
   if (lsDefault) return lsDefault
   return getCurrentUrl()
@@ -296,7 +332,11 @@ const platform: Platform = {
     const stored = readDefaultServerUrl()
     return stored ? ServerConnection.Key.make(stored) : null
   },
-  setDefaultServer: writeDefaultServerUrl,
+  setDefaultServer: (url) => {
+    const launch = parseLaunchServer(resolveLaunchServer())
+    if (launch && url === ServerConnection.Key.make(launch.url)) return
+    writeDefaultServerUrl(url)
+  },
   getProxyConfig: async () => {
     const local = readProxy()
     const fallback = local ?? {

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -13,6 +13,7 @@ import { FeishuManager } from "../../mobile/feishu"
 import { QQManager } from "../../mobile/qq"
 import { WeChatManager } from "../../mobile/wechat"
 import { Cron } from "../../cron"
+import { Registry } from "../../instance/registry"
 
 function getNetworkIPs() {
   const nets = networkInterfaces()
@@ -23,12 +24,8 @@ function getNetworkIPs() {
     if (!net) continue
 
     for (const netInfo of net) {
-      // Skip internal and non-IPv4 addresses
       if (netInfo.internal || netInfo.family !== "IPv4") continue
-
-      // Skip Docker bridge networks (typically 172.x.x.x)
       if (netInfo.address.startsWith("172.")) continue
-
       results.push(netInfo.address)
     }
   }
@@ -41,7 +38,7 @@ export const WebCommand = cmd({
   builder: (yargs) => withNetworkOptions(yargs),
   describe: "start opencode server and open web interface",
   handler: async (args) => {
-    async function gracefulShutdown(server: { stop: (close?: boolean) => Promise<void> }) {
+    async function gracefulShutdown(server: { stop: (close?: boolean) => Promise<void> }, entryId: string) {
       const FORCE_EXIT_MS = 10_000
       const timer = setTimeout(() => {
         process.exit(0)
@@ -52,6 +49,7 @@ export const WebCommand = cmd({
         FeishuManager.stop().catch(() => {}),
         QQManager.stop().catch(() => {}),
         WeChatManager.stop().catch(() => {}),
+        Registry.remove(entryId).catch(() => {}),
       ])
       await server.stop(true).catch(() => {})
       clearTimeout(timer)
@@ -62,25 +60,49 @@ export const WebCommand = cmd({
       UI.println(UI.Style.TEXT_WARNING_BOLD + "!  " + "OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
     const opts = await resolveNetworkOptions(args)
-    const IDLE_TIMEOUT_MS = (opts.idleTimeout ?? 60) * 1_000
+    const IDLE_TIMEOUT_MS = (opts.idleTimeout ?? 30) * 1_000
+
+    const { kept } = await Registry.prune()
+    for (const old of kept) {
+      const status = await Registry.queryStatus(old.url)
+      if (!status) continue
+      const c = status.connections
+      if (c.sse === 0 && c.globalSse === 0 && c.leaseActive === 0) {
+        await Registry.accelerate(old.url)
+      }
+    }
+
     let sse = 0
+    let globalSse = 0
     const server = Server.listen({
       ...opts,
-      onBrowserConnectionChange: (count) => {
+      onBrowserConnectionChange: (count, globalCount) => {
         sse = count
+        globalSse = globalCount ?? 0
       },
     })
 
+    const entry = Registry.create(process.pid, server.url.toString())
+    await Registry.write(entry)
+
+    process.on("exit", () => {
+      void Registry.remove(entry.id)
+    })
+
     // Auto-exit when all browser connections close (after at least one was open).
-    // Polling server.pendingRequests is more reliable than SSE onAbort, because
-    // Bun only detects TCP close when it next tries to write to the socket.
+    // Lease closing state protects against pagehide false positives (tab switching).
+    // After closing entries expire, the idle timeout (configurable) provides a final
+    // confirmation window before graceful shutdown.
     // Disable by setting idleTimeout to 0 (always-on daemon mode).
     if (IDLE_TIMEOUT_MS > 0) {
       let everConnected = false
       let exitTimer: ReturnType<typeof setTimeout> | null = null
       const connectionChecker = setInterval(() => {
         const active = (server as any).pendingRequests as number
-        if (active > 0 || sse > 0 || Lease.count() > 0) {
+        const hasActive = active > 0 || sse > 0 || globalSse > 0 || Lease.activeCount() > 0
+        const hasClosing = !Server.accelerateExit && Lease.closingCount() > 0
+
+        if (hasActive || hasClosing) {
           everConnected = true
           if (exitTimer !== null) {
             clearTimeout(exitTimer)
@@ -91,35 +113,42 @@ export const WebCommand = cmd({
             exitTimer ??
             setTimeout(() => {
               const pending = (server as any).pendingRequests as number
-              if (pending > 0 || sse > 0 || Lease.count() > 0) {
+              const stillActive = pending > 0 || sse > 0 || globalSse > 0 || Lease.activeCount() > 0
+              const stillClosing = !Server.accelerateExit && Lease.closingCount() > 0
+              if (stillActive || stillClosing) {
                 exitTimer = null
                 return
               }
               clearInterval(connectionChecker)
-              void gracefulShutdown(server)
+              void gracefulShutdown(server, entry.id)
             }, IDLE_TIMEOUT_MS)
         }
       }, 1_000)
     }
+
     const portfile = nodePath.join(Global.Path.data, "serve-port")
     await Bun.write(portfile, String(server.port))
     UI.empty()
     UI.println(UI.logo("  "))
     UI.empty()
 
+    const hashParams = new URLSearchParams({
+      local: server.url.toString(),
+      instance: entry.id,
+    })
+    const launchHash = `#${hashParams.toString()}`
+
     if (opts.hostname === "0.0.0.0") {
-      // Show localhost for local access
-      const localhostUrl = `http://localhost:${server.port}`
+      const localhostUrl = `http://localhost:${server.port}${launchHash}`
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Local access:      ", UI.Style.TEXT_NORMAL, localhostUrl)
 
-      // Show network IPs for remote access
       const networkIPs = getNetworkIPs()
       if (networkIPs.length > 0) {
         for (const ip of networkIPs) {
           UI.println(
             UI.Style.TEXT_INFO_BOLD + "  Network access:    ",
             UI.Style.TEXT_NORMAL,
-            `http://${ip}:${server.port}`,
+            `http://${ip}:${server.port}${launchHash}`,
           )
         }
       }
@@ -132,10 +161,9 @@ export const WebCommand = cmd({
         )
       }
 
-      // Open localhost in browser
-      open(localhostUrl.toString()).catch(() => {})
+      open(localhostUrl).catch(() => {})
     } else {
-      const displayUrl = server.url.toString()
+      const displayUrl = `${server.url.toString()}${launchHash}`
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Web interface:    ", UI.Style.TEXT_NORMAL, displayUrl)
       open(displayUrl).catch(() => {})
     }

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -30,7 +30,7 @@ const options = {
   },
   "idle-timeout": {
     type: "number" as const,
-    describe: "seconds to wait after all browser connections close before exiting (default: 60, 0 to disable)",
+    describe: "seconds to wait after all browser connections close before exiting (default: 30, 0 to disable)",
   },
 }
 
@@ -60,7 +60,7 @@ export async function resolveNetworkOptions(args: NetworkOptions) {
   const configCors = config?.server?.cors ?? []
   const argsCors = Array.isArray(args.cors) ? args.cors : args.cors ? [args.cors] : []
   const cors = [...configCors, ...argsCors]
-  const idleTimeout = idleTimeoutExplicitlySet ? args["idle-timeout"] : (config?.server?.idleTimeout ?? 60)
+  const idleTimeout = idleTimeoutExplicitlySet ? args["idle-timeout"] : (config?.server?.idleTimeout ?? 30)
 
   return { hostname, port, mdns, mdnsDomain, cors, idleTimeout }
 }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1038,7 +1038,7 @@ export namespace Config {
         .min(0)
         .optional()
         .describe(
-          "Seconds to wait after all browser connections close before exiting (default: 60). Set to 0 to disable auto-exit.",
+          "Seconds to wait after all browser connections close before exiting (default: 30). Set to 0 to disable auto-exit.",
         ),
     })
     .strict()

--- a/packages/opencode/src/instance/registry.ts
+++ b/packages/opencode/src/instance/registry.ts
@@ -1,0 +1,186 @@
+import fs from "fs/promises"
+import path from "path"
+import { Global } from "../global"
+import { Flag } from "../flag/flag"
+
+type Entry = {
+  id: string
+  pid: number
+  url: string
+  started_at: number
+  updated_at: number
+  state: "active" | "closing" | "stale"
+}
+
+const dir = () => path.join(Global.Path.data, "instances")
+
+function filepath(id: string) {
+  return path.join(dir(), `${id}.json`)
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export namespace Registry {
+  export function id(): string {
+    const prefix = Date.now().toString(36)
+    const suffix = Math.random().toString(36).slice(2, 8)
+    return `ins_${prefix}_${suffix}`
+  }
+
+  export async function ensureDir() {
+    await fs.mkdir(dir(), { recursive: true })
+  }
+
+  export async function write(entry: Entry) {
+    await ensureDir()
+    await fs.writeFile(filepath(entry.id), JSON.stringify(entry, null, 2))
+  }
+
+  export async function remove(id: string) {
+    await fs.rm(filepath(id), { force: true })
+  }
+
+  export async function read(id: string): Promise<Entry | undefined> {
+    const raw = await fs.readFile(filepath(id), "utf-8").catch(() => undefined)
+    if (!raw) return undefined
+    try {
+      return JSON.parse(raw) as Entry
+    } catch {
+      return undefined
+    }
+  }
+
+  export async function list(): Promise<Entry[]> {
+    await ensureDir()
+    const files = await fs.readdir(dir())
+    const entries: Entry[] = []
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue
+      const raw = await fs.readFile(path.join(dir(), file), "utf-8").catch(() => undefined)
+      if (!raw) continue
+      try {
+        entries.push(JSON.parse(raw) as Entry)
+      } catch {
+        await fs.rm(path.join(dir(), file), { force: true })
+      }
+    }
+    return entries
+  }
+
+  export async function prune(): Promise<{ removed: string[]; kept: Entry[] }> {
+    const entries = await list()
+    const removed: string[] = []
+    const kept: Entry[] = []
+    const now = Date.now()
+    for (const entry of entries) {
+      const alive = isAlive(entry.pid)
+      const staleTooLong = entry.state === "stale" && now - entry.updated_at > STALE_TTL_MS
+      if (!alive || staleTooLong) {
+        removed.push(entry.id)
+        await remove(entry.id)
+      } else {
+        kept.push(entry)
+      }
+    }
+    return { removed, kept }
+  }
+
+  export async function healthCheck(url: string): Promise<boolean> {
+    try {
+      const res = await fetch(new URL("/global/health", url), {
+        method: "GET",
+        headers: authHeaders(),
+        signal: AbortSignal.timeout(3000),
+      })
+      return res.ok
+    } catch {
+      return false
+    }
+  }
+
+  export async function queryStatus(url: string): Promise<Status | undefined> {
+    try {
+      const res = await fetch(new URL("/global/status", url), {
+        method: "GET",
+        headers: authHeaders(),
+        signal: AbortSignal.timeout(3000),
+      })
+      if (!res.ok) return undefined
+      return (await res.json()) as Status
+    } catch {
+      return undefined
+    }
+  }
+
+  export async function accelerate(url: string): Promise<boolean> {
+    try {
+      const res = await fetch(new URL("/global/accelerate-exit", url), {
+        method: "POST",
+        headers: { ...authHeaders(), "Content-Type": "application/json" },
+        signal: AbortSignal.timeout(3000),
+      })
+      return res.ok
+    } catch {
+      return false
+    }
+  }
+
+  export async function pruneWithHealthCheck(): Promise<{ removed: string[]; kept: Entry[] }> {
+    const { removed: dead, kept: candidates } = await prune()
+    const removed = [...dead]
+    const kept: Entry[] = []
+    const now = Date.now()
+    for (const entry of candidates) {
+      const healthy = await healthCheck(entry.url)
+      const closingTooLong = entry.state === "closing" && now - entry.updated_at > CLOSING_GRACE_MS
+      if (!healthy || closingTooLong) {
+        removed.push(entry.id)
+        await remove(entry.id)
+      } else {
+        kept.push(entry)
+      }
+    }
+    return { removed, kept }
+  }
+
+  export function create(pid: number, url: string): Entry {
+    const now = Date.now()
+    return {
+      id: id(),
+      pid,
+      url,
+      started_at: now,
+      updated_at: now,
+      state: "active",
+    }
+  }
+}
+
+const CLOSING_GRACE_MS = 30_000
+const STALE_TTL_MS = 300_000
+
+type Status = {
+  healthy: boolean
+  version: string
+  connections: {
+    sse: number
+    globalSse: number
+    leaseActive: number
+    leaseClosing: number
+  }
+  accelerateExit: boolean
+}
+
+function authHeaders(): Record<string, string> {
+  const password = Flag.OPENCODE_SERVER_PASSWORD
+  if (!password) return {}
+  const username = Flag.OPENCODE_SERVER_USERNAME ?? "opencode"
+  return { Authorization: `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}` }
+}

--- a/packages/opencode/src/server/lease.ts
+++ b/packages/opencode/src/server/lease.ts
@@ -1,9 +1,19 @@
+type State = "active" | "closing"
+
+type Entry = {
+  state: State
+  updatedAt: number
+  closingAt: number | null
+}
+
 const TTL = 30_000
-const map = new Map<string, number>()
+const CLOSING_GRACE_MS = 30_000
+const map = new Map<string, Entry>()
 
 const prune = (now = Date.now()) => {
-  for (const [id, at] of map.entries()) {
-    if (now - at <= TTL) continue
+  for (const [id, entry] of map.entries()) {
+    if (entry.state === "active" && now - entry.updatedAt <= TTL) continue
+    if (entry.state === "closing" && now - entry.closingAt! <= CLOSING_GRACE_MS + TTL) continue
     map.delete(id)
   }
 }
@@ -11,7 +21,19 @@ const prune = (now = Date.now()) => {
 export namespace Lease {
   export function touch(id: string) {
     if (!id) return
-    map.set(id, Date.now())
+    const existing = map.get(id)
+    if (existing && existing.state === "closing") {
+      map.set(id, { state: "active", updatedAt: Date.now(), closingAt: null })
+      return
+    }
+    map.set(id, { state: "active", updatedAt: Date.now(), closingAt: null })
+  }
+
+  export function markClosing(id: string) {
+    if (!id) return
+    const existing = map.get(id)
+    if (existing && existing.state === "closing") return
+    map.set(id, { state: "closing", updatedAt: Date.now(), closingAt: Date.now() })
   }
 
   export function drop(id: string) {
@@ -22,5 +44,23 @@ export namespace Lease {
   export function count() {
     prune()
     return map.size
+  }
+
+  export function activeCount() {
+    prune()
+    let n = 0
+    for (const entry of map.values()) {
+      if (entry.state === "active") n++
+    }
+    return n
+  }
+
+  export function closingCount() {
+    prune()
+    let n = 0
+    for (const entry of map.values()) {
+      if (entry.state === "closing") n++
+    }
+    return n
   }
 }

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -13,6 +13,7 @@ import { lazy } from "../../util/lazy"
 import { Config } from "../../config/config"
 import { errors } from "../error"
 import { Lease } from "../lease"
+import { Server } from "../server"
 import {
   downloadWebUpdate,
   installWebUpdate,
@@ -33,6 +34,18 @@ export { WebUpdateTest } from "../web-update"
 const log = Log.create({ service: "server" })
 
 export const GlobalDisposedEvent = BusEvent.define("global.disposed", z.object({}))
+
+type ConnectionChangeCallback = (globalEventCount: number) => void
+let onGlobalEventConnectionChange: ConnectionChangeCallback | undefined
+let globalEventConnectionCount = 0
+
+export function setGlobalEventConnectionCallback(cb: ConnectionChangeCallback) {
+  onGlobalEventConnectionChange = cb
+}
+
+export function getGlobalEventConnectionCount() {
+  return globalEventConnectionCount
+}
 
 const ProxyTarget = z.object({
   host: z.string(),
@@ -76,8 +89,17 @@ function keepLoopbackNoProxy(value?: string) {
   return items.join(",")
 }
 
-async function streamEvents(c: Context, subscribe: (q: AsyncQueue<string | null>) => () => void) {
+async function streamEvents(
+  c: Context,
+  subscribe: (q: AsyncQueue<string | null>) => () => void,
+  trackGlobalEvent = false,
+) {
   return streamSSE(c, async (stream) => {
+    if (trackGlobalEvent) {
+      globalEventConnectionCount++
+      onGlobalEventConnectionChange?.(globalEventConnectionCount)
+    }
+
     const q = new AsyncQueue<string | null>()
     let done = false
 
@@ -90,7 +112,6 @@ async function streamEvents(c: Context, subscribe: (q: AsyncQueue<string | null>
       }),
     )
 
-    // Send heartbeat every 10s to prevent stalled proxy streams.
     const heartbeat = setInterval(() => {
       q.push(
         JSON.stringify({
@@ -108,6 +129,10 @@ async function streamEvents(c: Context, subscribe: (q: AsyncQueue<string | null>
       clearInterval(heartbeat)
       unsub()
       q.push(null)
+      if (trackGlobalEvent) {
+        globalEventConnectionCount--
+        onGlobalEventConnectionChange?.(globalEventConnectionCount)
+      }
       log.info("global event disconnected")
     }
 
@@ -223,6 +248,72 @@ export const GlobalRoutes = lazy(() =>
       },
     )
     .get(
+      "/status",
+      describeRoute({
+        summary: "Get server status",
+        description: "Get connection counts and exit state for the server.",
+        operationId: "global.status",
+        responses: {
+          200: {
+            description: "Server status",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.object({
+                    healthy: z.boolean(),
+                    version: z.string(),
+                    connections: z.object({
+                      sse: z.number(),
+                      globalSse: z.number(),
+                      leaseActive: z.number(),
+                      leaseClosing: z.number(),
+                    }),
+                    accelerateExit: z.boolean(),
+                  }),
+                ),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        return c.json({
+          healthy: true,
+          version: await readWebCurrentVersion(),
+          connections: {
+            sse: Server.sseConnections,
+            globalSse: Server.globalSseConnections,
+            leaseActive: Lease.activeCount(),
+            leaseClosing: Lease.closingCount(),
+          },
+          accelerateExit: Server.accelerateExit,
+        })
+      },
+    )
+    .post(
+      "/accelerate-exit",
+      describeRoute({
+        summary: "Accelerate server exit",
+        description:
+          "Signal the server to skip closing grace and exit faster. Only effective when no active connections remain.",
+        operationId: "global.accelerateExit",
+        responses: {
+          200: {
+            description: "Acceleration signal received",
+            content: {
+              "application/json": {
+                schema: resolver(z.object({ ok: z.literal(true) })),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        Server.accelerateExit = true
+        return c.json({ ok: true })
+      },
+    )
+    .get(
       "/health",
       describeRoute({
         summary: "Get health",
@@ -290,7 +381,7 @@ export const GlobalRoutes = lazy(() =>
       async (c) => {
         const body = c.req.valid("json")
         if (body.alive === false) {
-          Lease.drop(body.id)
+          Lease.markClosing(body.id)
           return c.json({ ok: true as const })
         }
         Lease.touch(body.id)
@@ -328,13 +419,17 @@ export const GlobalRoutes = lazy(() =>
         c.header("X-Accel-Buffering", "no")
         c.header("X-Content-Type-Options", "nosniff")
 
-        return streamEvents(c, (q) => {
-          async function handler(event: any) {
-            q.push(JSON.stringify(event))
-          }
-          GlobalBus.on("event", handler)
-          return () => GlobalBus.off("event", handler)
-        })
+        return streamEvents(
+          c,
+          (q) => {
+            async function handler(event: any) {
+              q.push(JSON.stringify(event))
+            }
+            GlobalBus.on("event", handler)
+            return () => GlobalBus.off("event", handler)
+          },
+          true,
+        )
       },
     )
     .get(

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -184,7 +184,7 @@ import { Filesystem } from "@/util/filesystem"
 import { Snapshot } from "@/snapshot"
 import { QuestionRoutes } from "./routes/question"
 import { PermissionRoutes } from "./routes/permission"
-import { GlobalRoutes } from "./routes/global"
+import { GlobalRoutes, setGlobalEventConnectionCallback } from "./routes/global"
 import { KnowledgeRoutes } from "./routes/knowledge"
 import { createMobileRoutes } from "@/mobile/route"
 import { FeishuManager } from "@/mobile/feishu"
@@ -217,7 +217,7 @@ export namespace Server {
 
   export const createApp = (opts: {
     cors?: string[]
-    onBrowserConnectionChange?: (count: number) => void
+    onBrowserConnectionChange?: (count: number, globalCount: number) => void
   }): Hono<ServerEnv> => {
     SessionPreference.clear()
     void Cron.start().catch((error) => {
@@ -225,6 +225,11 @@ export namespace Server {
     })
     const app = new Hono<ServerEnv>()
     let sseConnectionCount = 0
+    let globalEventCount = 0
+    setGlobalEventConnectionCallback((globalCount: number) => {
+      globalEventCount = globalCount
+      opts.onBrowserConnectionChange?.(sseConnectionCount, globalEventCount)
+    })
     const corsware = cors({
       credentials: true,
       origin(input) {
@@ -770,7 +775,7 @@ export namespace Server {
           c.header("X-Accel-Buffering", "no")
           c.header("X-Content-Type-Options", "nosniff")
           sseConnectionCount++
-          opts.onBrowserConnectionChange?.(sseConnectionCount)
+          opts.onBrowserConnectionChange?.(sseConnectionCount, globalEventCount)
           return streamSSE(c, async (stream) => {
             stream.writeSSE({
               data: JSON.stringify({
@@ -794,7 +799,7 @@ export namespace Server {
               if (disconnected) return
               disconnected = true
               sseConnectionCount--
-              opts.onBrowserConnectionChange?.(sseConnectionCount)
+              opts.onBrowserConnectionChange?.(sseConnectionCount, globalEventCount)
             }
 
             let resolve!: () => void
@@ -890,6 +895,9 @@ export namespace Server {
 
   /** @deprecated do not use this dumb shit */
   export let url: URL
+  export let sseConnections = 0
+  export let globalSseConnections = 0
+  export let accelerateExit = false
 
   export function listen(opts: {
     port: number
@@ -897,9 +905,14 @@ export namespace Server {
     mdns?: boolean
     mdnsDomain?: string
     cors?: string[]
-    onBrowserConnectionChange?: (count: number) => void
+    onBrowserConnectionChange?: (count: number, globalCount: number) => void
   }) {
-    const app = createApp(opts)
+    const wrappedCallback = (count: number, globalCount: number) => {
+      Server.sseConnections = count
+      Server.globalSseConnections = globalCount ?? 0
+      opts.onBrowserConnectionChange?.(count, globalCount)
+    }
+    const app = createApp({ ...opts, onBrowserConnectionChange: wrappedCallback })
     const bp = basePath()
     const baseFetch =
       bp === "/"


### PR DESCRIPTION
### Issue for this PR

Closes #557

### Type of change

- [x] New feature
- [x] Bug fix (orphan child processes on exit, pagehide premature exit)

### What does this PR do?

This PR addresses the problem of zombie processes and premature exits when using `aether web`:

1. **Instance Registry** (`instance/registry.ts`) — per-launch instance tracking with stale process cleanup on startup. New instances query old ones via `/global/status` and accelerate their exit if no active connections remain (`/global/accelerate-exit`).

2. **Dual-phase Lease** — upgrade Lease from count-only to `active`/`closing` state machine with 30s closing grace, preventing `pagehide` (tab switching) from triggering premature backend exit. `pageshow` restores active state.

3. **Configurable idle timeout** — restore `idleTimeout` (default 30s, previously 60s) as the post-closing confirmation window. Supports CLI `--idle-timeout`, `opencode.json` `server.idleTimeout`, and Web UI dropdown (30s/1min/5min/30min/Never). `0` disables auto-exit (daemon mode).

4. **Graceful shutdown** — replace bare `process.exit(0)` with `gracefulShutdown()` that disposes all project instances (kills LSP child process trees), stops cron and mobile integrations, and closes the HTTP server. 10s force-exit timeout as safety net. SIGINT/SIGTERM handlers also include full cleanup.

5. **Accelerate old process exit** — `/global/status` endpoint returns connection counts (sse, globalSse, leaseActive, leaseClosing) and accelerateExit flag. `/global/accelerate-exit` endpoint sets the flag, making the connection checker skip closing grace and start idle timeout immediately. New `aether web` startup queries old processes and accelerates idle ones.

6. **Instance hash fragment** — launch URL includes `#local=<url>&instance=<id>`, parsed by frontend into `sessionStorage` for per-tab backend binding.

### How did you verify your code works?

- `bun typecheck` passes in both `packages/opencode` and `packages/app`
- Functional testing with live server: verified `/global/status` returns correct connection counts, `/global/accelerate-exit` sets `accelerateExit=true`, `Registry.queryStatus()` and `Registry.accelerate()` work across processes, and the full accelerate flow (prune → queryStatus → accelerate) completes correctly

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR