### PR TITLE
fix: stabilize child session navigation e2e

### DIFF
--- a/packages/app/e2e/session/session-child-navigation.spec.ts
+++ b/packages/app/e2e/session/session-child-navigation.spec.ts
@@ -1,7 +1,7 @@
 import { seedSessionTask, withSession } from "../actions"
 import { test, expect } from "../fixtures"
 
-test("task tool child-session link does not trigger stale show errors", async ({ page, sdk, gotoSession }) => {
+test("task tool child-session link does not trigger stale show errors", async ({ page, llm, project }) => {
   test.setTimeout(120_000)
 
   const errs: string[] = []
@@ -10,15 +10,29 @@ test("task tool child-session link does not trigger stale show errors", async ({
   }
   page.on("pageerror", onError)
 
-  await withSession(sdk, `e2e child nav ${Date.now()}`, async (session) => {
-    const child = await seedSessionTask(sdk, {
-      sessionID: session.id,
+  await project.open()
+
+  await withSession(project.sdk, `e2e child nav ${Date.now()}`, async (session) => {
+    const task = {
       description: "Open child session",
       prompt: "Search the repository for AssistantParts and then reply with exactly CHILD_OK.",
+      subagent_type: "general",
+    }
+
+    await llm.tool("task", task)
+    await llm.text("CHILD_OK")
+
+    const child = await seedSessionTask(project.sdk, {
+      sessionID: session.id,
+      description: task.description,
+      prompt: task.prompt,
+      subagentType: task.subagent_type,
     })
+    project.trackSession(child.sessionID)
+    await llm.wait(2)
 
     try {
-      await gotoSession(session.id)
+      await project.gotoSession(session.id)
 
       const link = page
         .locator("a.subagent-link")


### PR DESCRIPTION
### Issue for this PR

Closes #606

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Stabilizes `session-child-navigation.spec.ts` by moving it to the isolated `project`/`llm` e2e fixtures.

The test still exercises the real task tool path that creates a child session, but the model responses are now explicitly queued by `TestLLMServer`. This removes the Windows-only timing dependency on a real model call during test setup while preserving the test's actual assertion: clicking the child-session link should navigate without page errors.

### How did you verify your code works?

- Attempted `bun test:e2e:local e2e/session/session-child-navigation.spec.ts`, but this worktree could not start e2e because `@opentui/solid/preload` is missing.
- Attempted `bun typecheck` from `packages/app`, but this worktree is missing dependency/type resolution for modules such as `solid-js`, `@opencode-ai/ui`, and `bun:test`.

### Screenshots / recordings

Not applicable.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
