### PR TITLE
fix(skill): prefer existing category names when creating or editing skills

### DIFF
--- a/packages/opencode/src/session/skill-evolution.ts
+++ b/packages/opencode/src/session/skill-evolution.ts
@@ -6,6 +6,7 @@ import { SessionID } from "./schema"
 import { Bus } from "@/bus"
 import { BusEvent } from "@/bus/bus-event"
 import { SkillDirty } from "./skill-dirty"
+import { Config } from "../config/config"
 import z from "zod"
 
 const log = Log.create({ service: "skill.evolution" })
@@ -28,7 +29,7 @@ export const SKILL_NUDGE_INTERVAL = 10
 // so it never recursively triggers another review.
 export const SKILL_REVIEW_MARKER = "__skill_review__"
 
-export const SKILL_REVIEW_PROMPT = [
+export const SKILL_REVIEW_PROMPT_BASE = [
   "Review the conversation above and consider saving or updating a skill if appropriate.",
   "",
   "Focus on: was a non-trivial approach used to complete a task that required trial and error,",
@@ -41,22 +42,49 @@ export const SKILL_REVIEW_PROMPT = [
   "",
   "When creating or editing a skill, always include a 'category' field — a short label that",
   "groups related skills together (e.g. 'Git', 'Testing', 'Refactoring', 'Debugging', 'Build').",
+  "Prefer reusing an existing category name rather than inventing a new one.",
   "Infer it from the skill content if not obvious.",
 ].join("\n")
 
-export const SKILLS_GUIDANCE = [
-  "After completing a complex task (5+ tool calls), fixing a tricky error,",
-  "or discovering a non-trivial workflow, save the approach as a skill with",
-  "skill_manage so you can reuse it next time.",
-  "When using a skill and finding it outdated, incomplete, or wrong, update it",
-  "immediately with skill_manage — don't wait to be asked.",
-  "Use action='patch' for targeted fixes (a step changed, add content, fix wording).",
-  "Use action='edit' when the entire approach has fundamentally changed and a full rewrite is needed.",
-  "Always include a 'category' field when creating or editing a skill (e.g. 'Git', 'Testing', 'Debugging').",
-  "Skills that aren't maintained become liabilities.",
-].join("\n")
+export function buildCategoryHint(existingCategories: string[]): string {
+  if (existingCategories.length === 0) return ""
+  return `Existing skill categories (prefer reusing these): ${existingCategories.join(", ")}.`
+}
 
-export function buildReviewPrompt(messages: MessageV2.WithParts[]): string {
+export function buildSkillsGuidance(existingCategories: string[]): string {
+  const categoryLine =
+    existingCategories.length > 0
+      ? `Always include a 'category' field. Prefer reusing an existing category: ${existingCategories.join(", ")}.`
+      : "Always include a 'category' field when creating or editing a skill (e.g. 'Git', 'Testing', 'Debugging')."
+  return [
+    "After completing a complex task (5+ tool calls), fixing a tricky error,",
+    "or discovering a non-trivial workflow, save the approach as a skill with",
+    "skill_manage so you can reuse it next time.",
+    "When using a skill and finding it outdated, incomplete, or wrong, update it",
+    "immediately with skill_manage — don't wait to be asked.",
+    "Use action='patch' for targeted fixes (a step changed, add content, fix wording).",
+    "Use action='edit' when the entire approach has fundamentally changed and a full rewrite is needed.",
+    categoryLine,
+    "Skills that aren't maintained become liabilities.",
+  ].join("\n")
+}
+
+export const SKILLS_GUIDANCE = buildSkillsGuidance([])
+
+export async function buildReviewPrompt(messages: MessageV2.WithParts[]): Promise<string> {
+  const [managed, evolution, defaults] = await Promise.all([
+    Config.listManagedSkills().catch(() => [] as Awaited<ReturnType<typeof Config.listManagedSkills>>),
+    Config.listEvolutionSkills().catch(() => [] as Awaited<ReturnType<typeof Config.listEvolutionSkills>>),
+    Config.listDefaultSkills().catch(() => [] as Awaited<ReturnType<typeof Config.listDefaultSkills>>),
+  ])
+  const existingCategories = [
+    ...new Set(
+      [...managed, ...evolution, ...defaults]
+        .map((s) => s.category?.trim())
+        .filter((c): c is string => Boolean(c)),
+    ),
+  ].sort()
+
   // Summarise the conversation into text so the review agent can read it
   const lines: string[] = ["<conversation_history>"]
   for (const msg of messages) {
@@ -72,7 +100,11 @@ export function buildReviewPrompt(messages: MessageV2.WithParts[]): string {
       }
     }
   }
-  lines.push("</conversation_history>", "", SKILL_REVIEW_PROMPT)
+  const categoryHint = buildCategoryHint(existingCategories)
+  const reviewPrompt = categoryHint
+    ? `${SKILL_REVIEW_PROMPT_BASE}\n${categoryHint}`
+    : SKILL_REVIEW_PROMPT_BASE
+  lines.push("</conversation_history>", "", reviewPrompt)
   return lines.join("\n")
 }
 
@@ -95,7 +127,7 @@ export async function spawnBackgroundReview(input: {
 
     console.log(`[skill review] started childSession=${childSession.id} model=${model.providerID}/${model.modelID}`)
 
-    const reviewPrompt = buildReviewPrompt(messages)
+    const reviewPrompt = await buildReviewPrompt(messages)
 
     await SessionPrompt.prompt({
       sessionID: childSession.id,

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -13,7 +13,7 @@ import type { Provider } from "@/provider/provider"
 import type { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
 import { Skill } from "@/skill"
-import { SKILLS_GUIDANCE } from "./skill-evolution"
+import { buildSkillsGuidance } from "./skill-evolution"
 import { Config } from "@/config/config"
 
 export namespace SystemPrompt {
@@ -66,6 +66,27 @@ export namespace SystemPrompt {
     const cfg = await Config.get()
     const skillNudgeInterval = cfg.skills?.creation_nudge_interval ?? 10
 
+    let skillsGuidance = buildSkillsGuidance([])
+    if (skillNudgeInterval !== 0) {
+      try {
+        const [managed, evolution, defaults] = await Promise.all([
+          Config.listManagedSkills().catch(() => [] as Awaited<ReturnType<typeof Config.listManagedSkills>>),
+          Config.listEvolutionSkills().catch(() => [] as Awaited<ReturnType<typeof Config.listEvolutionSkills>>),
+          Config.listDefaultSkills().catch(() => [] as Awaited<ReturnType<typeof Config.listDefaultSkills>>),
+        ])
+        const existingCategories = [
+          ...new Set(
+            [...managed, ...evolution, ...defaults]
+              .map((s) => s.category?.trim())
+              .filter((c): c is string => Boolean(c)),
+          ),
+        ].sort()
+        skillsGuidance = buildSkillsGuidance(existingCategories)
+      } catch {
+        // fall back to guidance without category hints
+      }
+    }
+
     return [
       "## Skills (mandatory)",
       "Before replying, scan the skills below. If a skill matches or is even partially relevant to your task, you MUST follow its instructions.",
@@ -80,7 +101,7 @@ export namespace SystemPrompt {
         "After difficult/iterative tasks, offer to save as a skill.",
         "If a skill you loaded was missing steps, had wrong commands, or needed pitfalls you discovered, update it before finishing.",
         "",
-        SKILLS_GUIDANCE,
+        skillsGuidance,
       ] : []),
     ].join("\n")
   }

--- a/packages/opencode/src/tool/skill-manage.ts
+++ b/packages/opencode/src/tool/skill-manage.ts
@@ -144,43 +144,75 @@ async function atomicWrite(filePath: string, content: string): Promise<void> {
 
 // ── Tool ──────────────────────────────────────────────────────────────────────
 
-const parameters = z.preprocess(
-  (raw: any) => {
-    if (!raw || typeof raw !== "object") return raw
-    const out = { ...raw }
-    // Normalize camelCase/alternate variants that some models generate
-    if (out.old_str === undefined) out.old_str = out.oldStr ?? out.oldString ?? out.old_string
-    if (out.new_str === undefined) out.new_str = out.newStr ?? out.newString ?? out.new_string
-    if (out.relative_path === undefined) out.relative_path = out.relativePath ?? out.relativeP
-    return out
-  },
-  z.object({
-    action: z
-      .enum(["create", "edit", "patch", "delete", "write_file", "remove_file", "history", "rollback"])
-      .describe("Action to perform on a skill"),
-    name: z.string().describe("Skill name (directory name under the skills folder). Required for all actions."),
-    description: z
-      .string()
-      .optional()
-      .describe("One-line skill description for the frontmatter. Required for create and edit."),
-    category: z
-      .string()
-      .optional()
-      .describe(
-        "Short category label for grouping skills (e.g. 'Git', 'Testing', 'Refactoring'). Required for create and edit — always infer one from the skill content if not obvious.",
+const preprocess = (raw: any) => {
+  if (!raw || typeof raw !== "object") return raw
+  const out = { ...raw }
+  // Normalize camelCase/alternate variants that some models generate
+  if (out.old_str === undefined) out.old_str = out.oldStr ?? out.oldString ?? out.old_string
+  if (out.new_str === undefined) out.new_str = out.newStr ?? out.newString ?? out.new_string
+  if (out.relative_path === undefined) out.relative_path = out.relativePath ?? out.relativeP
+  return out
+}
+
+function buildParameters(existingCategories: string[]) {
+  const categoryDesc =
+    existingCategories.length > 0
+      ? `Short category label for grouping skills. Prefer reusing an existing category: ${existingCategories.join(", ")}. Only use a new label if none of the existing ones fit.`
+      : "Short category label for grouping skills (e.g. 'Git', 'Testing', 'Refactoring'). Required for create and edit — always infer one from the skill content if not obvious."
+  return z.preprocess(
+    preprocess,
+    z.object({
+      action: z
+        .enum(["create", "edit", "patch", "delete", "write_file", "remove_file", "history", "rollback"])
+        .describe("Action to perform on a skill"),
+      name: z.string().describe("Skill name (directory name under the skills folder). Required for all actions."),
+      description: z
+        .string()
+        .optional()
+        .describe("One-line skill description for the frontmatter. Required for create and edit."),
+      category: z.string().optional().describe(categoryDesc),
+      content: z
+        .string()
+        .optional()
+        .describe("Full skill body (markdown, without frontmatter) for create/edit; file content for write_file."),
+      old_str: z.string().optional().describe("Exact text to replace (patch action)"),
+      new_str: z.string().optional().describe("Replacement text (patch action)"),
+      relative_path: z
+        .string()
+        .optional()
+        .describe("Path relative to the skill directory for write_file/remove_file"),
+      version: z
+        .string()
+        .optional()
+        .describe("Version label to rollback to, e.g. 'v002' or '2' (rollback action)"),
+    }),
+  )
+}
+
+type SkillManageParams = z.infer<ReturnType<typeof buildParameters>>
+
+async function getExistingCategories(): Promise<string[]> {
+  try {
+    const [managed, evolution, defaults] = await Promise.all([
+      Config.listManagedSkills().catch(() => [] as Awaited<ReturnType<typeof Config.listManagedSkills>>),
+      Config.listEvolutionSkills().catch(() => [] as Awaited<ReturnType<typeof Config.listEvolutionSkills>>),
+      Config.listDefaultSkills().catch(() => [] as Awaited<ReturnType<typeof Config.listDefaultSkills>>),
+    ])
+    return [
+      ...new Set(
+        [...managed, ...evolution, ...defaults]
+          .map((s) => s.category?.trim())
+          .filter((c): c is string => Boolean(c)),
       ),
-    content: z
-      .string()
-      .optional()
-      .describe("Full skill body (markdown, without frontmatter) for create/edit; file content for write_file."),
-    old_str: z.string().optional().describe("Exact text to replace (patch action)"),
-    new_str: z.string().optional().describe("Replacement text (patch action)"),
-    relative_path: z.string().optional().describe("Path relative to the skill directory for write_file/remove_file"),
-    version: z.string().optional().describe("Version label to rollback to, e.g. 'v002' or '2' (rollback action)"),
-  }),
-)
+    ].sort()
+  } catch {
+    return []
+  }
+}
 
 export const SkillManageTool = Tool.define("skill_manage", async () => {
+  const existingCategories = await getExistingCategories()
+  const parameters = buildParameters(existingCategories)
   return {
     description: [
       "The sole tool for modifying skill files. Use instead of edit/write for any file under a skills/ directory.",
@@ -207,7 +239,7 @@ export const SkillManageTool = Tool.define("skill_manage", async () => {
     ].join("\n"),
     parameters,
     async execute(
-      params: z.infer<typeof parameters>,
+      params: SkillManageParams,
       ctx,
     ): Promise<{ title: string; output: string; metadata: Record<string, string> }> {
       const { action, name } = params

--- a/packages/opencode/test/skill/skill-disable-fixes.test.ts
+++ b/packages/opencode/test/skill/skill-disable-fixes.test.ts
@@ -306,9 +306,11 @@ describe("Fix 3: skill_manage disabled name check", () => {
 
   test("skill_manage blocks disabled skill: execute throws with clear message", async () => {
     await using configTmp = await tmpdir()
+    await using skillTmp = await tmpdir()
     const restoreConfig = patchGlobalConfig(configTmp.path)
     try {
-      const disabledPath = "/some/project/.aether/skills/blocked-skill"
+      const disabledPath = path.join(skillTmp.path, "blocked-skill")
+      await fs.mkdir(disabledPath, { recursive: true })
       await writeAetherConfig(configTmp.path, { skills: { disabled: [disabledPath] } })
 
       // Import and call skill_manage tool directly
@@ -333,9 +335,12 @@ describe("Fix 3: skill_manage disabled name check", () => {
 
   test("skill_manage allows non-disabled skill to proceed past the disabled check", async () => {
     await using configTmp = await tmpdir()
+    await using skillTmp = await tmpdir()
     const restoreConfig = patchGlobalConfig(configTmp.path)
     try {
-      await writeAetherConfig(configTmp.path, { skills: { disabled: ["/some/project/.aether/skills/other-skill"] } })
+      const otherSkillPath = path.join(skillTmp.path, "other-skill")
+      await fs.mkdir(otherSkillPath, { recursive: true })
+      await writeAetherConfig(configTmp.path, { skills: { disabled: [otherSkillPath] } })
 
       const { SkillManageTool } = await import("../../src/tool/skill-manage")
       const tool = await SkillManageTool.init()


### PR DESCRIPTION
Fixes #590

## Problem

`skill_manage` and the skill guidance prompts only show generic category examples (`'Git'`, `'Testing'`, etc.). The AI has no idea which categories already exist, so it keeps inventing new names for the same concept, fragmenting the skill list over time.

## Solution

At session initialisation and review time, collect all category names already in use across managed / evolution / default skills, then inject them dynamically into three places:

- **`skill_manage` tool parameter description** — the AI sees "Prefer reusing an existing category: Code Quality, Data, Git, ..." when it fills in the `category` field
- **System prompt skills guidance** — same list is visible throughout the whole session
- **Background review prompt** — the auto-review agent also gets the hint when deciding how to categorise a new skill

If no skills with categories exist yet, the behaviour is identical to before (falls back to generic examples).

## Changes

- `packages/opencode/src/tool/skill-manage.ts` — extract `buildParameters(existingCategories)` + `getExistingCategories()`; tool factory is already async so the lookup adds no new blocking
- `packages/opencode/src/session/skill-evolution.ts` — add `buildSkillsGuidance(categories)` and `buildCategoryHint(categories)`; make `buildReviewPrompt` async to fetch categories
- `packages/opencode/src/session/system.ts` — call `buildSkillsGuidance` with live category list instead of static constant

## Test plan

- [ ] Create two skills via `skill_manage` in a session — second skill should reuse the first skill's category
- [ ] Start a fresh session with no skills — behaviour unchanged (generic examples shown)
- [ ] Background skill review correctly inherits existing categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)