### PR TITLE
refactor: unify busy-state logic across UI and propagate child working to parent

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -256,7 +256,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       (msg) => msg.role === "assistant" && typeof msg.time.completed !== "number",
     ),
   )
-  const { working } = createWorkingState({ status: () => status(), pending: () => pending() })
+  const { interactive: working } = createWorkingState({ status: () => status(), pending: () => pending() })
   const tip = () => {
     if (working()) {
       return (

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -339,7 +339,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
           typeof (message as { time?: { completed?: unknown } }).time?.completed !== "number",
       ),
     blocked: hasPermissions,
-  }).working
+  }).visual
 
   const tint = createMemo(() => {
     return messageAgentColor(sessionStore.message[props.session.id], sessionStore.agent)

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -330,7 +330,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
       return !permission.autoResponds(item, props.session.directory)
     })
   })
-  const isWorking = createWorkingState({
+  const selfWorking = createWorkingState({
     status: () => sessionStore.session_status[props.session.id],
     pending: () =>
       (sessionStore.message[props.session.id] ?? []).findLast(
@@ -340,6 +340,22 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
       ),
     blocked: hasPermissions,
   }).visual
+  const childWorking = createMemo(() => {
+    const ids = props.children.get(props.session.id)
+    if (!ids?.length) return false
+    for (const id of ids) {
+      const status = sessionStore.session_status[id]
+      if (status?.type === "busy" || status?.type === "retry") return true
+      const pending = (sessionStore.message[id] ?? []).findLast(
+        (message) =>
+          message.role === "assistant" &&
+          typeof (message as { time?: { completed?: unknown } }).time?.completed !== "number",
+      )
+      if (pending) return true
+    }
+    return false
+  })
+  const isWorking = createMemo(() => selfWorking() || childWorking())
 
   const tint = createMemo(() => {
     return messageAgentColor(sessionStore.message[props.session.id], sessionStore.agent)

--- a/packages/app/src/pages/session/composer/session-composer-state.ts
+++ b/packages/app/src/pages/session/composer/session-composer-state.ts
@@ -114,7 +114,7 @@ export function createSessionComposerState(options?: { closeMs?: number | (() =>
     ),
   )
 
-  const { working: busy } = createWorkingState({ status: () => status(), pending: () => pending() })
+  const { visual: busy } = createWorkingState({ status: () => status(), pending: () => pending() })
   const live = createMemo(() => {
     if (test.on && test.live !== undefined) return test.live
     return busy() || blocked()

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -1,4 +1,5 @@
 import { For, createEffect, createMemo, on, onCleanup, Show, Index, type JSX, createSignal } from "solid-js"
+import { createWorkingState } from "@/utils/working-state"
 import { createStore, produce, reconcile } from "solid-js/store"
 import { useNavigate } from "@solidjs/router"
 import { useMutation } from "@tanstack/solid-query"
@@ -31,7 +32,13 @@ import { useSettings } from "@/context/settings"
 import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
 import { messageAgentColor } from "@/utils/agent"
-import { formatReadingPageRange, parseCommentNote, readCommentMetadata, readReadingQuoteMetadata, type ReadingQuote } from "@/utils/comment-note"
+import {
+  formatReadingPageRange,
+  parseCommentNote,
+  readCommentMetadata,
+  readReadingQuoteMetadata,
+  type ReadingQuote,
+} from "@/utils/comment-note"
 import { makeTimer } from "@solid-primitives/timer"
 import { createChatFind, ChatFindBar } from "@/pages/session/chat-find"
 
@@ -297,7 +304,10 @@ export function MessageTimeline(props: {
     if (!id) return idle
     return sync.data.session_status[id] ?? idle
   })
-  const working = createMemo(() => !!pending() || sessionStatus().type !== "idle")
+  const { visual: working } = createWorkingState({
+    status: () => sessionStatus(),
+    pending: () => pending(),
+  })
   const tint = createMemo(() => messageAgentColor(sessionMessages(), sync.data.agent))
 
   const [timeoutDone, setTimeoutDone] = createSignal(true)
@@ -348,7 +358,9 @@ export function MessageTimeline(props: {
     const visible = new Set(rendered())
     const pending = new Set(
       sessionMessages()
-        .filter((item): item is AssistantMessage => item.role === "assistant" && typeof item.time.completed !== "number")
+        .filter(
+          (item): item is AssistantMessage => item.role === "assistant" && typeof item.time.completed !== "number",
+        )
         .map((item) => item.parentID)
         .filter((item): item is string => !!item),
     )
@@ -1197,7 +1209,10 @@ export function MessageTimeline(props: {
                                           }}
                                         >
                                           <div class="flex items-center gap-1.5 min-w-0 text-11-medium text-text-strong">
-                                            <FileIcon node={{ path: q().pdfFileName, type: "file" }} class="size-3.5 shrink-0" />
+                                            <FileIcon
+                                              node={{ path: q().pdfFileName, type: "file" }}
+                                              class="size-3.5 shrink-0"
+                                            />
                                             <span class="truncate">{q().pdfFileName}</span>
                                           </div>
                                           <div class="pt-1 text-11-medium text-text-weak">

--- a/packages/app/src/utils/working-state.ts
+++ b/packages/app/src/utils/working-state.ts
@@ -1,4 +1,4 @@
-import { createEffect, createMemo, createSignal, onCleanup } from "solid-js"
+import { createEffect, createMemo, createSignal } from "solid-js"
 import { makeTimer } from "@solid-primitives/timer"
 
 const GRACE_MS = 3000
@@ -27,7 +27,7 @@ export function createWorkingState(input: {
     }
   })
 
-  const working = createMemo(() => {
+  const visual = createMemo(() => {
     if (input.blocked?.()) return false
     const s = input.status()
     if (s?.type === "busy" || s?.type === "retry") return true
@@ -35,5 +35,10 @@ export function createWorkingState(input: {
     return false
   })
 
-  return { working, grace }
+  const interactive = createMemo(() => {
+    const s = input.status()
+    return s?.type === "busy" || s?.type === "retry"
+  })
+
+  return { visual, interactive, grace }
 }


### PR DESCRIPTION
### Issue for this PR

Closes #570

### Type of change

- [x] Refactor / code improvement

### What does this PR do?

The busy/working state was determined differently across three UI locations (sidebar spinner, session header spinner, send/stop button), causing inconsistent behavior. This PR:

1. **Split `createWorkingState` into `visual` and `interactive` outputs** — `visual` (with grace period and pending fallback) is for spinner animations that tolerate brief delays; `interactive` (pure `session_status` check, no grace, no pending) is for interactive controls (send/stop button) that must respond immediately.
2. **Unified all locations to use `createWorkingState`** — `message-timeline.tsx` and `prompt-input.tsx` previously had custom inline logic (`!!pending() || status !== idle` and `status !== idle` respectively), now both use the hook.
3. **Propagate child session working state to parent** — when a fork session is busy, the parent session's sidebar spinner also shows busy.

Key insight: spinner animations can tolerate a 3s grace period (to avoid flickering from SSE delivery delays), but the send/stop button must not — if the session is truly idle, the user should be able to send a new message immediately, not wait 3 seconds.

### How did you verify your code works?

- `bun typecheck` passes for all packages
- Logic review: `interactive` output returns `true` only when `session_status` is `busy` or `retry`, matching the server-side authority signal. `visual` output retains the original grace period + pending fallback behavior.
- The `childWorking` memo checks both `session_status` and pending messages for each child, matching the visual logic without the blocked/grace complications.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR