### PR TITLE
feat(skill): add per-skill evolution disable toggle

### DIFF
--- a/packages/app/src/components/dialog-evolved-skills.tsx
+++ b/packages/app/src/components/dialog-evolved-skills.tsx
@@ -7,7 +7,7 @@ import { useGlobalSDK } from "@/context/global-sdk"
 import { useLanguage } from "@/context/language"
 import { useSDK } from "@/context/sdk"
 
-type ManagedSkill = { name: string; description: string; content: string; category?: string; enabled?: boolean; file?: string }
+type ManagedSkill = { name: string; description: string; content: string; category?: string; enabled?: boolean; evolution_enabled?: boolean; file?: string }
 type SortMode = "path" | "category"
 
 function parentDir(file: string): string {
@@ -34,6 +34,7 @@ export const DialogEvolvedSkills: Component = () => {
     return (result.data as unknown as ManagedSkill[]) ?? []
   })
   const [toggling, setToggling] = createSignal<string | null>(null)
+  const [togglingEvolution, setTogglingEvolution] = createSignal<string | null>(null)
 
   function toggleGroup(key: string) {
     setExpanded((prev) => {
@@ -42,6 +43,24 @@ export const DialogEvolvedSkills: Component = () => {
       else next.add(key)
       return next
     })
+  }
+
+  async function handleToggleEvolution(file: string, evolutionEnabled: boolean) {
+    setTogglingEvolution(file)
+    try {
+      await globalSDK.client.config.skills.toggleEvolution({ file, evolutionEnabled })
+      await refetch()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      showToast({
+        variant: "error",
+        icon: "circle-x",
+        title: language.t("evolvedSkills.operationFailed"),
+        description: message,
+      })
+    } finally {
+      setTogglingEvolution(null)
+    }
   }
 
   async function handleToggle(file: string, enabled: boolean) {
@@ -120,7 +139,23 @@ export const DialogEvolvedSkills: Component = () => {
           </span>
         </Show>
       </div>
-      <div class="flex items-center shrink-0">
+      <div class="flex items-center gap-1.5 shrink-0">
+        <Show when={props.skill.file}>
+          <button
+            class={[
+              "px-2 py-0.5 rounded text-11-regular transition-colors disabled:opacity-40",
+              props.skill.evolution_enabled !== false
+                ? "text-text-weak hover:text-danger hover:bg-danger/10"
+                : "text-success hover:bg-success/10",
+            ].join(" ")}
+            disabled={togglingEvolution() === props.skill.file}
+            onClick={() => props.skill.file && handleToggleEvolution(props.skill.file, props.skill.evolution_enabled === false)}
+          >
+            {props.skill.evolution_enabled !== false
+              ? language.t("evolvedSkills.disableEvolution")
+              : language.t("evolvedSkills.enableEvolution")}
+          </button>
+        </Show>
         <Switch
           checked={props.skill.enabled !== false}
           disabled={toggling() === props.skill.file}

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -471,6 +471,8 @@ export const dict = {
   "defaultSkills.addFailed": "Failed to add",
   "defaultSkills.dragToResize": "Drag up to expand list height",
   "evolvedSkills.title": "Skills Evolution",
+  "evolvedSkills.disableEvolution": "Disable Evolution",
+  "evolvedSkills.enableEvolution": "Enable Evolution",
   "evolvedSkills.loading": "Loading...",
   "evolvedSkills.empty": "No evolved skills yet",
   "evolvedSkills.noDescription": "No description",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -469,6 +469,8 @@ export const dict = {
   "defaultSkills.addFailed": "添加失败",
   "defaultSkills.dragToResize": "向上拖动可扩大列表高度",
   "evolvedSkills.title": "自进化Skills",
+  "evolvedSkills.disableEvolution": "取消自进化",
+  "evolvedSkills.enableEvolution": "恢复自进化",
   "evolvedSkills.loading": "加载中...",
   "evolvedSkills.empty": "暂无自进化技能",
   "evolvedSkills.noDescription": "暂无描述",

--- a/packages/app/src/utils/server.ts
+++ b/packages/app/src/utils/server.ts
@@ -173,6 +173,7 @@ export type AppClient = Base & {
       listEvolution(input?: { directory?: string }): Req<Skill[]>
       getManagedDir(): Req<{ path: string }>
       toggle(input: { name: string; enabled: boolean }): Req<{ ok: boolean }>
+      toggleEvolution(input: { file: string; evolutionEnabled: boolean }): Req<{ ok: boolean }>
       addDefaults(input?: { directory?: string }): Req<{ added: string[] }>
     }
   }
@@ -391,6 +392,9 @@ export function addSkillsExtraMethods(
     if (input?.directory) params.set("directory", input.directory)
     const suffix = params.toString() ? `?${params}` : ""
     return requestJSON(`${baseUrl}/config/skills/evolution${suffix}`, { headers }, options)
+  }
+  skills.toggleEvolution = async (input: { file: string; evolutionEnabled: boolean }) => {
+    return requestJSON(`${baseUrl}/config/skills/toggle-evolution`, { method: "POST", headers, body: JSON.stringify(input) }, options)
   }
   return client
 }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -786,6 +786,10 @@ export namespace Config {
       .min(1)
       .optional()
       .describe("Maximum number of version snapshots kept per skill before older snapshots are pruned (default: 100)"),
+    evolution_disabled: z
+      .array(z.string())
+      .optional()
+      .describe("Skill directory paths excluded from background auto-evolution"),
   })
   export type Skills = z.infer<typeof Skills>
 
@@ -1517,6 +1521,7 @@ export namespace Config {
     content: z.string(),
     category: z.string().optional(),
     enabled: z.boolean().optional(),
+    evolution_enabled: z.boolean().optional(),
     file: z.string().optional(),
   })
   export type DefaultSkill = z.infer<typeof DefaultSkill>
@@ -1659,6 +1664,7 @@ export namespace Config {
   export async function listEvolutionSkills(): Promise<DefaultSkill[]> {
     const global = await getGlobal()
     const disabled = getDisabledPaths(global.skills?.disabled)
+    const evolutionDisabled = new Set(global.skills?.evolution_disabled ?? [])
 
     // Remove stale disabled entries whose directories no longer exist
     const stale = (
@@ -1682,7 +1688,7 @@ export namespace Config {
         const skillFile = path.join(skillDir, "SKILL.md")
         const text = await Filesystem.readText(skillFile).catch(() => null)
         if (text === null) {
-          result.push({ name: entry.name, description: "", content: "", enabled: !disabled.has(skillDir), file: skillDir })
+          result.push({ name: entry.name, description: "", content: "", enabled: !disabled.has(skillDir), evolution_enabled: !evolutionDisabled.has(skillDir), file: skillDir })
           continue
         }
         try {
@@ -1694,10 +1700,11 @@ export namespace Config {
             content: parsed.content.trim(),
             category: parsed.data.category ? String(parsed.data.category) : undefined,
             enabled: !disabled.has(skillDir),
+            evolution_enabled: !evolutionDisabled.has(skillDir),
             file: skillDir,
           })
         } catch {
-          result.push({ name: entry.name, description: "", content: text, enabled: !disabled.has(skillDir), file: skillDir })
+          result.push({ name: entry.name, description: "", content: text, enabled: !disabled.has(skillDir), evolution_enabled: !evolutionDisabled.has(skillDir), file: skillDir })
         }
       }
       return result
@@ -1799,6 +1806,18 @@ export namespace Config {
     const aetherDir = path.dirname(path.dirname(file))
     const scope = path.resolve(aetherDir) === path.resolve(globalAetherDir) ? "all" : path.dirname(aetherDir)
     await Skill.clearSkillsPromptCache(scope)
+  }
+
+  export async function toggleSkillEvolution(file: string, evolutionEnabled: boolean): Promise<void> {
+    using _ = await Lock.write("config-skills-toggle")
+    const cfg = await getGlobal()
+    const disabled = new Set(cfg.skills?.evolution_disabled ?? [])
+    if (evolutionEnabled) {
+      disabled.delete(file)
+    } else {
+      disabled.add(file)
+    }
+    await updateGlobalInternal({ skills: { evolution_disabled: [...disabled] } } as any, { dispose: false })
   }
 
   function globalConfigFile() {

--- a/packages/opencode/src/server/routes/config.ts
+++ b/packages/opencode/src/server/routes/config.ts
@@ -226,6 +226,26 @@ export const ConfigRoutes = lazy(() =>
         return c.json({ ok: true })
       },
     )
+    .post(
+      "/skills/toggle-evolution",
+      describeRoute({
+        summary: "Toggle skill evolution",
+        description: "Enable or disable background auto-evolution for a skill by file path.",
+        operationId: "config.skills.toggleEvolution",
+        responses: {
+          200: {
+            description: "Skill evolution toggled",
+            content: { "application/json": { schema: resolver(z.object({ ok: z.boolean() })) } },
+          },
+        },
+      }),
+      validator("json", z.object({ file: z.string(), evolutionEnabled: z.boolean() })),
+      async (c) => {
+        const { file, evolutionEnabled } = c.req.valid("json")
+        await Config.toggleSkillEvolution(file, evolutionEnabled)
+        return c.json({ ok: true })
+      },
+    )
     .get(
       "/providers",
       describeRoute({

--- a/packages/opencode/src/tool/skill-manage.ts
+++ b/packages/opencode/src/tool/skill-manage.ts
@@ -250,6 +250,15 @@ export const SkillManageTool = Tool.define("skill_manage", async () => {
       const { skillDir, sourceLocation } = await resolveSkillDir(name)
       const skillFile = path.join(skillDir, "SKILL.md")
 
+      const evolutionDisabled = new Set(globalCfg.skills?.evolution_disabled ?? [])
+      const EVOLUTION_WRITE_ACTIONS = ["create", "edit", "patch", "write_file", "remove_file", "delete"]
+      if (evolutionDisabled.has(skillDir) && EVOLUTION_WRITE_ACTIONS.includes(action)) {
+        console.log(`[skill manage fail] call=${call} action=${action} name=${name} sig=${sig} reason=evolution_disabled`)
+        throw new Error(
+          `Skill "${name}" has evolution disabled. To manually edit it, use the edit tool on ${skillDir}/SKILL.md instead.`,
+        )
+      }
+
       if (disabledPaths.has(skillDir)) {
         // Stale entry: the shadow dir no longer exists (skill was disabled then deleted).
         // The same shadow path now belongs to a different source skill — clean it up.

--- a/packages/opencode/src/tool/skill-manage.ts
+++ b/packages/opencode/src/tool/skill-manage.ts
@@ -17,6 +17,10 @@ import {
 } from "./skill-versions"
 import { Log } from "../util/log"
 import { Config } from "../config/config"
+import { Bus } from "../bus"
+import { File } from "../file"
+import { FileWatcher } from "../file/watcher"
+import { FileTime } from "../file/time"
 
 const log = Log.create({ service: "skill.manage" })
 
@@ -303,6 +307,9 @@ export const SkillManageTool = Tool.define("skill_manage", async () => {
               await fs.rm(skillDir, { recursive: true, force: true })
               throw err
             }
+            Bus.publish(File.Event.Edited, { file: skillFile })
+            await Bus.publish(FileWatcher.Event.Updated, { file: skillFile, event: "add" })
+            if (ctx?.sessionID) await FileTime.read(ctx.sessionID, skillFile)
             await Skill.clearSkillsPromptCache()
             Skill.markClear()
             Skill.markDone(skillFile)
@@ -336,6 +343,9 @@ export const SkillManageTool = Tool.define("skill_manage", async () => {
               else await fs.rm(skillDir, { recursive: true, force: true })
               throw err
             }
+            Bus.publish(File.Event.Edited, { file: skillFile })
+            await Bus.publish(FileWatcher.Event.Updated, { file: skillFile, event: "change" })
+            if (ctx?.sessionID) await FileTime.read(ctx.sessionID, skillFile)
             await Skill.clearSkillsPromptCache()
             Skill.markClear()
             Skill.markDone(skillFile)
@@ -382,6 +392,9 @@ export const SkillManageTool = Tool.define("skill_manage", async () => {
               await atomicWrite(skillFile, raw)
               throw err
             }
+            Bus.publish(File.Event.Edited, { file: skillFile })
+            await Bus.publish(FileWatcher.Event.Updated, { file: skillFile, event: "change" })
+            if (ctx?.sessionID) await FileTime.read(ctx.sessionID, skillFile)
             await Skill.clearSkillsPromptCache()
             Skill.markClear()
             Skill.markDone(skillFile)
@@ -411,6 +424,8 @@ export const SkillManageTool = Tool.define("skill_manage", async () => {
               throw new Error(`Skill "${name}" not found`)
             }
             await fs.rm(skillDir, { recursive: true, force: true })
+            Bus.publish(File.Event.Edited, { file: skillFile })
+            await Bus.publish(FileWatcher.Event.Updated, { file: skillFile, event: "unlink" })
             await Skill.clearSkillsPromptCache()
             Skill.markClear()
             Skill.markDone(skillFile)
@@ -441,6 +456,9 @@ export const SkillManageTool = Tool.define("skill_manage", async () => {
             else await fs.unlink(targetPath).catch(() => {})
             throw err
           }
+          Bus.publish(File.Event.Edited, { file: targetPath })
+          await Bus.publish(FileWatcher.Event.Updated, { file: targetPath, event: originalFileContent !== null ? "change" : "add" })
+          if (ctx?.sessionID) await FileTime.read(ctx.sessionID, targetPath)
           await snapshot(skillDir, "write_file")
           return {
             title: `Wrote file in skill: ${name}`,
@@ -459,6 +477,8 @@ export const SkillManageTool = Tool.define("skill_manage", async () => {
           await fs.unlink(targetPath).catch(() => {
             throw new Error(`File not found: ${targetPath}`)
           })
+          Bus.publish(File.Event.Edited, { file: targetPath })
+          await Bus.publish(FileWatcher.Event.Updated, { file: targetPath, event: "unlink" })
           await snapshot(skillDir, "remove_file")
           return { title: `Removed file in skill: ${name}`, output: `File removed: ${targetPath}`, metadata: {} }
         }
@@ -478,6 +498,9 @@ export const SkillManageTool = Tool.define("skill_manage", async () => {
           try {
             if (sourceLocation && (await copyToShadowIfNeeded(sourceLocation, skillDir))) await snapshot(skillDir, "original")
             const { restoredFrom } = await versionRollback(skillDir, params.version)
+            Bus.publish(File.Event.Edited, { file: skillFile })
+            await Bus.publish(FileWatcher.Event.Updated, { file: skillFile, event: "change" })
+            if (ctx?.sessionID) await FileTime.read(ctx.sessionID, skillFile)
             await Skill.clearSkillsPromptCache()
             Skill.markClear()
             Skill.markDone(skillFile)


### PR DESCRIPTION
## Summary

- Add a toggle button per skill in the Evolved Skills dialog to disable/re-enable background auto-evolution for individual skills
- When evolution is disabled for a skill, `skill_manage` blocks write actions and directs the user to the edit tool
- Config, route, frontend, and i18n all updated

Closes #588

## Changes

| Area | Detail |
|---|---|
| `config.ts` | Added `evolution_disabled` to `Skills` schema, `evolution_enabled` to `DefaultSkill`, new `toggleSkillEvolution()` |
| `routes/config.ts` | New `POST /skills/toggle-evolution` endpoint |
| `skill-manage.ts` | Block write actions on evolution-disabled skills; publish file events after writes to refresh preview |
| `dialog-evolved-skills.tsx` | Per-skill toggle button with red/green hover state |
| `i18n/en.ts`, `i18n/zh.ts` | New strings for toggle button labels |

## Test plan

- [ ] Open Evolved Skills dialog — each skill card shows a "Disable Evolution" button
- [ ] Click Disable Evolution on a skill — button changes to "Enable Evolution" (green); config persists after reload
- [ ] With evolution disabled, confirm `skill_manage` write returns a clear error pointing to the edit tool
- [ ] Click Enable Evolution — restores normal auto-evolution behavior
- [ ] Verify other skills are unaffected by toggling one skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)