### PR TITLE
fix: thread AbortSignal through summarize_dirs tool so stop button works

### DIFF
--- a/packages/opencode/src/file/summary.ts
+++ b/packages/opencode/src/file/summary.ts
@@ -117,7 +117,8 @@ function buildFormatTemplate(format: FormatType): string {
 
 export namespace FolderSummary {
   /** Generate and write .summary for a single directory */
-  export async function generate(dir: string, root: string): Promise<void> {
+  export async function generate(dir: string, root: string, abort?: AbortSignal): Promise<void> {
+    if (abort?.aborted) return
     log.info("generating summary", { dir })
 
     const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => [])
@@ -197,6 +198,7 @@ export namespace FolderSummary {
         messages: [{ role: "user", content: prompt }],
         maxOutputTokens: 1500,
         temperature: 0.2,
+        abortSignal: abort,
       })
       return result.text.trim()
     }
@@ -234,9 +236,10 @@ export namespace FolderSummary {
     root: string,
     maxDepth: number,
     force: boolean,
+    abort?: AbortSignal,
   ): Promise<string[]> {
     const results: string[] = []
-    await traverse(root, root, 0, maxDepth, force, results)
+    await traverse(root, root, 0, maxDepth, force, results, abort)
     return results
   }
 
@@ -247,14 +250,16 @@ export namespace FolderSummary {
     maxDepth: number,
     force: boolean,
     results: string[],
+    abort?: AbortSignal,
   ): Promise<void> {
     if (depth > maxDepth) return
+    if (abort?.aborted) return
 
     const summaryPath = path.join(dir, SUMMARY_FILE)
 
     if (force || !(await Filesystem.exists(summaryPath))) {
       try {
-        await generate(dir, root)
+        await generate(dir, root, abort)
         results.push(summaryPath)
       } catch (err) {
         log.error("failed to generate summary", { dir, error: err })
@@ -266,7 +271,8 @@ export namespace FolderSummary {
     for (const entry of entries) {
       if (!entry.isDirectory()) continue
       if (SKIP_DIRS.has(entry.name) || entry.name.startsWith(".")) continue
-      await traverse(path.join(dir, entry.name), root, depth + 1, maxDepth, force, results)
+      if (abort?.aborted) return
+      await traverse(path.join(dir, entry.name), root, depth + 1, maxDepth, force, results, abort)
     }
   }
 }

--- a/packages/opencode/src/tool/summarize-dirs.ts
+++ b/packages/opencode/src/tool/summarize-dirs.ts
@@ -23,12 +23,12 @@ export const SummarizeDirsTool = Tool.define("summarize_dirs", {
       .optional()
       .describe("Regenerate summaries even if .summary already exists. Defaults to false."),
   }),
-  async execute(params, _ctx) {
+  async execute(params, ctx) {
     const root = params.directory ?? Instance.directory
     const maxDepth = params.maxDepth ?? 3
     const force = params.force ?? false
 
-    const generated = await FolderSummary.generateAll(root, maxDepth, force)
+    const generated = await FolderSummary.generateAll(root, maxDepth, force, ctx.abort)
 
     const title = `Summarized ${generated.length} director${generated.length === 1 ? "y" : "ies"}`
     const output =


### PR DESCRIPTION
### Issue for this PR

N/A — bug found during local use.

### Type of change

- [x] Bug fix

### What does this PR do?

The `summarize_dirs` tool ignored `ctx.abort` (AbortSignal), so clicking the UI "stop" button had no effect while it was running. The tool's `execute` used `_ctx` and never passed the signal to its internal call chain (`generateAll` → `traverse` → `generate`).

This PR threads `AbortSignal` through the entire chain:

- `SummarizeDirsTool.execute`: `_ctx` → `ctx`, pass `ctx.abort` to `generateAll`
- `generateAll` / `traverse`: add `abort?: AbortSignal` param, check `abort?.aborted` at entry and loop boundaries
- `generate`: add `abort?: AbortSignal` param, check at entry, pass `abortSignal: abort` to `generateText`

Same pattern already used by `BashTool`.

### How did you verify your code works?

- `bun typecheck` passes in `packages/opencode`
- Pre-push hook ran full repo typecheck (turbo) — all 12 packages pass

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR