### PR TITLE
fix: unify busy-state with recursive descendant check and block sending when busy

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1269,18 +1269,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault()
       if (event.repeat) return
-      if (
-        working() &&
-        prompt
-          .current()
-          .map((part) => ("content" in part ? part.content : ""))
-          .join("")
-          .trim().length === 0 &&
-        imageAttachments().length === 0 &&
-        commentCount() === 0
-      ) {
-        return
-      }
+      if (working()) return
       handleSubmit(event)
     }
   }

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -60,7 +60,8 @@ import { promptPlaceholder } from "./prompt-input/placeholder"
 import { ImagePreview } from "@opencode-ai/ui/image-preview"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { KnowledgeButton } from "@/components/knowledge-button"
-import { createWorkingState } from "@/utils/working-state"
+import { createWorkingState, type ChildrenSource } from "@/utils/working-state"
+import { childMapByParent } from "@/pages/layout/helpers"
 import { SteerButton } from "@/components/steer-button"
 import { DialogDefaultSkills } from "@/components/dialog-default-skills"
 
@@ -256,7 +257,16 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       (msg) => msg.role === "assistant" && typeof msg.time.completed !== "number",
     ),
   )
-  const { interactive: working } = createWorkingState({ status: () => status(), pending: () => pending() })
+  const children = createMemo<ChildrenSource>(() => ({
+    childMap: () => childMapByParent(sync.data.session),
+    status: (id: string) => sync.data.session_status[id],
+  }))
+  const { interactive: working } = createWorkingState({
+    status: () => status(),
+    pending: () => pending(),
+    sessionID: () => params.id,
+    children: () => children(),
+  })
   const tip = () => {
     if (working()) {
       return (

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -78,11 +78,14 @@ function buildAuthHeaders(input: { username?: string; password?: string; json?: 
   return headers
 }
 
-function fillReadingQuestionPrompt(template: string, input: {
-  selectedContent: string
-  userQuestion: string
-  contextPages: string
-}) {
+function fillReadingQuestionPrompt(
+  template: string,
+  input: {
+    selectedContent: string
+    userQuestion: string
+    contextPages: string
+  },
+) {
   return template
     .replaceAll("{selected_content}", input.selectedContent)
     .replaceAll("{user_question}", input.userQuestion)
@@ -435,13 +438,17 @@ export function createPromptSubmit(input: PromptSubmitInput) {
   const handleSubmit = async (event: Event) => {
     event.preventDefault()
 
+    if (input.working()) {
+      abort()
+      return
+    }
+
     const currentPrompt = prompt.current()
     const text = currentPrompt.map((part) => ("content" in part ? part.content : "")).join("")
     const images = input.imageAttachments().slice()
     const mode = input.mode()
 
     if (text.trim().length === 0 && images.length === 0 && input.commentCount() === 0) {
-      if (input.working()) abort()
       return
     }
 
@@ -546,7 +553,8 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     const selText = fileCtx.selectedText()
     const readingQuestion = readingMode?.store.pendingQuestion
     const quickReadingPendingQuestion = quickReadingMode?.store.pendingQuestion ?? null
-    const quickReadingQuestion = quickReadingPendingQuestion?.sessionID === params.id ? quickReadingPendingQuestion : null
+    const quickReadingQuestion =
+      quickReadingPendingQuestion?.sessionID === params.id ? quickReadingPendingQuestion : null
     const draft: FollowupDraft = {
       sessionID: session.id,
       sessionDirectory,
@@ -747,11 +755,11 @@ export function createPromptSubmit(input: PromptSubmitInput) {
             ignored: true,
           },
           {
-              text: fillReadingQuestionPrompt(settings.questionPrompt, {
-                selectedContent:
-                  quickReadingQuestion.kind === "image-question"
-                    ? `The user selected a screenshot region from page ${quickReadingQuestion.page} of ${quickReadingQuestion.pdfFileName}.`
-                    : `The user selected text from pages ${formatReadingPageRange({ startPage: quickReadingQuestion.startPage, endPage: quickReadingQuestion.endPage })} of ${quickReadingQuestion.pdfFileName}.\n\n${quickReadingQuestion.text}`,
+            text: fillReadingQuestionPrompt(settings.questionPrompt, {
+              selectedContent:
+                quickReadingQuestion.kind === "image-question"
+                  ? `The user selected a screenshot region from page ${quickReadingQuestion.page} of ${quickReadingQuestion.pdfFileName}.`
+                  : `The user selected text from pages ${formatReadingPageRange({ startPage: quickReadingQuestion.startPage, endPage: quickReadingQuestion.endPage })} of ${quickReadingQuestion.pdfFileName}.\n\n${quickReadingQuestion.text}`,
               userQuestion: typedQuestion,
               contextPages: "",
             }),
@@ -884,7 +892,8 @@ export function createPromptSubmit(input: PromptSubmitInput) {
             {
               text: fillReadingQuestionPrompt(sessionMeta.settings.questionPrompt, {
                 selectedContent: describeReadingSelection({
-                  startPage: readingQuestion.kind === "text-question" ? readingQuestion.startPage : readingQuestion.page,
+                  startPage:
+                    readingQuestion.kind === "text-question" ? readingQuestion.startPage : readingQuestion.page,
                   endPage: readingQuestion.kind === "text-question" ? readingQuestion.endPage : readingQuestion.page,
                   kind: readingQuestion.kind,
                   text: readingQuestion.kind === "text-question" ? readingQuestion.text : undefined,
@@ -977,7 +986,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       knowledgeBase:
         knowledge.enabled() && knowledge.activeKnowledgeBases().length > 0
           ? {
-              paths: knowledge.activeKnowledgeBases().map(kb => kb.path),
+              paths: knowledge.activeKnowledgeBases().map((kb) => kb.path),
               apiKey: knowledge.activeKnowledgeBases()[0]!.apiKey,
               baseURL: knowledge.activeKnowledgeBases()[0]!.baseURL,
             }

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -21,8 +21,8 @@ import { useNotification } from "@/context/notification"
 import { usePermission } from "@/context/permission"
 import { messageAgentColor } from "@/utils/agent"
 import { sessionPermissionRequest } from "../session/composer/session-request-tree"
-import { createWorkingState } from "@/utils/working-state"
-import { hasProjectPermissions } from "./helpers"
+import { createWorkingState, type ChildrenSource } from "@/utils/working-state"
+import { childMapByParent, hasProjectPermissions } from "./helpers"
 
 const OPENCODE_PROJECT_ID = "4b0ea68d7af9a6031a7ffda7ad66e0cb83315750"
 
@@ -330,7 +330,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
       return !permission.autoResponds(item, props.session.directory)
     })
   })
-  const selfWorking = createWorkingState({
+  const isWorking = createWorkingState({
     status: () => sessionStore.session_status[props.session.id],
     pending: () =>
       (sessionStore.message[props.session.id] ?? []).findLast(
@@ -339,23 +339,12 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
           typeof (message as { time?: { completed?: unknown } }).time?.completed !== "number",
       ),
     blocked: hasPermissions,
+    sessionID: () => props.session.id,
+    children: () => ({
+      childMap: () => childMapByParent(sessionStore.session),
+      status: (id: string) => sessionStore.session_status[id],
+    }),
   }).visual
-  const childWorking = createMemo(() => {
-    const ids = props.children.get(props.session.id)
-    if (!ids?.length) return false
-    for (const id of ids) {
-      const status = sessionStore.session_status[id]
-      if (status?.type === "busy" || status?.type === "retry") return true
-      const pending = (sessionStore.message[id] ?? []).findLast(
-        (message) =>
-          message.role === "assistant" &&
-          typeof (message as { time?: { completed?: unknown } }).time?.completed !== "number",
-      )
-      if (pending) return true
-    }
-    return false
-  })
-  const isWorking = createMemo(() => selfWorking() || childWorking())
 
   const tint = createMemo(() => {
     return messageAgentColor(sessionStore.message[props.session.id], sessionStore.agent)

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -57,6 +57,7 @@ import {
   focusTerminalById,
   shouldFocusTerminalOnKeyDown,
 } from "@/pages/session/helpers"
+import { childMapByParent } from "@/pages/layout/helpers"
 import { MessageTimeline } from "@/pages/session/message-timeline"
 import { type DiffStyle, SessionReviewTab, type SessionReviewTabProps } from "@/pages/session/review-tab"
 import { useSessionLayout } from "@/pages/session/session-layout"
@@ -444,11 +445,11 @@ function SessionPageContent(props: SessionPageProps = {}) {
     fileTreeOpen: quickReadingFileTreeOpen,
     layoutSwapped: () => quickReading.store.snapshot.layoutSwapped,
   })
-  const desktopReviewOpen = createMemo(() =>
-    isDesktop() && (propReadingModeActive() ? !!props.readingReviewOpen : view().reviewPanel.opened()),
+  const desktopReviewOpen = createMemo(
+    () => isDesktop() && (propReadingModeActive() ? !!props.readingReviewOpen : view().reviewPanel.opened()),
   )
-  const desktopFileTreeOpen = createMemo(() =>
-    isDesktop() && (propReadingModeActive() ? !!props.readingFileTreeOpen : layout.fileTree.opened()),
+  const desktopFileTreeOpen = createMemo(
+    () => isDesktop() && (propReadingModeActive() ? !!props.readingFileTreeOpen : layout.fileTree.opened()),
   )
   const desktopSidePanelOpen = createMemo(() => desktopReviewOpen() || desktopFileTreeOpen())
   let rowRef: HTMLDivElement | undefined
@@ -471,7 +472,7 @@ function SessionPageContent(props: SessionPageProps = {}) {
     const fallback = propReadingModeActive()
       ? rowWidth() > 0
         ? rowWidth()
-        : props.readingCompositeWidth ?? 0
+        : (props.readingCompositeWidth ?? 0)
       : quickReadingLayout.compositeResizeBounds().max
     return Math.max(readingCompositeMinWidth(), props.readingCompositeMaxWidth ?? fallback)
   })
@@ -495,11 +496,13 @@ function SessionPageContent(props: SessionPageProps = {}) {
   const effectiveCompositeWidth = createMemo(() => {
     if (!readingModeActive()) return 0
     const total = propReadingModeActive() ? rowWidth() : quickReadingLayout.rowWidth()
-    const fallback = propReadingModeActive() ? props.readingCompositeWidth ?? 0 : quickReadingLayout.compositePixelWidth()
+    const fallback = propReadingModeActive()
+      ? (props.readingCompositeWidth ?? 0)
+      : quickReadingLayout.compositePixelWidth()
     if (total <= 0) return Math.min(readingCompositeMaxWidth(), Math.max(readingCompositeMinWidth(), fallback))
     if (!desktopSidePanelOpen()) return total
     const requested = propReadingModeActive()
-      ? props.readingCompositeWidth ?? Math.max(0, total - (props.readingSidePanelWidth ?? 0))
+      ? (props.readingCompositeWidth ?? Math.max(0, total - (props.readingSidePanelWidth ?? 0)))
       : quickReadingLayout.compositePixelWidth()
     return Math.min(readingCompositeMaxWidth(), Math.max(readingCompositeMinWidth(), requested))
   })
@@ -527,7 +530,9 @@ function SessionPageContent(props: SessionPageProps = {}) {
     if (desktopReviewOpen()) {
       return `${Math.max(360, layout.session.width() - pdfWidth)}px`
     }
-    return pdfWidth > 0 ? `calc(100% - ${layout.fileTree.width()}px - ${pdfWidth}px)` : `calc(100% - ${layout.fileTree.width()}px)`
+    return pdfWidth > 0
+      ? `calc(100% - ${layout.fileTree.width()}px - ${pdfWidth}px)`
+      : `calc(100% - ${layout.fileTree.width()}px)`
   })
   const centered = createMemo(() => isDesktop() && !desktopReviewOpen())
   const readingSessionResizeSize = createMemo(() => {
@@ -542,7 +547,8 @@ function SessionPageContent(props: SessionPageProps = {}) {
   })
   const readingSessionResizeMax = createMemo(() => {
     if (propReadingModeActive()) return Math.max(readingSessionResizeMin(), props.readingSessionResizeMax ?? 0)
-    if (quickReadingModeActive()) return Math.max(readingSessionResizeMin(), quickReadingLayout.sessionResizeBounds().max)
+    if (quickReadingModeActive())
+      return Math.max(readingSessionResizeMin(), quickReadingLayout.sessionResizeBounds().max)
     return 0
   })
   const readingFileTreeResizable = createMemo(() => {
@@ -1837,9 +1843,19 @@ function SessionPageContent(props: SessionPageProps = {}) {
 
   const busy = (sessionID: string) => {
     if ((sync.data.session_status[sessionID] ?? { type: "idle" as const }).type !== "idle") return true
-    return (sync.data.message[sessionID] ?? []).some(
-      (item) => item.role === "assistant" && typeof item.time.completed !== "number",
+    if (
+      (sync.data.message[sessionID] ?? []).some(
+        (item) => item.role === "assistant" && typeof item.time.completed !== "number",
+      )
     )
+      return true
+    const map = childMapByParent(sync.data.session)
+    const children = map.get(sessionID)
+    if (!children?.length) return false
+    for (const id of children) {
+      if (busy(id)) return true
+    }
+    return false
   }
 
   const queuedFollowups = createMemo(() => {
@@ -2402,122 +2418,122 @@ function SessionPageContent(props: SessionPageProps = {}) {
               order: String(sessionPanelOrder()),
             }}
           >
-          <div class="flex-1 min-h-0 overflow-hidden">
-            <Switch>
-              <Match when={params.id}>
-                <Show when={messagesReady()}>
-                  <MessageTimeline
-                    mobileChanges={mobileChanges()}
-                    mobileFallback={reviewContent({
-                      diffStyle: "unified",
-                      classes: {
-                        root: "pb-8",
-                        header: "px-4",
-                        container: "px-4",
-                      },
-                      loadingClass: "px-4 py-4 text-text-weak",
-                      emptyClass: "h-full pb-64 -mt-4 flex flex-col items-center justify-center text-center gap-6",
-                    })}
-                    actions={actions}
-                    scroll={ui.scroll}
-                    onResumeScroll={resumeScroll}
-                    setScrollRef={setScrollRef}
-                    onScheduleScrollState={scheduleScrollState}
-                    onAutoScrollHandleScroll={autoScroll.handleScroll}
-                    onMarkScrollGesture={markScrollGesture}
-                    hasScrollGesture={hasScrollGesture}
-                    onUserScroll={markUserScroll}
-                    onTurnBackfillScroll={historyWindow.onScrollerScroll}
-                    onAutoScrollInteraction={autoScroll.handleInteraction}
-                    centered={centered()}
-                    setContentRef={(el) => {
-                      content = el
-                      autoScroll.contentRef(el)
+            <div class="flex-1 min-h-0 overflow-hidden">
+              <Switch>
+                <Match when={params.id}>
+                  <Show when={messagesReady()}>
+                    <MessageTimeline
+                      mobileChanges={mobileChanges()}
+                      mobileFallback={reviewContent({
+                        diffStyle: "unified",
+                        classes: {
+                          root: "pb-8",
+                          header: "px-4",
+                          container: "px-4",
+                        },
+                        loadingClass: "px-4 py-4 text-text-weak",
+                        emptyClass: "h-full pb-64 -mt-4 flex flex-col items-center justify-center text-center gap-6",
+                      })}
+                      actions={actions}
+                      scroll={ui.scroll}
+                      onResumeScroll={resumeScroll}
+                      setScrollRef={setScrollRef}
+                      onScheduleScrollState={scheduleScrollState}
+                      onAutoScrollHandleScroll={autoScroll.handleScroll}
+                      onMarkScrollGesture={markScrollGesture}
+                      hasScrollGesture={hasScrollGesture}
+                      onUserScroll={markUserScroll}
+                      onTurnBackfillScroll={historyWindow.onScrollerScroll}
+                      onAutoScrollInteraction={autoScroll.handleInteraction}
+                      centered={centered()}
+                      setContentRef={(el) => {
+                        content = el
+                        autoScroll.contentRef(el)
 
-                      const root = scroller
-                      if (root) scheduleScrollState(root)
-                    }}
-                    turnStart={historyWindow.turnStart()}
-                    historyMore={historyMore()}
-                    historyLoading={historyLoading()}
-                    onLoadEarlier={() => {
-                      void historyWindow.loadAndReveal()
-                    }}
-                    renderedUserMessages={historyWindow.renderedUserMessages()}
-                    anchor={anchor}
-                  />
-                </Show>
-              </Match>
-              <Match when={true}>
-                <NewSessionView worktree={newSessionWorktree()} />
-              </Match>
-            </Switch>
-          </div>
-
-          <SessionComposerRegion
-            state={composer}
-            ready={!store.deferRender && messagesReady()}
-            centered={centered()}
-            inputRef={(el) => {
-              inputRef = el
-            }}
-            newSessionWorktree={newSessionWorktree()}
-            onNewSessionWorktreeReset={() => setStore("newSessionWorktree", "main")}
-            onSubmit={() => {
-              comments.clear()
-              resumeScroll()
-            }}
-            onResponseSubmit={resumeScroll}
-            followup={
-              params.id
-                ? {
-                    queue: queueEnabled,
-                    items: followupDock(),
-                    sending: sendingFollowup(),
-                    edit: editingFollowup(),
-                    onQueue: queueFollowup,
-                    onAbort: () => {
-                      const id = params.id
-                      if (!id) return
-                      setFollowup("paused", id, true)
-                    },
-                    onSend: (id) => {
-                      void sendFollowup(params.id!, id, { manual: true })
-                    },
-                    onEdit: editFollowup,
-                    onEditLoaded: clearFollowupEdit,
-                  }
-                : undefined
-            }
-            revert={
-              rolled().length > 0
-                ? {
-                    items: rolled(),
-                    restoring: restoring(),
-                    disabled: reverting(),
-                    onRestore: restore,
-                  }
-                : undefined
-            }
-            setPromptDockRef={(el) => {
-              promptDock = el
-            }}
-          />
-
-          <Show when={desktopReviewOpen()}>
-            <div onPointerDown={() => size.start()}>
-              <ResizeHandle
-                direction="horizontal"
-                size={layout.session.width()}
-                min={450}
-                max={typeof window === "undefined" ? 1000 : window.innerWidth * 0.45}
-                onResize={(width) => {
-                  size.touch()
-                  layout.session.resize(width)
-                }}
-              />
+                        const root = scroller
+                        if (root) scheduleScrollState(root)
+                      }}
+                      turnStart={historyWindow.turnStart()}
+                      historyMore={historyMore()}
+                      historyLoading={historyLoading()}
+                      onLoadEarlier={() => {
+                        void historyWindow.loadAndReveal()
+                      }}
+                      renderedUserMessages={historyWindow.renderedUserMessages()}
+                      anchor={anchor}
+                    />
+                  </Show>
+                </Match>
+                <Match when={true}>
+                  <NewSessionView worktree={newSessionWorktree()} />
+                </Match>
+              </Switch>
             </div>
-          </Show>
+
+            <SessionComposerRegion
+              state={composer}
+              ready={!store.deferRender && messagesReady()}
+              centered={centered()}
+              inputRef={(el) => {
+                inputRef = el
+              }}
+              newSessionWorktree={newSessionWorktree()}
+              onNewSessionWorktreeReset={() => setStore("newSessionWorktree", "main")}
+              onSubmit={() => {
+                comments.clear()
+                resumeScroll()
+              }}
+              onResponseSubmit={resumeScroll}
+              followup={
+                params.id
+                  ? {
+                      queue: queueEnabled,
+                      items: followupDock(),
+                      sending: sendingFollowup(),
+                      edit: editingFollowup(),
+                      onQueue: queueFollowup,
+                      onAbort: () => {
+                        const id = params.id
+                        if (!id) return
+                        setFollowup("paused", id, true)
+                      },
+                      onSend: (id) => {
+                        void sendFollowup(params.id!, id, { manual: true })
+                      },
+                      onEdit: editFollowup,
+                      onEditLoaded: clearFollowupEdit,
+                    }
+                  : undefined
+              }
+              revert={
+                rolled().length > 0
+                  ? {
+                      items: rolled(),
+                      restoring: restoring(),
+                      disabled: reverting(),
+                      onRestore: restore,
+                    }
+                  : undefined
+              }
+              setPromptDockRef={(el) => {
+                promptDock = el
+              }}
+            />
+
+            <Show when={desktopReviewOpen()}>
+              <div onPointerDown={() => size.start()}>
+                <ResizeHandle
+                  direction="horizontal"
+                  size={layout.session.width()}
+                  min={450}
+                  max={typeof window === "undefined" ? 1000 : window.innerWidth * 0.45}
+                  onResize={(width) => {
+                    size.touch()
+                    layout.session.resize(width)
+                  }}
+                />
+              </div>
+            </Show>
           </div>
         </Show>
 

--- a/packages/app/src/pages/session/composer/session-composer-state.ts
+++ b/packages/app/src/pages/session/composer/session-composer-state.ts
@@ -8,7 +8,8 @@ import { useLanguage } from "@/context/language"
 import { usePermission } from "@/context/permission"
 import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
-import { createWorkingState } from "@/utils/working-state"
+import { createWorkingState, type ChildrenSource } from "@/utils/working-state"
+import { childMapByParent } from "@/pages/layout/helpers"
 import { composerDriver, composerEnabled, composerEvent } from "@/testing/session-composer"
 import { sessionPermissionRequest, sessionQuestionRequest } from "./session-request-tree"
 
@@ -114,7 +115,15 @@ export function createSessionComposerState(options?: { closeMs?: number | (() =>
     ),
   )
 
-  const { visual: busy } = createWorkingState({ status: () => status(), pending: () => pending() })
+  const { visual: busy } = createWorkingState({
+    status: () => status(),
+    pending: () => pending(),
+    sessionID: () => params.id,
+    children: () => ({
+      childMap: () => childMapByParent(sync.data.session),
+      status: (id: string) => sync.data.session_status[id],
+    }),
+  })
   const live = createMemo(() => {
     if (test.on && test.live !== undefined) return test.live
     return busy() || blocked()

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -1,5 +1,6 @@
 import { For, createEffect, createMemo, on, onCleanup, Show, Index, type JSX, createSignal } from "solid-js"
-import { createWorkingState } from "@/utils/working-state"
+import { createWorkingState, type ChildrenSource } from "@/utils/working-state"
+import { childMapByParent } from "@/pages/layout/helpers"
 import { createStore, produce, reconcile } from "solid-js/store"
 import { useNavigate } from "@solidjs/router"
 import { useMutation } from "@tanstack/solid-query"
@@ -304,9 +305,15 @@ export function MessageTimeline(props: {
     if (!id) return idle
     return sync.data.session_status[id] ?? idle
   })
+  const children = createMemo<ChildrenSource>(() => ({
+    childMap: () => childMapByParent(sync.data.session),
+    status: (id: string) => sync.data.session_status[id],
+  }))
   const { visual: working } = createWorkingState({
     status: () => sessionStatus(),
     pending: () => pending(),
+    sessionID: () => sessionID(),
+    children: () => children(),
   })
   const tint = createMemo(() => messageAgentColor(sessionMessages(), sync.data.agent))
 

--- a/packages/app/src/utils/working-state.ts
+++ b/packages/app/src/utils/working-state.ts
@@ -9,16 +9,35 @@ export type SessionStatus =
   | { type: "retry"; attempt: number; message: string; next: number }
   | undefined
 
+export type ChildrenSource = {
+  childMap: () => Map<string, string[]>
+  status: (id: string) => SessionStatus
+}
+
+const isBusy = (s: SessionStatus) => s?.type === "busy" || s?.type === "retry"
+
+function descendantBusy(sessionID: string, source: ChildrenSource): boolean {
+  const children = source.childMap().get(sessionID)
+  if (!children?.length) return false
+  for (const id of children) {
+    if (isBusy(source.status(id))) return true
+    if (descendantBusy(id, source)) return true
+  }
+  return false
+}
+
 export function createWorkingState(input: {
   status: () => SessionStatus
   pending: () => unknown
   blocked?: () => boolean
+  sessionID?: () => string | undefined
+  children?: () => ChildrenSource
 }) {
   const [grace, setGrace] = createSignal(false)
 
   createEffect(() => {
     const s = input.status()
-    if (s?.type === "busy" || s?.type === "retry") {
+    if (isBusy(s)) {
       setGrace(true)
       return
     }
@@ -27,18 +46,28 @@ export function createWorkingState(input: {
     }
   })
 
-  const visual = createMemo(() => {
+  const selfVisual = createMemo(() => {
     if (input.blocked?.()) return false
     const s = input.status()
-    if (s?.type === "busy" || s?.type === "retry") return true
+    if (isBusy(s)) return true
     if (grace()) return !!input.pending()
     return false
   })
 
-  const interactive = createMemo(() => {
+  const selfInteractive = createMemo(() => {
     const s = input.status()
-    return s?.type === "busy" || s?.type === "retry"
+    return isBusy(s)
   })
+
+  const descBusy = createMemo(() => {
+    const id = input.sessionID?.()
+    const src = input.children
+    if (!id || !src) return false
+    return descendantBusy(id, src())
+  })
+
+  const visual = createMemo(() => selfVisual() || descBusy())
+  const interactive = createMemo(() => selfInteractive() || descBusy())
 
   return { visual, interactive, grace }
 }


### PR DESCRIPTION
### Issue for this PR

Closes #577

### Type of change

- [x] Bug fix

### What does this PR do?

Two fixes for busy-state UI behavior:

1. **Recursive descendant busy check**: `createWorkingState` now accepts optional `sessionID` and `children` parameters. When provided, `visual` and `interactive` outputs include `descendantBusy` — a recursive traversal of the session tree via `childMapByParent` that checks all descendant sessions' `session_status`. This ensures header spinner, send/stop button, sidebar spinner, and composer panel all reflect busy state when any descendant (subagent) is running.

   Previously each location used different logic:
   - Sidebar: `selfWorking() || childWorking()` (only direct children)
   - Header: `session_status[currentID]` only
   - Send/stop: `session_status[currentID]` only
   
   Now all locations pass `children` to `createWorkingState`, which handles the recursion uniformly.

2. **Block all message sending when busy**: Enter key handler now returns immediately when `working()` is true — no abort, no submit, the message stays in the input box. `handleSubmit` now checks `working()` first and aborts if true. This prevents accidental message submission during busy state; only Esc/Ctrl+G or clicking the stop button can abort.

### How did you verify your code works?

- `bun typecheck` passed for both `packages/app` and `packages/opencode`
- Server-side recursive subagent cancellation is already handled by `task.ts:123-127` (abort signal propagation via `ctx.abort.addEventListener("abort", cancel)`)

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR