### PR TITLE
fix: block revert when session is busy, offer Cancel/Fork instead

### DIFF
--- a/packages/app/src/components/dialog-revert-confirm.tsx
+++ b/packages/app/src/components/dialog-revert-confirm.tsx
@@ -24,6 +24,10 @@ const reasonDescriptions: Record<RevertProtectionReason, { titleKey: string; des
     titleKey: "dialog.revert.protected.incompleteTurnInheritedPrefix.title",
     descKey: "dialog.revert.protected.incompleteTurnInheritedPrefix.description",
   },
+  "session-busy": {
+    titleKey: "dialog.revert.protected.sessionBusy.title",
+    descKey: "dialog.revert.protected.sessionBusy.description",
+  },
 }
 
 export const DialogRevertConfirm: Component<DialogRevertConfirmProps> = (props) => {

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -333,15 +333,22 @@ export const dict = {
   "dialog.fork.empty": "No messages to fork from",
 
   "dialog.revert.confirm.title": "Revert to this point?",
-  "dialog.revert.confirm.description": "This will discard all messages after the selected point and restore files to their earlier state. This action cannot be undone.",
+  "dialog.revert.confirm.description":
+    "This will discard all messages after the selected point and restore files to their earlier state. This action cannot be undone.",
   "dialog.revert.confirmAction": "Revert",
   "dialog.revert.forkAction": "Fork instead",
   "dialog.revert.protected.inheritedPrefix.title": "Cannot revert here",
-  "dialog.revert.protected.inheritedPrefix.description": "This message belongs to the parent session's conversation history. Reverting it would modify shared history that other branches depend on. You can fork from this point to create a new branch instead.",
+  "dialog.revert.protected.inheritedPrefix.description":
+    "This message belongs to the parent session's conversation history. Reverting it would modify shared history that other branches depend on. You can fork from this point to create a new branch instead.",
   "dialog.revert.protected.descendantBranch.title": "Cannot revert here",
-  "dialog.revert.protected.descendantBranch.description": "A branch session already depends on messages at or after this point. Reverting would break that branch's connection. You can fork from this point to create a new branch instead.",
+  "dialog.revert.protected.descendantBranch.description":
+    "A branch session already depends on messages at or after this point. Reverting would break that branch's connection. You can fork from this point to create a new branch instead.",
   "dialog.revert.protected.incompleteTurnInheritedPrefix.title": "Cannot revert here",
-  "dialog.revert.protected.incompleteTurnInheritedPrefix.description": "The assistant has not finished responding to this message yet, so the system cannot determine whether this turn is within the inherited conversation history. To avoid modifying shared history, a fork is recommended. You can fork from this point to create a new branch instead.",
+  "dialog.revert.protected.incompleteTurnInheritedPrefix.description":
+    "The assistant has not finished responding to this message yet, so the system cannot determine whether this turn is within the inherited conversation history. To avoid modifying shared history, a fork is recommended. You can fork from this point to create a new branch instead.",
+  "dialog.revert.protected.sessionBusy.title": "Cannot revert while task is running",
+  "dialog.revert.protected.sessionBusy.description":
+    "A task is still running in this session. Reverting now would discard in-progress work. Stop the task first, or fork from this point to create a new branch instead.",
 
   "dialog.directory.search.placeholder": "Search folders",
   "dialog.directory.empty": "No subfolders in this directory",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -353,11 +353,17 @@ export const dict = {
   "dialog.revert.confirmAction": "重置",
   "dialog.revert.forkAction": "分叉到新会话",
   "dialog.revert.protected.inheritedPrefix.title": "无法重置到此位置",
-  "dialog.revert.protected.inheritedPrefix.description": "此消息属于父会话的对话历史。重置它会修改其他分支依赖的共享历史。可以从这里分叉，创建一个新分支。",
+  "dialog.revert.protected.inheritedPrefix.description":
+    "此消息属于父会话的对话历史。重置它会修改其他分支依赖的共享历史。可以从这里分叉，创建一个新分支。",
   "dialog.revert.protected.descendantBranch.title": "无法重置到此位置",
-  "dialog.revert.protected.descendantBranch.description": "已有分支会话依赖此位置或之后的消息。重置会破坏该分支的连接。可以从这里分叉，创建一个新分支。",
+  "dialog.revert.protected.descendantBranch.description":
+    "已有分支会话依赖此位置或之后的消息。重置会破坏该分支的连接。可以从这里分叉，创建一个新分支。",
   "dialog.revert.protected.incompleteTurnInheritedPrefix.title": "无法重置到此位置",
-  "dialog.revert.protected.incompleteTurnInheritedPrefix.description": "助手尚未完成对此消息的回复，系统无法判断此轮次是否位于继承的对话历史内。为避免修改共享历史，建议分叉。可以从这里分叉，创建一个新分支。",
+  "dialog.revert.protected.incompleteTurnInheritedPrefix.description":
+    "助手尚未完成对此消息的回复，系统无法判断此轮次是否位于继承的对话历史内。为避免修改共享历史，建议分叉。可以从这里分叉，创建一个新分支。",
+  "dialog.revert.protected.sessionBusy.title": "任务正在执行，无法重置",
+  "dialog.revert.protected.sessionBusy.description":
+    "会话中有任务正在执行，重置会丢弃正在进行的工作。请先停止任务，或从此处分叉到新会话。",
 
   "dialog.directory.search.placeholder": "搜索文件夹",
   "dialog.directory.empty": "该目录下无子文件夹",

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -2084,6 +2084,7 @@ function SessionPageContent(props: SessionPageProps = {}) {
 
   const restore = (id: string) => {
     if (!params.id || reverting()) return
+    if (busy(params.id)) return
     return restoreMutation.mutateAsync(id)
   }
 

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -2055,6 +2055,11 @@ function SessionPageContent(props: SessionPageProps = {}) {
       return revertMutation.mutateAsync(input)
     }
 
+    if (busy(input.sessionID)) {
+      dialog.show(() => <DialogRevertConfirm reason="session-busy" onFork={() => fork(input)} />)
+      return
+    }
+
     return sdk.client.session
       .graph({ sessionID: input.sessionID })
       .then((result) => {

--- a/packages/app/src/pages/session/helpers.ts
+++ b/packages/app/src/pages/session/helpers.ts
@@ -270,7 +270,11 @@ export const hasProtectedDescendantBranch = (input: {
   return false
 }
 
-export type RevertProtectionReason = "inherited-prefix" | "descendant-branch" | "incomplete-turn-inherited-prefix"
+export type RevertProtectionReason =
+  | "inherited-prefix"
+  | "descendant-branch"
+  | "incomplete-turn-inherited-prefix"
+  | "session-busy"
 
 export type RevertProtectionResult = { protected: false } | { protected: true; reason: RevertProtectionReason }
 

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -453,6 +453,9 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
         onSelect: async () => {
           const sessionID = params.id
           if (!sessionID) return
+          if (status().type !== "idle") {
+            await sdk.client.session.abort({ sessionID }).catch(() => {})
+          }
           const revertMessageID = info()?.revert?.messageID
           if (!revertMessageID) return
           const nextMessage = userMessages().find((x) => x.id > revertMessageID)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
@@ -6,6 +6,35 @@ import { useRoute } from "@tui/context/route"
 import { Clipboard } from "@tui/util/clipboard"
 import type { PromptInfo } from "@tui/component/prompt/history"
 import { strip } from "@tui/component/prompt/part"
+import { createWorkingState, type SessionStatus } from "@tui/util/working-state"
+import { useDialog } from "../../ui/dialog"
+
+function DialogBusyWarning(props: { sessionID: string; messageID: string; onFork: () => void }) {
+  const dialog = useDialog()
+
+  return (
+    <DialogSelect
+      title="Task is running"
+      options={[
+        {
+          title: "Cancel",
+          value: "cancel",
+          description: "close this dialog",
+          onSelect: () => dialog.clear(),
+        },
+        {
+          title: "Fork",
+          value: "session.fork",
+          description: "create a new session from this point",
+          onSelect: () => {
+            props.onFork()
+          },
+        },
+      ]}
+      skipFilter
+    />
+  )
+}
 
 export function DialogMessage(props: {
   messageID: string
@@ -14,8 +43,42 @@ export function DialogMessage(props: {
 }) {
   const sync = useSync()
   const sdk = useSDK()
+  const dialog = useDialog()
   const message = createMemo(() => sync.data.message[props.sessionID]?.find((x) => x.id === props.messageID))
   const route = useRoute()
+  const status = createMemo(() => sync.data.session_status?.[props.sessionID] ?? ({ type: "idle" } as SessionStatus))
+  const pending = createMemo(() =>
+    (sync.data.message[props.sessionID] ?? []).findLast(
+      (msg) => msg.role === "assistant" && typeof msg.time?.completed !== "number",
+    ),
+  )
+  const { working } = createWorkingState({ status: () => status(), pending: () => pending() })
+
+  async function forkFromMessage() {
+    const result = await sdk.client.session.fork({
+      sessionID: props.sessionID,
+      messageID: props.messageID,
+    })
+    const msg = message()
+    const initialPrompt = msg
+      ? (sync.data.part[msg.id] ?? []).reduce(
+          (agg, part) => {
+            if (part.type === "text") {
+              if (!part.synthetic) agg.input += part.text
+            }
+            if (part.type === "file") agg.parts.push(part)
+            return agg
+          },
+          { input: "", parts: [] as PromptInfo["parts"] },
+        )
+      : undefined
+    route.navigate({
+      sessionID: result.data!.id,
+      type: "session",
+      initialPrompt,
+    })
+    dialog.clear()
+  }
 
   return (
     <DialogSelect
@@ -24,16 +87,20 @@ export function DialogMessage(props: {
         {
           title: "Revert",
           value: "session.revert",
-          description: "undo messages and file changes",
-          onSelect: (dialog) => {
+          description: working() ? "task is running — stop first or fork instead" : "undo messages and file changes",
+          onSelect: () => {
+            if (working()) {
+              dialog.replace(() => (
+                <DialogBusyWarning sessionID={props.sessionID} messageID={props.messageID} onFork={forkFromMessage} />
+              ))
+              return
+            }
             const msg = message()
             if (!msg) return
-
             sdk.client.session.revert({
               sessionID: props.sessionID,
               messageID: msg.id,
             })
-
             if (props.setPrompt) {
               const parts = sync.data.part[msg.id]
               const promptInfo = parts.reduce(
@@ -48,7 +115,6 @@ export function DialogMessage(props: {
               )
               props.setPrompt(promptInfo)
             }
-
             dialog.clear()
           },
         },
@@ -56,18 +122,14 @@ export function DialogMessage(props: {
           title: "Copy",
           value: "message.copy",
           description: "message text to clipboard",
-          onSelect: async (dialog) => {
+          onSelect: async () => {
             const msg = message()
             if (!msg) return
-
             const parts = sync.data.part[msg.id]
             const text = parts.reduce((agg, part) => {
-              if (part.type === "text" && !part.synthetic) {
-                agg += part.text
-              }
+              if (part.type === "text" && !part.synthetic) agg += part.text
               return agg
             }, "")
-
             await Clipboard.copy(text)
             dialog.clear()
           },
@@ -76,33 +138,7 @@ export function DialogMessage(props: {
           title: "Fork",
           value: "session.fork",
           description: "create a new session",
-          onSelect: async (dialog) => {
-            const result = await sdk.client.session.fork({
-              sessionID: props.sessionID,
-              messageID: props.messageID,
-            })
-            const initialPrompt = (() => {
-              const msg = message()
-              if (!msg) return undefined
-              const parts = sync.data.part[msg.id]
-              return parts.reduce(
-                (agg, part) => {
-                  if (part.type === "text") {
-                    if (!part.synthetic) agg.input += part.text
-                  }
-                  if (part.type === "file") agg.parts.push(part)
-                  return agg
-                },
-                { input: "", parts: [] as PromptInfo["parts"] },
-              )
-            })()
-            route.navigate({
-              sessionID: result.data!.id,
-              type: "session",
-              initialPrompt,
-            })
-            dialog.clear()
-          },
+          onSelect: forkFromMessage,
         },
       ]}
     />

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -549,6 +549,10 @@ export function Session() {
       },
       onSelect: (dialog) => {
         dialog.clear()
+        const status = sync.data.session_status?.[route.sessionID]
+        if (status?.type !== "idle") {
+          sdk.client.session.abort({ sessionID: route.sessionID }).catch(() => {})
+        }
         const messageID = session()?.revert?.messageID
         if (!messageID) return
         const message = messages().find((x) => x.role === "user" && x.id > messageID)

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -1085,11 +1085,18 @@ export const SessionRoutes = lazy(() =>
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
         log.info("revert", c.req.valid("json"))
-        const session = await SessionRevert.revert({
-          sessionID,
-          ...c.req.valid("json"),
-        })
-        return c.json(session)
+        try {
+          const session = await SessionRevert.revert({
+            sessionID,
+            ...c.req.valid("json"),
+          })
+          return c.json(session)
+        } catch (err) {
+          if (err instanceof Session.BusyError) {
+            return c.json({ error: "Session is busy", sessionID }, 409)
+          }
+          throw err
+        }
       },
     )
     .post(

--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -27,6 +27,7 @@ export namespace SessionRevert {
   export type RevertInput = z.infer<typeof RevertInput>
 
   export async function revert(input: RevertInput) {
+    SessionPrompt.assertNotBusy(input.sessionID)
     const done = Promise.withResolvers<void>()
     pending[input.sessionID] = done.promise
     try {


### PR DESCRIPTION
### Issue for this PR

Closes #579

### Type of change

- [x] Bug fix

### What does this PR do?

When a session is busy (a task is running), the "Revert to this point" action could still execute without any warning, discarding in-progress work. This PR adds busy-state guards across **all** revert entry points:

**Backend (root-level protection):**
- `SessionRevert.revert()` now calls `assertNotBusy()` — throws `BusyError` if session is busy, blocking ALL callers regardless of UI
- `POST /revert` API route catches `BusyError` and returns HTTP 409

**Web UI:**
- `revert()` in session.tsx checks `busy()` before proceeding; shows `DialogRevertConfirm` with reason `"session-busy"` (Cancel + Fork buttons) instead of the normal confirm dialog
- `/redo` slash command aborts the running task first if session is not idle
- `restore()` (RevertDock) silently blocks when session is busy
- Added `"session-busy"` to `RevertProtectionReason` type and `DialogRevertConfirm` reason map
- Added i18n strings in both English and Chinese

**TUI:**
- `DialogMessage` Revert option checks `working()` state; when busy, replaces dialog with `DialogBusyWarning` (Cancel + Fork)
- `/redo` command aborts the running task first if session is not idle

### How did you verify your code works?

- `bun typecheck` passes in both `packages/opencode` and `packages/app`
- The backend `assertNotBusy()` guard is consistent with the existing pattern in `SessionRevert.unrevert()` which already calls it
- The Web UI reuses the existing `DialogRevertConfirm` protected-mode UI (Cancel/Fork layout) which was already working for `inherited-prefix`, `descendant-branch`, and `incomplete-turn-inherited-prefix` reasons

### Screenshots / recordings

Not applicable (TUI + backend changes, Web UI uses existing dialog layout).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR