### PR TITLE
fix: use pending message as fallback for busy-state to prevent stale idle display

### DIFF
--- a/packages/app/src/components/steer-button.tsx
+++ b/packages/app/src/components/steer-button.tsx
@@ -24,7 +24,10 @@ export const SteerButton: Component = () => {
     const id = params.id
     if (!id) return false
     const status = sync.data.session_status[id]
-    return status?.type !== "idle"
+    if (status?.type !== "idle") return true
+    return (sync.data.message[id] ?? []).some(
+      (msg) => msg.role === "assistant" && typeof msg.time.completed !== "number",
+    )
   }
 
   const popupStyle = () => {

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -338,13 +338,12 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
           message.role === "assistant" &&
           typeof (message as { time?: { completed?: unknown } }).time?.completed !== "number",
       ),
-    blocked: hasPermissions,
     sessionID: () => props.session.id,
     children: () => ({
       childMap: () => childMapByParent(sessionStore.session),
       status: (id: string) => sessionStore.session_status[id],
     }),
-  }).visual
+  }).interactive
 
   const tint = createMemo(() => {
     return messageAgentColor(sessionStore.message[props.session.id], sessionStore.agent)

--- a/packages/app/src/pages/session/composer/session-composer-state.ts
+++ b/packages/app/src/pages/session/composer/session-composer-state.ts
@@ -115,7 +115,7 @@ export function createSessionComposerState(options?: { closeMs?: number | (() =>
     ),
   )
 
-  const { visual: busy } = createWorkingState({
+  const { interactive: busy } = createWorkingState({
     status: () => status(),
     pending: () => pending(),
     sessionID: () => params.id,

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -309,7 +309,7 @@ export function MessageTimeline(props: {
     childMap: () => childMapByParent(sync.data.session),
     status: (id: string) => sync.data.session_status[id],
   }))
-  const { visual: working } = createWorkingState({
+  const { interactive: working } = createWorkingState({
     status: () => sessionStatus(),
     pending: () => pending(),
     sessionID: () => sessionID(),

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -79,6 +79,8 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     if (!id) return []
     return sync.data.message[id] ?? []
   }
+  const pending = () => messages().findLast((msg) => msg.role === "assistant" && typeof msg.time.completed !== "number")
+  const busy = () => status().type !== "idle" || !!pending()
   const userMessages = () => messages().filter((m) => m.role === "user") as UserMessage[]
   const visibleUserMessages = () => {
     const revert = info()?.revert?.messageID
@@ -428,7 +430,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
         onSelect: async () => {
           const sessionID = params.id
           if (!sessionID) return
-          if (status().type !== "idle") {
+          if (busy()) {
             await sdk.client.session.abort({ sessionID }).catch(() => {})
           }
           const revert = info()?.revert?.messageID

--- a/packages/app/src/utils/working-state.ts
+++ b/packages/app/src/utils/working-state.ts
@@ -56,7 +56,8 @@ export function createWorkingState(input: {
 
   const selfInteractive = createMemo(() => {
     const s = input.status()
-    return isBusy(s)
+    if (isBusy(s)) return true
+    return !!input.pending()
   })
 
   const descBusy = createMemo(() => {


### PR DESCRIPTION
### Issue for this PR

Closes #597

### Type of change

- [x] Bug fix

### What does this PR do?

The web/electron frontend's `interactive` working-state memo only checked `session_status` (busy/retry) without a `!!pending` fallback. When `session_status` was overwritten by `reconcile()` calls during long model reasoning phases (e.g. glm-5.1's 150s reasoning), the UI incorrectly showed idle — sidebar spinner gone, stop button replaced by send, header showed no activity.

This PR adds `!!pending` (any incomplete assistant message) as a fallback, matching the TUI's existing logic (`busy/retry || !!pending`). Changes:

- `working-state.ts`: `interactive` memo now returns `!!pending` when status is idle
- `sidebar-items.tsx`, `message-timeline.tsx`, `session-composer-state.ts`: use `.interactive` instead of `.visual` (which had a `blocked` guard that hid spinners during permission pauses)
- `steer-button.tsx`: `busy()` checks pending messages
- `use-session-commands.tsx`: adds `pending()` and `busy()` helpers, uses `busy()` for undo abort guard
- Removed unused `blocked: hasPermissions` from sidebar (TUI doesn't hide spinners when blocked either)

### How did you verify your code works?

- Confirmed `interactive` memo logic matches TUI's `working` memo (`busy/retry || !!pending`)
- Verified all 5 consumers now consistently use `interactive` or equivalent `busy()` logic
- Verified no forward reference issues in `use-session-commands.tsx`

### Screenshots / recordings

Not applicable (behavioral fix, no visual layout change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR