### PR TITLE
feat(settings): add collapse messages by default toggle in general settings

### DIFF
--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -376,6 +376,18 @@ export const SettingsGeneral: Component = () => {
         </SettingsRow>
 
         <SettingsRow
+          title={language.t("settings.general.row.collapseMessages.title")}
+          description={language.t("settings.general.row.collapseMessages.description")}
+        >
+          <div data-action="settings-feed-collapse-messages">
+            <Switch
+              checked={settings.general.collapseMessages()}
+              onChange={(checked) => settings.general.setCollapseMessages(checked)}
+            />
+          </div>
+        </SettingsRow>
+
+        <SettingsRow
           title={language.t("settings.general.row.shellToolPartsExpanded.title")}
           description={language.t("settings.general.row.shellToolPartsExpanded.description")}
         >

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -31,6 +31,7 @@ export interface Settings {
     showReasoningSummaries: boolean
     shellToolPartsExpanded: boolean
     editToolPartsExpanded: boolean
+    collapseMessages: boolean
   }
   updates: {
     startup: boolean
@@ -60,6 +61,7 @@ const defaultSettings: Settings = {
     showReasoningSummaries: false,
     shellToolPartsExpanded: true,
     editToolPartsExpanded: false,
+    collapseMessages: true,
   },
   updates: {
     startup: true,
@@ -204,6 +206,13 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
         ),
         setEditToolPartsExpanded(value: boolean) {
           setStore("general", "editToolPartsExpanded", value)
+        },
+        collapseMessages: withFallback(
+          () => store.general?.collapseMessages,
+          defaultSettings.general.collapseMessages,
+        ),
+        setCollapseMessages(value: boolean) {
+          setStore("general", "collapseMessages", value)
         },
       },
       updates: {

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -1171,6 +1171,9 @@ export const dict = {
     "How many file changes the review panel loads at a time. The same count is used by Load more.",
   "settings.general.row.reasoningSummaries.title": "Show reasoning summaries",
   "settings.general.row.reasoningSummaries.description": "Display model reasoning summaries in the timeline",
+  "settings.general.row.collapseMessages.title": "Collapse messages by default",
+  "settings.general.row.collapseMessages.description":
+    "Collapse all previous messages when opening a session, keeping only the latest expanded",
   "settings.general.row.shellToolPartsExpanded.title": "Expand shell tool parts",
   "settings.general.row.shellToolPartsExpanded.description":
     "Show shell tool parts expanded by default in the timeline",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -983,6 +983,8 @@ export const dict = {
     "设置审查栏每次加载多少个文件变更，“加载更多”也会按这个数量继续加载。",
   "settings.general.row.reasoningSummaries.title": "显示推理摘要",
   "settings.general.row.reasoningSummaries.description": "在时间线中显示模型推理摘要",
+  "settings.general.row.collapseMessages.title": "默认收起历史消息",
+  "settings.general.row.collapseMessages.description": "打开会话时自动收起除最新一条外的所有消息",
   "settings.general.row.shellToolPartsExpanded.title": "展开 shell 工具部分",
   "settings.general.row.shellToolPartsExpanded.description": "默认在时间线中展开 shell 工具部分",
   "settings.general.row.editToolPartsExpanded.title": "展开编辑工具部分",

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -431,13 +431,15 @@ export function MessageTimeline(props: {
   createEffect(() => {
     const id = sessionID()
     if (!id || !loaded() || entry.session !== id || entry.done) return
-    const ids = collapsibleTurnIDs()
-    const tail = ids[ids.length - 1]
-    setAssistantCollapse(
-      "bySession",
-      id,
-      reconcile(Object.fromEntries(ids.filter((item) => item !== tail).map((item) => [item, true] as const))),
-    )
+    if (settings.general.collapseMessages()) {
+      const ids = collapsibleTurnIDs()
+      const tail = ids[ids.length - 1]
+      setAssistantCollapse(
+        "bySession",
+        id,
+        reconcile(Object.fromEntries(ids.filter((item) => item !== tail).map((item) => [item, true] as const))),
+      )
+    }
     setEntry("prev", id, rendered().slice())
     setEntry("done", true)
   })


### PR DESCRIPTION
## Summary

- Add a **"Collapse messages by default"** toggle in Settings → General
- When turned off, all messages are shown expanded when opening a session (instead of the default behavior of collapsing all except the latest)
- Setting is persisted via the existing `settings.v3` store — survives app restarts

Closes #611

## Changes

- `context/settings.tsx` — new `collapseMessages` field (default: `true`), getter + setter
- `settings-general.tsx` — new Switch row in the General section
- `message-timeline.tsx` — init effect respects the setting; skips collapse logic when disabled
- `i18n/en.ts` + `i18n/zh.ts` — translation keys added

## Behavior

| Setting | On open session |
|---|---|
| On (default) | Collapse all except latest (existing behavior) |
| Off | All messages expanded |

No component disposal involved — the change is a pure store value update that gates the existing `setAssistantCollapse` call.

## Test plan

- [ ] Default on: open a session with multiple turns → all but latest are collapsed ✓
- [ ] Toggle off: open a session → all turns expanded ✓
- [ ] Restart app with setting off → sessions still open expanded ✓
- [ ] Manual "Collapse All" / "Expand All" in session dropdown still works independently ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)