### PR TITLE
fix(provider): strip responses reasoning options for chat completions

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -278,11 +278,8 @@ export namespace Provider {
         autoload: false,
         async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
           if (useLanguageModel(sdk)) return sdk.languageModel(modelID)
-          if (options?.["useCompletionUrls"]) {
-            return sdk.chat(modelID)
-          } else {
-            return sdk.responses(modelID)
-          }
+          if (options?.["useCompletionUrls"]) return sdk.chat(modelID)
+          return sdk.responses(modelID)
         },
         options: {},
         vars(_options) {
@@ -298,11 +295,8 @@ export namespace Provider {
         autoload: false,
         async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
           if (useLanguageModel(sdk)) return sdk.languageModel(modelID)
-          if (options?.["useCompletionUrls"]) {
-            return sdk.chat(modelID)
-          } else {
-            return sdk.responses(modelID)
-          }
+          if (options?.["useCompletionUrls"]) return sdk.chat(modelID)
+          return sdk.responses(modelID)
         },
         options: {
           baseURL: resourceName ? `https://${resourceName}.cognitiveservices.azure.com/openai` : undefined,

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -931,7 +931,40 @@ export namespace ProviderTransform {
     amazon: "bedrock",
   }
 
-  export function providerOptions(model: Provider.Model, options: { [x: string]: any }) {
+  function copilotChat(model: Provider.Model) {
+    const match = /^gpt-(\d+)/.exec(model.api.id)
+    if (!match) return true
+    return Number(match[1]) < 5 || model.api.id.startsWith("gpt-5-mini")
+  }
+
+  function chat(model: Provider.Model, cfg?: Record<string, unknown>) {
+    if (model.api.npm === "@ai-sdk/openai-compatible") return true
+    if (model.api.npm === "@ai-sdk/azure") return cfg?.useCompletionUrls === true
+    if (model.api.npm === "@ai-sdk/github-copilot") return copilotChat(model)
+    return false
+  }
+
+  function scrub(options: Record<string, unknown>) {
+    const result = { ...options }
+    delete result.reasoningSummary
+    delete result.reasoning_summary
+
+    if (Array.isArray(result.include)) {
+      const include = result.include.filter((item) => item !== "reasoning.encrypted_content")
+      if (include.length > 0) result.include = include
+      else delete result.include
+    }
+
+    return result
+  }
+
+  export function providerOptions(
+    model: Provider.Model,
+    options: Record<string, unknown>,
+    cfg?: Record<string, unknown>,
+  ) {
+    const opts = chat(model, cfg) ? scrub(options) : options
+
     if (model.api.npm === "@ai-sdk/gateway") {
       // Gateway providerOptions are split across two namespaces:
       // - `gateway`: gateway-native routing/caching controls (order, only, byok, etc.)
@@ -941,8 +974,8 @@ export namespace ProviderTransform {
       const i = model.api.id.indexOf("/")
       const rawSlug = i > 0 ? model.api.id.slice(0, i) : undefined
       const slug = rawSlug ? (SLUG_OVERRIDES[rawSlug] ?? rawSlug) : undefined
-      const gateway = options.gateway
-      const rest = Object.fromEntries(Object.entries(options).filter(([k]) => k !== "gateway"))
+      const gateway = opts.gateway
+      const rest = Object.fromEntries(Object.entries(opts).filter(([k]) => k !== "gateway"))
       const has = Object.keys(rest).length > 0
 
       const result: Record<string, any> = {}
@@ -963,7 +996,7 @@ export namespace ProviderTransform {
     }
 
     const key = sdkKey(model.api.npm) ?? model.providerID
-    return { [key]: options }
+    return { [key]: opts }
   }
 
   export function maxOutputTokens(model: Provider.Model): number {

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -248,7 +248,10 @@ export namespace LLM {
       temperature: params.temperature,
       topP: params.topP,
       topK: params.topK,
-      providerOptions: ProviderTransform.providerOptions(input.model, params.options),
+      providerOptions: ProviderTransform.providerOptions(input.model, params.options, {
+        ...provider.options,
+        ...input.model.options,
+      }),
       activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
       tools,
       toolChoice: input.toolChoice,

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -341,6 +341,111 @@ describe("ProviderTransform.providerOptions", () => {
     })
   })
 
+  test("removes responses-only reasoning fields for chat completions models", () => {
+    const model = createModel({
+      providerID: "custom",
+      api: {
+        id: "gpt-5.5",
+        url: "https://api.custom.com",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+
+    expect(
+      ProviderTransform.providerOptions(model, {
+        reasoningEffort: "high",
+        reasoningSummary: "auto",
+        include: ["reasoning.encrypted_content"],
+      }),
+    ).toEqual({
+      custom: {
+        reasoningEffort: "high",
+      },
+    })
+  })
+
+  test("keeps responses-only reasoning fields for azure responses models", () => {
+    const model = createModel({
+      providerID: "azure",
+      api: {
+        id: "gpt-5",
+        url: "https://azure.com",
+        npm: "@ai-sdk/azure",
+      },
+    })
+
+    expect(
+      ProviderTransform.providerOptions(model, {
+        reasoningEffort: "high",
+        reasoningSummary: "auto",
+        include: ["reasoning.encrypted_content"],
+      }),
+    ).toEqual({
+      azure: {
+        reasoningEffort: "high",
+        reasoningSummary: "auto",
+        include: ["reasoning.encrypted_content"],
+      },
+    })
+  })
+
+  test("removes responses-only reasoning fields for azure chat completions models", () => {
+    const model = createModel({
+      providerID: "azure",
+      api: {
+        id: "gpt-5",
+        url: "https://azure.com",
+        npm: "@ai-sdk/azure",
+      },
+    })
+
+    expect(
+      ProviderTransform.providerOptions(
+        model,
+        {
+          reasoningEffort: "high",
+          reasoningSummary: "auto",
+          include: ["reasoning.encrypted_content"],
+        },
+        { useCompletionUrls: true },
+      ),
+    ).toEqual({
+      azure: {
+        reasoningEffort: "high",
+      },
+    })
+  })
+
+  test("removes responses-only reasoning fields for azure model-level chat completions models", () => {
+    const model = createModel({
+      providerID: "azure",
+      api: {
+        id: "gpt-5",
+        url: "https://azure.com",
+        npm: "@ai-sdk/azure",
+      },
+      options: {
+        useCompletionUrls: true,
+      },
+    })
+
+    expect(
+      ProviderTransform.providerOptions(
+        model,
+        {
+          reasoningEffort: "high",
+          reasoningSummary: "auto",
+          include: ["reasoning.encrypted_content"],
+        },
+        model.options,
+      ),
+    ).toEqual({
+      azure: {
+        reasoningEffort: "high",
+      },
+    })
+  })
+
   test("uses gateway model provider slug for gateway models", () => {
     const model = createModel({
       providerID: "vercel",

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -329,6 +329,98 @@ describe("session.llm.stream", () => {
     })
   })
 
+  test("strips reasoning summary options from chat completions requests", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "alibaba"
+    const modelID = "qwen-plus"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await Provider.getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-chat-reasoning")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {
+            reasoningSummary: "auto",
+            include: ["reasoning.encrypted_content"],
+          },
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("user-chat-reasoning"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: resolved.id },
+          variant: "high",
+        } satisfies MessageV2.User
+
+        const stream = await LLM.stream({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        for await (const _ of stream.fullStream) {
+        }
+
+        const capture = await request
+        const body = capture.body
+
+        expect(capture.url.pathname.endsWith("/chat/completions")).toBe(true)
+        expect(body.reasoningSummary).toBeUndefined()
+        expect(body.reasoning_summary).toBeUndefined()
+        expect(body.include).toBeUndefined()
+
+        const reasoning = (body.reasoningEffort as string | undefined) ?? (body.reasoning_effort as string | undefined)
+        expect(reasoning).toBe("high")
+      },
+    })
+  })
+
   test("keeps tools enabled by prompt permissions", async () => {
     const server = state.server
     if (!server) {


### PR DESCRIPTION
### Issue for this PR

Closes #582

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Removes Responses API-only reasoning options from provider options when a request is sent through chat completions.

This prevents custom/OpenAI-compatible providers from receiving unsupported `reasoningSummary` and `include: ["reasoning.encrypted_content"]` fields. Azure `useCompletionUrls` is also handled using the same merged provider/model options that model loading uses, so provider-level and model-level configuration stay consistent.

### How did you verify your code works?

- `bun typecheck`
- `env TMPDIR=/tmp/opencode-test-run bun test test/provider/transform.test.ts`
- `env TMPDIR=/tmp/opencode-test-run bun test test/session/llm.test.ts`
- `git diff --cached --check`
- `git push -u origin fix/chat-completions-reasoning-options` push hook ran `bun turbo typecheck` successfully

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR