### PR TITLE
feat: register aether:// custom URL scheme for one-click browser launch

### DIFF
--- a/Update/update_darwin.command
+++ b/Update/update_darwin.command
@@ -287,6 +287,18 @@ build_app() {
 set -euo pipefail
 
 cmd="$cmd"
+portfile="\$HOME/Library/Application Support/aether/serve-port"
+port=""
+if [ -f "\$portfile" ]; then
+  port="\$(head -1 "\$portfile" 2>/dev/null || true)"
+fi
+if [ -n "\$port" ]; then
+  if curl -s -o /dev/null --max-time 2 "http://127.0.0.1:\$port/" >/dev/null 2>&1; then
+    open "http://127.0.0.1:\$port/"
+    exit 0
+  fi
+fi
+
 if [ -x "\$cmd" ]; then
   if open "\$cmd"; then
     exit 0
@@ -325,6 +337,17 @@ EOF
   <string>Aether</string>
   <key>LSMinimumSystemVersion</key>
   <string>11.0</string>
+  <key>CFBundleURLTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleURLName</key>
+      <string>Aether</string>
+      <key>CFBundleURLSchemes</key>
+      <array>
+        <string>aether</string>
+      </array>
+    </dict>
+  </array>
 </dict>
 </plist>
 EOF

--- a/Update/update_linux.sh
+++ b/Update/update_linux.sh
@@ -638,6 +638,7 @@ if [ -n "$copy_target" ]; then
   start_target="$copy_target"
 fi
 launch="$(write_launch "$start_target" || true)"
+register_protocol "$start_target"
 if [ -n "$launch" ]; then
   echo "[install] Desktop launcher: $launch"
   echo "[install] To start Aether, right-click the Aether.sh file on your desktop and choose Run as a Program."
@@ -680,3 +681,27 @@ if [ -n "$copy_note" ]; then
   echo "$copy_note"
 fi
 exit "$ok"
+
+register_protocol() {
+  local target="$1"
+  local handler="$target/aether-protocol-handler.sh"
+  [ -f "$handler" ] || return 0
+  local apps="$HOME/.local/share/applications"
+  mkdir -p "$apps" || return 0
+  local desk="$apps/aether-url-handler.desktop"
+  cat > "$desk" <<DEOF
+[Desktop Entry]
+Type=Application
+Name=Aether URL Handler
+Exec=\"$handler\" %u
+MimeType=x-scheme-handler/aether;
+NoDisplay=true
+DEOF
+  chmod +x "$desk" || return 0
+  if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database "$apps" 2>/dev/null || true
+  fi
+  if command -v xdg-mime >/dev/null 2>&1; then
+    xdg-mime default aether-url-handler.desktop x-scheme-handler/aether 2>/dev/null || true
+  fi
+}

--- a/Update/update_windows.bat
+++ b/Update/update_windows.bat
@@ -141,6 +141,7 @@ if defined MIRROR set "START=%MIRROR%"
 if defined MIRROR call :prune_mirror
 if not defined START set "START=%TARGET%"
 call :write_launch "%START%"
+call :register_protocol "%START%"
 
 if "%RESTART%"=="1" call :restart
 
@@ -306,4 +307,11 @@ for %%i in ("%AETHER_CURRENT_DIR%\..") do set "PROOT=%%~fi"
 if not defined PROOT exit /b 0
 for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "& { $root=$env:PROOT; $keep=5; $hold=''; if($env:MIRROR){ $hold=[IO.Path]::GetFullPath($env:MIRROR) }; $items=Get-ChildItem -Path $root -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { $ver=''; if(Test-Path (Join-Path $_.FullName '.aether_web_version')){ $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim() }; if(-not $ver -and $_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)($|_[0-9]{12}$)'){ $ver=$matches[1] }; if($ver){ [PSCustomObject]@{ Dir=$_.FullName; Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending; $keepers=New-Object System.Collections.Generic.List[string]; foreach($dir in @($hold)){ if($dir -and ($items | Where-Object { $_.Dir -eq $dir }) -and -not $keepers.Contains($dir)){ $keepers.Add($dir) } }; foreach($item in $items){ if($keepers.Count -ge $keep){ break }; if(-not $keepers.Contains($item.Dir)){ $keepers.Add($item.Dir) } }; $gone=0; foreach($item in $items){ if($keepers.Contains($item.Dir)){ continue }; Remove-Item $item.Dir -Recurse -Force -ErrorAction SilentlyContinue; if(-not (Test-Path $item.Dir)){ $gone++ } }; Write-Output $gone }"`) do set "MPRUNE=%%i"
 if not defined MPRUNE set "MPRUNE=0"
+exit /b 0
+
+:register_protocol
+set "PROT_DIR=%~1"
+set "PROT_HANDLER=%PROT_DIR%\aether-protocol-handler.vbs"
+if not exist "%PROT_HANDLER%" exit /b 0
+powershell -NoProfile -Command "& { $hkcu='HKCU:\Software\Classes\aether'; $handler=$env:PROT_HANDLER; if(-not (Test-Path $hkcu)){ New-Item -Path $hkcu -Force | Out-Null }; Set-ItemProperty -Path $hkcu -Name '(Default)' -Value 'URL:Aether Protocol' -Force; Set-ItemProperty -Path $hkcu -Name 'URL Protocol' -Value '' -Force; $cmd=$hkcu+'\shell\open\command'; if(-not (Test-Path $cmd)){ New-Item -Path $cmd -Force | Out-Null }; Set-ItemProperty -Path $cmd -Name '(Default)' -Value ('wscript.exe \"' + $handler + '\"') -Force }" >nul 2>nul
 exit /b 0

--- a/packages/opencode/launcher/aether-protocol-handler.sh
+++ b/packages/opencode/launcher/aether-protocol-handler.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dir="$(cd "$(dirname "$0")" && pwd)"
+portfile="$HOME/.local/share/aether/serve-port"
+port=""
+if [ -f "$portfile" ]; then
+  port="$(head -1 "$portfile" 2>/dev/null || true)"
+fi
+if [ -n "$port" ]; then
+  if curl -s -o /dev/null --max-time 2 "http://127.0.0.1:$port/" >/dev/null 2>&1; then
+    xdg-open "http://127.0.0.1:$port/" 2>/dev/null || sensible-browser "http://127.0.0.1:$port/" 2>/dev/null || true
+    exit 0
+  fi
+fi
+exec "$dir/Aether.sh"

--- a/packages/opencode/launcher/aether-protocol-handler.vbs
+++ b/packages/opencode/launcher/aether-protocol-handler.vbs
@@ -1,0 +1,57 @@
+Dim fso, scriptDir, portFile, port, wsh, url
+
+Set fso = CreateObject("Scripting.FileSystemObject")
+scriptDir = fso.GetParentFolderName(WScript.ScriptFullName)
+
+portFile = CreateObject("WScript.Shell").ExpandEnvironmentStrings("%APPDATA%") & "\aether\serve-port"
+port = ""
+
+If fso.FileExists(portFile) Then
+    On Error Resume Next
+    Dim ts
+    Set ts = fso.OpenTextFile(portFile, 1)
+    port = ts.ReadLine
+    ts.Close
+    On Error GoTo 0
+End If
+
+If port = "" Then port = "19527"
+
+url = "http://127.0.0.1:" & port & "/"
+
+On Error Resume Next
+Dim http
+Set http = CreateObject("MSXML2.XMLHTTP.6.0")
+If Err.Number <> 0 Then
+    Err.Clear
+    Set http = CreateObject("MSXML2.XMLHTTP.3.0")
+End If
+If Err.Number <> 0 Then
+    Err.Clear
+    Set http = CreateObject("MSXML2.XMLHTTP")
+End If
+If Err.Number <> 0 Then
+    On Error GoTo 0
+    GoTo NoCheck
+End If
+http.Open "GET", url, False
+http.setRequestHeader "Connection", "close"
+http.Send
+If Err.Number = 0 Then
+    On Error GoTo 0
+    CreateObject("WScript.Shell").Run url, 1, False
+    WScript.Quit 0
+End If
+On Error GoTo 0
+
+NoCheck:
+
+Dim vbsPath
+vbsPath = scriptDir & "\Aether.vbs"
+If Not fso.FileExists(vbsPath) Then
+    MsgBox "找不到: " & vbsPath, 16, "启动失败"
+    WScript.Quit 1
+End If
+
+CreateObject("WScript.Shell").Run "wscript.exe """ & vbsPath & """", 1, False
+WScript.Quit 0

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -300,6 +300,8 @@ for (const item of targets) {
   // Copy launcher
   if (item.os === "win32") {
     fs.copyFileSync(path.resolve(dir, "launcher/Aether.vbs"), `dist/${name}/bin/Aether.vbs`)
+    const phDest = `dist/${name}/bin/aether-protocol-handler.vbs`
+    fs.copyFileSync(path.resolve(dir, "launcher/aether-protocol-handler.vbs"), phDest)
   } else if (item.os === "darwin") {
     const dest = `dist/${name}/bin/Aether.command`
     fs.copyFileSync(path.resolve(dir, "launcher/Aether.command"), dest)
@@ -308,6 +310,9 @@ for (const item of targets) {
     const dest = `dist/${name}/bin/Aether.sh`
     fs.copyFileSync(path.resolve(dir, "launcher/Aether.sh"), dest)
     fs.chmodSync(dest, 0o755)
+    const phDest = `dist/${name}/bin/aether-protocol-handler.sh`
+    fs.copyFileSync(path.resolve(dir, "launcher/aether-protocol-handler.sh"), phDest)
+    fs.chmodSync(phDest, 0o755)
   }
 
   await Bun.file(`dist/${name}/package.json`).write(

--- a/packing_scripts/release-linux-web.sh
+++ b/packing_scripts/release-linux-web.sh
@@ -75,6 +75,10 @@ if [ -f "$out/Aether.sh" ]; then
   chmod +x "$out/Aether.sh"
 fi
 
+if [ -f "$out/aether-protocol-handler.sh" ]; then
+  chmod +x "$out/aether-protocol-handler.sh"
+fi
+
 cat >"$out/README_FIRST.txt" <<'EOF'
 Aether Web (Linux ARCH)
 


### PR DESCRIPTION
## Summary

- Register `aether://` custom URL scheme on all three platforms so users can type `aether://start` in the browser address bar to start the server and open the web UI, instead of manually clicking a launcher script
- Installation/update scripts automatically register the protocol — zero user configuration needed

## Changes

### Windows
- New `aether-protocol-handler.vbs`: checks if server is already running (read port file → HTTP probe) and opens browser directly, otherwise falls back to `Aether.vbs`
- `update_windows.bat`: new `:register_protocol` subroutine writing HKCU registry entries (no admin privilege needed)
- MSXML2.XMLHTTP fallback chain (`.6.0` → `.3.0` → no version) for compatibility with older Windows

### macOS
- `update_darwin.command`: added `CFBundleURLTypes` with `aether` scheme to `Info.plist` in `build_app()`
- Aether.app wrapper script now checks for an existing server before launching a new instance (curl probe with 2s timeout, any HTTP response = server running)

### Linux
- New `aether-protocol-handler.sh`: same logic as Windows handler, using curl + xdg-open
- `update_linux.sh`: new `register_protocol()` creating a `.desktop` file with `MimeType=x-scheme-handler/aether` and registering via `xdg-mime`
- `.desktop` Exec path quoted (`\"`) to handle install directories with spaces

### Build & packaging
- `build.ts`: copy protocol handler scripts to dist for Windows and Linux
- `release-linux-web.sh`: chmod +x for the new handler script

## Bug fixes applied during review

| Bug | Fix |
|-----|-----|
| Server returns 401 (password set) → `Status=200` / `curl -f` falsely detected as "not running" | VBS: check `Err.Number=0` (any response); macOS/Linux: `curl -s -o /dev/null --max-time 2` without `-f` |
| Linux `.desktop` Exec path unquoted → breaks with spaces | `Exec=\"$handler\" %u` via heredoc escaped quotes |
| `MSXML2.XMLHTTP.6.0` missing on old Windows | Fallback chain `.6.0` → `.3.0` → bare, all fail → skip probe and start server |