### PR TITLE
fix: resolve WeChat connection oscillation and message handling failure

### DIFF
--- a/packages/app/src/context/mobile.ts
+++ b/packages/app/src/context/mobile.ts
@@ -433,24 +433,7 @@ export async function logout(p: MobilePlatform) {
 }
 
 export async function retryBridge(p: MobilePlatform) {
-  if (p === "wechat") {
-    patch("wechat", { status: "loading", loadingMsg: "正在重新连接微信...", error: null })
-    connectSSE("wechat")
-    try {
-      const { url, headers } = api()
-      const res = await fetch(`${url}/mobile/wechat/retry`, {
-        method: "POST",
-        headers: { ...headers, "Content-Type": "application/json" },
-      })
-      const data = await res.json()
-      if (!data.success) {
-        patch("wechat", { error: { code: "retry_failed", message: data.message || "重连失败" }, status: "error" })
-      }
-    } catch (err) {
-      patch("wechat", { error: { code: "network_error", message: String(err) }, status: "error" })
-    }
-    return
-  }
+  if (p === "wechat") return startBridge(p)
   if (p === "qq") return startBridge(p)
   patch(p, { status: "reconnecting", loadingMsg: "正在重新连接飞书...", error: null })
   patch(p, { status: "reconnecting", loadingMsg: "正在重新连接微信...", error: null })

--- a/packages/app/src/context/mobile.ts
+++ b/packages/app/src/context/mobile.ts
@@ -90,6 +90,7 @@ const sseRetryTimers: Record<MobilePlatform, ReturnType<typeof setTimeout> | und
 const pingTimer: ReturnType<typeof setInterval> | undefined = undefined
 let clientId: string | null = null
 let pingInterval: ReturnType<typeof setInterval> | undefined
+let pingFails = 0
 
 type Resolver = () => { url: string; headers: HeadersInit }
 let resolve: Resolver | null = null
@@ -201,13 +202,17 @@ function connectSSE(p: MobilePlatform) {
       }
 
       const s = prev(p).status
-      if (s !== "idle" && s !== "error" && s !== "stolen") {
+      if (p === "wechat") {
+        if (s !== "idle" && s !== "error" && s !== "stolen") scheduleSseRetry(p)
+      } else if (s !== "idle" && s !== "error" && s !== "stolen") {
         updateStatus(p, "reconnecting")
         scheduleSseRetry(p)
       }
     } catch {
       const s = prev(p).status
-      if (s !== "idle" && s !== "error" && s !== "stolen") {
+      if (p === "wechat") {
+        if (s !== "idle" && s !== "error" && s !== "stolen") scheduleSseRetry(p)
+      } else if (s !== "idle" && s !== "error" && s !== "stolen") {
         updateStatus(p, "reconnecting")
         scheduleSseRetry(p)
       }
@@ -245,6 +250,7 @@ function startPing(p: MobilePlatform) {
         body: JSON.stringify({ clientId }),
       })
       const data = await res.json()
+      pingFails = 0
       if (data.stolen) {
         stopPing()
         if (sseControllers.wechat) {
@@ -255,6 +261,9 @@ function startPing(p: MobilePlatform) {
         patch("wechat", { status: "stolen" })
       }
     } catch {
+      pingFails += 1
+      if (pingFails < 3) return
+      pingFails = 0
       const s = prev("wechat").status
       if (s !== "idle" && s !== "stolen") patch("wechat", { status: "reconnecting" })
     }
@@ -424,7 +433,24 @@ export async function logout(p: MobilePlatform) {
 }
 
 export async function retryBridge(p: MobilePlatform) {
-  if (p === "wechat") return startBridge(p)
+  if (p === "wechat") {
+    patch("wechat", { status: "loading", loadingMsg: "正在重新连接微信...", error: null })
+    connectSSE("wechat")
+    try {
+      const { url, headers } = api()
+      const res = await fetch(`${url}/mobile/wechat/retry`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+      })
+      const data = await res.json()
+      if (!data.success) {
+        patch("wechat", { error: { code: "retry_failed", message: data.message || "重连失败" }, status: "error" })
+      }
+    } catch (err) {
+      patch("wechat", { error: { code: "network_error", message: String(err) }, status: "error" })
+    }
+    return
+  }
   if (p === "qq") return startBridge(p)
   patch(p, { status: "reconnecting", loadingMsg: "正在重新连接飞书...", error: null })
   patch(p, { status: "reconnecting", loadingMsg: "正在重新连接微信...", error: null })

--- a/packages/opencode/src/mobile/wechat.ts
+++ b/packages/opencode/src/mobile/wechat.ts
@@ -10,7 +10,7 @@ import type { MobileAdapter } from "./base"
 import * as ilink from "./ilink"
 import type { LoginStatusResult } from "./ilink"
 
-export type WeChatStatus = "idle" | "starting" | "qrcode" | "connected" | "error"
+export type WeChatStatus = "idle" | "starting" | "qrcode" | "connected" | "reconnecting" | "error"
 
 export interface WeChatSession {
   connected: boolean
@@ -271,6 +271,12 @@ class WeChatManagerImpl extends MobileManagerBase {
     this.status = "reconnecting"
     Bus.publish(this.busEvents.Reconnecting, { attempt: 1, delay: 0 })
 
+    if (!this._ilinkToken) {
+      this._ilinkToken = ""
+      void this.loginAndPoll()
+      return
+    }
+
     const state = await this.loadILinkState()
     if (state?.token) {
       this._ilinkToken = state.token
@@ -368,6 +374,11 @@ class WeChatManagerImpl extends MobileManagerBase {
         if (result.expired) {
           console.warn("[wechat] session expired during poll, reconnecting...")
           this._pollRunning = false
+          this._ilinkToken = ""
+          this._cursor = ""
+          try {
+            await rm(wcFile("ilink_state.json"), { force: true })
+          } catch {}
           this.status = "reconnecting"
           Bus.publish(this.busEvents.Reconnecting, { attempt: 1, delay: 0 })
           void this.reconnect()

--- a/packages/opencode/src/mobile/wechat.ts
+++ b/packages/opencode/src/mobile/wechat.ts
@@ -98,6 +98,7 @@ class WeChatManagerImpl extends MobileManagerBase {
   private _seenIds: Set<string> = new Set()
   private _qrUuid: string = ""
   private _loginAbort: AbortController | null = null
+  private _tokenKnownExpired: boolean = false
 
   get lockHolder(): string | null {
     try {
@@ -258,13 +259,20 @@ class WeChatManagerImpl extends MobileManagerBase {
     this._pollRunning = false
     this.unsubscribeBusEvents()
     this._error = null
-    this._ilinkToken = ""
-    try {
-      await rm(wcFile("ilink_state.json"), { force: true })
-    } catch {}
-    this.status = "starting"
-    void this.loginAndPoll()
-    return { success: true }
+
+    if (this._tokenKnownExpired) {
+      this._ilinkToken = ""
+      this._tokenKnownExpired = false
+      try {
+        await rm(wcFile("ilink_state.json"), { force: true })
+      } catch {}
+      this.status = "starting"
+      void this.loginAndPoll()
+      return { success: true }
+    }
+
+    this.status = "idle"
+    return this.start()
   }
 
   private async reconnect(): Promise<void> {
@@ -374,6 +382,7 @@ class WeChatManagerImpl extends MobileManagerBase {
         if (result.expired) {
           console.warn("[wechat] session expired during poll, reconnecting...")
           this._pollRunning = false
+          this._tokenKnownExpired = true
           this._ilinkToken = ""
           this._cursor = ""
           try {


### PR DESCRIPTION
### Issue for this PR

Closes #601

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes WeChat Web UI continuously oscillating between "connecting" and "connected" states, and messages failing to send/receive on WeChat while QQ and Feishu work normally.

Three root causes addressed:

1. **Frontend SSE closure treated as disconnect for WeChat**: WeChat uses HTTP long-polling (not WebSocket). SSE stream closure is a normal HTTP transport event, not a real disconnect — the backend pollLoop keeps running. Fix: on SSE stream close/catch for WeChat, only reconnect SSE without changing status to "reconnecting".

2. **Ping zero-failure tolerance**: Single ping failure immediately set "reconnecting" for WeChat, while Feishu tolerates 3 heartbeat failures. Fix: add `pingFails` counter, only trigger "reconnecting" after 3 consecutive ping failures.

3. **Backend reconnect loop with expired token**: When pollLoop detects errcode=-14 (token expired), `reconnect()` loaded the same expired token from `ilink_state.json` and immediately set "connected", causing infinite loop: reconnecting → connected → expired → reconnecting → ... Fix: clear `_ilinkToken` and delete `ilink_state.json` on expiry detection; in `reconnect()`, skip saved-token branch when `_ilinkToken` is empty and fall through to QR login.

4. **Conditional retry logic**: Added `_tokenKnownExpired` flag set on errcode=-14. `retry()` now checks this flag: if token is known expired, clear state and go to QR scan; if not expired, reuse saved token via `start()`. This preserves valid tokens while still handling expired ones correctly.

5. **WeChatStatus type fix**: Added missing "reconnecting" to the `WeChatStatus` type definition.

### How did you verify your code works?

- `bun typecheck` passes on both `packages/opencode` and `packages/app`
- Tested on live WeChat connection: oscillation eliminated, messages send/receive normally
- After restart, saved token still connects immediately (valid token preserved)

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR