### PR TITLE
fix: use query param for WebSocket auth instead of URL-embedded credentials

### DIFF
--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -518,9 +518,10 @@ export const Terminal = (props: TerminalProps) => {
         const next = new URL(url + `/pty/${id}/connect`)
         next.searchParams.set("directory", directory)
         next.searchParams.set("cursor", String(seek))
+        if (password) {
+          next.searchParams.set("token", btoa(`${username}:${password}`))
+        }
         next.protocol = next.protocol === "https:" ? "wss:" : "ws:"
-        next.username = username
-        next.password = password
 
         const socket = new WebSocket(next)
         socket.binaryType = "arraybuffer"


### PR DESCRIPTION
### Issue for this PR

Related to #522

### Type of change

- [x] Bug fix

### What does this PR do?

When deploying behind a reverse proxy (e.g. SCOW), WebSocket connections fail because the browser sends auth credentials as URL-embedded `user:pass@host` format. Reverse proxies do not forward these credentials in WebSocket upgrade requests, causing basicAuth middleware to reject the connection.

The terminal component now sends auth as a `token` query parameter (`btoa(username:password)`) instead of embedding `username`/`password` in the URL authority. The server-side token-to-header middleware (already committed in the base-path fix PR) converts this back to an `Authorization: Basic ...` header so basicAuth validates it normally.

### How did you verify your code works?

- `bun typecheck` passes for both `packages/opencode` and `packages/app`
- All base-path tests pass (`test/server/server-web-cache.test.ts`)

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR