### PR TITLE
feat(chat): 支持引用 AI 回复继续追问

### DIFF
--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -20,19 +20,10 @@ const storedSessions: Record<string, Array<{ id: string; title?: string }>> = {}
 const promoted: Array<{ directory: string; sessionID: string }> = []
 const sentShell: string[] = []
 const syncedDirectories: string[] = []
-const promptAsyncCalls: Array<{ sessionID: string; parts: Array<Record<string, unknown>> }> = []
 
 let params: { id?: string } = {}
 let selected = "/repo/worktree-a"
 let variant: string | undefined
-let conversationQuotePendingQuestion: {
-  kind: "assistant-text-question"
-  sessionID: string
-  sourceMessageID: string
-  text: string
-  summary: string
-  createdAt: number
-} | null = null
 
 const promptValue: Prompt = [{ type: "text", content: "ls", start: 0, end: 2 }]
 
@@ -54,10 +45,7 @@ const clientFor = (directory: string) => {
         return { data: undefined }
       },
       prompt: async () => ({ data: undefined }),
-      promptAsync: async (input: { sessionID: string; parts: Array<Record<string, unknown>> }) => {
-        promptAsyncCalls.push(input)
-        return { data: undefined }
-      },
+      promptAsync: async () => ({ data: undefined }),
       command: async () => ({ data: undefined }),
       abort: async () => ({ data: undefined }),
     },
@@ -220,27 +208,6 @@ beforeAll(async () => {
     }),
   }))
 
-  mock.module("@/context/conversation-quote", () => ({
-    useMaybeConversationQuote: () => ({
-      store: {
-        get pendingQuestion() {
-          return conversationQuotePendingQuestion
-        },
-      },
-      clearPendingQuestion() {
-        conversationQuotePendingQuestion = null
-      },
-    }),
-  }))
-
-  mock.module("@/context/reading-mode", () => ({
-    useMaybeReadingMode: () => undefined,
-  }))
-
-  mock.module("@/context/quick-reading-mode", () => ({
-    useMaybeQuickReadingMode: () => undefined,
-  }))
-
   mock.module("@/context/server", () => ({
     useServer: () => ({
       current: undefined,
@@ -263,14 +230,12 @@ beforeEach(() => {
   enabledAutoAccept.length = 0
   optimistic.length = 0
   optimisticSeeded.length = 0
-  promptAsyncCalls.length = 0
   promoted.length = 0
   params = {}
   sentShell.length = 0
   syncedDirectories.length = 0
   selected = "/repo/worktree-a"
   variant = undefined
-  conversationQuotePendingQuestion = null
   for (const key of Object.keys(storedSessions)) delete storedSessions[key]
 })
 
@@ -400,63 +365,5 @@ describe("prompt submit worktree selection", () => {
 
     expect(storedSessions["/repo/worktree-a"]).toEqual([{ id: "session-1", title: "New session 1" }])
     expect(optimisticSeeded).toEqual([true])
-  })
-
-  test("submits assistant quote follow-up and clears pending question", async () => {
-    params = { id: "session-1" }
-    conversationQuotePendingQuestion = {
-      kind: "assistant-text-question",
-      sessionID: "session-1",
-      sourceMessageID: "message-123",
-      text: "quoted assistant text",
-      summary: "quoted assistant text",
-      createdAt: Date.now(),
-    }
-
-    const submit = createPromptSubmit({
-      info: () => ({ id: "session-1" }),
-      imageAttachments: () => [],
-      commentCount: () => 0,
-      autoAccept: () => false,
-      mode: () => "normal",
-      working: () => false,
-      editor: () => undefined,
-      queueScroll: () => undefined,
-      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
-      addToHistory: () => undefined,
-      resetHistoryNavigation: () => undefined,
-      setMode: () => undefined,
-      setPopover: () => undefined,
-      onSubmit: () => undefined,
-    })
-
-    const event = { preventDefault: () => undefined } as unknown as Event
-    await submit.handleSubmit(event)
-    await new Promise((resolve) => setTimeout(resolve, 0))
-
-    expect(promptAsyncCalls).toHaveLength(1)
-    expect(promptAsyncCalls[0]!.parts).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: "text",
-          synthetic: true,
-          text: expect.stringContaining("[Quoted assistant content]"),
-        }),
-        expect.objectContaining({
-          type: "text",
-          synthetic: true,
-          ignored: true,
-          metadata: expect.objectContaining({
-            opencodeConversationQuote: expect.objectContaining({
-              kind: "conversation-quote",
-              source: "assistant",
-              action: "ask",
-              sourceMessageID: "message-123",
-            }),
-          }),
-        }),
-      ]),
-    )
-    expect(conversationQuotePendingQuestion).toBeNull()
   })
 })

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -20,10 +20,19 @@ const storedSessions: Record<string, Array<{ id: string; title?: string }>> = {}
 const promoted: Array<{ directory: string; sessionID: string }> = []
 const sentShell: string[] = []
 const syncedDirectories: string[] = []
+const promptAsyncCalls: Array<{ sessionID: string; parts: Array<Record<string, unknown>> }> = []
 
 let params: { id?: string } = {}
 let selected = "/repo/worktree-a"
 let variant: string | undefined
+let conversationQuotePendingQuestion: {
+  kind: "assistant-text-question"
+  sessionID: string
+  sourceMessageID: string
+  text: string
+  summary: string
+  createdAt: number
+} | null = null
 
 const promptValue: Prompt = [{ type: "text", content: "ls", start: 0, end: 2 }]
 
@@ -45,7 +54,10 @@ const clientFor = (directory: string) => {
         return { data: undefined }
       },
       prompt: async () => ({ data: undefined }),
-      promptAsync: async () => ({ data: undefined }),
+      promptAsync: async (input: { sessionID: string; parts: Array<Record<string, unknown>> }) => {
+        promptAsyncCalls.push(input)
+        return { data: undefined }
+      },
       command: async () => ({ data: undefined }),
       abort: async () => ({ data: undefined }),
     },
@@ -208,6 +220,27 @@ beforeAll(async () => {
     }),
   }))
 
+  mock.module("@/context/conversation-quote", () => ({
+    useMaybeConversationQuote: () => ({
+      store: {
+        get pendingQuestion() {
+          return conversationQuotePendingQuestion
+        },
+      },
+      clearPendingQuestion() {
+        conversationQuotePendingQuestion = null
+      },
+    }),
+  }))
+
+  mock.module("@/context/reading-mode", () => ({
+    useMaybeReadingMode: () => undefined,
+  }))
+
+  mock.module("@/context/quick-reading-mode", () => ({
+    useMaybeQuickReadingMode: () => undefined,
+  }))
+
   mock.module("@/context/server", () => ({
     useServer: () => ({
       current: undefined,
@@ -230,12 +263,14 @@ beforeEach(() => {
   enabledAutoAccept.length = 0
   optimistic.length = 0
   optimisticSeeded.length = 0
+  promptAsyncCalls.length = 0
   promoted.length = 0
   params = {}
   sentShell.length = 0
   syncedDirectories.length = 0
   selected = "/repo/worktree-a"
   variant = undefined
+  conversationQuotePendingQuestion = null
   for (const key of Object.keys(storedSessions)) delete storedSessions[key]
 })
 
@@ -365,5 +400,63 @@ describe("prompt submit worktree selection", () => {
 
     expect(storedSessions["/repo/worktree-a"]).toEqual([{ id: "session-1", title: "New session 1" }])
     expect(optimisticSeeded).toEqual([true])
+  })
+
+  test("submits assistant quote follow-up and clears pending question", async () => {
+    params = { id: "session-1" }
+    conversationQuotePendingQuestion = {
+      kind: "assistant-text-question",
+      sessionID: "session-1",
+      sourceMessageID: "message-123",
+      text: "quoted assistant text",
+      summary: "quoted assistant text",
+      createdAt: Date.now(),
+    }
+
+    const submit = createPromptSubmit({
+      info: () => ({ id: "session-1" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    const event = { preventDefault: () => undefined } as unknown as Event
+    await submit.handleSubmit(event)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(promptAsyncCalls).toHaveLength(1)
+    expect(promptAsyncCalls[0]!.parts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "text",
+          synthetic: true,
+          text: expect.stringContaining("[Quoted assistant content]"),
+        }),
+        expect.objectContaining({
+          type: "text",
+          synthetic: true,
+          ignored: true,
+          metadata: expect.objectContaining({
+            opencodeConversationQuote: expect.objectContaining({
+              kind: "conversation-quote",
+              source: "assistant",
+              action: "ask",
+              sourceMessageID: "message-123",
+            }),
+          }),
+        }),
+      ]),
+    )
+    expect(conversationQuotePendingQuestion).toBeNull()
   })
 })

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -5,6 +5,7 @@ import { Binary } from "@opencode-ai/util/binary"
 import { useNavigate, useParams } from "@solidjs/router"
 import type { Accessor } from "solid-js"
 import type { FileSelection } from "@/context/file"
+import { useMaybeConversationQuote } from "@/context/conversation-quote"
 import { useFile } from "@/context/file"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
@@ -23,7 +24,12 @@ import { Identifier } from "@/utils/id"
 import { Worktree as WorktreeState } from "@/utils/worktree"
 import { buildRequestParts, type DataAttachment } from "./build-request-parts"
 import { setCursorPosition } from "./editor-dom"
-import { createReadingQuoteMetadata, formatReadingPageRange, summarizeReadingQuoteText } from "@/utils/comment-note"
+import {
+  createConversationQuoteMetadata,
+  createReadingQuoteMetadata,
+  formatReadingPageRange,
+  summarizeReadingQuoteText,
+} from "@/utils/comment-note"
 import { formatServerError } from "@/utils/server-errors"
 
 type PendingPrompt = {
@@ -102,6 +108,20 @@ function describeReadingSelection(input: {
     return `用户选中的是一张来自 PDF 第 ${formatReadingPageRange(input)} 页的截图区域，请结合截图与上下文回答。`
   }
   return input.text ?? ""
+}
+
+function fillConversationQuotePrompt(input: { selectedContent: string; userQuestion: string }) {
+  return [
+    "The user selected a passage from a previous assistant reply and wants to ask a follow-up question about it.",
+    "",
+    "[Quoted assistant content]",
+    input.selectedContent,
+    "",
+    "[User question]",
+    input.userQuestion,
+    "",
+    "Answer the user's question based on the quoted assistant content. If the quoted content is incomplete or ambiguous, say so clearly.",
+  ].join("\n")
 }
 
 function blobToDataUrl(blob: Blob) {
@@ -296,6 +316,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
   const local = useLocal()
   const permission = usePermission()
   const prompt = usePrompt()
+  const conversationQuote = useMaybeConversationQuote()
   const quickReadingMode = useMaybeQuickReadingMode()
   const readingMode = useMaybeReadingMode()
   const layout = useLayout()
@@ -551,6 +572,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     const context = prompt.context.items().slice()
     const openPaths = input.openTabPaths?.() ?? []
     const selText = fileCtx.selectedText()
+    const conversationQuoteQuestion = conversationQuote?.store.pendingQuestion ?? null
     const readingQuestion = readingMode?.store.pendingQuestion
     const quickReadingPendingQuestion = quickReadingMode?.store.pendingQuestion ?? null
     const quickReadingQuestion =
@@ -615,7 +637,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       return
     }
 
-    if (!readingQuestion && !quickReadingQuestion && text.startsWith("/")) {
+    if (!conversationQuoteQuestion && !readingQuestion && !quickReadingQuestion && text.startsWith("/")) {
       const [cmdName, ...args] = text.split(" ")
       const commandName = cmdName.slice(1)
       const customCommand = sync.data.command.find((c) => c.name === commandName)
@@ -715,6 +737,96 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       if (controller.signal.aborted) return false
       if (result.status === "failed") throw new Error(result.message)
       return true
+    }
+
+    if (mode === "normal" && conversationQuoteQuestion) {
+      const typedQuestion = text.trim()
+      if (!typedQuestion) {
+        restoreCommentItems(commentItems)
+        restoreInput()
+        showToast({
+          title: language.t("prompt.toast.promptSendFailed.title"),
+          description: language.t("prompt.toast.promptSendFailed.description"),
+        })
+        return
+      }
+
+      const requestDraft: FollowupDraft = {
+        sessionID: session.id,
+        sessionDirectory,
+        prompt: [DEFAULT_PROMPT[0]!, ...images],
+        context,
+        agent,
+        model,
+        variant,
+        selectedPaths: openPaths.length > 0 ? openPaths : undefined,
+        extraTextParts: [
+          {
+            text: typedQuestion,
+            ignored: true,
+          },
+          {
+            text: fillConversationQuotePrompt({
+              selectedContent: conversationQuoteQuestion.text,
+              userQuestion: typedQuestion,
+            }),
+            synthetic: true,
+          },
+          {
+            text: "",
+            synthetic: true,
+            ignored: true,
+            metadata: createConversationQuoteMetadata({
+              kind: "conversation-quote",
+              source: "assistant",
+              action: "ask",
+              sourceMessageID: conversationQuoteQuestion.sourceMessageID,
+              summary: conversationQuoteQuestion.summary,
+              fullText: conversationQuoteQuestion.text,
+            }),
+          },
+        ],
+      }
+
+      void sendFollowupDraft({
+        client,
+        sync,
+        globalSync,
+        draft: requestDraft,
+        messageID,
+        optimisticBusy: sessionDirectory === projectDirectory,
+        before: waitForWorktree,
+        knowledgeBase:
+          knowledge.enabled() && knowledge.activeKnowledgeBases().length > 0
+            ? {
+                paths: knowledge.activeKnowledgeBases().map((kb) => kb.path),
+                apiKey: knowledge.activeKnowledgeBases()[0]!.apiKey,
+                baseURL: knowledge.activeKnowledgeBases()[0]!.baseURL,
+              }
+            : undefined,
+      })
+        .then((ok) => {
+          if (ok) {
+            conversationQuote?.clearPendingQuestion()
+            return
+          }
+          restoreCommentItems(commentItems)
+          restoreInput()
+        })
+        .catch((err) => {
+          pending.delete(session.id)
+          if (sessionDirectory === projectDirectory) {
+            sync.set("session_status", session.id, { type: "idle" })
+          }
+          showToast({
+            title: language.t("prompt.toast.promptSendFailed.title"),
+            description: errorMessage(err),
+          })
+          removeOptimisticMessage()
+          restoreCommentItems(commentItems)
+          restoreInput()
+        })
+      return
     }
 
     if (mode === "normal" && quickReadingQuestion) {

--- a/packages/app/src/context/conversation-quote.tsx
+++ b/packages/app/src/context/conversation-quote.tsx
@@ -1,0 +1,49 @@
+import { createContext, useContext, type ParentProps } from "solid-js"
+import { createStore } from "solid-js/store"
+
+export type ConversationQuotePendingQuestion =
+  | {
+      kind: "assistant-text-question"
+      sessionID: string
+      sourceMessageID: string
+      text: string
+      summary: string
+      createdAt: number
+    }
+  | null
+
+type Store = {
+  pendingQuestion: ConversationQuotePendingQuestion
+}
+
+type Ctx = {
+  store: Store
+  setPendingQuestion: (question: ConversationQuotePendingQuestion) => void
+  clearPendingQuestion: () => void
+}
+
+const ConversationQuoteContext = createContext<Ctx>()
+
+export function ConversationQuoteProvider(props: ParentProps) {
+  const [store, setStore] = createStore<Store>({
+    pendingQuestion: null,
+  })
+
+  const ctx: Ctx = {
+    store,
+    setPendingQuestion: (question) => setStore("pendingQuestion", question),
+    clearPendingQuestion: () => setStore("pendingQuestion", null),
+  }
+
+  return <ConversationQuoteContext.Provider value={ctx}>{props.children}</ConversationQuoteContext.Provider>
+}
+
+export function useConversationQuote() {
+  const ctx = useContext(ConversationQuoteContext)
+  if (!ctx) throw new Error("useConversationQuote must be used within ConversationQuoteProvider")
+  return ctx
+}
+
+export function useMaybeConversationQuote() {
+  return useContext(ConversationQuoteContext)
+}

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -38,6 +38,7 @@ import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { useLayout } from "@/context/layout"
 import { usePrompt } from "@/context/prompt"
+import { ConversationQuoteProvider } from "@/context/conversation-quote"
 import { useSDK } from "@/context/sdk"
 import { useSettings } from "@/context/settings"
 import { useSync } from "@/context/sync"
@@ -2295,10 +2296,11 @@ function SessionPageContent(props: SessionPageProps = {}) {
                         historyLoading={historyLoading()}
                         onLoadEarlier={() => {
                           void historyWindow.loadAndReveal()
-                        }}
-                        renderedUserMessages={historyWindow.renderedUserMessages()}
-                        anchor={anchor}
-                      />
+                            }}
+                            renderedUserMessages={historyWindow.renderedUserMessages()}
+                            anchor={anchor}
+                            onFocusInput={focusInput}
+                          />
                     </Show>
                   </Match>
                   <Match when={true}>
@@ -2464,10 +2466,11 @@ function SessionPageContent(props: SessionPageProps = {}) {
                       historyLoading={historyLoading()}
                       onLoadEarlier={() => {
                         void historyWindow.loadAndReveal()
-                      }}
-                      renderedUserMessages={historyWindow.renderedUserMessages()}
-                      anchor={anchor}
-                    />
+                        }}
+                        renderedUserMessages={historyWindow.renderedUserMessages()}
+                        anchor={anchor}
+                        onFocusInput={focusInput}
+                      />
                   </Show>
                 </Match>
                 <Match when={true}>
@@ -2573,8 +2576,10 @@ function SessionPageContent(props: SessionPageProps = {}) {
 
 export default function Page(props: SessionPageProps = {}) {
   return (
-    <QuickReadingModeProvider>
-      <SessionPageContent {...props} />
-    </QuickReadingModeProvider>
+    <ConversationQuoteProvider>
+      <QuickReadingModeProvider>
+        <SessionPageContent {...props} />
+      </QuickReadingModeProvider>
+    </ConversationQuoteProvider>
   )
 }

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -3,6 +3,7 @@ import { createStore } from "solid-js/store"
 import { useSpring } from "@opencode-ai/ui/motion-spring"
 import { PromptInput } from "@/components/prompt-input"
 import { type FollowupDraft } from "@/components/prompt-input/submit"
+import { useMaybeConversationQuote } from "@/context/conversation-quote"
 import { useLanguage } from "@/context/language"
 import { useMaybeQuickReadingMode } from "@/context/quick-reading-mode"
 import { useMaybeReadingMode } from "@/context/reading-mode"
@@ -47,10 +48,13 @@ export function SessionComposerRegion(props: {
 }) {
   const prompt = usePrompt()
   const language = useLanguage()
+  const conversationQuote = useMaybeConversationQuote()
   const readingMode = useMaybeReadingMode()
   const quickReadingMode = useMaybeQuickReadingMode()
   const route = useSessionKey()
   const pendingQuestion = createMemo(() => {
+    const pending = conversationQuote?.store.pendingQuestion
+    if (pending?.sessionID === route.params.id) return pending
     const quickPending = quickReadingMode?.store.pendingQuestion
     if (quickPending?.sessionID === route.params.id) return quickPending
     return readingMode?.store.pendingQuestion ?? null
@@ -256,25 +260,31 @@ export function SessionComposerRegion(props: {
                     <div class="flex items-start justify-between gap-3">
                       <div class="min-w-0 flex-1">
                         <div class="text-11-medium uppercase tracking-wide text-text-weak">
-                          {"pdfFileName" in question
+                          {"sourceMessageID" in question
+                            ? "AI Reply Quote"
+                            : "pdfFileName" in question
                             ? `${question.pdfFileName} · p.${formatReadingPageRange({ startPage: question.kind === "text-question" ? question.startPage : question.page, endPage: question.kind === "text-question" ? question.endPage : question.page })}`
                             : `PDF Quote - p.${formatReadingPageRange({ startPage: question.kind === "text-question" ? question.startPage : question.page, endPage: question.kind === "text-question" ? question.endPage : question.page })}`}
                         </div>
-                          <Show when={question.kind === "image-question"}>
-                            <img
-                              src={question.kind === "image-question" ? question.imageDataUrl : undefined}
-                              alt={`Captured region from page ${question.kind === "image-question" ? question.page : question.startPage}`}
-                              class="mt-2 h-20 max-w-full rounded-md border border-border-weak-base bg-background-base object-contain"
-                            />
-                          </Show>
+                        <Show when={"kind" in question && question.kind === "image-question"}>
+                          <img
+                            src={"kind" in question && question.kind === "image-question" ? question.imageDataUrl : undefined}
+                            alt={`Captured region from page ${"kind" in question && question.kind === "image-question" ? question.page : 0}`}
+                            class="mt-2 h-20 max-w-full rounded-md border border-border-weak-base bg-background-base object-contain"
+                          />
+                        </Show>
                         <div class="mt-1 line-clamp-3 whitespace-pre-wrap break-words text-13-regular text-text-strong">
-                          {question.text}
+                          {"summary" in question ? question.summary : question.text}
                         </div>
                       </div>
                       <button
                         type="button"
                         class="shrink-0 rounded-md px-1 py-0.5 text-12-medium text-text-weak transition hover:bg-surface-hover hover:text-text-strong"
                         onClick={() => {
+                          if ("sourceMessageID" in question) {
+                            conversationQuote?.clearPendingQuestion()
+                            return
+                          }
                           if ("pdfFileName" in question) {
                             quickReadingMode?.setPendingQuestion(null)
                             return

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -1,4 +1,4 @@
-import { For, createEffect, createMemo, on, onCleanup, Show, Index, type JSX, createSignal } from "solid-js"
+import { For, batch, createEffect, createMemo, on, onCleanup, Show, Index, type JSX, createSignal } from "solid-js"
 import { createWorkingState, type ChildrenSource } from "@/utils/working-state"
 import { childMapByParent } from "@/pages/layout/helpers"
 import { createStore, produce, reconcile } from "solid-js/store"
@@ -21,9 +21,11 @@ import { Binary } from "@opencode-ai/util/binary"
 import { getFilename } from "@opencode-ai/util/path"
 import { Popover as KobaltePopover } from "@kobalte/core/popover"
 import { shouldMarkBoundaryGesture, normalizeWheelDelta } from "@/pages/session/message-gesture"
+import { resolveSelectionAnchorRect } from "@/pages/session/selection-anchor"
 import { SessionContextUsage } from "@/components/session-context-usage"
 import { useI18n } from "@opencode-ai/ui/context"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { useConversationQuote } from "@/context/conversation-quote"
 import { useLayout } from "@/context/layout"
 import { useLanguage } from "@/context/language"
 import { useSessionKey } from "@/pages/session/session-layout"
@@ -35,9 +37,12 @@ import { useSync } from "@/context/sync"
 import { messageAgentColor } from "@/utils/agent"
 import {
   formatReadingPageRange,
+  readConversationQuoteMetadata,
   parseCommentNote,
   readCommentMetadata,
   readReadingQuoteMetadata,
+  summarizeReadingQuoteText,
+  type ConversationQuote,
   type ReadingQuote,
 } from "@/utils/comment-note"
 import { makeTimer } from "@solid-primitives/timer"
@@ -53,6 +58,7 @@ type MessageComment = {
 }
 
 type MessageReadingQuote = ReadingQuote
+type MessageConversationQuote = ConversationQuote
 
 const emptyMessages: MessageType[] = []
 const idle = { type: "idle" as const }
@@ -88,6 +94,13 @@ const messageReadingQuotes = (parts: Part[]): MessageReadingQuote[] =>
     return next && next.contentType === "text" ? [next] : []
   })
 
+const messageConversationQuotes = (parts: Part[]): MessageConversationQuote[] =>
+  parts.flatMap((part) => {
+    if (part.type !== "text" || !(part as TextPart).synthetic) return []
+    const next = readConversationQuoteMetadata(part.metadata)
+    return next ? [next] : []
+  })
+
 function DialogReadingQuoteTextContent(props: { quote: MessageReadingQuote }) {
   return (
     <Dialog title="PDF Quote" class="w-[min(720px,calc(100vw-32px))] max-w-[calc(100vw-32px)]">
@@ -102,6 +115,18 @@ function DialogReadingQuoteTextContent(props: { quote: MessageReadingQuote }) {
           <div class="min-w-0 w-full max-w-full whitespace-pre-wrap break-words text-13-regular text-text-strong [overflow-wrap:anywhere]">
             {props.quote.fullText || props.quote.summary}
           </div>
+        </div>
+      </div>
+    </Dialog>
+  )
+}
+
+function DialogConversationQuoteTextContent(props: { quote: MessageConversationQuote }) {
+  return (
+    <Dialog title="AI Reply Quote" class="w-[min(720px,calc(100vw-32px))] max-w-[calc(100vw-32px)]">
+      <div class="max-h-[70vh] min-w-0 w-full max-w-full overflow-auto px-4 pb-4">
+        <div class="min-w-0 w-full max-w-full whitespace-pre-wrap break-words text-13-regular text-text-strong [overflow-wrap:anywhere]">
+          {props.quote.fullText}
         </div>
       </div>
     </Dialog>
@@ -258,9 +283,12 @@ export function MessageTimeline(props: {
   onLoadEarlier: () => void
   renderedUserMessages: UserMessage[]
   anchor: (id: string) => string
+  onFocusInput?: () => void
 }) {
   let touchGesture: number | undefined
+  let root: HTMLDivElement | undefined
   let log: HTMLDivElement | undefined
+  let ask: HTMLButtonElement | undefined
 
   const navigate = useNavigate()
   const globalSDK = useGlobalSDK()
@@ -271,6 +299,7 @@ export function MessageTimeline(props: {
   const layout = useLayout()
   const language = useLanguage()
   const uiI18n = useI18n()
+  const conversationQuote = useConversationQuote()
   const { params, sessionKey } = useSessionKey()
   const platform = usePlatform()
   const [assistantCollapse, setAssistantCollapse] = createStore({
@@ -281,6 +310,16 @@ export function MessageTimeline(props: {
     done: false,
     mode: {} as Record<string, "default" | "open" | "closed">,
     prev: {} as Record<string, string[]>,
+  })
+  const [selection, setSelection] = createStore({
+    open: false,
+    sourceMessageID: "",
+    text: "",
+    summary: "",
+    anchorTop: 0,
+    anchorLeft: 0,
+    top: 0,
+    left: 0,
   })
 
   const rendered = createMemo(() => props.renderedUserMessages.map((message) => message.id))
@@ -519,6 +558,180 @@ export function MessageTimeline(props: {
     return language.t("common.requestFailed")
   }
 
+  const clearSelectionAsk = () =>
+    setSelection({
+      open: false,
+      sourceMessageID: "",
+      text: "",
+      summary: "",
+      anchorTop: 0,
+      anchorLeft: 0,
+      top: 0,
+      left: 0,
+    })
+
+  const placeSelectionAsk = (input?: { top: number; left: number }) => {
+    const top = input?.top ?? selection.anchorTop
+    const left = input?.left ?? selection.anchorLeft
+    const buttonRect = ask?.getBoundingClientRect()
+    const rootRect = root?.getBoundingClientRect()
+    const buttonWidth = buttonRect?.width ?? 52
+    const buttonHeight = buttonRect?.height ?? 34
+    const rootWidth = rootRect?.width ?? window.innerWidth
+    const rootTop = rootRect?.top ?? 0
+    const rootLeft = rootRect?.left ?? 0
+    setSelection({
+      top: Math.max(12, top - rootTop - buttonHeight - 10),
+      left: Math.min(rootWidth - buttonWidth - 12, Math.max(12, left - rootLeft - buttonWidth / 2)),
+    })
+  }
+
+  const selectionParent = (node: Node | null) => (node instanceof Element ? node : node?.parentElement ?? undefined)
+
+  const selectionRects = (input: { range: Range; container: HTMLElement }) => {
+    const rects: Array<{
+      top: number
+      left: number
+      right: number
+      bottom: number
+      width: number
+      height: number
+    }> = []
+    const walker = document.createTreeWalker(input.container, NodeFilter.SHOW_TEXT, {
+      acceptNode(node) {
+        if (!(node instanceof Text) || !node.data.trim()) return NodeFilter.FILTER_REJECT
+        if (!input.range.intersectsNode(node)) return NodeFilter.FILTER_REJECT
+        return NodeFilter.FILTER_ACCEPT
+      },
+    })
+    let node = walker.nextNode()
+    while (node) {
+      const text = node as Text
+      const area = document.createRange()
+      area.selectNodeContents(text)
+      const overlap = document.createRange()
+      if (input.range.compareBoundaryPoints(Range.START_TO_START, area) > 0) overlap.setStart(input.range.startContainer, input.range.startOffset)
+      else overlap.setStart(text, 0)
+      if (input.range.compareBoundaryPoints(Range.END_TO_END, area) < 0) overlap.setEnd(input.range.endContainer, input.range.endOffset)
+      else overlap.setEnd(text, text.data.length)
+      rects.push(
+        ...Array.from(overlap.getClientRects()).map((rect) => ({
+          top: rect.top,
+          left: rect.left,
+          right: rect.right,
+          bottom: rect.bottom,
+          width: rect.width,
+          height: rect.height,
+        })),
+      )
+      node = walker.nextNode()
+    }
+    return rects
+  }
+
+  const resolveAssistantSelection = () => {
+    const selection = window.getSelection()
+    if (!log || !selection || selection.rangeCount === 0 || selection.isCollapsed) return
+    const text = selection.toString().trim()
+    if (!text) return
+
+    const anchor = selectionParent(selection.anchorNode)
+    const focus = selectionParent(selection.focusNode)
+    const anchorContainer = anchor?.closest('[data-slot="session-turn-assistant-content"]')
+    const focusContainer = focus?.closest('[data-slot="session-turn-assistant-content"]')
+    if (!(anchorContainer instanceof HTMLElement) || anchorContainer !== focusContainer) return
+    if (!log.contains(anchorContainer)) return
+
+    const sourceMessageID = anchorContainer.closest("[data-message-id]")?.getAttribute("data-message-id")
+    if (!sourceMessageID) return
+
+    const range = selection.getRangeAt(0)
+    const rect = range.getBoundingClientRect()
+    const target =
+      resolveSelectionAnchorRect({
+        rects: selectionRects({ range, container: anchorContainer }),
+        containerWidth: anchorContainer.getBoundingClientRect().width,
+        fallbackRect: {
+          top: rect.top,
+          left: rect.left,
+          right: rect.right,
+          bottom: rect.bottom,
+          width: rect.width,
+          height: rect.height,
+        },
+      }) ?? rect
+    if (!Number.isFinite(target.top) || !Number.isFinite(target.left)) return
+
+    const anchorLeft = (target.left + target.right) / 2
+    const anchorTop = target.top
+    setSelection({
+      open: true,
+      sourceMessageID,
+      text,
+      summary: summarizeReadingQuoteText(text),
+      anchorTop,
+      anchorLeft,
+      top: anchorTop,
+      left: anchorLeft,
+    })
+    requestAnimationFrame(() => placeSelectionAsk({ top: anchorTop, left: anchorLeft }))
+  }
+
+  const submitAssistantSelection = () => {
+    if (!selection.open || !params.id) return
+    const sessionID = params.id
+    batch(() => {
+      conversationQuote.setPendingQuestion({
+        kind: "assistant-text-question",
+        sessionID,
+        sourceMessageID: selection.sourceMessageID,
+        text: selection.text,
+        summary: selection.summary,
+        createdAt: Date.now(),
+      })
+    })
+    window.getSelection()?.removeAllRanges()
+    clearSelectionAsk()
+    props.onFocusInput?.()
+  }
+
+  createEffect(() => {
+    if (props.mobileChanges) {
+      clearSelectionAsk()
+      return
+    }
+    const handleSelectionChange = () => {
+      const active = window.getSelection()
+      if (!active || active.rangeCount === 0 || active.isCollapsed || !active.toString().trim()) clearSelectionAsk()
+    }
+    const handlePointerUp = () => {
+      queueMicrotask(() => resolveAssistantSelection())
+    }
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target instanceof Element ? event.target : undefined
+      if (target?.closest('[data-component="conversation-quote-ask-button"]')) return
+      clearSelectionAsk()
+    }
+    const handleViewportChange = () => clearSelectionAsk()
+    document.addEventListener("selectionchange", handleSelectionChange)
+    document.addEventListener("pointerup", handlePointerUp)
+    document.addEventListener("pointerdown", handlePointerDown)
+    window.addEventListener("resize", handleViewportChange)
+    window.addEventListener("scroll", handleViewportChange, true)
+    onCleanup(() => {
+      document.removeEventListener("selectionchange", handleSelectionChange)
+      document.removeEventListener("pointerup", handlePointerUp)
+      document.removeEventListener("pointerdown", handlePointerDown)
+      window.removeEventListener("resize", handleViewportChange)
+      window.removeEventListener("scroll", handleViewportChange, true)
+    })
+  })
+
+  createEffect(() => {
+    if (!selection.open) return
+    placeSelectionAsk()
+  })
+
   const shareMutation = useMutation(() => ({
     mutationFn: (id: string) => globalSDK.client.session.share({ sessionID: id, directory: sdk.directory }),
     onError: (err) => {
@@ -743,7 +956,7 @@ export function MessageTimeline(props: {
       when={!props.mobileChanges}
       fallback={<div class="relative h-full overflow-hidden">{props.mobileFallback}</div>}
     >
-      <div class="relative w-full h-full min-w-0">
+      <div ref={root} class="relative w-full h-full min-w-0">
         <Show when={find.open()}>
           <ChatFindBar find={find} text={findText()} />
         </Show>
@@ -1095,6 +1308,7 @@ export function MessageTimeline(props: {
               </div>
             </Show>
             <div
+              ref={log}
               role="log"
               data-slot="session-turn-list"
               class="flex flex-col items-start justify-start pb-16 transition-[margin]"
@@ -1150,8 +1364,22 @@ export function MessageTimeline(props: {
                           quote.imageDataUrl === b[i].imageDataUrl,
                       ),
                   })
+                  const conversationQuotes = createMemo(() => messageConversationQuotes(sync.data.part[messageID] ?? []), [], {
+                    equals: (a, b) =>
+                      a.length === b.length &&
+                      a.every(
+                        (quote, i) =>
+                          quote.kind === b[i].kind &&
+                          quote.source === b[i].source &&
+                          quote.action === b[i].action &&
+                          quote.sourceMessageID === b[i].sourceMessageID &&
+                          quote.summary === b[i].summary &&
+                          quote.fullText === b[i].fullText,
+                      ),
+                  })
                   const commentCount = createMemo(() => comments().length)
                   const readingQuoteCount = createMemo(() => readingQuotes().length)
+                  const conversationQuoteCount = createMemo(() => conversationQuotes().length)
                   return (
                     <div
                       id={props.anchor(messageID)}
@@ -1166,7 +1394,7 @@ export function MessageTimeline(props: {
                         "contain-intrinsic-size": isAssistantCollapsed(messageID) ? "auto 20px" : "auto 500px",
                       }}
                     >
-                      <Show when={commentCount() > 0 || readingQuoteCount() > 0}>
+                      <Show when={commentCount() > 0 || readingQuoteCount() > 0 || conversationQuoteCount() > 0}>
                         <div class="w-full px-4 md:px-5 pb-2">
                           <div class="ml-auto max-w-[82%] overflow-x-auto no-scrollbar">
                             <div class="flex w-max min-w-full justify-end gap-2">
@@ -1234,6 +1462,29 @@ export function MessageTimeline(props: {
                                   )
                                 }}
                               </Index>
+                              <Index each={conversationQuotes()}>
+                                {(quoteAccessor: () => MessageConversationQuote) => {
+                                  const quote = createMemo(() => quoteAccessor())
+                                  return (
+                                    <Show when={quote()}>
+                                      {(q) => (
+                                        <button
+                                          type="button"
+                                          class="shrink-0 max-w-[260px] rounded-[6px] border border-border-weak-base bg-background-stronger px-2.5 py-2 text-left transition hover:bg-background-base"
+                                          onClick={() => {
+                                            dialog.show(() => <DialogConversationQuoteTextContent quote={q()} />)
+                                          }}
+                                        >
+                                          <div class="pt-1 text-11-medium text-text-weak">Ask</div>
+                                          <div class="pt-1 text-12-regular text-text-strong whitespace-pre-wrap break-words line-clamp-3">
+                                            {q().summary}
+                                          </div>
+                                        </button>
+                                      )}
+                                    </Show>
+                                  )
+                                }}
+                              </Index>
                             </div>
                           </div>
                         </div>
@@ -1263,6 +1514,25 @@ export function MessageTimeline(props: {
             </div>
           </div>
         </ScrollView>
+        <Show when={selection.open}>
+          <button
+            ref={ask}
+            type="button"
+            data-component="conversation-quote-ask-button"
+            class="absolute z-50 rounded-full border border-border-weak-base bg-background-stronger px-3 py-1.5 text-12-medium text-text-strong shadow-lg transition hover:bg-background-base"
+            style={{
+              top: `${selection.top}px`,
+              left: `${selection.left}px`,
+            }}
+            onPointerDown={(event) => {
+              event.preventDefault()
+              event.stopPropagation()
+            }}
+            onClick={() => submitAssistantSelection()}
+          >
+            Ask
+          </button>
+        </Show>
       </div>
     </Show>
   )

--- a/packages/app/src/pages/session/selection-anchor.test.ts
+++ b/packages/app/src/pages/session/selection-anchor.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test"
+import { resolveSelectionAnchorRect } from "./selection-anchor"
+
+describe("resolveSelectionAnchorRect", () => {
+  test("returns the first-line rect for single-line selections", () => {
+    const result = resolveSelectionAnchorRect({
+      containerWidth: 800,
+      rects: [{ top: 100, left: 120, right: 280, bottom: 124, width: 160, height: 24 }],
+    })
+
+    expect(result).toEqual({
+      top: 100,
+      left: 120,
+      right: 280,
+      bottom: 124,
+      width: 160,
+      height: 24,
+    })
+  })
+
+  test("filters oversized container rects before positioning", () => {
+    const result = resolveSelectionAnchorRect({
+      containerWidth: 800,
+      rects: [
+        { top: 100, left: 120, right: 280, bottom: 124, width: 160, height: 24 },
+        { top: 96, left: 40, right: 760, bottom: 132, width: 720, height: 36 },
+      ],
+    })
+
+    expect(result).toEqual({
+      top: 100,
+      left: 120,
+      right: 280,
+      bottom: 124,
+      width: 160,
+      height: 24,
+    })
+  })
+
+  test("uses only the first line for multi-line text rects", () => {
+    const result = resolveSelectionAnchorRect({
+      containerWidth: 800,
+      rects: [
+        { top: 100, left: 120, right: 280, bottom: 124, width: 160, height: 24 },
+        { top: 132, left: 120, right: 360, bottom: 156, width: 240, height: 24 },
+      ],
+    })
+
+    expect(result).toEqual({
+      top: 100,
+      left: 120,
+      right: 280,
+      bottom: 124,
+      width: 160,
+      height: 24,
+    })
+  })
+
+  test("falls back to original first-line rects when filtered first-line rects become empty", () => {
+    const result = resolveSelectionAnchorRect({
+      containerWidth: 800,
+      rects: [
+        { top: 96, left: 40, right: 760, bottom: 132, width: 720, height: 36 },
+        { top: 132, left: 120, right: 360, bottom: 156, width: 240, height: 24 },
+      ],
+    })
+
+    expect(result).toEqual({
+      top: 96,
+      left: 40,
+      right: 760,
+      bottom: 132,
+      width: 720,
+      height: 36,
+    })
+  })
+
+  test("uses fallback rect when no client rects are available", () => {
+    const result = resolveSelectionAnchorRect({
+      containerWidth: 800,
+      rects: [],
+      fallbackRect: { top: 100, left: 120, right: 280, bottom: 124, width: 160, height: 24 },
+    })
+
+    expect(result).toEqual({
+      top: 100,
+      left: 120,
+      right: 280,
+      bottom: 124,
+      width: 160,
+      height: 24,
+    })
+  })
+})

--- a/packages/app/src/pages/session/selection-anchor.ts
+++ b/packages/app/src/pages/session/selection-anchor.ts
@@ -1,0 +1,67 @@
+export type SelectionAnchorRect = {
+  top: number
+  left: number
+  right: number
+  bottom: number
+  width: number
+  height: number
+}
+
+const FIRST_LINE_TOLERANCE_PX = 4
+
+const rectFromEdges = (input: { top: number; left: number; right: number; bottom: number }): SelectionAnchorRect => ({
+  top: input.top,
+  left: input.left,
+  right: input.right,
+  bottom: input.bottom,
+  width: input.right - input.left,
+  height: input.bottom - input.top,
+})
+
+const isValidRect = (rect: SelectionAnchorRect) =>
+  Number.isFinite(rect.top) &&
+  Number.isFinite(rect.left) &&
+  Number.isFinite(rect.right) &&
+  Number.isFinite(rect.bottom) &&
+  Number.isFinite(rect.width) &&
+  Number.isFinite(rect.height) &&
+  rect.width > 0 &&
+  rect.height > 0
+
+const median = (values: number[]) => {
+  const sorted = [...values].sort((a, b) => a - b)
+  const middle = Math.floor(sorted.length / 2)
+  if (sorted.length % 2 === 0) return (sorted[middle - 1]! + sorted[middle]!) / 2
+  return sorted[middle]!
+}
+
+export function resolveSelectionAnchorRect(input: {
+  rects: SelectionAnchorRect[]
+  containerWidth: number
+  fallbackRect?: SelectionAnchorRect
+}) {
+  const rects = input.rects.filter(isValidRect)
+  const fallback = input.fallbackRect && isValidRect(input.fallbackRect) ? input.fallbackRect : undefined
+  if (rects.length === 0) return fallback
+
+  const top = Math.min(...rects.map((rect) => rect.top))
+  const lines = rects.filter((rect) => Math.abs(rect.top - top) <= FIRST_LINE_TOLERANCE_PX)
+  if (lines.length === 0) return fallback
+
+  const width = median(lines.map((rect) => rect.width))
+  const filtered = lines.filter((rect) => {
+    if (input.containerWidth > 0 && rect.width >= input.containerWidth * 0.9) return false
+    if (lines.length > 1 && width > 0 && rect.width >= width * 2.5) return false
+    return true
+  })
+
+  const anchor = filtered.length > 0 ? filtered : lines
+  if (anchor.length === 1) return anchor[0]
+
+  return rectFromEdges({
+    left: Math.min(...anchor.map((rect) => rect.left)),
+    right: Math.max(...anchor.map((rect) => rect.right)),
+    top: Math.min(...anchor.map((rect) => rect.top)),
+    bottom: Math.max(...anchor.map((rect) => rect.bottom)),
+  })
+}

--- a/packages/app/src/utils/comment-note.test.ts
+++ b/packages/app/src/utils/comment-note.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test"
+import {
+  createConversationQuoteMetadata,
+  createReadingQuoteMetadata,
+  readConversationQuoteMetadata,
+  readReadingQuoteMetadata,
+  summarizeReadingQuoteText,
+} from "./comment-note"
+
+describe("reading quote metadata", () => {
+  test("round-trips text quotes", () => {
+    const metadata = createReadingQuoteMetadata({
+      mode: "classic",
+      action: "ask",
+      contentType: "text",
+      pdfFileName: "paper.pdf",
+      startPage: 12,
+      endPage: 13,
+      summary: "short summary",
+      fullText: "full selected text",
+    })
+
+    expect(readReadingQuoteMetadata(metadata)).toEqual({
+      mode: "classic",
+      action: "ask",
+      contentType: "text",
+      pdfFileName: "paper.pdf",
+      startPage: 12,
+      endPage: 13,
+      summary: "short summary",
+      fullText: "full selected text",
+      imageDataUrl: undefined,
+    })
+  })
+
+  test("round-trips image quotes", () => {
+    const metadata = createReadingQuoteMetadata({
+      mode: "quick",
+      action: "translate",
+      contentType: "image",
+      pdfFileName: "paper.pdf",
+      startPage: 7,
+      summary: "captured region",
+      imageDataUrl: "data:image/png;base64,abc",
+    })
+
+    expect(readReadingQuoteMetadata(metadata)).toEqual({
+      mode: "quick",
+      action: "translate",
+      contentType: "image",
+      pdfFileName: "paper.pdf",
+      startPage: 7,
+      endPage: undefined,
+      summary: "captured region",
+      fullText: undefined,
+      imageDataUrl: "data:image/png;base64,abc",
+    })
+  })
+
+  test("summarizes long text", () => {
+    const summary = summarizeReadingQuoteText("a".repeat(40), 12)
+    expect(summary).toBe("aaaaaaaaa...")
+  })
+})
+
+describe("conversation quote metadata", () => {
+  test("round-trips assistant quote metadata", () => {
+    const metadata = createConversationQuoteMetadata({
+      kind: "conversation-quote",
+      source: "assistant",
+      action: "ask",
+      sourceMessageID: "message-123",
+      summary: "short summary",
+      fullText: "full quoted assistant text",
+    })
+
+    expect(readConversationQuoteMetadata(metadata)).toEqual({
+      kind: "conversation-quote",
+      source: "assistant",
+      action: "ask",
+      sourceMessageID: "message-123",
+      summary: "short summary",
+      fullText: "full quoted assistant text",
+    })
+  })
+})

--- a/packages/app/src/utils/comment-note.ts
+++ b/packages/app/src/utils/comment-note.ts
@@ -20,6 +20,15 @@ export type ReadingQuote = {
   imageDataUrl?: string
 }
 
+export type ConversationQuote = {
+  kind: "conversation-quote"
+  source: "assistant"
+  action: "ask"
+  sourceMessageID: string
+  summary: string
+  fullText: string
+}
+
 function selection(selection: unknown) {
   if (!selection || typeof selection !== "object") return undefined
   const startLine = Number((selection as FileSelection).startLine)
@@ -76,6 +85,19 @@ export function createReadingQuoteMetadata(input: ReadingQuote) {
   }
 }
 
+export function createConversationQuoteMetadata(input: ConversationQuote) {
+  return {
+    opencodeConversationQuote: {
+      kind: input.kind,
+      source: input.source,
+      action: input.action,
+      sourceMessageID: input.sourceMessageID,
+      summary: input.summary,
+      fullText: input.fullText,
+    },
+  }
+}
+
 export function readReadingQuoteMetadata(value: unknown) {
   if (!value || typeof value !== "object") return
   const meta = (value as { opencodeReadingQuote?: unknown }).opencodeReadingQuote
@@ -112,6 +134,35 @@ export function readReadingQuoteMetadata(value: unknown) {
     fullText: typeof fullText === "string" ? fullText : undefined,
     imageDataUrl: typeof imageDataUrl === "string" ? imageDataUrl : undefined,
   } satisfies ReadingQuote
+}
+
+export function readConversationQuoteMetadata(value: unknown) {
+  if (!value || typeof value !== "object") return
+  const meta = (value as { opencodeConversationQuote?: unknown }).opencodeConversationQuote
+  if (!meta || typeof meta !== "object") return
+
+  const kind = (meta as { kind?: unknown }).kind
+  const source = (meta as { source?: unknown }).source
+  const action = (meta as { action?: unknown }).action
+  const sourceMessageID = (meta as { sourceMessageID?: unknown }).sourceMessageID
+  const summary = (meta as { summary?: unknown }).summary
+  const fullText = (meta as { fullText?: unknown }).fullText
+
+  if (kind !== "conversation-quote") return
+  if (source !== "assistant") return
+  if (action !== "ask") return
+  if (typeof sourceMessageID !== "string" || !sourceMessageID) return
+  if (typeof summary !== "string") return
+  if (typeof fullText !== "string" || !fullText) return
+
+  return {
+    kind,
+    source,
+    action,
+    sourceMessageID,
+    summary,
+    fullText,
+  } satisfies ConversationQuote
 }
 
 export function readCommentMetadata(value: unknown) {


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR adds follow-up questions from assistant reply selections in the session timeline.

Users can now select text inside an assistant reply, click Ask, and continue the conversation with that quoted assistant content attached to the next user message. The quoted content is shown in the composer as AI Reply Quote, stored through message part metadata, and rendered back on the sent user message so the follow-up context stays visible.

This change only targets normal chat timeline assistant-message quoting. It does not modify the existing PDF / reading quote flows.

### How did you verify your code works?

- Ran un test src/utils/comment-note.test.ts src/pages/session/selection-anchor.test.ts
- Ran un typecheck
- Manually tested selecting assistant reply text, clicking Ask, sending a follow-up, clearing the pending quote, and opening the sent quote card
- Confirmed normal chat flow still works without using the quote feature
- Confirmed PDF-related quote behavior was not changed

### Screenshots / recordings

_Not included here. This is a UI change and was verified locally._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR