### PR TITLE
fix: publish workflow 中 ossWarnings 不再阻断流程

### DIFF
--- a/.github/scripts/upload-downloadbeta.ts
+++ b/.github/scripts/upload-downloadbeta.ts
@@ -163,7 +163,9 @@ const done = await post(root, "/api/downloadbeta/admin/commit", pass, {
 })
 
 if (!commit(done)) fail("Invalid commit response")
-if (Array.isArray(done.ossWarnings) && done.ossWarnings.length > 0) fail("Commit returned OSS warnings")
+if (Array.isArray(done.ossWarnings) && done.ossWarnings.length > 0) {
+    console.warn("Commit returned OSS warnings:", JSON.stringify(done.ossWarnings))
+  }
 if (!Array.isArray(done.files) || done.files.length < Object.keys(items).length)
   fail("Commit response is missing files")
 const links = done.files.map(urls)


### PR DESCRIPTION
### Issue for this PR

Closes #568

### Type of change

- [x] Bug fix

### What does this PR do?

`upload-downloadbeta.ts` 在 commit API 返回 `ok: true` 但附带 `ossWarnings` 时，原代码调用 `fail()` 导致 `process.exit(1)`，使整个 workflow 失败。实际上产物已成功上传，`ossWarnings` 仅是非关键提示信息。改为 `console.warn()` 输出警告日志，不再中断流程。

### How did you verify your code works?

`bun build --no-bundle` 验证脚本无语法/类型错误。

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR