### PR TITLE
fix(session): make Ctrl+F search bar always visible and properly triggered

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -2246,6 +2246,7 @@ function SessionPageContent(props: SessionPageProps = {}) {
               </div>
             </Show>
             <div
+              data-chat-panel
               classList={{
                 "@container relative shrink-0 flex flex-col min-h-0 h-full bg-background-stronger flex-1 md:flex-none": true,
                 "transition-[width] duration-[240ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[width] motion-reduce:transition-none":
@@ -2416,6 +2417,7 @@ function SessionPageContent(props: SessionPageProps = {}) {
 
         <Show when={!readingModeActive()}>
           <div
+            data-chat-panel
             classList={{
               "@container relative shrink-0 flex flex-col min-h-0 h-full bg-background-stronger flex-1 md:flex-none": true,
               "transition-[width] duration-[240ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[width] motion-reduce:transition-none":

--- a/packages/app/src/pages/session/chat-find.tsx
+++ b/packages/app/src/pages/session/chat-find.tsx
@@ -5,6 +5,7 @@ import { Portal } from "solid-js/web"
 
 type Find = {
   root: () => HTMLElement | undefined
+  panel?: () => HTMLElement | undefined
   active?: () => boolean
 }
 
@@ -127,7 +128,8 @@ export function createChatFind(input: Find) {
   const place = () => {
     const root = input.root()
     if (!root) return
-    const box = root.getBoundingClientRect()
+    const anchor = input.panel?.() ?? root
+    const box = anchor.getBoundingClientRect()
     const raw = parseFloat(getComputedStyle(root).getPropertyValue("--session-title-height"))
     const head = Number.isNaN(raw) ? 0 : raw
     setState("pos", {
@@ -209,8 +211,15 @@ export function createChatFind(input: Find) {
       const k = event.key.toLowerCase()
 
       if (k === "f") {
-        if (!scope) return
-        if (editable(event.target)) return
+        if (!root || !document.contains(root)) return
+        const panel = root.closest("[data-chat-panel]")
+        const ae = document.activeElement
+        const inScope =
+          scope ||
+          (panel !== null && (owns(panel as HTMLElement, event.target) || owns(panel as HTMLElement, ae))) ||
+          !ae ||
+          ae === document.body
+        if (!inScope) return
         event.preventDefault()
         event.stopPropagation()
         focus()

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -518,6 +518,7 @@ export function MessageTimeline(props: {
   })
   const find = createChatFind({
     root: () => log,
+    panel: () => root,
     active: () => !props.mobileChanges,
   })
   const findText = createMemo(() => ({


### PR DESCRIPTION
## 问题

会话界面按 Ctrl+F 搜索框无法弹出，即使弹出后滚动对话记录时搜索框也会消失。

**根因一**：`createChatFind` 的 scope 检查要求焦点必须落在消息列表（`log` div）内部才能触发，导致焦点在聊天输入框、页面无焦点等常见状态下 Ctrl+F 完全无响应。

**根因二**：搜索框位置根据消息列表容器（`log` div）的 `getBoundingClientRect()` 计算，而该容器随对话滚动上下移动，滚动后 `top` 变为负值，搜索框跑到屏幕上方不可见。

## 改动

- **`chat-find.tsx`**：为 `createChatFind` 增加可选的 `panel` 字段，`place()` 改为用 `panel` 容器而非 `root`（消息列表）计算位置，使搜索框始终固定在会话面板右上角；Ctrl+F 的触发条件从"焦点在消息列表内"扩展为"焦点在整个会话面板内（含输入框）或页面无焦点"
- **`session.tsx`**：两处会话面板容器加 `data-chat-panel` 标记，覆盖桌面端和移动端布局路径
- **`message-timeline.tsx`**：`createChatFind` 传入外层容器 ref 作为 `panel`，用于稳定定位

## 效果

| 场景 | 修复前 | 修复后 |
|------|--------|--------|
| 页面无焦点时按 Ctrl+F | ❌ 无响应 | ✅ 弹出搜索框 |
| 焦点在聊天输入框时按 Ctrl+F | ❌ 无响应 | ✅ 弹出搜索框 |
| 点击消息后按 Ctrl+F | ❌ 无响应 | ✅ 弹出搜索框 |
| 滚动对话后搜索框消失 | ❌ 消失 | ✅ 始终固定在右上角 |
| 焦点在文件编辑器时按 Ctrl+F | ✅ 不干扰 | ✅ 不干扰 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)