### PR TITLE
fix: restrict summarize_dirs tool to explicit full-repo exploration only

### DIFF
--- a/packages/opencode/src/agent/prompt/explore.txt
+++ b/packages/opencode/src/agent/prompt/explore.txt
@@ -25,4 +25,4 @@ Navigation strategy:
 - If the summary clearly indicates the directory is irrelevant to your search, skip its subdirectories
 - If the summary suggests the directory is likely relevant, use Read on the specific subdirectories of interest
 - If no summary is present, fall back to normal exploration (Glob, Grep, reading entry lists)
-- Use the summarize_dirs tool if summaries are missing and you need to navigate a large codebase efficiently
+- Only use the summarize_dirs tool when the user explicitly asks to comprehensively explore or map out the entire codebase

--- a/packages/opencode/src/session/prompt/anthropic-20250930.txt
+++ b/packages/opencode/src/session/prompt/anthropic-20250930.txt
@@ -164,7 +164,7 @@ Navigation strategy:
 - Read a directory → check for <summary> → decide which subdirectories are relevant to the task
 - If the summary clearly indicates a directory is irrelevant, skip its subdirectories
 - If no <summary> is present, fall back to reading the entry list directly
-- Use the summarize_dirs tool if summaries are missing and you need to navigate a large codebase efficiently
+- Only use the summarize_dirs tool when the user explicitly asks to comprehensively explore or map out the entire codebase
 
 # Code References
 

--- a/packages/opencode/src/session/prompt/anthropic.txt
+++ b/packages/opencode/src/session/prompt/anthropic.txt
@@ -103,7 +103,7 @@ Navigation strategy:
 - Read a directory → check for <summary> → decide which subdirectories are relevant to the task
 - If the summary clearly indicates a directory is irrelevant, skip its subdirectories
 - If no <summary> is present, fall back to reading the entry list directly
-- Use the summarize_dirs tool if summaries are missing and you need to navigate a large codebase efficiently
+- Only use the summarize_dirs tool when the user explicitly asks to comprehensively explore or map out the entire codebase
 
 # Code References
 

--- a/packages/opencode/src/session/prompt/default.txt
+++ b/packages/opencode/src/session/prompt/default.txt
@@ -103,7 +103,7 @@ Navigation strategy:
 - Read a directory → check for <summary> → decide which subdirectories are relevant to the task
 - If the summary clearly indicates a directory is irrelevant, skip its subdirectories
 - If no <summary> is present, fall back to reading the entry list directly
-- Use the summarize_dirs tool if summaries are missing and you need to navigate a large codebase efficiently
+- Only use the summarize_dirs tool when the user explicitly asks to comprehensively explore or map out the entire codebase
 
 # Code References
 

--- a/packages/opencode/src/session/prompt/trinity.txt
+++ b/packages/opencode/src/session/prompt/trinity.txt
@@ -95,7 +95,7 @@ Navigation strategy:
 - Read a directory → check for <summary> → decide which subdirectories are relevant to the task
 - If the summary clearly indicates a directory is irrelevant, skip its subdirectories
 - If no <summary> is present, fall back to reading the entry list directly
-- Use the summarize_dirs tool if summaries are missing and you need to navigate a large codebase efficiently
+- Only use the summarize_dirs tool when the user explicitly asks to comprehensively explore or map out the entire codebase
 
 # Code References
 

--- a/packages/opencode/src/tool/summarize-dirs.txt
+++ b/packages/opencode/src/tool/summarize-dirs.txt
@@ -1,15 +1,10 @@
 Generate .summary files for directories in the project.
 
-Each summary is a brief (2-4 sentence) description of the directory's purpose, its key files, and which subdirectories are most relevant for different tasks. Once generated, the Read tool automatically displays these summaries when listing directory contents, enabling efficient navigation of large codebases.
+Each summary is a navigation signpost (markdown table) describing the directory's purpose, key files, and relevant subdirectories. Once generated, the Read tool displays these summaries when listing directory contents.
 
-Use this tool when:
-- Starting work on an unfamiliar or large codebase
-- You want to enable efficient directory navigation for future sessions
-- Summaries are outdated after major refactoring
+IMPORTANT — This tool is expensive and should only be used when the user EXPLICITLY requests a comprehensive, top-to-bottom exploration of the entire codebase (e.g. "thoroughly explore this entire repo", "map out the full project structure", "generate summaries for the whole codebase"). Do NOT use it for targeted tasks, bug fixes, feature work, or general navigation — prefer Read, Grep, and Glob for those.
 
 Parameters:
 - directory: Root directory to start from (defaults to project root)
 - maxDepth: How many levels deep to recurse (1-5, default 3)
 - force: Set to true to regenerate summaries that already exist
-
-After running this tool, the Read tool will show a <summary> block before the entry list whenever you navigate into a directory, allowing you to decide whether to explore its subdirectories without reading all the files.


### PR DESCRIPTION
### Issue for this PR

Closes #

_No associated issue._

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `summarize_dirs` tool was too easy to trigger — it would fire on routine navigation or whenever a large codebase was detected. This PR makes the trigger condition much stricter: the tool should only be invoked when the user **explicitly asks to comprehensively explore or map out the entire codebase**. For all other tasks (bug fixes, feature work, targeted navigation), the agent should use Read/Grep/Glob instead.

Changes:
- Rewrote `summarize-dirs.txt` tool description with an `IMPORTANT` block restricting usage to explicit full-repo exploration requests
- Updated 5 prompt templates (`trinity.txt`, `default.txt`, `anthropic.txt`, `anthropic-20250930.txt`, `explore.txt`) to reflect the stricter trigger condition

### How did you verify your code works?

Reviewed all 6 changed files to confirm consistent wording across tool description and prompt templates.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR