### PR TITLE
fix: align windows installer mirror root handling

### DIFF
--- a/Update/update_windows.bat
+++ b/Update/update_windows.bat
@@ -129,7 +129,8 @@ call :in_work "%WORK%"
 if errorlevel 1 (
   call :mirror || (
     set "MSG=!COPY_NOTE!"
-    if not defined MSG set "MSG=Failed to mirror the new version near %AETHER_CURRENT_DIR%"
+    if not defined MSG if defined AETHER_CURRENT_DIR set "MSG=Failed to mirror the new version near %AETHER_CURRENT_DIR%"
+    if not defined MSG set "MSG=Failed to mirror the new version near the current app"
     call :write_result "failed" "mirror" "!MSG!"
     echo !MSG!
     goto :fail
@@ -200,6 +201,10 @@ if not defined AETHER_CURRENT_DIR exit /b 1
 for %%i in ("%AETHER_CURRENT_DIR%\..") do set "MROOT=%%~fi"
 :mirror_have_root
 if not defined MROOT exit /b 1
+if not exist "%MROOT%" mkdir "%MROOT%" >nul 2>nul || (
+  set "COPY_NOTE=Warning: failed to prepare mirror root %MROOT%"
+  exit /b 1
+)
 set "MIRROR=%MROOT%\aether_%VER%"
 if exist "%MIRROR%" call :stamp TS & set "MIRROR=%MROOT%\aether_%VER%_!TS!"
 set "MCOPY=%MIRROR%.copy"
@@ -301,8 +306,10 @@ if not defined PRUNE set "PRUNE=0"
 exit /b 0
 
 :prune_mirror
+if defined AETHER_MIRROR_ROOT set "PROOT=%AETHER_MIRROR_ROOT%" & goto prune_mirror_have_root
 if not defined AETHER_CURRENT_DIR exit /b 0
 for %%i in ("%AETHER_CURRENT_DIR%\..") do set "PROOT=%%~fi"
+:prune_mirror_have_root
 if not defined PROOT exit /b 0
 for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "& { $root=$env:PROOT; $keep=5; $hold=''; if($env:MIRROR){ $hold=[IO.Path]::GetFullPath($env:MIRROR) }; $items=Get-ChildItem -Path $root -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { $ver=''; if(Test-Path (Join-Path $_.FullName '.aether_web_version')){ $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim() }; if(-not $ver -and $_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)($|_[0-9]{12}$)'){ $ver=$matches[1] }; if($ver){ [PSCustomObject]@{ Dir=$_.FullName; Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending; $keepers=New-Object System.Collections.Generic.List[string]; foreach($dir in @($hold)){ if($dir -and ($items | Where-Object { $_.Dir -eq $dir }) -and -not $keepers.Contains($dir)){ $keepers.Add($dir) } }; foreach($item in $items){ if($keepers.Count -ge $keep){ break }; if(-not $keepers.Contains($item.Dir)){ $keepers.Add($item.Dir) } }; $gone=0; foreach($item in $items){ if($keepers.Contains($item.Dir)){ continue }; Remove-Item $item.Dir -Recurse -Force -ErrorAction SilentlyContinue; if(-not (Test-Path $item.Dir)){ $gone++ } }; Write-Output $gone }"`) do set "MPRUNE=%%i"
 if not defined MPRUNE set "MPRUNE=0"

--- a/packages/opencode/test/server/web-update-script.test.ts
+++ b/packages/opencode/test/server/web-update-script.test.ts
@@ -409,4 +409,40 @@ describe("web update scripts", () => {
     },
     { timeout: 30000 },
   )
+
+  windows(
+    "windows script fails mirror when current app location is unknown",
+    async () => {
+      const links = winLinks()
+      const prev = await stash(links)
+      try {
+        await using tmp = await tmpdir()
+        const work = path.join(tmp.path, "aether")
+        const dl = path.join(work, "downloads")
+        const src = path.join(tmp.path, "src-windows")
+        const out = path.join(dl, "aether-windows-x64-1.2.7.zip")
+        const script = path.join(dl, "update_windows.bat")
+
+        await fs.mkdir(dl, { recursive: true })
+        await winApp(src)
+        winZip(src, out)
+        await fs.copyFile(path.join(update, "update_windows.bat"), script)
+
+        const env = { ...process.env }
+        delete env.AETHER_CURRENT_DIR
+        delete env.AETHER_MIRROR_ROOT
+        const log = fail("cmd", ["/c", script, "1.2.7"], dl, env)
+        const text = `${log.stdout}${log.stderr}`
+
+        expect(log.status).not.toBe(0)
+        expect(text).toContain("Failed to mirror the new version near the current app")
+        expect(text).toContain("Update failed.")
+        expect(await Bun.file(path.join(work, "aether_1.2.7", "Aether.vbs")).exists()).toBe(true)
+        expect((await dirs(work)).some((x) => /^aether_1\.2\.7_\d{12}$/.test(x))).toBe(false)
+      } finally {
+        await restore(prev)
+      }
+    },
+    { timeout: 30000 },
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #572

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Aligns the Windows local update script with the macOS/Linux init installer mirror-root behavior.

The Windows update script now prepares `AETHER_MIRROR_ROOT` before mirroring, uses that same root when pruning mirrored versions, and keeps the macOS/Linux failure semantics when neither `AETHER_MIRROR_ROOT` nor `AETHER_CURRENT_DIR` is available. It also avoids emitting an empty-path mirror failure message.

A Windows regression test covers the missing-current-location failure path.

### How did you verify your code works?

Attempted:

`bun test test/server/web-update-script.test.ts`

The test command did not run to the target cases because this worktree is missing dependencies during test startup:

- `xdg-basedir`
- `drizzle-orm/bun-sqlite/migrator`

### Screenshots / recordings

Not applicable.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
