### PR TITLE
fix: define linux protocol registration before use

### DIFF
--- a/Update/update_linux.sh
+++ b/Update/update_linux.sh
@@ -509,6 +509,30 @@ boot() {
   nohup "$app" >/dev/null 2>&1 < /dev/null &
 }
 
+register_protocol() {
+  local target="$1"
+  local handler="$target/aether-protocol-handler.sh"
+  [ -f "$handler" ] || return 0
+  local apps="$HOME/.local/share/applications"
+  mkdir -p "$apps" || return 0
+  local desk="$apps/aether-url-handler.desktop"
+  cat > "$desk" <<DEOF
+[Desktop Entry]
+Type=Application
+Name=Aether URL Handler
+Exec=\"$handler\" %u
+MimeType=x-scheme-handler/aether;
+NoDisplay=true
+DEOF
+  chmod +x "$desk" || return 0
+  if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database "$apps" 2>/dev/null || true
+  fi
+  if command -v xdg-mime >/dev/null 2>&1; then
+    xdg-mime default aether-url-handler.desktop x-scheme-handler/aether 2>/dev/null || true
+  fi
+}
+
 mirror_dir() {
   local root dst tmp
   root="$(mirror_root || true)"
@@ -681,27 +705,3 @@ if [ -n "$copy_note" ]; then
   echo "$copy_note"
 fi
 exit "$ok"
-
-register_protocol() {
-  local target="$1"
-  local handler="$target/aether-protocol-handler.sh"
-  [ -f "$handler" ] || return 0
-  local apps="$HOME/.local/share/applications"
-  mkdir -p "$apps" || return 0
-  local desk="$apps/aether-url-handler.desktop"
-  cat > "$desk" <<DEOF
-[Desktop Entry]
-Type=Application
-Name=Aether URL Handler
-Exec=\"$handler\" %u
-MimeType=x-scheme-handler/aether;
-NoDisplay=true
-DEOF
-  chmod +x "$desk" || return 0
-  if command -v update-desktop-database >/dev/null 2>&1; then
-    update-desktop-database "$apps" 2>/dev/null || true
-  fi
-  if command -v xdg-mime >/dev/null 2>&1; then
-    xdg-mime default aether-url-handler.desktop x-scheme-handler/aether 2>/dev/null || true
-  fi
-}


### PR DESCRIPTION
### Issue for this PR

Closes #584

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Moves `register_protocol()` in `Update/update_linux.sh` before the install flow calls it.

The function was previously placed after `exit "$ok"`, so Bash had not defined it when the script reached `register_protocol "$start_target"`. That made Linux update installs fail with `register_protocol: command not found`.

### How did you verify your code works?

- `bun install --lock-file`
- `bun test test/server/web-update-script.test.ts` from `packages/opencode`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
