### PR TITLE
feat: add skill scan paths command

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -63,6 +63,7 @@ export namespace Command {
   export const Default = {
     INIT: "init",
     REVIEW: "review",
+    SKILL_SCAN_PATHS: "skill-scan-paths",
   } as const
 
   export interface Interface {
@@ -98,8 +99,16 @@ export namespace Command {
           subtask: true,
           hints: hints(PROMPT_REVIEW),
         }
+        commands[Default.SKILL_SCAN_PATHS] = {
+          name: Default.SKILL_SCAN_PATHS,
+          description: "print live skill scan paths",
+          source: "command",
+          template: "",
+          hints: [],
+        }
 
         for (const [name, command] of Object.entries(cfg.command ?? {})) {
+          if (name === Default.SKILL_SCAN_PATHS) continue
           commands[name] = {
             name,
             agent: command.agent,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -55,6 +55,7 @@ import { Process } from "@/util/process"
 import { Memory } from "@/memory"
 import { SKILL_NUDGE_INTERVAL, SKILL_REVIEW_MARKER, spawnBackgroundReview } from "./skill-evolution"
 import { Config } from "../config/config"
+import { Skill } from "../skill"
 import { SkillRefresh } from "./skill-refresh"
 
 // @ts-ignore
@@ -2015,6 +2016,79 @@ NOTE: At any point in time through this workflow you should feel free to ask the
    * Does not match when preceded by word characters or backticks (to avoid email addresses and quoted references)
    */
 
+  function paths(list: Skill.Source[]) {
+    if (list.length === 0) return "No skill scan paths are currently active."
+    return [
+      "Skill scan paths (low -> high priority)",
+      "",
+      ...list.map((item, i) => `${i + 1}. [${item.scope}] ${path.join(item.dir, item.pattern)}`),
+    ].join("\n")
+  }
+
+  async function scan(input: CommandInput) {
+    assertNotBusy(input.sessionID)
+    await SessionRevert.awaitPending(input.sessionID)
+    await SessionRevert.cleanup(await Session.get(input.sessionID))
+
+    const text = input.arguments.trim() ? `/${input.command} ${input.arguments}` : `/${input.command}`
+    const user = await createUserMessage({
+      sessionID: input.sessionID,
+      messageID: input.messageID,
+      agent: input.agent,
+      model: input.model ? Provider.parseModel(input.model) : undefined,
+      variant: input.variant,
+      parts: [{ type: "text", text }, ...(input.parts ?? [])],
+    })
+
+    const now = Date.now()
+    const msg: MessageV2.Assistant = {
+      id: MessageID.ascending(),
+      sessionID: input.sessionID,
+      parentID: user.info.id,
+      mode: user.info.agent,
+      agent: user.info.agent,
+      cost: 0,
+      path: {
+        cwd: Instance.directory,
+        root: Instance.worktree,
+      },
+      time: {
+        created: now,
+        completed: now,
+      },
+      role: "assistant",
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+      modelID: user.info.model.modelID,
+      providerID: user.info.model.providerID,
+      variant: user.info.variant,
+      finish: "stop",
+    }
+    const part: MessageV2.TextPart = {
+      type: "text",
+      id: PartID.ascending(),
+      messageID: msg.id,
+      sessionID: input.sessionID,
+      text: paths(await Skill.sources()),
+    }
+
+    await Session.updateMessage(msg)
+    await Session.updatePart(part)
+    await Session.touch(input.sessionID)
+    Bus.publish(Command.Event.Executed, {
+      name: input.command,
+      sessionID: input.sessionID,
+      arguments: input.arguments,
+      messageID: msg.id,
+    })
+
+    return { info: msg, parts: [part] }
+  }
+
   export async function command(input: CommandInput) {
     log.info("command", input)
     const command = await Command.get(input.command)
@@ -2028,6 +2102,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       })
       throw error
     }
+    if (input.command === Command.Default.SKILL_SCAN_PATHS) return scan(input)
     const agentName = command.agent ?? input.agent ?? (await Agent.defaultAgent())
 
     const raw = input.arguments.match(argsRegex) ?? []

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -220,8 +220,8 @@ export namespace Skill {
   // mirrors Hermes _SKILLS_SNAPSHOT_VERSION
   const SKILLS_SNAPSHOT_VERSION = 3
 
-  type Scope = "global" | "project"
-  type Source = {
+  export type Scope = "global" | "project"
+  export type Source = {
     dir: string
     pattern: string
     dot?: boolean
@@ -694,6 +694,7 @@ export namespace Skill {
     readonly get: (name: string) => Effect.Effect<Info | undefined>
     readonly all: () => Effect.Effect<Info[]>
     readonly dirs: () => Effect.Effect<string[]>
+    readonly sources: () => Effect.Effect<Source[]>
     readonly available: (agent?: Agent.Info) => Effect.Effect<Info[]>
     readonly invalidate: () => Effect.Effect<void>
   }
@@ -1109,6 +1110,12 @@ export namespace Skill {
         return Array.from(s.dirs)
       })
 
+      const sources = Effect.fn("Skill.sources")(function* () {
+        return yield* Effect.promise(() =>
+          Config.get().then((cfg) => buildSources(Instance.directory, Instance.worktree, cfg)),
+        )
+      })
+
       const available = Effect.fn("Skill.available")(function* (agent?: Agent.Info) {
         yield* ensureWatch()
         const cached = yield* InstanceState.has(state)
@@ -1131,7 +1138,7 @@ export namespace Skill {
         yield* InstanceState.invalidate(state)
       })
 
-      return Service.of({ get, all, dirs, available, invalidate })
+      return Service.of({ get, all, dirs, sources, available, invalidate })
     }),
   )
 
@@ -1197,6 +1204,10 @@ export namespace Skill {
 
   export async function dirs() {
     return runPromise((skill) => skill.dirs())
+  }
+
+  export async function sources() {
+    return runPromise((skill) => skill.sources())
   }
 
   export async function available(agent?: Agent.Info) {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -285,4 +285,51 @@ describe("session.agent-resolution", () => {
       },
     })
   }, 30000)
+
+  test("skill-scan-paths command returns scan paths without model lookup", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        agent: {
+          build: {
+            model: "missing-provider/missing-model",
+          },
+        },
+      },
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, ".aether", "skills", "demo", "SKILL.md"),
+          `---
+name: demo
+description: Demo skill.
+---
+
+# Demo
+`,
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const result = await SessionPrompt.command({
+          sessionID: session.id,
+          command: "skill-scan-paths",
+          arguments: "",
+          agent: "build",
+          model: "missing-provider/missing-model",
+        })
+        const text = result.parts
+          .filter((part): part is MessageV2.TextPart => part.type === "text")
+          .map((part) => part.text)
+          .join("\n")
+
+        expect(result.info.role).toBe("assistant")
+        expect(text).toContain("Skill scan paths (low -> high priority)")
+        expect(text).toContain(path.join(tmp.path, ".aether", "{skill,skills}", "**", "SKILL.md"))
+      },
+    })
+  }, 30000)
 })

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -95,6 +95,42 @@ description: Skill for dirs test.
   }
 })
 
+test("returns live skill scan sources in priority order", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    config: {
+      skills: {
+        paths: ["team-skills"],
+      },
+    },
+    init: async (dir) => {
+      await Promise.all(
+        [".agents", ".claude", ".opencode", ".aether", "team-skills"].map((name) =>
+          fs.mkdir(path.join(dir, name), { recursive: true }),
+        ),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const sources = await Skill.sources()
+      const local = sources
+        .filter((item) => item.dir.startsWith(tmp.path))
+        .map((item) => `${path.relative(tmp.path, item.dir)}:${item.pattern}`)
+
+      expect(local).toEqual([
+        ".agents:skills/**/SKILL.md",
+        ".claude:skills/**/SKILL.md",
+        ".opencode:{skill,skills}/**/SKILL.md",
+        ".aether:{skill,skills}/**/SKILL.md",
+        `team-skills:**/SKILL.md`,
+      ])
+    },
+  })
+})
+
 test("discovers multiple skills from .opencode/skill/ directory", async () => {
   await using tmp = await tmpdir({
     git: true,


### PR DESCRIPTION
### Issue for this PR

Closes #603

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a built-in `/skill-scan-paths` slash command that prints the active session's live skill scan paths from low to high priority.

The command reuses the existing skill source construction logic through `Skill.sources()`, so the output reflects the actual runtime scan behavior instead of relying on an LLM-generated explanation. The command writes a direct assistant response in the session and does not invoke model prompting.

### How did you verify your code works?

- `bun test test/skill/skill.test.ts`
- `bun test test/session/prompt.test.ts`
- `bun typecheck`
- pre-push `bun turbo typecheck`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR