### PR TITLE
feat(app): add initial Git Graph view to side panel

### DIFF
--- a/docs/git-graph-integration-plan.md
+++ b/docs/git-graph-integration-plan.md
@@ -1,0 +1,325 @@
+# Git Graph 集成方案
+
+> 在 Aether web-ui 变更视图栏中新增 "Git Graph" Tab，基于 vscode-git-graph 算法提供可视化的 git 历史查看与交互。
+
+## 参考仓库
+
+- **vscode-git-graph**: https://github.com/mhutchie/vscode-git-graph.git（已 clone 到 `reference/vscode-git-graph`；如果在修改时发现该仓库已被删除，则需要请示后重新clone作为参照。）
+- 核心借鉴：`web/graph.ts` 的图布局算法、`web/main.ts` 的渲染同步机制、`dataSource.ts` 的 git 命令封装
+
+## 总体架构决策
+
+| vscode-git-graph 组件                                      | Aether 对应                                                    | 说明                        |
+| ---------------------------------------------------------- | -------------------------------------------------------------- | --------------------------- |
+| `dataSource.ts` — `getCommits()` / `getRefs()`             | `packages/opencode/src/git/index.ts` — 新增 `log()` / `refs()` | Effect Service 模式         |
+| `dataSource.ts` — `getRepoInfo()`                          | `packages/opencode/src/project/vcs.ts` — 新增 `graph()`        | 组合 log + refs             |
+| Extension ↔ Webview messaging                              | Hono HTTP API (`GET /vcs/graph`) → SDK                         | 同步 REST 请求              |
+| `web/graph.ts` — `Graph.loadCommits()` / `determinePath()` | `model.ts` — 纯函数 `computeGraphLayout()`                     | 无框架依赖，可测试          |
+| `web/graph.ts` — `Graph.render()` SVG 线 + 圆              | `render.tsx` — SVG `<For>` + `<path>` / `<circle>`             | SolidJS 响应式              |
+| `web/main.ts` — `renderTable()` HTML commit 列表           | `render.tsx` — HTML `<For>` 行列表                             | **固定行高**，无需 DOM 测量 |
+| `web/main.ts` — `renderGraph()` SVG-HTML 同步              | **无需此层**                                                   | 固定行高消除同步需求        |
+| `web/graph.ts` — tooltip system                            | 独立 Tooltip SolidJS 组件                                      | HTML 定位层                 |
+| `web/contextMenu.ts`                                       | 复用 `@kobalte/core` 菜单组件                                  |                             |
+
+### 核心分歧决策：渲染同步方式
+
+- **vscode-git-graph**：先渲染 HTML table → 测量 DOM 获取行高 → 回填 SVG 的 `grid.y`（后测量）
+- **Aether**：固定 `rowHeight` → SVG 和 HTML 使用同一个值渲染（预计算）
+
+SolidJS 声明式渲染天然保证二者一致性，消除了 DOM 测量带来的复杂性。
+
+## 触发入口
+
+在变更模式下拉框（审查页面上方，包含 `git` / `branch` / `session` / `turn`）中添加 `"graph"` 选项。选中时调用 `tabs().open("git-graph")` + `tabs().setActive("git-graph")`。
+
+## Tab 行为
+
+遵循 **context 模式**：
+
+- 存入 `all[]` 前缀（不可拖拽，排在 context 之后，文件 tabs 之前）
+- 可关闭（有 X 按钮）
+- 滚动位置持久化（`view().setScroll("git-graph", ...)`）
+
+---
+
+## 阶段 0：后端 API 基础 — Git Log & Refs
+
+**目标**：为前端提供 git graph 所需的全部数据（一个请求）。
+
+### 文件变更
+
+| 文件                                     | 变更                                                 |
+| ---------------------------------------- | ---------------------------------------------------- |
+| `packages/opencode/src/git/index.ts`     | 新增 `log()` 方法、公共化 `refs()` 支持多种 ref 类型 |
+| `packages/opencode/src/project/vcs.ts`   | 新增 `graph()` 方法，组合 log + refs 数据            |
+| `packages/opencode/src/server/server.ts` | 新增 `GET /vcs/graph` 路由（带 `describeRoute()`）   |
+| `packages/sdk/js/`                       | `bun ./script/build.ts` 重新生成 SDK                 |
+
+### Git 命令
+
+```bash
+# commit log
+git log --format="%H %P %an %ae %at %s" --max-count=300 --all --topo-order
+
+# refs (heads + tags + remotes)
+git for-each-ref --format="%(refname:short) %(objectname) %(objecttype)" \
+  refs/heads/ refs/tags/ refs/remotes/
+```
+
+### API 设计
+
+```
+GET /vcs/graph?max=300&branch=all
+  → {
+      commits: CommitLogItem[],
+      head: string,
+      tags: TagRef[],
+      moreAvailable: boolean
+    }
+```
+
+```ts
+type CommitLogItem = {
+  hash: string
+  parents: string[]
+  author: string
+  email: string
+  date: number // unix timestamp
+  message: string // subject line
+  heads: string[] // 本地分支 refs
+  tags: TagRef[] // { name, annotated }
+  remotes: RemoteRef[] // { name, remote }
+}
+```
+
+### Effect 新增服务方式
+
+```
+1. 在 Git.Interface 中新增方法签名
+2. 在 Service.of({...}) 中实现
+3. 在文件底部添加 standalone runPromise 函数
+4. 在 Hono route handler 中调用 standalone 函数
+5. 在 route 上添加 describeRoute() 以生成 OpenAPI spec
+6. 运行 bun ./packages/sdk/js/script/build.ts 重新生成 SDK
+```
+
+---
+
+## 阶段 1：前端图模型 + 基础 SVG 渲染
+
+**目标**：纯函数实现 git graph lane 分配算法 + SolidJS 渲染组件，可独立开发和验证。
+
+### 新建文件
+
+| 文件                                                  | 职责                                            |
+| ----------------------------------------------------- | ----------------------------------------------- |
+| `packages/app/src/pages/session/git-graph/model.ts`   | 纯函数：lane 分配 + 颜色分配（无 SolidJS 依赖） |
+| `packages/app/src/pages/session/git-graph/render.tsx` | SolidJS 渲染组件（SVG + HTML）                  |
+
+### model.ts — 图布局算法
+
+参考 vscode-git-graph `graph.ts` 的 `loadCommits()` + `determinePath()` 算法，结合 Aether `conversation-graph-model.ts` 的函数式风格：
+
+```
+输入: CommitLogItem[], head: string | null
+输出: { nodes: GraphNode[], edges: GraphEdge[], lanes: number }
+
+GraphNode = {
+  hash, row, lane, colorIndex,
+  isHead, isUncommitted,
+  message, author, date
+}
+
+GraphEdge = {
+  fromRow, toRow,
+  fromLane, toLane,
+  isMerge
+}
+```
+
+**Lane 分配规则**：
+
+1. First parent 继承父节点的 lane（主干直行）
+2. 额外 parent（merge commit）分配新 lane（向右分叉）
+3. 已结束的分支释放 lane 供复用
+4. HEAD 上方添加 uncommitted changes 虚拟节点（灰色空心圆）
+
+**颜色回收**：vscode-git-graph 的 `getAvailableColour()` 算法 —— 每个 Branch 有 `end`（该分支最后一个 commit 的 index），当 `end > currentRow` 时该颜色可回收。默认 12 色调色板：
+
+```
+#0085d9, #d9008f, #00d90a, #d98500, #a300d9, #ff0000,
+#00d9cc, #e138e8, #85d900, #dc5b23, #6f24d6, #ffcc00
+```
+
+### render.tsx — 渲染方案
+
+```
+┌─────────────────────────────────────────────┐
+│  ┌─SVG (left, fixed width)──┬──HTML (right)──────────────────────┐
+│  │  ●───● main              │  ● main  feat: add git graph       │
+│  │  │   │                   │    abc1234  author  2 hours ago    │
+│  │  │   ● feat/git-graph    │  ● feat/git-graph  merge commit    │
+│  │  ●───┤                   │    def5678  author  3 hours ago    │
+│  │      │  ● feat/other     │  ● feat/other  some feature        │
+│  │      ●───●               │    ghi9012  author  5 hours ago    │
+│  │      │                   │  ○ main  Uncommitted Changes (3)   │
+│  │  ●───●                   │  ● main  previous commit           │
+│  └──────────────────────────┴────────────────────────────────────┘
+│                              ↕ scroll
+└─────────────────────────────────────────────┘
+```
+
+- 左侧 SVG（固定宽度 = `laneCount * 16 + 24`）：
+  - 分支线：Cubic Bezier (`C` 命令)，参考 vscode-git-graph 的 rounded 风格（delta = `rowHeight * 0.8`）
+  - commit 节点：`<circle r="4">`（HEAD 为空心圆，uncommitted 为灰色空心圆）
+- 右侧 HTML 列表：
+  - 每行固定高度 `rowHeight`（约 28px）
+  - 显示：refs 标签、message、hash 缩写、author、日期
+- **不使用 DOM 测量**：rowHeight 固定值，SVG 和 HTML 天然对齐
+
+### 此阶段可独立测试
+
+使用 mock 数据在开发环境渲染，验证：分支分叉/合并、颜色一致性、lane 回收、HEAD/uncommitted 指示。
+
+---
+
+## 阶段 2：Tab 系统集成
+
+**目标**：将 Git Graph 组件挂入 side panel Tab 系统。
+
+### 文件变更
+
+| 文件                                                       | 变更                                                               |
+| ---------------------------------------------------------- | ------------------------------------------------------------------ |
+| `packages/app/src/context/layout.tsx`                      | `nextSessionTabsForOpen()` 添加 `"git-graph"` case（context 模式） |
+| `packages/app/src/pages/session/helpers.ts`                | `createSessionTabs()` 添加 `gitGraphOpen` memo + 回退链            |
+| `packages/app/src/pages/session/session-side-panel.tsx`    | 新增 `<Tabs.Trigger value="git-graph">` + `<Tabs.Content>`         |
+| `packages/app/src/pages/session/git-graph/tab.tsx`（新建） | Tab 主组件：数据加载 + 响应式 + 滚动持久化                         |
+| 18 个 locale 文件 (`packages/app/src/i18n/*.ts`)           | 新增 `"session.tab.gitGraph": "Git Graph"`                         |
+
+### 联动变更
+
+- **变更模式下拉框**（`session.tsx`）：`ChangeMode` 类型扩展为 `"git" | "branch" | "session" | "turn" | "graph"`，选中 `"graph"` 时调用 `tabs().open("git-graph")` + `tabs().setActive("git-graph")`
+- **滚动持久化**（`tab.tsx`）：仿照 `SessionContextTab` 模式：
+
+```ts
+const scrollKey = () => "git-graph" as const
+const restore = view().scroll(scrollKey())
+
+<ScrollView
+  onScroll={(e) => view().setScroll(scrollKey(), { top: e.target.scrollTop })}
+  initialScrollTop={restore.top}
+>
+```
+
+---
+
+## 阶段 3：交互增强
+
+1. **Hover Tooltip** — 悬停 commit 圆点 → 显示完整 hash、所有 refs、时间戳
+   - HTML 定位层（非 SVG title），参考 vscode-git-graph `showTooltip()`（`web/graph.ts:807-889`）
+   - 彩色边框匹配 branch 颜色
+   - 超出视口时 clamp
+
+2. **分支过滤下拉** — `all` / `current` / 多选 branch
+   - 重新请求 `/vcs/graph?branch=...`
+
+3. **Scroll-to-HEAD** — 按钮/快捷键跳转到 HEAD commit 位置
+
+4. **加载更多** — 滚动触底自动调用 `sdk.client.vcs.graph({ skip: nextSkip, max: 100 })`
+
+5. **未提交变更** — HEAD 上方灰色空心圆
+   - 复用现有 `sdk.client.vcs.diff({ mode: "git" })` 获取文件数量
+   - hover 时显示变更文件列表
+
+---
+
+## 阶段 4：Commit 详情与 Git 操作
+
+### Commit 详情面板
+
+- 点击 commit → 面板从右侧或底部滑入（**非 inline 插入**，避免 `expandY` 复杂性）
+- 显示：完整 author/committer/date/message body
+- 文件变更列表（tree 或 list 视图，+/- 统计）
+- 点击文件 → 复用 Aether 现有 diff 渲染器（`@pierre/diffs`）
+
+```
+新增 API:
+GET /vcs/commit/:hash
+  → { hash, parents, author, authorEmail, authorDate,
+      committer, committerEmail, committerDate,
+      message, fileChanges: FileChange[] }
+```
+
+### Git 操作（右键菜单）
+
+优先级如下：
+
+| 优先级 | 操作                      | 说明                                |
+| ------ | ------------------------- | ----------------------------------- |
+| P0     | Checkout branch           | 切换到某个分支                      |
+| P0     | Create branch from commit | 在某个 commit 创建新分支            |
+| P0     | Copy hash / message       | 复制到剪贴板                        |
+| P1     | Merge into current        | 将选中 commit/branch 合并到当前分支 |
+| P1     | Rebase current on this    | 将当前分支 rebase 到选中 commit     |
+| P2     | Reset to this commit      | 重置当前分支（soft/mixed/hard）     |
+| P2     | Revert this commit        | 回滚某个 commit                     |
+| P2     | Cherry-pick               | 拣选 commit                         |
+| P2     | Tag operations            | 添加/删除 Tag                       |
+| P2     | Push/Pull/Fetch           | 远程同步操作                        |
+
+操作通过后端 API 执行（新增 `/vcs/checkout`、`/vcs/merge` 等端点），或复用现有终端面板（`terminal-panel.tsx`）执行 git 命令。
+
+---
+
+## 阶段 5：打磨
+
+- **性能优化**：大数据仓库的虚拟滚动（只渲染可见区域 commits）
+- **主题适配**：深色/浅色主题下的配色方案（`tailwindcss` class）
+- **移动端适配**：响应式布局，移动端用 `mobileTab` 机制切换
+- **i18n 完整覆盖**：所有 UI 文本走国际化
+- **设置面板**：用户偏好（graph 配色、默认列可见性、排序方式 date/topo/author-date）
+- **分支标签对齐到 graph**（可选）：分支标签显示在 graph lane 中，而非 description 列
+
+---
+
+## 不在此范围的功能（明确排除）
+
+以下 vscode-git-graph 功能不在本次集成范围：
+
+- Graph mask/fade-out（宽度限制渐变蒙版）
+- Angular graph style（仅实现 rounded 风格）
+- Commit comparison（两个 commit 的比较视图）
+- Code review 模式
+- External diff tool 集成
+- Avatar 头像获取（从 Gravatar/GitHub）
+- Issue linking（从 commit message 解析 issue 引用）
+- Markdown 渲染 commit message
+- GPG 签名状态显示
+- Interactive rebase in terminal
+- 多 repo 支持（仅单 repo）
+
+---
+
+## 关键实现参考
+
+### vscode-git-graph 核心文件对照
+
+| 文件                                           | 行数  | 核心内容                                                                                        |
+| ---------------------------------------------- | ----- | ----------------------------------------------------------------------------------------------- |
+| `reference/vscode-git-graph/src/dataSource.ts` | 1330+ | Git 命令封装、格式字符串定义                                                                    |
+| `reference/vscode-git-graph/src/types.ts`      | 1401  | 完整类型定义（GitCommit, GitFileChange, etc.）                                                  |
+| `reference/vscode-git-graph/web/graph.ts`      | 913   | 图布局算法（`determinePath`、`loadCommits`）、SVG 渲染（`Branch.draw`、`Vertex.draw`）、Tooltip |
+| `reference/vscode-git-graph/web/main.ts`       | -     | HTML 表格渲染、SVG-HTML 同步、commit 详情展开                                                   |
+
+### Aether 现有代码可复用模式
+
+| 文件                                                                | 可复用内容                                                   |
+| ------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `packages/app/src/pages/session/branch/conversation-graph-model.ts` | Lane 分配算法框架、函数式纯函数模式、Edge 路径生成           |
+| `packages/app/src/pages/session/branch/conversation-graph-list.tsx` | SVG+HTML 双层渲染架构、颜色管理、滚动                        |
+| `packages/app/src/pages/session/branch/sidebar-branch-view.tsx`     | SolidJS 响应式数据流（signal → memo → view）、持久化模式     |
+| `packages/opencode/src/git/index.ts`                                | Effect Service 模式、`run()` → `lines()` / `text()` 解析模式 |
+| `packages/opencode/src/project/vcs.ts`                              | Effect Service + 路由集成模式                                |
+| `packages/app/src/context/layout.tsx`                               | Tab 状态管理、`nextSessionTabsForOpen` 路由函数              |
+| `packages/app/src/pages/session/helpers.ts`                         | `createSessionTabs` 派生状态模式                             |

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -100,6 +100,7 @@ function nextSessionTabsForOpen(current: SessionTabs | undefined, tab: string): 
   const all = current?.all ?? []
   if (tab === "review") return { all: all.filter((x) => x !== "review"), active: tab }
   if (tab === "context") return { all: [tab, ...all.filter((x) => x !== tab)], active: tab }
+  if (tab === "git-graph") return { all: [tab, ...all.filter((x) => x !== tab)], active: tab }
   if (!all.includes(tab)) return { all: [...all, tab], active: tab }
   return { all, active: tab }
 }

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -450,6 +450,7 @@ export const dict = {
   "session.tab.session": "جلسة",
   "session.tab.review": "مراجعة",
   "session.tab.context": "سياق",
+  "session.tab.gitGraph": "رسم بياني",
   "session.panel.reviewAndFiles": "المراجعة والملفات",
   "session.review.filesChanged": "تم تغيير {{count}} ملفات",
   "session.review.change.one": "تغيير",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -461,6 +461,7 @@ export const dict = {
   "session.tab.session": "Sessão",
   "session.tab.review": "Revisão",
   "session.tab.context": "Contexto",
+  "session.tab.gitGraph": "Gráfico Git",
   "session.panel.reviewAndFiles": "Revisão e arquivos",
   "session.review.filesChanged": "{{count}} Arquivos Alterados",
   "session.review.change.one": "Alteração",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -506,6 +506,7 @@ export const dict = {
   "session.tab.session": "Sesija",
   "session.tab.review": "Pregled",
   "session.tab.context": "Kontekst",
+  "session.tab.gitGraph": "Git Graf",
   "session.panel.reviewAndFiles": "Pregled i datoteke",
   "session.review.filesChanged": "Izmijenjeno {{count}} datoteka",
   "session.review.change.one": "Izmjena",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -503,6 +503,7 @@ export const dict = {
   "session.tab.session": "Session",
   "session.tab.review": "Gennemgang",
   "session.tab.context": "Kontekst",
+  "session.tab.gitGraph": "Git Graf",
   "session.panel.reviewAndFiles": "Gennemgang og filer",
   "session.review.filesChanged": "{{count}} Filer ændret",
   "session.review.change.one": "Ændring",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -469,6 +469,7 @@ export const dict = {
   "session.tab.session": "Sitzung",
   "session.tab.review": "Überprüfung",
   "session.tab.context": "Kontext",
+  "session.tab.gitGraph": "Git-Diagramm",
   "session.panel.reviewAndFiles": "Überprüfung und Dateien",
   "session.review.filesChanged": "{{count}} Dateien geändert",
   "session.review.change.one": "Änderung",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -854,6 +854,7 @@ export const dict = {
   "session.tab.session": "Session",
   "session.tab.review": "Review",
   "session.tab.context": "Context",
+  "session.tab.gitGraph": "Git Graph",
   "session.panel.reviewAndFiles": "Review and files",
   "session.review.filesChanged": "{{count}} Files Changed",
   "session.review.change.one": "Change",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -514,6 +514,7 @@ export const dict = {
   "session.tab.session": "Sesión",
   "session.tab.review": "Revisión",
   "session.tab.context": "Contexto",
+  "session.tab.gitGraph": "Gráfico Git",
   "session.panel.reviewAndFiles": "Revisión y archivos",
   "session.review.filesChanged": "{{count}} Archivos Cambiados",
   "session.review.change.one": "Cambio",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -466,6 +466,7 @@ export const dict = {
   "session.tab.session": "Session",
   "session.tab.review": "Revue",
   "session.tab.context": "Contexte",
+  "session.tab.gitGraph": "Graphique Git",
   "session.panel.reviewAndFiles": "Revue et fichiers",
   "session.review.filesChanged": "{{count}} fichiers modifiés",
   "session.review.change.one": "Modification",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -459,6 +459,7 @@ export const dict = {
   "session.tab.session": "セッション",
   "session.tab.review": "レビュー",
   "session.tab.context": "コンテキスト",
+  "session.tab.gitGraph": "Gitグラフ",
   "session.panel.reviewAndFiles": "レビューとファイル",
   "session.review.filesChanged": "{{count}} ファイル変更",
   "session.review.change.one": "変更",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -461,6 +461,7 @@ export const dict = {
   "session.tab.session": "세션",
   "session.tab.review": "검토",
   "session.tab.context": "컨텍스트",
+  "session.tab.gitGraph": "Git 그래프",
   "session.panel.reviewAndFiles": "검토 및 파일",
   "session.review.filesChanged": "{{count}}개 파일 변경됨",
   "session.review.change.one": "변경",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -507,6 +507,7 @@ export const dict = {
   "session.tab.session": "Sesjon",
   "session.tab.review": "Gjennomgang",
   "session.tab.context": "Kontekst",
+  "session.tab.gitGraph": "Git-graf",
   "session.panel.reviewAndFiles": "Gjennomgang og filer",
   "session.review.filesChanged": "{{count}} filer endret",
   "session.review.change.one": "Endring",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -453,6 +453,7 @@ export const dict = {
   "session.tab.session": "Sesja",
   "session.tab.review": "Przegląd",
   "session.tab.context": "Kontekst",
+  "session.tab.gitGraph": "Git Graf",
   "session.panel.reviewAndFiles": "Przegląd i pliki",
   "session.review.filesChanged": "Zmieniono {{count}} plików",
   "session.review.change.one": "Zmiana",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -514,6 +514,7 @@ export const dict = {
   "session.tab.session": "Сессия",
   "session.tab.review": "Обзор",
   "session.tab.context": "Контекст",
+  "session.tab.gitGraph": "Git Граф",
   "session.panel.reviewAndFiles": "Обзор и файлы",
   "session.review.filesChanged": "{{count}} файлов изменено",
   "session.review.change.one": "Изменение",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -502,6 +502,7 @@ export const dict = {
   "session.tab.session": "เซสชัน",
   "session.tab.review": "ตรวจสอบ",
   "session.tab.context": "บริบท",
+  "session.tab.gitGraph": "กราฟ Git",
   "session.panel.reviewAndFiles": "ตรวจสอบและไฟล์",
   "session.review.filesChanged": "{{count}} ไฟล์ที่เปลี่ยนแปลง",
   "session.review.change.one": "การเปลี่ยนแปลง",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -518,6 +518,7 @@ export const dict = {
   "session.tab.session": "Oturum",
   "session.tab.review": "İnceleme",
   "session.tab.context": "Bağlam",
+  "session.tab.gitGraph": "Git Grafiği",
   "session.panel.reviewAndFiles": "İnceleme ve dosyalar",
   "session.review.filesChanged": "{{count}} Dosya Değişti",
   "session.review.change.one": "Değişiklik",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -822,6 +822,7 @@ export const dict = {
   "session.tab.session": "会话",
   "session.tab.review": "审查",
   "session.tab.context": "上下文",
+  "session.tab.gitGraph": "Git 图",
   "session.panel.reviewAndFiles": "审查和文件",
   "session.review.filesChanged": "{{count}} 个文件变更",
   "session.review.change.one": "更改",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -508,6 +508,7 @@ export const dict = {
   "session.tab.session": "工作階段",
   "session.tab.review": "審查",
   "session.tab.context": "上下文",
+  "session.tab.gitGraph": "Git 圖",
   "session.panel.reviewAndFiles": "審查與檔案",
   "session.review.filesChanged": "{{count}} 個檔案變更",
   "session.review.change.one": "變更",

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -79,7 +79,7 @@ const emptyFollowups: (FollowupDraft & { id: string })[] = []
 const READING_CHAT_MIN_WIDTH = 360
 const READING_REVIEW_MIN_WIDTH = 320
 
-type ChangeMode = "git" | "branch" | "session" | "turn"
+type ChangeMode = "git" | "branch" | "session" | "turn" | "graph"
 type VcsMode = "git" | "branch"
 
 type SessionHistoryWindowInput = {
@@ -867,7 +867,7 @@ function SessionPageContent(props: SessionPageProps = {}) {
   })
   const changesOptions = createMemo<ChangeMode[]>(() => {
     const list: ChangeMode[] = []
-    if (sync.project?.vcs === "git") list.push("git")
+    if (sync.project?.vcs === "git") list.push("git", "graph")
     if (
       sync.project?.vcs === "git" &&
       sync.data.vcs?.branch &&
@@ -885,12 +885,14 @@ function SessionPageContent(props: SessionPageProps = {}) {
   const reviewDiffs = createMemo(() => {
     if (store.changes === "git") return vcs.diff.git
     if (store.changes === "branch") return vcs.diff.branch
+    if (store.changes === "graph") return []
     if (store.changes === "session") return diffs()
     return turnDiffs()
   })
   const reviewCount = createMemo(() => {
     if (store.changes === "git") return vcs.diff.git.length
     if (store.changes === "branch") return vcs.diff.branch.length
+    if (store.changes === "graph") return 0
     if (store.changes === "session") return sessionCount()
     return turnDiffs().length
   })
@@ -898,6 +900,7 @@ function SessionPageContent(props: SessionPageProps = {}) {
   const reviewReady = createMemo(() => {
     if (store.changes === "git") return vcs.ready.git
     if (store.changes === "branch") return vcs.ready.branch
+    if (store.changes === "graph") return true
     if (store.changes === "session") return !hasSessionReview() || diffsReady()
     return true
   })
@@ -1360,6 +1363,7 @@ function SessionPageContent(props: SessionPageProps = {}) {
     const label = (option: ChangeMode) => {
       if (option === "git") return language.t("ui.sessionReview.title.git")
       if (option === "branch") return language.t("ui.sessionReview.title.branch")
+      if (option === "graph") return language.t("session.tab.gitGraph")
       if (option === "session") return language.t("ui.sessionReview.title")
       return language.t("ui.sessionReview.title.lastTurn")
     }
@@ -1369,7 +1373,16 @@ function SessionPageContent(props: SessionPageProps = {}) {
         options={changesOptions()}
         current={store.changes}
         label={label}
-        onSelect={(option) => option && setStore("changes", option)}
+        onSelect={(option) => {
+          if (!option) return
+          setStore("changes", option)
+          if (option === "graph") {
+            batch(() => {
+              tabs().open("git-graph")
+              tabs().setActive("git-graph")
+            })
+          }
+        }}
         variant="ghost"
         size="small"
         valueClass="text-14-medium"
@@ -1386,6 +1399,7 @@ function SessionPageContent(props: SessionPageProps = {}) {
   const reviewEmptyText = createMemo(() => {
     if (store.changes === "git") return language.t("session.review.noUncommittedChanges")
     if (store.changes === "branch") return language.t("session.review.noBranchChanges")
+    if (store.changes === "graph") return ""
     if (store.changes === "turn") return language.t("session.review.noChanges")
     return language.t(sessionEmptyKey())
   })
@@ -2296,11 +2310,11 @@ function SessionPageContent(props: SessionPageProps = {}) {
                         historyLoading={historyLoading()}
                         onLoadEarlier={() => {
                           void historyWindow.loadAndReveal()
-                            }}
-                            renderedUserMessages={historyWindow.renderedUserMessages()}
-                            anchor={anchor}
-                            onFocusInput={focusInput}
-                          />
+                        }}
+                        renderedUserMessages={historyWindow.renderedUserMessages()}
+                        anchor={anchor}
+                        onFocusInput={focusInput}
+                      />
                     </Show>
                   </Match>
                   <Match when={true}>
@@ -2466,11 +2480,11 @@ function SessionPageContent(props: SessionPageProps = {}) {
                       historyLoading={historyLoading()}
                       onLoadEarlier={() => {
                         void historyWindow.loadAndReveal()
-                        }}
-                        renderedUserMessages={historyWindow.renderedUserMessages()}
-                        anchor={anchor}
-                        onFocusInput={focusInput}
-                      />
+                      }}
+                      renderedUserMessages={historyWindow.renderedUserMessages()}
+                      anchor={anchor}
+                      onFocusInput={focusInput}
+                    />
                   </Show>
                 </Match>
                 <Match when={true}>

--- a/packages/app/src/pages/session/git-graph/model.ts
+++ b/packages/app/src/pages/session/git-graph/model.ts
@@ -1,0 +1,173 @@
+import type { CommitLogItem } from "@opencode-ai/sdk/v2"
+
+export const PALETTE = [
+  "#0085d9",
+  "#d9008f",
+  "#00d90a",
+  "#d98500",
+  "#a300d9",
+  "#ff0000",
+  "#00d9cc",
+  "#e138e8",
+  "#85d900",
+  "#dc5b23",
+  "#6f24d6",
+  "#ffcc00",
+]
+
+export const UNCOMMITTED = "UNCOMMITTED"
+
+export type GraphNode = {
+  hash: string
+  row: number
+  lane: number
+  colorIndex: number
+  isHead: boolean
+  isUncommitted: boolean
+  message: string
+  author: string
+  date: number
+  heads: string[]
+}
+
+export type GraphEdge = {
+  fromRow: number
+  toRow: number
+  fromLane: number
+  toLane: number
+  isMerge: boolean
+}
+
+export type GraphView = {
+  nodes: GraphNode[]
+  edges: GraphEdge[]
+  lanes: number
+}
+
+const available = (bag: { end: number }[], start: number) => {
+  for (let i = 0; i < bag.length; i++) {
+    if (start > bag[i].end) return i
+  }
+  bag.push({ end: 0 })
+  return bag.length - 1
+}
+
+const idx = (commits: CommitLogItem[]) => {
+  const map = new Map<string, number>()
+  for (let i = 0; i < commits.length; i++) map.set(commits[i].hash, i)
+  return map
+}
+
+export function computeGraphLayout(commits: CommitLogItem[], head: string | null): GraphView {
+  const n = commits.length
+  if (n === 0) return { nodes: [], edges: [], lanes: 0 }
+
+  const lookup = idx(commits)
+  const slot = commits.map(() => ({ lane: -1, nextX: 0, parent: 0 }))
+  const bag: { end: number }[] = []
+
+  for (let i = 0; i < n; i++) {
+    while (slot[i].parent < commits[i].parents.length) {
+      const parentHash = commits[i].parents[slot[i].parent]
+      const parentRow = lookup.get(parentHash)
+
+      if (parentRow === undefined) {
+        slot[i].parent++
+        continue
+      }
+
+      const here = slot[i]
+      const there = slot[parentRow]
+      const isMerge = slot[i].parent > 0
+
+      if (here.lane !== -1 && there.lane !== -1 && isMerge) {
+        for (let j = i + 1; j < n; j++) {
+          if (j === parentRow) {
+            slot[i].parent++
+            break
+          }
+          slot[j].nextX++
+        }
+        continue
+      }
+
+      const laneIdx = available(bag, i)
+      let cur = i
+      let target = parentRow
+
+      if (here.lane === -1) {
+        here.lane = laneIdx
+        here.nextX++
+      }
+
+      for (let j = i + 1; j < n; j++) {
+        const s = slot[j]
+
+        if (j === target) {
+          const wasLaned = s.lane !== -1
+          if (s.lane === -1) s.lane = laneIdx
+          bag[laneIdx] = { end: j }
+          s.nextX++
+
+          slot[cur].parent++
+
+          if (wasLaned) {
+            slot[i].parent++
+            break
+          }
+
+          cur = target
+          if (slot[cur].parent >= commits[cur].parents.length) break
+
+          const next = commits[cur].parents[slot[cur].parent]
+          const nxt = lookup.get(next)
+          if (nxt === undefined) {
+            slot[i].parent++
+            break
+          }
+          target = nxt
+        } else {
+          s.nextX++
+        }
+      }
+
+      bag[laneIdx] = { end: Math.max(bag[laneIdx].end, i) }
+    }
+  }
+
+  const lanes = bag.length || 1
+  const color = (l: number) => l % PALETTE.length
+
+  const nodes: GraphNode[] = commits.map((c, i) => {
+    const lane = slot[i].lane >= 0 ? slot[i].lane : 0
+    return {
+      hash: c.hash,
+      row: i,
+      lane,
+      colorIndex: color(lane),
+      isHead: c.hash === head,
+      isUncommitted: c.hash === UNCOMMITTED,
+      message: c.message,
+      author: c.author,
+      date: c.date,
+      heads: c.heads,
+    }
+  })
+
+  const edges: GraphEdge[] = []
+  for (let i = 0; i < n; i++) {
+    for (let p = 0; p < commits[i].parents.length; p++) {
+      const parentRow = lookup.get(commits[i].parents[p])
+      if (parentRow === undefined) continue
+      edges.push({
+        fromRow: i,
+        toRow: parentRow,
+        fromLane: slot[i].lane >= 0 ? slot[i].lane : 0,
+        toLane: slot[parentRow].lane >= 0 ? slot[parentRow].lane : 0,
+        isMerge: p > 0,
+      })
+    }
+  }
+
+  return { nodes, edges, lanes }
+}

--- a/packages/app/src/pages/session/git-graph/render.tsx
+++ b/packages/app/src/pages/session/git-graph/render.tsx
@@ -1,0 +1,132 @@
+import { For, Show, createMemo } from "solid-js"
+import { PALETTE, type GraphEdge, type GraphNode } from "./model"
+
+const ROW_HEIGHT = 28
+const LANE_GAP = 16
+const RAIL_PAD = 12
+const DELTA = ROW_HEIGHT * 0.8
+
+const color = (idx: number) => PALETTE[idx % PALETTE.length]
+
+const xForLane = (lane: number) => RAIL_PAD + lane * LANE_GAP
+const yForRow = (row: number) => row * ROW_HEIGHT + ROW_HEIGHT / 2
+
+const abbrev = (hash: string) => hash.slice(0, 7)
+
+const ago = (date: number) => {
+  const now = Math.floor(Date.now() / 1000)
+  const diff = now - date
+  if (diff < 60) return "now"
+  if (diff < 3600) return `${Math.floor(diff / 60)}m`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h`
+  if (diff < 604800) return `${Math.floor(diff / 86400)}d`
+  return `${Math.floor(diff / 604800)}w`
+}
+
+const edgePath = (edge: GraphEdge) => {
+  const x1 = xForLane(edge.fromLane)
+  const y1 = yForRow(edge.fromRow)
+  const x2 = xForLane(edge.toLane)
+  const y2 = yForRow(edge.toRow)
+
+  if (edge.fromLane === edge.toLane) {
+    return `M ${x1} ${y1} L ${x2} ${y2}`
+  }
+
+  const d = Math.min(DELTA, Math.abs(y2 - y1) * 0.5)
+  return `M ${x1} ${y1} C ${x1} ${y1 + d}, ${x2} ${y2 - d}, ${x2} ${y2}`
+}
+
+export function GitGraphList(props: { nodes: GraphNode[]; edges: GraphEdge[]; lanes: number }) {
+  const railWidth = createMemo(() => props.lanes * LANE_GAP + RAIL_PAD * 2)
+  const height = createMemo(() => Math.max(ROW_HEIGHT, props.nodes.length * ROW_HEIGHT))
+
+  return (
+    <div class="relative h-full min-h-0 overflow-auto">
+      <div class="relative min-w-0" style={{ height: `${height()}px` }}>
+        <svg
+          class="pointer-events-none absolute left-0 top-0 z-20"
+          width={railWidth()}
+          height={height()}
+          viewBox={`0 0 ${railWidth()} ${height()}`}
+          preserveAspectRatio="none"
+        >
+          <For each={props.edges}>
+            {(edge) => (
+              <path
+                d={edgePath(edge)}
+                fill="none"
+                stroke={color(edge.fromLane)}
+                stroke-width="1.5"
+                stroke-linecap="round"
+                opacity="0.6"
+              />
+            )}
+          </For>
+
+          <For each={props.nodes}>
+            {(node) => {
+              const cx = createMemo(() => xForLane(node.lane))
+              const cy = createMemo(() => yForRow(node.row))
+              const c = createMemo(() => color(node.colorIndex))
+              const r = createMemo(() => (node.isHead ? 5 : 4))
+
+              return (
+                <>
+                  <Show when={node.isUncommitted}>
+                    <circle cx={cx()} cy={cy()} r={r()} fill="transparent" stroke="#808080" stroke-width="1.5" />
+                  </Show>
+                  <Show when={!node.isUncommitted && node.isHead}>
+                    <circle cx={cx()} cy={cy()} r={r()} fill="transparent" stroke={c()} stroke-width="2" />
+                  </Show>
+                  <Show when={!node.isUncommitted && !node.isHead}>
+                    <circle cx={cx()} cy={cy()} r={r()} fill={c()} />
+                  </Show>
+                </>
+              )
+            }}
+          </For>
+        </svg>
+
+        <div class="relative z-10">
+          <For each={props.nodes}>
+            {(node) => (
+              <div
+                class="flex items-center gap-2 border-b border-border-weaker-base text-sm"
+                style={{
+                  height: `${ROW_HEIGHT}px`,
+                  "padding-left": `${railWidth() + 8}px`,
+                  "padding-right": "8px",
+                }}
+              >
+                <Show when={node.heads.length > 0 || node.isHead}>
+                  <span class="shrink-0 flex items-center gap-1">
+                    <For each={node.heads}>
+                      {(h) => (
+                        <span class="inline-flex items-center rounded bg-accent-base/10 px-1 text-[11px] text-accent-base">
+                          {h === "HEAD" ? "HEAD" : h}
+                        </span>
+                      )}
+                    </For>
+                  </span>
+                </Show>
+
+                <span class="min-w-0 flex-1 truncate text-text-base">
+                  {node.isUncommitted ? "Uncommitted Changes" : node.message}
+                </span>
+
+                <Show when={!node.isUncommitted}>
+                  <span class="shrink-0 font-mono text-[11px] text-text-weaker">{abbrev(node.hash)}</span>
+                </Show>
+
+                <span class="shrink-0 text-[11px] text-text-weaker">{node.author}</span>
+
+                <span class="shrink-0 w-10 text-right text-[11px] text-text-weaker">{ago(node.date)}</span>
+              </div>
+            )}
+          </For>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/pages/session/git-graph/tab.tsx
+++ b/packages/app/src/pages/session/git-graph/tab.tsx
@@ -1,0 +1,84 @@
+import { createMemo, createSignal, onCleanup, onMount, Show } from "solid-js"
+import { ScrollView } from "@opencode-ai/ui/scroll-view"
+import { useSDK } from "@/context/sdk"
+import { useLanguage } from "@/context/language"
+import { useSessionLayout } from "@/pages/session/session-layout"
+import { computeGraphLayout } from "./model"
+import { GitGraphList } from "./render"
+
+export function GitGraphTab() {
+  const sdk = useSDK()
+  const language = useLanguage()
+  const { view } = useSessionLayout()
+
+  const [data, setData] = createSignal<Awaited<ReturnType<typeof sdk.client.vcs.graph>> | null>(null)
+
+  const load = async () => {
+    try {
+      const result = await sdk.client.vcs.graph({ max: 300 })
+      setData(result)
+    } catch {
+      setData(null)
+    }
+  }
+
+  onMount(() => {
+    void load()
+  })
+
+  const graph = createMemo(() => {
+    const raw = data()
+    if (!raw?.data) return null
+    return computeGraphLayout(raw.data.commits, raw.data.head)
+  })
+
+  let scroll: HTMLDivElement | undefined
+  let frame: number | undefined
+  let pending: { x: number; y: number } | undefined
+
+  const handleScroll = (event: Event & { currentTarget: HTMLDivElement }) => {
+    pending = { x: event.currentTarget.scrollLeft, y: event.currentTarget.scrollTop }
+    if (frame !== undefined) return
+    frame = requestAnimationFrame(() => {
+      frame = undefined
+      const next = pending
+      pending = undefined
+      if (!next) return
+      view().setScroll("git-graph", next)
+    })
+  }
+
+  return (
+    <div class="flex flex-col h-full overflow-hidden contain-strict">
+      <Show
+        when={graph()}
+        fallback={
+          <div class="flex-1 flex items-center justify-center">
+            <div class="text-12-regular text-text-weak">
+              {data() ? language.t("session.review.loadingChanges") : language.t("common.loading.ellipsis")}
+            </div>
+          </div>
+        }
+      >
+        {(g) => (
+          <ScrollView
+            class="h-full"
+            onScroll={handleScroll}
+            viewportRef={(el) => {
+              scroll = el
+              const s = view().scroll("git-graph")
+              if (s) {
+                requestAnimationFrame(() => {
+                  if (el.scrollTop !== s.y) el.scrollTop = s.y
+                  if (el.scrollLeft !== s.x) el.scrollLeft = s.x
+                })
+              }
+            }}
+          >
+            <GitGraphList nodes={g().nodes} edges={g().edges} lanes={g().lanes} />
+          </ScrollView>
+        )}
+      </Show>
+    </div>
+  )
+}

--- a/packages/app/src/pages/session/helpers.ts
+++ b/packages/app/src/pages/session/helpers.ts
@@ -24,6 +24,9 @@ export const createSessionTabs = (input: TabsInput) => {
   const review = input.review ?? (() => false)
   const hasReview = input.hasReview ?? (() => false)
   const contextOpen = createMemo(() => input.tabs().active() === "context" || input.tabs().all().includes("context"))
+  const gitGraphOpen = createMemo(
+    () => input.tabs().active() === "git-graph" || input.tabs().all().includes("git-graph"),
+  )
   const openedTabs = createMemo(
     () => {
       const seen = new Set<string>()
@@ -31,7 +34,7 @@ export const createSessionTabs = (input: TabsInput) => {
         .tabs()
         .all()
         .flatMap((tab) => {
-          if (tab === "context" || tab === "review") return []
+          if (tab === "context" || tab === "review" || tab === "git-graph") return []
           const value = input.pathFromTab(tab) ? input.normalizeTab(tab) : tab
           if (seen.has(value)) return []
           seen.add(value)
@@ -44,12 +47,14 @@ export const createSessionTabs = (input: TabsInput) => {
   const activeTab = createMemo(() => {
     const active = input.tabs().active()
     if (active === "context") return active
+    if (active === "git-graph") return active
     if (active === "review" && review()) return active
     if (active && input.pathFromTab(active)) return input.normalizeTab(active)
 
     const first = openedTabs()[0]
     if (first) return first
     if (contextOpen()) return "context"
+    if (gitGraphOpen()) return "git-graph"
     if (review() && hasReview()) return "review"
     return "empty"
   })
@@ -61,12 +66,14 @@ export const createSessionTabs = (input: TabsInput) => {
   const closableTab = createMemo(() => {
     const active = activeTab()
     if (active === "context") return active
+    if (active === "git-graph") return active
     if (!openedTabs().includes(active)) return
     return active
   })
 
   return {
     contextOpen,
+    gitGraphOpen,
     openedTabs,
     activeTab,
     activeFileTab,

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -23,6 +23,7 @@ import { DialogSelectFile } from "@/components/dialog-select-file"
 import { DialogPdfToMarkdown } from "@/components/dialog-pdf-to-markdown"
 import { DialogBatchPdfConvert } from "@/components/dialog-batch-pdf-convert"
 import { SessionContextTab, SortableTab, FileVisual } from "@/components/session"
+import { GitGraphTab } from "@/pages/session/git-graph/tab"
 import { useCommand } from "@/context/command"
 import { useFile, type SelectedLineRange } from "@/context/file"
 import { useLanguage } from "@/context/language"
@@ -445,6 +446,7 @@ export function SessionSidePanel(props: {
     hasReview: props.canReview,
   })
   const contextOpen = tabState.contextOpen
+  const gitGraphOpen = tabState.gitGraphOpen
   const openedTabs = tabState.openedTabs
   const activeTab = tabState.activeTab
   const activeFileTab = tabState.activeFileTab
@@ -940,6 +942,31 @@ export function SessionSidePanel(props: {
                           </div>
                         </Tabs.Trigger>
                       </Show>
+                      <Show when={gitGraphOpen()}>
+                        <Tabs.Trigger
+                          value="git-graph"
+                          closeButton={
+                            <TooltipKeybind
+                              title={language.t("common.closeTab")}
+                              keybind={command.keybind("tab.close")}
+                              placement="bottom"
+                              gutter={10}
+                            >
+                              <IconButton
+                                icon="close-small"
+                                variant="ghost"
+                                class="h-5 w-5"
+                                onClick={() => tabs().close("git-graph")}
+                                aria-label={language.t("common.closeTab")}
+                              />
+                            </TooltipKeybind>
+                          }
+                          hideCloseButton
+                          onMiddleClick={() => tabs().close("git-graph")}
+                        >
+                          <div>{language.t("session.tab.gitGraph")}</div>
+                        </Tabs.Trigger>
+                      </Show>
                       <SortableProvider ids={openedTabs()}>
                         <For each={openedTabs()}>{(tab) => <SortableTab tab={tab} onTabClose={tabs().close} />}</For>
                       </SortableProvider>
@@ -989,6 +1016,14 @@ export function SessionSidePanel(props: {
                         <div class="relative pt-2 flex-1 min-h-0 overflow-hidden">
                           <SessionContextTab />
                         </div>
+                      </Show>
+                    </Tabs.Content>
+                  </Show>
+
+                  <Show when={gitGraphOpen()}>
+                    <Tabs.Content value="git-graph" class="flex flex-col h-full overflow-hidden contain-strict">
+                      <Show when={activeTab() === "git-graph"}>
+                        <GitGraphTab />
                       </Show>
                     </Tabs.Content>
                   </Show>

--- a/packages/opencode/src/git/index.ts
+++ b/packages/opencode/src/git/index.ts
@@ -48,6 +48,21 @@ export namespace Git {
     readonly deletions: number
   }
 
+  export type LogItem = {
+    readonly hash: string
+    readonly parents: readonly string[]
+    readonly author: string
+    readonly email: string
+    readonly date: number
+    readonly message: string
+  }
+
+  export type Ref = {
+    readonly name: string
+    readonly hash: string
+    readonly type: string
+  }
+
   export interface Result {
     readonly exitCode: number
     readonly text: () => string
@@ -71,6 +86,8 @@ export namespace Git {
     readonly status: (cwd: string) => Effect.Effect<Item[]>
     readonly diff: (cwd: string, ref: string) => Effect.Effect<Item[]>
     readonly stats: (cwd: string, ref: string) => Effect.Effect<Stat[]>
+    readonly log: (cwd: string, opts?: { max?: number }) => Effect.Effect<readonly LogItem[]>
+    readonly refs: (cwd: string, ...prefixes: string[]) => Effect.Effect<readonly Ref[]>
   }
 
   const kind = (code: string): Kind => {
@@ -125,7 +142,7 @@ export namespace Git {
           .filter(Boolean)
       })
 
-      const refs = Effect.fnUntraced(function* (cwd: string) {
+      const headRefs = Effect.fnUntraced(function* (cwd: string) {
         return yield* lines(["for-each-ref", "--format=%(refname:short)", "refs/heads"], { cwd })
       })
 
@@ -168,7 +185,7 @@ export namespace Git {
           }
         }
 
-        const list = yield* refs(cwd)
+        const list = yield* headRefs(cwd)
         const next = yield* configured(cwd, list)
         if (next) return next
         if (list.includes("main")) return { name: "main", ref: "main" } satisfies Base
@@ -243,6 +260,47 @@ export namespace Git {
         })
       })
 
+      const log = Effect.fn("Git.log")(function* (cwd: string, opts?: { max?: number }) {
+        const max = opts?.max ?? 300
+        const sep = "\x1F"
+        return (yield* lines(
+          [
+            "log",
+            `--format=%H${sep}%P${sep}%an${sep}%ae${sep}%at${sep}%s`,
+            "--max-count=" + String(max),
+            "--all",
+            "--topo-order",
+          ],
+          { cwd },
+        )).map((line) => {
+          const [hash, parents, author, email, date, ...rest] = line.split(sep)
+          return {
+            hash,
+            parents: parents ? parents.split(" ").filter(Boolean) : [],
+            author,
+            email,
+            date: parseInt(date, 10),
+            message: rest.join(sep),
+          } satisfies LogItem
+        })
+      })
+
+      const refs = Effect.fn("Git.refs")(function* (cwd: string, ...prefixes: string[]) {
+        const list = prefixes.length > 0 ? prefixes : ["refs/heads/", "refs/tags/", "refs/remotes/"]
+        const sep = "\x1F"
+        return (yield* lines(
+          ["for-each-ref", `--format=%(refname:short)${sep}%(objectname)${sep}%(objecttype)`, ...list],
+          { cwd },
+        )).map((line) => {
+          const idx = line.indexOf(sep)
+          const idx2 = line.indexOf(sep, idx + 1)
+          const name = line.slice(0, idx)
+          const hash = line.slice(idx + 1, idx2)
+          const type = line.slice(idx2 + 1)
+          return { name, hash, type } satisfies Ref
+        })
+      })
+
       return Service.of({
         run,
         branch,
@@ -254,6 +312,8 @@ export namespace Git {
         status,
         diff,
         stats,
+        log,
+        refs,
       })
     }),
   )
@@ -304,5 +364,13 @@ export namespace Git {
 
   export function stats(cwd: string, ref: string) {
     return runPromise((git) => git.stats(cwd, ref))
+  }
+
+  export function log(cwd: string, opts?: { max?: number }) {
+    return runPromise((git) => git.log(cwd, opts))
+  }
+
+  export function refs(cwd: string, ...prefixes: string[]) {
+    return runPromise((git) => git.refs(cwd, ...prefixes))
   }
 }

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -130,7 +130,49 @@ export namespace Vcs {
     readonly branch: () => Effect.Effect<string | undefined>
     readonly defaultBranch: () => Effect.Effect<string | undefined>
     readonly diff: (mode: Mode) => Effect.Effect<Snapshot.FileDiff[]>
+    readonly graph: (opts?: { max?: number }) => Effect.Effect<GraphResult>
   }
+
+  export const TagRef = z
+    .object({
+      name: z.string(),
+      annotated: z.boolean(),
+    })
+    .meta({ ref: "TagRef" })
+  export type TagRef = z.infer<typeof TagRef>
+
+  export const RemoteRef = z
+    .object({
+      name: z.string(),
+      remote: z.string().nullable(),
+    })
+    .meta({ ref: "RemoteRef" })
+  export type RemoteRef = z.infer<typeof RemoteRef>
+
+  export const CommitLogItem = z
+    .object({
+      hash: z.string(),
+      parents: z.string().array(),
+      author: z.string(),
+      email: z.string(),
+      date: z.number(),
+      message: z.string(),
+      heads: z.string().array(),
+      tags: TagRef.array(),
+      remotes: RemoteRef.array(),
+    })
+    .meta({ ref: "CommitLogItem" })
+  export type CommitLogItem = z.infer<typeof CommitLogItem>
+
+  export const GraphResult = z
+    .object({
+      commits: CommitLogItem.array(),
+      head: z.string().nullable(),
+      tags: z.string().array(),
+      moreAvailable: z.boolean(),
+    })
+    .meta({ ref: "VcsGraphResult" })
+  export type GraphResult = z.infer<typeof GraphResult>
 
   interface State {
     current: string | undefined
@@ -207,6 +249,71 @@ export namespace Vcs {
           if (!ref) return []
           return yield* compare(fs, git, Instance.directory, ref)
         }),
+        graph: Effect.fn("Vcs.graph")(function* (opts?: { max?: number }) {
+          if (Instance.project.vcs !== "git") {
+            return { commits: [], head: null, tags: [], moreAvailable: false } satisfies GraphResult
+          }
+          const cwd = Instance.directory
+          const max = opts?.max ?? 300
+          const [commits, heads, tags, remotes, head] = yield* Effect.all(
+            [
+              git.log(cwd, { max: max + 1 }),
+              git.refs(cwd, "refs/heads/"),
+              git.refs(cwd, "refs/tags/"),
+              git.refs(cwd, "refs/remotes/"),
+              git.branch(cwd),
+            ],
+            { concurrency: 5 },
+          )
+
+          const moreAvailable = commits.length === max + 1
+          const items = moreAvailable ? commits.slice(0, max) : commits
+
+          const lookup = new Map<string, number>()
+          items.forEach((item, i) => lookup.set(item.hash, i))
+
+          const enriched = items.map((item, _i) => {
+            const commit: CommitLogItem = {
+              hash: item.hash,
+              parents: [...item.parents],
+              author: item.author,
+              email: item.email,
+              date: item.date,
+              message: item.message,
+              heads: [],
+              tags: [],
+              remotes: [],
+            }
+            return commit
+          })
+
+          for (const ref of heads) {
+            const idx = lookup.get(ref.hash)
+            if (idx !== undefined) enriched[idx].heads.push(ref.name)
+          }
+
+          for (const ref of tags) {
+            const idx = lookup.get(ref.hash)
+            if (idx !== undefined) {
+              enriched[idx].tags.push({ name: ref.name, annotated: ref.type === "tag" })
+            }
+          }
+
+          for (const ref of remotes) {
+            const idx = lookup.get(ref.hash)
+            if (idx !== undefined) {
+              const slash = ref.name.indexOf("/")
+              enriched[idx].remotes.push({
+                name: ref.name,
+                remote: slash !== -1 ? ref.name.slice(0, slash) : null,
+              })
+            }
+          }
+
+          const tagsList = [...new Set(tags.map((t) => t.name))]
+
+          return { commits: enriched, head: head ?? null, tags: tagsList, moreAvailable } satisfies GraphResult
+        }),
       })
     }),
   )
@@ -233,5 +340,9 @@ export namespace Vcs {
 
   export function diff(mode: Mode) {
     return runPromise((svc) => svc.diff(mode))
+  }
+
+  export function graph(opts?: { max?: number }) {
+    return runPromise((svc) => svc.graph(opts))
   }
 }

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -605,6 +605,34 @@ export namespace Server {
         },
       )
       .get(
+        "/vcs/graph",
+        describeRoute({
+          summary: "Get VCS graph data",
+          description: "Retrieve git log and refs data for rendering the git graph visualization.",
+          operationId: "vcs.graph",
+          responses: {
+            200: {
+              description: "VCS graph data",
+              content: {
+                "application/json": {
+                  schema: resolver(Vcs.GraphResult),
+                },
+              },
+            },
+          },
+        }),
+        validator(
+          "query",
+          z.object({
+            max: z.coerce.number().optional(),
+          }),
+        ),
+        async (c) => {
+          const query = c.req.valid("query")
+          return c.json(await Vcs.graph(query.max !== undefined ? { max: query.max } : undefined))
+        },
+      )
+      .get(
         "/command",
         describeRoute({
           summary: "List commands",

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -19,10 +19,15 @@ import type {
   ConfigProvidersResponses,
   ConfigSkillsAddDefaultsResponses,
   ConfigSkillsDeleteResponses,
+  ConfigSkillsGetManagedDirResponses,
+  ConfigSkillsListEvolutionResponses,
   ConfigSkillsListManagedResponses,
   ConfigSkillsListResponses,
   ConfigSkillsSaveResponses,
+  ConfigSkillsToggleEvolutionResponses,
   ConfigSkillsToggleResponses,
+  ConfigSkillsUpdateIntervalResponses,
+  ConfigSkillsUpdateMaxVersionsResponses,
   ConfigUpdateErrors,
   ConfigUpdateResponses,
   CronJobsCreateResponses,
@@ -106,11 +111,14 @@ import type {
   FindTextResponses,
   FormatterStatusResponses,
   GlobalConfigGetResponses,
+  GlobalConfigSkillsUpdateErrors,
+  GlobalConfigSkillsUpdateResponses,
   GlobalConfigUpdateErrors,
   GlobalConfigUpdateResponses,
   GlobalDisposeResponses,
   GlobalEventResponses,
   GlobalHealthResponses,
+  GlobalInstancesListResponses,
   GlobalPingErrors,
   GlobalPingResponses,
   GlobalProxyGetResponses,
@@ -224,6 +232,8 @@ import type {
   ReadingModeAnnotationsUpdateErrors,
   ReadingModeAnnotationsUpdateResponses,
   ReadingModePagePdfErrors,
+  ReadingModePagePdfFromFileErrors,
+  ReadingModePagePdfFromFileResponses,
   ReadingModePagePdfResponses,
   ReadingModePageTextErrors,
   ReadingModePageTextResponses,
@@ -278,6 +288,8 @@ import type {
   SessionShellResponses,
   SessionStatusErrors,
   SessionStatusResponses,
+  SessionSteerErrors,
+  SessionSteerResponses,
   SessionSummarizeErrors,
   SessionSummarizeResponses,
   SessionTodoErrors,
@@ -317,6 +329,7 @@ import type {
   TuiSubmitPromptResponses,
   VcsDiffResponses,
   VcsGetResponses,
+  VcsGraphResponses,
   WechatEventsResponses,
   WechatPing2Responses,
   WechatPing3Responses,
@@ -602,6 +615,55 @@ export class SyncEvent extends HeyApiClient {
   }
 }
 
+export class Skills extends HeyApiClient {
+  /**
+   * Update skills configuration
+   *
+   * Update skills settings without triggering a full instance reload.
+   */
+  public update<ThrowOnError extends boolean = false>(
+    parameters?: {
+      paths?: Array<string>
+      urls?: Array<string>
+      disabled?: Array<string>
+      creation_nudge_interval?: number
+      max_versions?: number
+      evolution_disabled?: Array<string>
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "body", key: "paths" },
+            { in: "body", key: "urls" },
+            { in: "body", key: "disabled" },
+            { in: "body", key: "creation_nudge_interval" },
+            { in: "body", key: "max_versions" },
+            { in: "body", key: "evolution_disabled" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).patch<
+      GlobalConfigSkillsUpdateResponses,
+      GlobalConfigSkillsUpdateErrors,
+      ThrowOnError
+    >({
+      url: "/global/config/skills",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+}
+
 export class Config extends HeyApiClient {
   /**
    * Get global configuration
@@ -636,6 +698,25 @@ export class Config extends HeyApiClient {
         ...options?.headers,
         ...params.headers,
       },
+    })
+  }
+
+  private _skills?: Skills
+  get skills(): Skills {
+    return (this._skills ??= new Skills({ client: this.client }))
+  }
+}
+
+export class Instances extends HeyApiClient {
+  /**
+   * List active instances
+   *
+   * List all active OpenCode instance directories currently held in memory.
+   */
+  public list<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<GlobalInstancesListResponses, unknown, ThrowOnError>({
+      url: "/global/instances",
+      ...options,
     })
   }
 }
@@ -755,6 +836,11 @@ export class Global extends HeyApiClient {
   get config(): Config {
     return (this._config ??= new Config({ client: this.client }))
   }
+
+  private _instances?: Instances
+  get instances(): Instances {
+    return (this._instances ??= new Instances({ client: this.client }))
+  }
 }
 
 export class Auth extends HeyApiClient {
@@ -827,6 +913,7 @@ export class Project extends HeyApiClient {
       name?: string
       icon?: {
         url?: string
+        override?: string
         color?: string
       }
     },
@@ -1292,7 +1379,7 @@ export class Pty extends HeyApiClient {
   }
 }
 
-export class Skills extends HeyApiClient {
+export class Skills2 extends HeyApiClient {
   /**
    * List default skills
    *
@@ -1318,6 +1405,85 @@ export class Skills extends HeyApiClient {
     )
     return (options?.client ?? this.client).get<ConfigSkillsListResponses, unknown, ThrowOnError>({
       url: "/config/skills",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Create or update a default skill
+   *
+   * Create or update a skill in .aether/skills/.
+   */
+  public save<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      name?: string
+      description?: string
+      content?: string
+      category?: string
+      enabled?: boolean
+      evolution_enabled?: boolean
+      file?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "name" },
+            { in: "body", key: "description" },
+            { in: "body", key: "content" },
+            { in: "body", key: "category" },
+            { in: "body", key: "enabled" },
+            { in: "body", key: "evolution_enabled" },
+            { in: "body", key: "file" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<ConfigSkillsSaveResponses, unknown, ThrowOnError>({
+      url: "/config/skills",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * List evolution skills
+   *
+   * List skills from the current project's .aether/skills/ and all global .aether/skills/ directories.
+   */
+  public listEvolution<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<ConfigSkillsListEvolutionResponses, unknown, ThrowOnError>({
+      url: "/config/skills/evolution",
       ...options,
       ...params,
     })
@@ -1354,18 +1520,14 @@ export class Skills extends HeyApiClient {
   }
 
   /**
-   * Create or update a default skill
+   * Get managed skills directory
    *
-   * Create or update a skill in .aether/skills/.
+   * Get the absolute path of the managed skills directory.
    */
-  public save<ThrowOnError extends boolean = false>(
+  public getManagedDir<ThrowOnError extends boolean = false>(
     parameters?: {
       directory?: string
       workspace?: string
-      name?: string
-      description?: string
-      content?: string
-      enabled?: boolean
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -1376,23 +1538,14 @@ export class Skills extends HeyApiClient {
           args: [
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
-            { in: "body", key: "name" },
-            { in: "body", key: "description" },
-            { in: "body", key: "content" },
-            { in: "body", key: "enabled" },
           ],
         },
       ],
     )
-    return (options?.client ?? this.client).post<ConfigSkillsSaveResponses, unknown, ThrowOnError>({
-      url: "/config/skills",
+    return (options?.client ?? this.client).get<ConfigSkillsGetManagedDirResponses, unknown, ThrowOnError>({
+      url: "/config/skills/managed/dir",
       ...options,
       ...params,
-      headers: {
-        "Content-Type": "application/json",
-        ...options?.headers,
-        ...params.headers,
-      },
     })
   }
 
@@ -1487,6 +1640,119 @@ export class Skills extends HeyApiClient {
     )
     return (options?.client ?? this.client).post<ConfigSkillsToggleResponses, unknown, ThrowOnError>({
       url: "/config/skills/toggle",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Toggle skill evolution
+   *
+   * Enable or disable background auto-evolution for a skill by file path.
+   */
+  public toggleEvolution<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      file?: string
+      evolutionEnabled?: boolean
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "file" },
+            { in: "body", key: "evolutionEnabled" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<ConfigSkillsToggleEvolutionResponses, unknown, ThrowOnError>({
+      url: "/config/skills/toggle-evolution",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Update skill review interval
+   *
+   * Update the creation_nudge_interval without restarting instances.
+   */
+  public updateInterval<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      interval?: number
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "interval" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<ConfigSkillsUpdateIntervalResponses, unknown, ThrowOnError>({
+      url: "/config/skills/update-interval",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Update skill max versions
+   *
+   * Update the max_versions without restarting instances.
+   */
+  public updateMaxVersions<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      max?: number
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "max" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<ConfigSkillsUpdateMaxVersionsResponses, unknown, ThrowOnError>({
+      url: "/config/skills/update-max-versions",
       ...options,
       ...params,
       headers: {
@@ -1596,9 +1862,9 @@ export class Config2 extends HeyApiClient {
     })
   }
 
-  private _skills?: Skills
-  get skills(): Skills {
-    return (this._skills ??= new Skills({ client: this.client }))
+  private _skills?: Skills2
+  get skills(): Skills2 {
+    return (this._skills ??= new Skills2({ client: this.client }))
   }
 }
 
@@ -3225,6 +3491,45 @@ export class Session2 extends HeyApiClient {
       url: "/session/{sessionID}/unrevert",
       ...options,
       ...params,
+    })
+  }
+
+  /**
+   * Add steer text
+   *
+   * Append a steer/supplement text to the last user message in a session, visible to the AI from the next iteration.
+   */
+  public steer<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+      text?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "text" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionSteerResponses, SessionSteerErrors, ThrowOnError>({
+      url: "/session/{sessionID}/steer",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
     })
   }
 
@@ -7474,6 +7779,49 @@ export class ReadingMode extends HeyApiClient {
     })
   }
 
+  /**
+   * Get a ranged PDF subdocument for a workspace file
+   */
+  public pagePdfFromFile<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      path?: string
+      startPage?: number
+      endPage?: number
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "path" },
+            { in: "body", key: "startPage" },
+            { in: "body", key: "endPage" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      ReadingModePagePdfFromFileResponses,
+      ReadingModePagePdfFromFileErrors,
+      ThrowOnError
+    >({
+      url: "/reading-mode/page-pdf-from-file",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
   private _session?: Session6
   get session(): Session6 {
     return (this._session ??= new Session6({ client: this.client }))
@@ -7612,6 +7960,38 @@ export class Vcs extends HeyApiClient {
     )
     return (options?.client ?? this.client).get<VcsDiffResponses, unknown, ThrowOnError>({
       url: "/vcs/diff",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get VCS graph data
+   *
+   * Retrieve git log and refs data for rendering the git graph visualization.
+   */
+  public graph<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      max?: number
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "query", key: "max" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<VcsGraphResponses, unknown, ThrowOnError>({
+      url: "/vcs/graph",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -167,6 +167,14 @@ export type EventSessionIdle = {
   }
 }
 
+export type EventSkillSaved = {
+  type: "skill.saved"
+  properties: {
+    sessionID: string
+    actions: Array<string>
+  }
+}
+
 export type QuestionOption = {
   /**
    * Display text (1-5 words, concise)
@@ -1041,6 +1049,7 @@ export type Event =
   | EventPermissionReplied
   | EventSessionStatus
   | EventSessionIdle
+  | EventSkillSaved
   | EventQuestionAsked
   | EventQuestionReplied
   | EventQuestionRejected
@@ -1541,6 +1550,18 @@ export type Config = {
      * List of skill names to deactivate
      */
     disabled?: Array<string>
+    /**
+     * LLM steps without skill_manage before background skill review triggers (default: 10, 0 to disable)
+     */
+    creation_nudge_interval?: number
+    /**
+     * Maximum number of version snapshots kept per skill before older snapshots are pruned (default: 100)
+     */
+    max_versions?: number
+    /**
+     * Skill directory paths excluded from background auto-evolution
+     */
+    evolution_disabled?: Array<string>
   }
   watcher?: {
     ignore?: Array<string>
@@ -1848,6 +1869,7 @@ export type Model = {
     output: number
   }
   status: "alpha" | "beta" | "deprecated" | "active"
+  disabled?: boolean
   options: {
     [key: string]: unknown
   }
@@ -1855,7 +1877,6 @@ export type Model = {
     [key: string]: string
   }
   release_date: string
-  disabled?: boolean
   variants?: {
     [key: string]: {
       [key: string]: unknown
@@ -2231,6 +2252,35 @@ export type VcsInfo = {
   default_branch?: string
 }
 
+export type TagRef = {
+  name: string
+  annotated: boolean
+}
+
+export type RemoteRef = {
+  name: string
+  remote: string | null
+}
+
+export type CommitLogItem = {
+  hash: string
+  parents: Array<string>
+  author: string
+  email: string
+  date: number
+  message: string
+  heads: Array<string>
+  tags: Array<TagRef>
+  remotes: Array<RemoteRef>
+}
+
+export type VcsGraphResult = {
+  commits: Array<CommitLogItem>
+  head: string | null
+  tags: Array<string>
+  moreAvailable: boolean
+}
+
 export type Command = {
   name: string
   description?: string
@@ -2489,6 +2539,98 @@ export type GlobalConfigUpdateResponses = {
 
 export type GlobalConfigUpdateResponse = GlobalConfigUpdateResponses[keyof GlobalConfigUpdateResponses]
 
+export type GlobalConfigSkillsUpdateData = {
+  body?: {
+    /**
+     * Additional paths to skill folders
+     */
+    paths?: Array<string>
+    /**
+     * URLs to fetch skills from (e.g., https://example.com/.well-known/skills/)
+     */
+    urls?: Array<string>
+    /**
+     * List of skill names to deactivate
+     */
+    disabled?: Array<string>
+    /**
+     * LLM steps without skill_manage before background skill review triggers (default: 10, 0 to disable)
+     */
+    creation_nudge_interval?: number
+    /**
+     * Maximum number of version snapshots kept per skill before older snapshots are pruned (default: 100)
+     */
+    max_versions?: number
+    /**
+     * Skill directory paths excluded from background auto-evolution
+     */
+    evolution_disabled?: Array<string>
+  }
+  path?: never
+  query?: never
+  url: "/global/config/skills"
+}
+
+export type GlobalConfigSkillsUpdateErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type GlobalConfigSkillsUpdateError = GlobalConfigSkillsUpdateErrors[keyof GlobalConfigSkillsUpdateErrors]
+
+export type GlobalConfigSkillsUpdateResponses = {
+  /**
+   * Successfully updated skills config
+   */
+  200: {
+    /**
+     * Additional paths to skill folders
+     */
+    paths?: Array<string>
+    /**
+     * URLs to fetch skills from (e.g., https://example.com/.well-known/skills/)
+     */
+    urls?: Array<string>
+    /**
+     * List of skill names to deactivate
+     */
+    disabled?: Array<string>
+    /**
+     * LLM steps without skill_manage before background skill review triggers (default: 10, 0 to disable)
+     */
+    creation_nudge_interval?: number
+    /**
+     * Maximum number of version snapshots kept per skill before older snapshots are pruned (default: 100)
+     */
+    max_versions?: number
+    /**
+     * Skill directory paths excluded from background auto-evolution
+     */
+    evolution_disabled?: Array<string>
+  }
+}
+
+export type GlobalConfigSkillsUpdateResponse =
+  GlobalConfigSkillsUpdateResponses[keyof GlobalConfigSkillsUpdateResponses]
+
+export type GlobalInstancesListData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/global/instances"
+}
+
+export type GlobalInstancesListResponses = {
+  /**
+   * Active instance directories
+   */
+  200: Array<string>
+}
+
+export type GlobalInstancesListResponse = GlobalInstancesListResponses[keyof GlobalInstancesListResponses]
+
 export type GlobalDisposeData = {
   body?: never
   path?: never
@@ -2746,6 +2888,7 @@ export type ProjectUpdateDirectoryMetaData = {
     name?: string
     icon?: {
       url?: string
+      override?: string
       color?: string
     }
   }
@@ -3164,42 +3307,24 @@ export type ConfigSkillsListResponses = {
     name: string
     description: string
     content: string
+    category?: string
     enabled?: boolean
+    evolution_enabled?: boolean
+    file?: string
   }>
 }
 
 export type ConfigSkillsListResponse = ConfigSkillsListResponses[keyof ConfigSkillsListResponses]
-
-export type ConfigSkillsListManagedData = {
-  body?: never
-  path?: never
-  query?: {
-    directory?: string
-    workspace?: string
-  }
-  url: "/config/skills/managed"
-}
-
-export type ConfigSkillsListManagedResponses = {
-  /**
-   * List of managed skills
-   */
-  200: Array<{
-    name: string
-    description: string
-    content: string
-    enabled?: boolean
-  }>
-}
-
-export type ConfigSkillsListManagedResponse = ConfigSkillsListManagedResponses[keyof ConfigSkillsListManagedResponses]
 
 export type ConfigSkillsSaveData = {
   body?: {
     name: string
     description: string
     content: string
+    category?: string
     enabled?: boolean
+    evolution_enabled?: boolean
+    file?: string
   }
   path?: never
   query?: {
@@ -3219,6 +3344,83 @@ export type ConfigSkillsSaveResponses = {
 }
 
 export type ConfigSkillsSaveResponse = ConfigSkillsSaveResponses[keyof ConfigSkillsSaveResponses]
+
+export type ConfigSkillsListEvolutionData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/config/skills/evolution"
+}
+
+export type ConfigSkillsListEvolutionResponses = {
+  /**
+   * List of evolution skills
+   */
+  200: Array<{
+    name: string
+    description: string
+    content: string
+    category?: string
+    enabled?: boolean
+    evolution_enabled?: boolean
+    file?: string
+  }>
+}
+
+export type ConfigSkillsListEvolutionResponse =
+  ConfigSkillsListEvolutionResponses[keyof ConfigSkillsListEvolutionResponses]
+
+export type ConfigSkillsListManagedData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/config/skills/managed"
+}
+
+export type ConfigSkillsListManagedResponses = {
+  /**
+   * List of managed skills
+   */
+  200: Array<{
+    name: string
+    description: string
+    content: string
+    category?: string
+    enabled?: boolean
+    evolution_enabled?: boolean
+    file?: string
+  }>
+}
+
+export type ConfigSkillsListManagedResponse = ConfigSkillsListManagedResponses[keyof ConfigSkillsListManagedResponses]
+
+export type ConfigSkillsGetManagedDirData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/config/skills/managed/dir"
+}
+
+export type ConfigSkillsGetManagedDirResponses = {
+  /**
+   * Managed skills directory path
+   */
+  200: {
+    path: string
+  }
+}
+
+export type ConfigSkillsGetManagedDirResponse =
+  ConfigSkillsGetManagedDirResponses[keyof ConfigSkillsGetManagedDirResponses]
 
 export type ConfigSkillsDeleteData = {
   body?: never
@@ -3287,6 +3489,79 @@ export type ConfigSkillsToggleResponses = {
 }
 
 export type ConfigSkillsToggleResponse = ConfigSkillsToggleResponses[keyof ConfigSkillsToggleResponses]
+
+export type ConfigSkillsToggleEvolutionData = {
+  body?: {
+    file: string
+    evolutionEnabled: boolean
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/config/skills/toggle-evolution"
+}
+
+export type ConfigSkillsToggleEvolutionResponses = {
+  /**
+   * Skill evolution toggled
+   */
+  200: {
+    ok: boolean
+  }
+}
+
+export type ConfigSkillsToggleEvolutionResponse =
+  ConfigSkillsToggleEvolutionResponses[keyof ConfigSkillsToggleEvolutionResponses]
+
+export type ConfigSkillsUpdateIntervalData = {
+  body?: {
+    interval: number
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/config/skills/update-interval"
+}
+
+export type ConfigSkillsUpdateIntervalResponses = {
+  /**
+   * Interval updated
+   */
+  200: {
+    ok: boolean
+  }
+}
+
+export type ConfigSkillsUpdateIntervalResponse =
+  ConfigSkillsUpdateIntervalResponses[keyof ConfigSkillsUpdateIntervalResponses]
+
+export type ConfigSkillsUpdateMaxVersionsData = {
+  body?: {
+    max: number
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/config/skills/update-max-versions"
+}
+
+export type ConfigSkillsUpdateMaxVersionsResponses = {
+  /**
+   * Max versions updated
+   */
+  200: {
+    ok: boolean
+  }
+}
+
+export type ConfigSkillsUpdateMaxVersionsResponse =
+  ConfigSkillsUpdateMaxVersionsResponses[keyof ConfigSkillsUpdateMaxVersionsResponses]
 
 export type ConfigProvidersData = {
   body?: never
@@ -4844,6 +5119,44 @@ export type PermissionRespondResponses = {
 
 export type PermissionRespondResponse = PermissionRespondResponses[keyof PermissionRespondResponses]
 
+export type SessionSteerData = {
+  body?: {
+    text: string
+  }
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/steer"
+}
+
+export type SessionSteerErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionSteerError = SessionSteerErrors[keyof SessionSteerErrors]
+
+export type SessionSteerResponses = {
+  /**
+   * Steer text added
+   */
+  200: {
+    ok: boolean
+  }
+}
+
+export type SessionSteerResponse = SessionSteerResponses[keyof SessionSteerResponses]
+
 export type SessionPreferenceGetData = {
   body?: never
   path: {
@@ -5145,7 +5458,6 @@ export type ProviderListResponses = {
           }
           experimental?: boolean
           status?: "alpha" | "beta" | "deprecated"
-          disabled?: boolean
           options: {
             [key: string]: unknown
           }
@@ -8639,6 +8951,40 @@ export type ReadingModePagePdfResponses = {
   200: unknown
 }
 
+export type ReadingModePagePdfFromFileData = {
+  body?: {
+    path: string
+    startPage: number
+    endPage: number
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/reading-mode/page-pdf-from-file"
+}
+
+export type ReadingModePagePdfFromFileErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type ReadingModePagePdfFromFileError = ReadingModePagePdfFromFileErrors[keyof ReadingModePagePdfFromFileErrors]
+
+export type ReadingModePagePdfFromFileResponses = {
+  /**
+   * PDF binary for the requested page range
+   */
+  200: unknown
+}
+
 export type ReadingModeAnnotationsGetData = {
   body?: never
   path?: never
@@ -8862,6 +9208,26 @@ export type VcsDiffResponses = {
 
 export type VcsDiffResponse = VcsDiffResponses[keyof VcsDiffResponses]
 
+export type VcsGraphData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+    max?: number
+  }
+  url: "/vcs/graph"
+}
+
+export type VcsGraphResponses = {
+  /**
+   * VCS graph data
+   */
+  200: VcsGraphResult
+}
+
+export type VcsGraphResponse = VcsGraphResponses[keyof VcsGraphResponses]
+
 export type CommandListData = {
   body?: never
   path?: never
@@ -8966,6 +9332,13 @@ export type AppSkillsResponses = {
     description: string
     location: string
     content: string
+    conditions?: {
+      requires_tools?: Array<string>
+      requires_toolsets?: Array<string>
+      fallback_for_tools?: Array<string>
+      fallback_for_toolsets?: Array<string>
+    }
+    platforms?: Array<string>
   }>
 }
 

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -6,6 +6,205 @@
     "version": "1.0.0"
   },
   "paths": {
+    "/global/proxy": {
+      "get": {
+        "operationId": "global.proxy.get",
+        "summary": "Get proxy configuration",
+        "description": "Get current process-level HTTP/HTTPS proxy configuration.",
+        "responses": {
+          "200": {
+            "description": "Proxy config",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "http": {
+                      "type": "object",
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 65535
+                        }
+                      },
+                      "required": [
+                        "host",
+                        "port"
+                      ]
+                    },
+                    "https": {
+                      "type": "object",
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 65535
+                        }
+                      },
+                      "required": [
+                        "host",
+                        "port"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "enabled",
+                    "http",
+                    "https"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.proxy.get({\n  ...\n})"
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "global.proxy.update",
+        "summary": "Update proxy configuration",
+        "description": "Update process-level HTTP/HTTPS proxy configuration.",
+        "responses": {
+          "200": {
+            "description": "Updated proxy config",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "http": {
+                      "type": "object",
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 65535
+                        }
+                      },
+                      "required": [
+                        "host",
+                        "port"
+                      ]
+                    },
+                    "https": {
+                      "type": "object",
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 65535
+                        }
+                      },
+                      "required": [
+                        "host",
+                        "port"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "enabled",
+                    "http",
+                    "https"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "http": {
+                    "type": "object",
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 65535
+                      }
+                    },
+                    "required": [
+                      "host",
+                      "port"
+                    ]
+                  },
+                  "https": {
+                    "type": "object",
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 65535
+                      }
+                    },
+                    "required": [
+                      "host",
+                      "port"
+                    ]
+                  }
+                },
+                "required": [
+                  "enabled",
+                  "http",
+                  "https"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.proxy.update({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/global/health": {
       "get": {
         "operationId": "global.health",
@@ -27,7 +226,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["healthy", "version"]
+                  "required": [
+                    "healthy",
+                    "version"
+                  ]
                 }
               }
             }
@@ -37,6 +239,104 @@
           {
             "lang": "js",
             "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.health({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/global/web-update/current": {
+      "get": {
+        "operationId": "global.web-update.current",
+        "summary": "Get current web version",
+        "description": "Read the current web app version from local update state.",
+        "responses": {
+          "200": {
+            "description": "Current local web version",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "currentVersion": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "currentVersion"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.web-update.current({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/global/ping": {
+      "post": {
+        "operationId": "global.ping",
+        "summary": "Ping lease",
+        "description": "Refresh or release browser lease for web auto-exit detection.",
+        "responses": {
+          "200": {
+            "description": "Lease touched",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "alive": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.ping({\n  ...\n})"
           }
         ]
       }
@@ -158,6 +458,162 @@
         ]
       }
     },
+    "/global/config/skills": {
+      "patch": {
+        "operationId": "global.config.skills.update",
+        "summary": "Update skills configuration",
+        "description": "Update skills settings without triggering a full instance reload.",
+        "responses": {
+          "200": {
+            "description": "Successfully updated skills config",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "paths": {
+                      "description": "Additional paths to skill folders",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "urls": {
+                      "description": "URLs to fetch skills from (e.g., https://example.com/.well-known/skills/)",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "disabled": {
+                      "description": "List of skill names to deactivate",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "creation_nudge_interval": {
+                      "description": "LLM steps without skill_manage before background skill review triggers (default: 10, 0 to disable)",
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "max_versions": {
+                      "description": "Maximum number of version snapshots kept per skill before older snapshots are pruned (default: 100)",
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 9007199254740991
+                    },
+                    "evolution_disabled": {
+                      "description": "Skill directory paths excluded from background auto-evolution",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "paths": {
+                    "description": "Additional paths to skill folders",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "urls": {
+                    "description": "URLs to fetch skills from (e.g., https://example.com/.well-known/skills/)",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "disabled": {
+                    "description": "List of skill names to deactivate",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "creation_nudge_interval": {
+                    "description": "LLM steps without skill_manage before background skill review triggers (default: 10, 0 to disable)",
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "max_versions": {
+                    "description": "Maximum number of version snapshots kept per skill before older snapshots are pruned (default: 100)",
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 9007199254740991
+                  },
+                  "evolution_disabled": {
+                    "description": "Skill directory paths excluded from background auto-evolution",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.config.skills.update({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/global/instances": {
+      "get": {
+        "operationId": "global.instances.list",
+        "summary": "List active instances",
+        "description": "List all active OpenCode instance directories currently held in memory.",
+        "responses": {
+          "200": {
+            "description": "Active instance directories",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.instances.list({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/global/dispose": {
       "post": {
         "operationId": "global.dispose",
@@ -179,6 +635,392 @@
           {
             "lang": "js",
             "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.dispose({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/global/web-update/check": {
+      "get": {
+        "operationId": "global.web-update.check",
+        "summary": "Check web update",
+        "description": "Check for available web application updates by fetching remote version metadata.",
+        "responses": {
+          "200": {
+            "description": "Version check result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "currentVersion": {
+                      "type": "string"
+                    },
+                    "remoteVersion": {
+                      "type": "string"
+                    },
+                    "updateAvailable": {
+                      "type": "boolean"
+                    },
+                    "downloaded": {
+                      "type": "boolean"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "available",
+                        "downloading",
+                        "downloaded",
+                        "installing",
+                        "failed"
+                      ]
+                    },
+                    "workDir": {
+                      "type": "string"
+                    },
+                    "updateAction": {
+                      "type": "string",
+                      "enum": [
+                        "recover",
+                        "mirror"
+                      ]
+                    },
+                    "updateError": {
+                      "type": "string"
+                    },
+                    "checkError": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "currentVersion",
+                    "remoteVersion",
+                    "updateAvailable",
+                    "downloaded",
+                    "status",
+                    "workDir"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.web-update.check({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/global/web-update/download": {
+      "post": {
+        "operationId": "global.web-update.download",
+        "summary": "Download web update script",
+        "description": "Download the update/install script for the specified OS and version.",
+        "responses": {
+          "200": {
+            "description": "Download result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "const": true
+                        },
+                        "path": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "success",
+                        "path"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "const": false
+                        },
+                        "error": {
+                          "type": "string"
+                        },
+                        "action": {
+                          "type": "string",
+                          "enum": [
+                            "recover",
+                            "mirror"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "success",
+                        "error"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "os": {
+                    "type": "string",
+                    "enum": [
+                      "darwin",
+                      "linux",
+                      "windows"
+                    ]
+                  },
+                  "version": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "force": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "os",
+                  "version"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.web-update.download({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/global/web-update/install": {
+      "post": {
+        "operationId": "global.web-update.install",
+        "summary": "Execute web update script",
+        "description": "Execute the previously downloaded update script to install the new version.",
+        "responses": {
+          "200": {
+            "description": "Install result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "const": true
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "const": false
+                        },
+                        "error": {
+                          "type": "string"
+                        },
+                        "action": {
+                          "type": "string",
+                          "enum": [
+                            "recover",
+                            "mirror"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "success",
+                        "error"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "os": {
+                    "type": "string",
+                    "enum": [
+                      "darwin",
+                      "linux",
+                      "windows"
+                    ]
+                  },
+                  "version": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "os"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.web-update.install({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/global/web-update/mirror": {
+      "post": {
+        "operationId": "global.web-update.mirror",
+        "summary": "Retry web update mirror",
+        "description": "Retry only the mirror step for a failed web update install.",
+        "responses": {
+          "200": {
+            "description": "Mirror retry result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "const": true
+                        }
+                      },
+                      "required": [
+                        "success"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "const": false
+                        },
+                        "error": {
+                          "type": "string"
+                        },
+                        "action": {
+                          "type": "string",
+                          "enum": [
+                            "recover",
+                            "mirror"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "success",
+                        "error"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "os": {
+                    "type": "string",
+                    "enum": [
+                      "darwin",
+                      "linux",
+                      "windows"
+                    ]
+                  },
+                  "version": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "mirrorRoot": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "os"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.global.web-update.mirror({\n  ...\n})"
           }
         ]
       }
@@ -206,7 +1048,10 @@
                           "type": "string"
                         }
                       },
-                      "required": ["success", "version"]
+                      "required": [
+                        "success",
+                        "version"
+                      ]
                     },
                     {
                       "type": "object",
@@ -219,7 +1064,10 @@
                           "type": "string"
                         }
                       },
-                      "required": ["success", "error"]
+                      "required": [
+                        "success",
+                        "error"
+                      ]
                     }
                   ]
                 }
@@ -356,6 +1204,91 @@
         ]
       }
     },
+    "/project-directory-meta": {
+      "post": {
+        "operationId": "project.updateDirectoryMeta",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Update directory metadata",
+        "description": "Update name and icon for a plain directory (no git project entry). Persisted in project_recent table.",
+        "responses": {
+          "200": {
+            "description": "Updated directory metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectRecent"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "directory": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "icon": {
+                    "type": "object",
+                    "properties": {
+                      "url": {
+                        "type": "string"
+                      },
+                      "override": {
+                        "type": "string"
+                      },
+                      "color": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "directory"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.project.updateDirectoryMeta({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/project": {
       "get": {
         "operationId": "project.list",
@@ -396,6 +1329,94 @@
           {
             "lang": "js",
             "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.project.list({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/project/recent": {
+      "get": {
+        "operationId": "project.recent",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "List recent projects and directories",
+        "description": "Returns the recent project feed used by the web app and WeChat bridge.",
+        "responses": {
+          "200": {
+            "description": "Recent project feed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProjectRecent"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.project.recent({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/project/directories": {
+      "get": {
+        "operationId": "project.directories",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "List all known directories",
+        "description": "Returns all project worktrees plus unique session directories.",
+        "responses": {
+          "200": {
+            "description": "List of directory paths",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.project.directories({\n  ...\n})"
           }
         ]
       }
@@ -845,7 +1866,10 @@
                         "type": "number"
                       }
                     },
-                    "required": ["rows", "cols"]
+                    "required": [
+                      "rows",
+                      "cols"
+                    ]
                   }
                 }
               }
@@ -1077,6 +2101,740 @@
         ]
       }
     },
+    "/config/skills": {
+      "get": {
+        "operationId": "config.skills.list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "List default skills",
+        "description": "List all default skills from the .aether/skills/ directory.",
+        "responses": {
+          "200": {
+            "description": "List of default skills",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "content": {
+                        "type": "string"
+                      },
+                      "category": {
+                        "type": "string"
+                      },
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "evolution_enabled": {
+                        "type": "boolean"
+                      },
+                      "file": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "description",
+                      "content"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.config.skills.list({\n  ...\n})"
+          }
+        ]
+      },
+      "post": {
+        "operationId": "config.skills.save",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Create or update a default skill",
+        "description": "Create or update a skill in .aether/skills/.",
+        "responses": {
+          "200": {
+            "description": "Skill saved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "content": {
+                    "type": "string"
+                  },
+                  "category": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "evolution_enabled": {
+                    "type": "boolean"
+                  },
+                  "file": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "description",
+                  "content"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.config.skills.save({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/config/skills/evolution": {
+      "get": {
+        "operationId": "config.skills.listEvolution",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "List evolution skills",
+        "description": "List skills from the current project's .aether/skills/ and all global .aether/skills/ directories.",
+        "responses": {
+          "200": {
+            "description": "List of evolution skills",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "content": {
+                        "type": "string"
+                      },
+                      "category": {
+                        "type": "string"
+                      },
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "evolution_enabled": {
+                        "type": "boolean"
+                      },
+                      "file": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "description",
+                      "content"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.config.skills.listEvolution({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/config/skills/managed": {
+      "get": {
+        "operationId": "config.skills.listManaged",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "List managed skills",
+        "description": "List all skills from the managed skills directory (~/.local/share/aether/skills/).",
+        "responses": {
+          "200": {
+            "description": "List of managed skills",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "content": {
+                        "type": "string"
+                      },
+                      "category": {
+                        "type": "string"
+                      },
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "evolution_enabled": {
+                        "type": "boolean"
+                      },
+                      "file": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "description",
+                      "content"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.config.skills.listManaged({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/config/skills/managed/dir": {
+      "get": {
+        "operationId": "config.skills.getManagedDir",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Get managed skills directory",
+        "description": "Get the absolute path of the managed skills directory.",
+        "responses": {
+          "200": {
+            "description": "Managed skills directory path",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "path"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.config.skills.getManagedDir({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/config/skills/{name}": {
+      "delete": {
+        "operationId": "config.skills.delete",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "name",
+            "required": true
+          }
+        ],
+        "summary": "Delete a default skill",
+        "description": "Delete a skill from .aether/skills/.",
+        "responses": {
+          "200": {
+            "description": "Skill deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.config.skills.delete({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/config/skills/defaults": {
+      "post": {
+        "operationId": "config.skills.addDefaults",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Add default skills to project config",
+        "description": "Add the default skills from .aether/skills/ to the project's aether.jsonc skills.paths.",
+        "responses": {
+          "200": {
+            "description": "Successfully added default skills",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "added": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "added"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.config.skills.addDefaults({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/config/skills/toggle": {
+      "post": {
+        "operationId": "config.skills.toggle",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Toggle skill activation",
+        "description": "Enable or disable a default skill by name.",
+        "responses": {
+          "200": {
+            "description": "Skill toggled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "file",
+                  "enabled"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.config.skills.toggle({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/config/skills/toggle-evolution": {
+      "post": {
+        "operationId": "config.skills.toggleEvolution",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Toggle skill evolution",
+        "description": "Enable or disable background auto-evolution for a skill by file path.",
+        "responses": {
+          "200": {
+            "description": "Skill evolution toggled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string"
+                  },
+                  "evolutionEnabled": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "file",
+                  "evolutionEnabled"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.config.skills.toggleEvolution({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/config/skills/update-interval": {
+      "post": {
+        "operationId": "config.skills.updateInterval",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Update skill review interval",
+        "description": "Update the creation_nudge_interval without restarting instances.",
+        "responses": {
+          "200": {
+            "description": "Interval updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "interval": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "required": [
+                  "interval"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.config.skills.updateInterval({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/config/skills/update-max-versions": {
+      "post": {
+        "operationId": "config.skills.updateMaxVersions",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Update skill max versions",
+        "description": "Update the max_versions without restarting instances.",
+        "responses": {
+          "200": {
+            "description": "Max versions updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "max": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "required": [
+                  "max"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.config.skills.updateMaxVersions({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/config/providers": {
       "get": {
         "operationId": "config.providers",
@@ -1122,7 +2880,10 @@
                       }
                     }
                   },
-                  "required": ["providers", "default"]
+                  "required": [
+                    "providers",
+                    "default"
+                  ]
                 }
               }
             }
@@ -1132,6 +2893,300 @@
           {
             "lang": "js",
             "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.config.providers({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/memory": {
+      "get": {
+        "operationId": "memory.get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Get memory stores",
+        "description": "Read effective memory settings, durable stores, and optional session active memory.",
+        "responses": {
+          "200": {
+            "description": "Memory settings and store snapshots",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "settings": {
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "memory_reflection_model": {
+                          "type": "object",
+                          "properties": {
+                            "providerID": {
+                              "type": "string"
+                            },
+                            "modelID": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "providerID",
+                            "modelID"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "enabled"
+                      ]
+                    },
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "store": {
+                          "type": "string",
+                          "enum": [
+                            "user",
+                            "memory"
+                          ]
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "file": {
+                          "type": "string"
+                        },
+                        "limit": {
+                          "type": "integer",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991
+                        },
+                        "used": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        },
+                        "usage": {
+                          "type": "number"
+                        },
+                        "entries": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "explicit_entries": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "inferred_entries": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "invalid_entries": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        }
+                      },
+                      "required": [
+                        "store",
+                        "enabled",
+                        "file",
+                        "limit",
+                        "used",
+                        "usage",
+                        "entries"
+                      ]
+                    },
+                    "memory": {
+                      "type": "object",
+                      "properties": {
+                        "store": {
+                          "type": "string",
+                          "enum": [
+                            "user",
+                            "memory"
+                          ]
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "file": {
+                          "type": "string"
+                        },
+                        "limit": {
+                          "type": "integer",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991
+                        },
+                        "used": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        },
+                        "usage": {
+                          "type": "number"
+                        },
+                        "entries": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "explicit_entries": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "inferred_entries": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "invalid_entries": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        }
+                      },
+                      "required": [
+                        "store",
+                        "enabled",
+                        "file",
+                        "limit",
+                        "used",
+                        "usage",
+                        "entries"
+                      ]
+                    },
+                    "daily": {
+                      "type": "object",
+                      "properties": {
+                        "root": {
+                          "type": "string"
+                        },
+                        "days": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "date": {
+                                "type": "string"
+                              },
+                              "file": {
+                                "type": "string"
+                              },
+                              "entries": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "invalid_entries": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 9007199254740991
+                              }
+                            },
+                            "required": [
+                              "date",
+                              "file",
+                              "entries",
+                              "invalid_entries"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "root",
+                        "days"
+                      ]
+                    },
+                    "active": {
+                      "type": "object",
+                      "properties": {
+                        "session_id": {
+                          "type": "string"
+                        },
+                        "prompt": {
+                          "type": "string"
+                        },
+                        "entries": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "type": "string",
+                                "enum": [
+                                  "user",
+                                  "daily",
+                                  "session"
+                                ]
+                              },
+                              "store": {
+                                "type": "string",
+                                "enum": [
+                                  "user",
+                                  "memory"
+                                ]
+                              },
+                              "index": {
+                                "type": "number"
+                              },
+                              "text": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "source",
+                              "index",
+                              "text"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "session_id",
+                        "prompt",
+                        "entries"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "settings",
+                    "user",
+                    "memory",
+                    "daily"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.memory.get({\n  ...\n})"
           }
         ]
       }
@@ -1329,7 +3384,11 @@
                     ]
                   }
                 },
-                "required": ["type", "branch", "extra"]
+                "required": [
+                  "type",
+                  "branch",
+                  "extra"
+                ]
               }
             }
           }
@@ -1725,6 +3784,19 @@
           },
           {
             "in": "query",
+            "name": "archivedMode",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "exclude",
+                "include",
+                "only"
+              ]
+            },
+            "description": "Archive filtering mode (exclude/include/only). Takes precedence over archived."
+          },
+          {
+            "in": "query",
             "name": "archived",
             "schema": {
               "type": "boolean"
@@ -2042,7 +4114,9 @@
         ],
         "summary": "Get session",
         "description": "Retrieve detailed information about a specific OpenCode session.",
-        "tags": ["Session"],
+        "tags": [
+          "Session"
+        ],
         "responses": {
           "200": {
             "description": "Get session",
@@ -2270,7 +4344,9 @@
           }
         ],
         "summary": "Get session children",
-        "tags": ["Session"],
+        "tags": [
+          "Session"
+        ],
         "description": "Retrieve all child sessions that were forked from the specified parent session.",
         "responses": {
           "200": {
@@ -2311,6 +4387,152 @@
           {
             "lang": "js",
             "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.children({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/tree": {
+      "get": {
+        "operationId": "session.tree",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string",
+              "pattern": "^ses.*"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Get session branch tree",
+        "tags": [
+          "Session"
+        ],
+        "description": "Retrieve the branch tree for the specified session. Legacy sessions return an explicit unsupported result.",
+        "responses": {
+          "200": {
+            "description": "Branch tree result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionTreeResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.tree({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/graph": {
+      "get": {
+        "operationId": "session.graph",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string",
+              "pattern": "^ses.*"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Get session conversation graph",
+        "tags": [
+          "Session"
+        ],
+        "description": "Retrieve the message-level conversation graph for the specified session. Legacy sessions return an explicit unsupported result.",
+        "responses": {
+          "200": {
+            "description": "Conversation graph result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionGraphResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.graph({\n  ...\n})"
           }
         ]
       }
@@ -2384,6 +4606,146 @@
           {
             "lang": "js",
             "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.todo({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/archive": {
+      "post": {
+        "operationId": "session.archive",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string",
+              "pattern": "^ses.*"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Archive session subtree",
+        "description": "Archive a session. Child branches are detached into an archived subtree root.",
+        "responses": {
+          "200": {
+            "description": "Archived session subtree root",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Session"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.archive({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/unarchive": {
+      "post": {
+        "operationId": "session.unarchive",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string",
+              "pattern": "^ses.*"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Unarchive session subtree",
+        "description": "Restore an archived session subtree as an independent active root.",
+        "responses": {
+          "200": {
+            "description": "Unarchived session subtree root",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Session"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.unarchive({\n  ...\n})"
           }
         ]
       }
@@ -2467,7 +4829,11 @@
                     "pattern": "^msg.*"
                   }
                 },
-                "required": ["modelID", "providerID", "messageID"]
+                "required": [
+                  "modelID",
+                  "providerID",
+                  "messageID"
+                ]
               }
             }
           }
@@ -2893,7 +5259,10 @@
                     "type": "boolean"
                   }
                 },
-                "required": ["providerID", "modelID"]
+                "required": [
+                  "providerID",
+                  "modelID"
+                ]
               }
             }
           }
@@ -2973,7 +5342,10 @@
                         }
                       }
                     },
-                    "required": ["info", "parts"]
+                    "required": [
+                      "info",
+                      "parts"
+                    ]
                   }
                 }
               }
@@ -3054,7 +5426,10 @@
                       }
                     }
                   },
-                  "required": ["info", "parts"]
+                  "required": [
+                    "info",
+                    "parts"
+                  ]
                 }
               }
             }
@@ -3100,7 +5475,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["providerID", "modelID"]
+                    "required": [
+                      "providerID",
+                      "modelID"
+                    ]
                   },
                   "agent": {
                     "type": "string"
@@ -3127,6 +5505,26 @@
                   "variant": {
                     "type": "string"
                   },
+                  "knowledgeBase": {
+                    "type": "object",
+                    "properties": {
+                      "path": {
+                        "type": "string"
+                      },
+                      "paths": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "apiKey": {
+                        "type": "string"
+                      },
+                      "baseURL": {
+                        "type": "string"
+                      }
+                    }
+                  },
                   "parts": {
                     "type": "array",
                     "items": {
@@ -3147,7 +5545,9 @@
                     }
                   }
                 },
-                "required": ["parts"]
+                "required": [
+                  "parts"
+                ]
               }
             }
           }
@@ -3217,7 +5617,10 @@
                       }
                     }
                   },
-                  "required": ["info", "parts"]
+                  "required": [
+                    "info",
+                    "parts"
+                  ]
                 }
               }
             }
@@ -3584,7 +5987,10 @@
                         "type": "string"
                       }
                     },
-                    "required": ["providerID", "modelID"]
+                    "required": [
+                      "providerID",
+                      "modelID"
+                    ]
                   },
                   "agent": {
                     "type": "string"
@@ -3611,6 +6017,26 @@
                   "variant": {
                     "type": "string"
                   },
+                  "knowledgeBase": {
+                    "type": "object",
+                    "properties": {
+                      "path": {
+                        "type": "string"
+                      },
+                      "paths": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "apiKey": {
+                        "type": "string"
+                      },
+                      "baseURL": {
+                        "type": "string"
+                      }
+                    }
+                  },
                   "parts": {
                     "type": "array",
                     "items": {
@@ -3631,7 +6057,9 @@
                     }
                   }
                 },
-                "required": ["parts"]
+                "required": [
+                  "parts"
+                ]
               }
             }
           }
@@ -3692,7 +6120,10 @@
                       }
                     }
                   },
-                  "required": ["info", "parts"]
+                  "required": [
+                    "info",
+                    "parts"
+                  ]
                 }
               }
             }
@@ -3771,13 +6202,20 @@
                               "$ref": "#/components/schemas/FilePartSource"
                             }
                           },
-                          "required": ["type", "mime", "url"]
+                          "required": [
+                            "type",
+                            "mime",
+                            "url"
+                          ]
                         }
                       ]
                     }
                   }
                 },
-                "required": ["arguments", "command"]
+                "required": [
+                  "arguments",
+                  "command"
+                ]
               }
             }
           }
@@ -3871,13 +6309,19 @@
                         "type": "string"
                       }
                     },
-                    "required": ["providerID", "modelID"]
+                    "required": [
+                      "providerID",
+                      "modelID"
+                    ]
                   },
                   "command": {
                     "type": "string"
                   }
                 },
-                "required": ["agent", "command"]
+                "required": [
+                  "agent",
+                  "command"
+                ]
               }
             }
           }
@@ -3967,7 +6411,9 @@
                     "pattern": "^prt.*"
                   }
                 },
-                "required": ["messageID"]
+                "required": [
+                  "messageID"
+                ]
               }
             }
           }
@@ -4130,10 +6576,16 @@
                 "properties": {
                   "response": {
                     "type": "string",
-                    "enum": ["once", "always", "reject"]
+                    "enum": [
+                      "once",
+                      "always",
+                      "reject"
+                    ]
                   }
                 },
-                "required": ["response"]
+                "required": [
+                  "response"
+                ]
               }
             }
           }
@@ -4142,6 +6594,369 @@
           {
             "lang": "js",
             "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.permission.respond({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/steer": {
+      "post": {
+        "operationId": "session.steer",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string",
+              "pattern": "^ses.*"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Add steer text",
+        "description": "Append a steer/supplement text to the last user message in a session, visible to the AI from the next iteration.",
+        "responses": {
+          "200": {
+            "description": "Steer text added",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "text"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.steer({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/preference": {
+      "get": {
+        "operationId": "session.preference.get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string",
+              "pattern": "^ses.*"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Get session preference",
+        "description": "Retrieve the current preference for a session from in-memory store.",
+        "responses": {
+          "200": {
+            "description": "Session preference",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "sessionID": {
+                          "type": "string",
+                          "pattern": "^ses.*"
+                        },
+                        "agent": {
+                          "type": "string"
+                        },
+                        "model": {
+                          "type": "object",
+                          "properties": {
+                            "providerID": {
+                              "type": "string"
+                            },
+                            "modelID": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "providerID",
+                            "modelID"
+                          ]
+                        },
+                        "variant": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "autoAccept": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "sessionID"
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.preference.get({\n  ...\n})"
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "session.preference.update",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string",
+              "pattern": "^ses.*"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Update session preference",
+        "description": "Patch preference for a session. Stored in memory and broadcast via SSE.",
+        "responses": {
+          "200": {
+            "description": "Preference updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "sessionID": {
+                      "type": "string",
+                      "pattern": "^ses.*"
+                    },
+                    "agent": {
+                      "type": "string"
+                    },
+                    "model": {
+                      "type": "object",
+                      "properties": {
+                        "providerID": {
+                          "type": "string"
+                        },
+                        "modelID": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "providerID",
+                        "modelID"
+                      ]
+                    },
+                    "variant": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "autoAccept": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "sessionID"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "agent": {
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "object",
+                    "properties": {
+                      "providerID": {
+                        "type": "string"
+                      },
+                      "modelID": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "providerID",
+                      "modelID"
+                    ]
+                  },
+                  "variant": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "autoAccept": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.preference.update({\n  ...\n})"
           }
         ]
       }
@@ -4216,13 +7031,19 @@
                 "properties": {
                   "reply": {
                     "type": "string",
-                    "enum": ["once", "always", "reject"]
+                    "enum": [
+                      "once",
+                      "always",
+                      "reject"
+                    ]
                   },
                   "message": {
                     "type": "string"
                   }
                 },
-                "required": ["reply"]
+                "required": [
+                  "reply"
+                ]
               }
             }
           }
@@ -4399,7 +7220,9 @@
                     }
                   }
                 },
-                "required": ["answers"]
+                "required": [
+                  "answers"
+                ]
               }
             }
           }
@@ -4577,10 +7400,15 @@
                                       "properties": {
                                         "field": {
                                           "type": "string",
-                                          "enum": ["reasoning_content", "reasoning_details"]
+                                          "enum": [
+                                            "reasoning_content",
+                                            "reasoning_details"
+                                          ]
                                         }
                                       },
-                                      "required": ["field"],
+                                      "required": [
+                                        "field"
+                                      ],
                                       "additionalProperties": false
                                     }
                                   ]
@@ -4616,10 +7444,16 @@
                                           "type": "number"
                                         }
                                       },
-                                      "required": ["input", "output"]
+                                      "required": [
+                                        "input",
+                                        "output"
+                                      ]
                                     }
                                   },
-                                  "required": ["input", "output"]
+                                  "required": [
+                                    "input",
+                                    "output"
+                                  ]
                                 },
                                 "limit": {
                                   "type": "object",
@@ -4634,7 +7468,10 @@
                                       "type": "number"
                                     }
                                   },
-                                  "required": ["context", "output"]
+                                  "required": [
+                                    "context",
+                                    "output"
+                                  ]
                                 },
                                 "modalities": {
                                   "type": "object",
@@ -4643,25 +7480,44 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string",
-                                        "enum": ["text", "audio", "image", "video", "pdf"]
+                                        "enum": [
+                                          "text",
+                                          "audio",
+                                          "image",
+                                          "video",
+                                          "pdf"
+                                        ]
                                       }
                                     },
                                     "output": {
                                       "type": "array",
                                       "items": {
                                         "type": "string",
-                                        "enum": ["text", "audio", "image", "video", "pdf"]
+                                        "enum": [
+                                          "text",
+                                          "audio",
+                                          "image",
+                                          "video",
+                                          "pdf"
+                                        ]
                                       }
                                     }
                                   },
-                                  "required": ["input", "output"]
+                                  "required": [
+                                    "input",
+                                    "output"
+                                  ]
                                 },
                                 "experimental": {
                                   "type": "boolean"
                                 },
                                 "status": {
                                   "type": "string",
-                                  "enum": ["alpha", "beta", "deprecated"]
+                                  "enum": [
+                                    "alpha",
+                                    "beta",
+                                    "deprecated"
+                                  ]
                                 },
                                 "options": {
                                   "type": "object",
@@ -4718,7 +7574,12 @@
                             }
                           }
                         },
-                        "required": ["name", "env", "id", "models"]
+                        "required": [
+                          "name",
+                          "env",
+                          "id",
+                          "models"
+                        ]
                       }
                     },
                     "default": {
@@ -4737,7 +7598,11 @@
                       }
                     }
                   },
-                  "required": ["all", "default", "connected"]
+                  "required": [
+                    "all",
+                    "default",
+                    "connected"
+                  ]
                 }
               }
             }
@@ -4797,6 +7662,136 @@
           {
             "lang": "js",
             "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.provider.auth({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/provider/{providerID}/connection": {
+      "get": {
+        "operationId": "provider.connection",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "providerID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Provider ID"
+          }
+        ],
+        "summary": "Get provider connection info",
+        "description": "Get resolved API key, base URL, and embedding models for a connected provider.",
+        "responses": {
+          "200": {
+            "description": "Provider connection info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "providerID": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "embeddingProvider": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "const": "openai"
+                        },
+                        {
+                          "type": "string",
+                          "const": "custom"
+                        }
+                      ]
+                    },
+                    "apiKey": {
+                      "type": "string"
+                    },
+                    "baseURL": {
+                      "type": "string"
+                    },
+                    "embeddingModels": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "dimensions": {
+                            "type": "integer",
+                            "minimum": -9007199254740991,
+                            "maximum": 9007199254740991
+                          },
+                          "provider": {
+                            "type": "string"
+                          },
+                          "source": {
+                            "type": "string",
+                            "enum": [
+                              "runtime",
+                              "config",
+                              "remote",
+                              "whitelist"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "source"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "providerID",
+                    "name",
+                    "embeddingProvider",
+                    "apiKey",
+                    "baseURL",
+                    "embeddingModels"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.provider.connection({\n  ...\n})"
           }
         ]
       }
@@ -4874,7 +7869,9 @@
                     }
                   }
                 },
-                "required": ["method"]
+                "required": [
+                  "method"
+                ]
               }
             }
           }
@@ -4954,7 +7951,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["method"]
+                "required": [
+                  "method"
+                ]
               }
             }
           }
@@ -4963,6 +7962,572 @@
           {
             "lang": "js",
             "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.provider.oauth.callback({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/database/legacy/status": {
+      "get": {
+        "operationId": "database.legacy.status",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Scan legacy databases",
+        "description": "Scan current data directory and report whether the latest legacy database should be copied.",
+        "responses": {
+          "200": {
+            "description": "Legacy database scan status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "type": "string"
+                    },
+                    "target": {
+                      "type": "string"
+                    },
+                    "has_legacy": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "dismissed": {
+                      "type": "boolean"
+                    },
+                    "should_merge": {
+                      "type": "boolean"
+                    },
+                    "source_count": {
+                      "type": "number"
+                    },
+                    "legacy_count": {
+                      "type": "number"
+                    },
+                    "files": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "channel": {
+                            "type": "string"
+                          },
+                          "mtime": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "path",
+                          "channel",
+                          "mtime"
+                        ]
+                      }
+                    },
+                    "naming": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "additionalProperties": {
+                        "type": "number"
+                      }
+                    },
+                    "versions": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "additionalProperties": {
+                        "type": "number"
+                      }
+                    }
+                  },
+                  "required": [
+                    "directory",
+                    "target",
+                    "has_legacy",
+                    "message",
+                    "dismissed",
+                    "should_merge",
+                    "source_count",
+                    "legacy_count",
+                    "files",
+                    "naming",
+                    "versions"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.database.legacy.status({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/database/legacy/merge/state": {
+      "get": {
+        "operationId": "database.legacy.merge.state",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Get merge state",
+        "description": "Get legacy database copy state.",
+        "responses": {
+          "200": {
+            "description": "Merge state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "state": {
+                      "type": "string",
+                      "enum": [
+                        "idle",
+                        "running",
+                        "done",
+                        "error"
+                      ]
+                    },
+                    "updated": {
+                      "type": "number"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "state",
+                    "updated"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.database.legacy.merge.state({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/database/legacy/merge/state/reset": {
+      "post": {
+        "operationId": "database.legacy.merge.state.reset",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Reset merge state",
+        "description": "Mark copy completion state as consumed so restart will not re-show the completion toast.",
+        "responses": {
+          "200": {
+            "description": "Reset merge state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "state": {
+                      "type": "string",
+                      "enum": [
+                        "idle",
+                        "running",
+                        "done",
+                        "error"
+                      ]
+                    },
+                    "updated": {
+                      "type": "number"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "state",
+                    "updated"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.database.legacy.merge.state.reset({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/database/legacy/merge": {
+      "post": {
+        "operationId": "database.legacy.merge",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Copy latest legacy database",
+        "description": "Copy the latest legacy database into aether-prod.db when the target database is missing.",
+        "responses": {
+          "200": {
+            "description": "Copy result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "object",
+                      "properties": {
+                        "directory": {
+                          "type": "string"
+                        },
+                        "target": {
+                          "type": "string"
+                        },
+                        "has_legacy": {
+                          "type": "boolean"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "dismissed": {
+                          "type": "boolean"
+                        },
+                        "should_merge": {
+                          "type": "boolean"
+                        },
+                        "source_count": {
+                          "type": "number"
+                        },
+                        "legacy_count": {
+                          "type": "number"
+                        },
+                        "files": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "channel": {
+                                "type": "string"
+                              },
+                              "mtime": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "path",
+                              "channel",
+                              "mtime"
+                            ]
+                          }
+                        },
+                        "naming": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "additionalProperties": {
+                            "type": "number"
+                          }
+                        },
+                        "versions": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "additionalProperties": {
+                            "type": "number"
+                          }
+                        }
+                      },
+                      "required": [
+                        "directory",
+                        "target",
+                        "has_legacy",
+                        "message",
+                        "dismissed",
+                        "should_merge",
+                        "source_count",
+                        "legacy_count",
+                        "files",
+                        "naming",
+                        "versions"
+                      ]
+                    },
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "noop",
+                        "copy"
+                      ]
+                    },
+                    "merge_state": {
+                      "type": "object",
+                      "properties": {
+                        "state": {
+                          "type": "string",
+                          "enum": [
+                            "idle",
+                            "running",
+                            "done",
+                            "error"
+                          ]
+                        },
+                        "updated": {
+                          "type": "number"
+                        },
+                        "error": {
+                          "type": "string"
+                        },
+                        "details": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "state",
+                        "updated"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "mode",
+                    "merge_state"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.database.legacy.merge({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/active-tasks": {
+      "get": {
+        "operationId": "file.activeTasks",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "List active conversion/translation tasks",
+        "description": "Returns all currently running PDF conversion and markdown translation tasks, allowing the frontend to restore progress bars after page reload.",
+        "responses": {
+          "200": {
+            "description": "Active tasks",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "taskID": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "taskType": {
+                        "type": "string",
+                        "enum": [
+                          "convert",
+                          "translate"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "taskID",
+                      "status",
+                      "path",
+                      "taskType"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.activeTasks({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/check-directory": {
+      "get": {
+        "operationId": "file.checkDirectory",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Check directory",
+        "description": "Check whether a path exists and points to a directory.",
+        "responses": {
+          "200": {
+            "description": "Directory check result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "path"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.checkDirectory({\n  ...\n})"
           }
         ]
       }
@@ -5013,7 +8578,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["text"]
+                        "required": [
+                          "text"
+                        ]
                       },
                       "lines": {
                         "type": "object",
@@ -5022,7 +8589,9 @@
                             "type": "string"
                           }
                         },
-                        "required": ["text"]
+                        "required": [
+                          "text"
+                        ]
                       },
                       "line_number": {
                         "type": "number"
@@ -5042,7 +8611,9 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["text"]
+                              "required": [
+                                "text"
+                              ]
                             },
                             "start": {
                               "type": "number"
@@ -5051,11 +8622,21 @@
                               "type": "number"
                             }
                           },
-                          "required": ["match", "start", "end"]
+                          "required": [
+                            "match",
+                            "start",
+                            "end"
+                          ]
                         }
                       }
                     },
-                    "required": ["path", "lines", "line_number", "absolute_offset", "submatches"]
+                    "required": [
+                      "path",
+                      "lines",
+                      "line_number",
+                      "absolute_offset",
+                      "submatches"
+                    ]
                   }
                 }
               }
@@ -5101,7 +8682,10 @@
             "name": "dirs",
             "schema": {
               "type": "string",
-              "enum": ["true", "false"]
+              "enum": [
+                "true",
+                "false"
+              ]
             }
           },
           {
@@ -5109,7 +8693,10 @@
             "name": "type",
             "schema": {
               "type": "string",
-              "enum": ["file", "directory"]
+              "enum": [
+                "file",
+                "directory"
+              ]
             }
           },
           {
@@ -5249,6 +8836,304 @@
             "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.list({\n  ...\n})"
           }
         ]
+      },
+      "post": {
+        "operationId": "file.create",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Create file or directory",
+        "description": "Create a new file or directory at the specified path within the project.",
+        "responses": {
+          "200": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file",
+                      "directory"
+                    ]
+                  }
+                },
+                "required": [
+                  "path",
+                  "type"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.create({\n  ...\n})"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "file.delete",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Delete file or directory",
+        "description": "Delete a file or directory at the specified path within the project.",
+        "responses": {
+          "200": {
+            "description": "Deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.delete({\n  ...\n})"
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "file.rename",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Rename file or directory",
+        "description": "Rename a file or directory within the project.",
+        "responses": {
+          "200": {
+            "description": "Renamed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "path": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "path"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path",
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.rename({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/metadata": {
+      "get": {
+        "operationId": "file.metadata",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Read file metadata",
+        "description": "Read lightweight metadata for a file or directory without loading file contents.",
+        "responses": {
+          "200": {
+            "description": "File metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileMetadata"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.metadata({\n  ...\n})"
+          }
+        ]
       }
     },
     "/file/content": {
@@ -5298,6 +9183,755 @@
             "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.read({\n  ...\n})"
           }
         ]
+      },
+      "put": {
+        "operationId": "file.write",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Write file",
+        "description": "Write content to a specified file within the project.",
+        "responses": {
+          "200": {
+            "description": "Written",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Write conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "const": "conflict"
+                    },
+                    "currentChecksum": {
+                      "type": "string"
+                    },
+                    "currentContent": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "currentChecksum",
+                    "currentContent"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "content": {
+                    "type": "string"
+                  },
+                  "expectedChecksum": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path",
+                  "content"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.write({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/download": {
+      "get": {
+        "operationId": "file.download",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Download file or directory",
+        "description": "Download a file directly or a directory as a zip archive.",
+        "responses": {
+          "200": {
+            "description": "File payload"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.download({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/upload": {
+      "post": {
+        "operationId": "file.upload",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Upload files or directories",
+        "description": "Upload one or more files or directories into the current project.",
+        "responses": {
+          "200": {
+            "description": "Uploaded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "dirs": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "created": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "updated": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "failed": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "error": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "error"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "dirs",
+                    "created",
+                    "updated",
+                    "failed"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.upload({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/ensure-directory": {
+      "post": {
+        "operationId": "file.ensureDirectory",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Ensure directory exists",
+        "description": "Create a directory at the given absolute path if it does not exist, including any intermediate directories.",
+        "responses": {
+          "200": {
+            "description": "Directory ensured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "path": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "path"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.ensureDirectory({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/summarize": {
+      "post": {
+        "operationId": "file.summarize",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Generate directory summaries",
+        "description": "Generate .summary files for all directories in the project using LLM.",
+        "responses": {
+          "200": {
+            "description": "Generated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "count"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "directory": {
+                    "type": "string"
+                  },
+                  "maxDepth": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 5
+                  },
+                  "force": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.summarize({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/open-in-explorer": {
+      "post": {
+        "operationId": "file.openInExplorer",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Open in explorer",
+        "description": "Open a file or directory in the system file explorer (server-side implementation).",
+        "responses": {
+          "200": {
+            "description": "Opened",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.openInExplorer({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/open": {
+      "post": {
+        "operationId": "file.open",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Open file",
+        "description": "Open a file or directory with the system default application.",
+        "responses": {
+          "200": {
+            "description": "Opened",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "app": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.open({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/pick-folder": {
+      "post": {
+        "operationId": "file.pickFolder",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Pick folder",
+        "description": "Open the native OS folder picker dialog and return the selected directory path.",
+        "responses": {
+          "200": {
+            "description": "Selected folder path or null if cancelled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "unavailable": {
+                      "type": "boolean"
+                    },
+                    "reason": {
+                      "type": "string",
+                      "enum": [
+                        "missing_picker"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "path"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.pickFolder({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/gitignore": {
+      "post": {
+        "operationId": "file.addToGitignore",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Add to .gitignore",
+        "description": "Add a file or directory path to the project's .gitignore file, creating it if necessary.",
+        "responses": {
+          "200": {
+            "description": "Result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "created": {
+                      "type": "boolean"
+                    },
+                    "alreadyExists": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "created",
+                    "alreadyExists"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file",
+                      "directory"
+                    ]
+                  }
+                },
+                "required": [
+                  "path",
+                  "type"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.addToGitignore({\n  ...\n})"
+          }
+        ]
       }
     },
     "/file/status": {
@@ -5340,6 +9974,770 @@
           {
             "lang": "js",
             "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.status({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/pdf-page-count": {
+      "get": {
+        "operationId": "file.pdfPageCount",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "outputDir",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Get PDF page count",
+        "description": "Get total page count and expected output paths for a PDF file.",
+        "responses": {
+          "200": {
+            "description": "Page count and output paths",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "pageCount": {
+                      "type": "number"
+                    },
+                    "outputPath": {
+                      "type": "object",
+                      "properties": {
+                        "merged": {
+                          "type": "string"
+                        },
+                        "perPage": {
+                          "type": "string"
+                        },
+                        "images": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "merged",
+                        "perPage",
+                        "images"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "pageCount",
+                    "outputPath"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.pdfPageCount({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/pdf-python-check": {
+      "get": {
+        "operationId": "file.pdfPythonCheck",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Check Python availability",
+        "description": "Check if Python + PyMuPDF + Pillow are available for PDF rendering.",
+        "responses": {
+          "200": {
+            "description": "Python status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "available": {
+                      "type": "boolean"
+                    },
+                    "pythonPath": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "missingDeps": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "available",
+                    "pythonPath",
+                    "missingDeps"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.pdfPythonCheck({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/pdf-to-markdown": {
+      "post": {
+        "operationId": "file.pdfToMarkdown",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Start PDF to Markdown conversion",
+        "description": "Start an async PDF to Markdown conversion task.",
+        "responses": {
+          "200": {
+            "description": "Task started",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "taskID": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "taskID"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "providerID": {
+                    "type": "string"
+                  },
+                  "modelID": {
+                    "type": "string"
+                  },
+                  "startPage": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 9007199254740991
+                  },
+                  "endPage": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 9007199254740991
+                  },
+                  "outputMode": {
+                    "type": "string",
+                    "enum": [
+                      "merged",
+                      "per-page"
+                    ]
+                  },
+                  "conflictAction": {
+                    "type": "string",
+                    "enum": [
+                      "replace",
+                      "rename",
+                      "cancel"
+                    ]
+                  },
+                  "outputDir": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path",
+                  "providerID",
+                  "modelID",
+                  "startPage",
+                  "endPage",
+                  "outputMode",
+                  "conflictAction"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.pdfToMarkdown({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/pdf-to-markdown/progress": {
+      "get": {
+        "operationId": "file.pdfToMarkdownProgress",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "taskID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Get conversion progress",
+        "description": "SSE endpoint for real-time PDF conversion progress.",
+        "responses": {
+          "200": {
+            "description": "Progress event stream",
+            "content": {
+              "text/event-stream": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.pdfToMarkdownProgress({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/pdf-to-markdown/cancel": {
+      "post": {
+        "operationId": "file.pdfToMarkdownCancel",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Cancel PDF conversion",
+        "description": "Cancel a running PDF to Markdown conversion task.",
+        "responses": {
+          "200": {
+            "description": "Cancelled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "taskID": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "taskID"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.pdfToMarkdownCancel({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/raw": {
+      "get": {
+        "operationId": "file.raw",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Serve raw file",
+        "description": "Serve a file's raw bytes with support for range requests.",
+        "responses": {
+          "200": {
+            "description": "File content"
+          },
+          "206": {
+            "description": "Partial file content"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "416": {
+            "description": "Invalid range"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.raw({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/translate-markdown/check": {
+      "get": {
+        "operationId": "file.translateMarkdownCheck",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "outputDir",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Check markdown for translation",
+        "description": "Pre-check a markdown file before translation: detect _data.json, estimate chunks, check conflicts.",
+        "responses": {
+          "200": {
+            "description": "Pre-check result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "hasDataJson": {
+                      "type": "boolean"
+                    },
+                    "chunkCount": {
+                      "type": "number"
+                    },
+                    "outputPath": {
+                      "type": "string"
+                    },
+                    "existingFiles": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "fileSize": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "hasDataJson",
+                    "chunkCount",
+                    "outputPath",
+                    "existingFiles",
+                    "fileSize"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.translateMarkdownCheck({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/translate-markdown": {
+      "post": {
+        "operationId": "file.translateMarkdown",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Start markdown translation",
+        "description": "Start an async markdown translation task.",
+        "responses": {
+          "200": {
+            "description": "Task started",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "taskID": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "taskID"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "providerID": {
+                    "type": "string"
+                  },
+                  "modelID": {
+                    "type": "string"
+                  },
+                  "targetLanguage": {
+                    "default": "zh-CN",
+                    "type": "string"
+                  },
+                  "conflictAction": {
+                    "type": "string",
+                    "enum": [
+                      "replace",
+                      "rename",
+                      "cancel"
+                    ]
+                  },
+                  "outputDir": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path",
+                  "providerID",
+                  "modelID",
+                  "conflictAction"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.translateMarkdown({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/translate-markdown/progress": {
+      "get": {
+        "operationId": "file.translateMarkdownProgress",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "taskID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Get translation progress",
+        "description": "SSE endpoint for real-time markdown translation progress.",
+        "responses": {
+          "200": {
+            "description": "Progress event stream",
+            "content": {
+              "text/event-stream": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.translateMarkdownProgress({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/file/translate-markdown/cancel": {
+      "post": {
+        "operationId": "file.translateMarkdownCancel",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Cancel markdown translation",
+        "description": "Cancel a running markdown translation task.",
+        "responses": {
+          "200": {
+            "description": "Cancelled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "taskID": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "taskID"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.file.translateMarkdownCancel({\n  ...\n})"
           }
         ]
       }
@@ -5499,7 +10897,10 @@
                     ]
                   }
                 },
-                "required": ["name", "config"]
+                "required": [
+                  "name",
+                  "config"
+                ]
               }
             }
           }
@@ -5554,7 +10955,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["authorizationUrl"]
+                  "required": [
+                    "authorizationUrl"
+                  ]
                 }
               }
             }
@@ -5628,7 +11031,9 @@
                       "const": true
                     }
                   },
-                  "required": ["success"]
+                  "required": [
+                    "success"
+                  ]
                 }
               }
             }
@@ -5724,7 +11129,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["code"]
+                "required": [
+                  "code"
+                ]
               }
             }
           }
@@ -5955,7 +11362,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["text"]
+                "required": [
+                  "text"
+                ]
               }
             }
           }
@@ -6267,7 +11676,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["command"]
+                "required": [
+                  "command"
+                ]
               }
             }
           }
@@ -6327,7 +11738,12 @@
                   },
                   "variant": {
                     "type": "string",
-                    "enum": ["info", "success", "warning", "error"]
+                    "enum": [
+                      "info",
+                      "success",
+                      "warning",
+                      "error"
+                    ]
                   },
                   "duration": {
                     "description": "Duration in milliseconds",
@@ -6335,7 +11751,10 @@
                     "type": "number"
                   }
                 },
-                "required": ["message", "variant"]
+                "required": [
+                  "message",
+                  "variant"
+                ]
               }
             }
           }
@@ -6486,7 +11905,9 @@
                     "pattern": "^ses.*"
                   }
                 },
-                "required": ["sessionID"]
+                "required": [
+                  "sessionID"
+                ]
               }
             }
           }
@@ -6533,7 +11954,10 @@
                     },
                     "body": {}
                   },
-                  "required": ["path", "body"]
+                  "required": [
+                    "path",
+                    "body"
+                  ]
                 }
               }
             }
@@ -6591,6 +12015,5383 @@
           {
             "lang": "js",
             "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.tui.control.response({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/knowledge/models": {
+      "get": {
+        "operationId": "knowledge.models.list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "List embedding models",
+        "description": "获取所有可用的嵌入模型列表",
+        "responses": {
+          "200": {
+            "description": "嵌入模型列表",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "provider": {
+                        "type": "string",
+                        "enum": [
+                          "openai",
+                          "local",
+                          "custom"
+                        ]
+                      },
+                      "dimensions": {
+                        "type": "number"
+                      },
+                      "description": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "name",
+                      "provider",
+                      "dimensions"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.knowledge.models.list({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/knowledge": {
+      "post": {
+        "operationId": "knowledge.create",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Create knowledge base",
+        "description": "创建新的知识库",
+        "responses": {
+          "200": {
+            "description": "知识库创建成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "version": {
+                      "type": "number",
+                      "const": 1
+                    },
+                    "config": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "embeddingProvider": {
+                          "type": "string",
+                          "enum": [
+                            "openai",
+                            "local",
+                            "custom"
+                          ]
+                        },
+                        "embeddingModel": {
+                          "type": "string"
+                        },
+                        "embeddingDimensions": {
+                          "type": "number"
+                        },
+                        "apiKey": {
+                          "type": "string"
+                        },
+                        "baseURL": {
+                          "type": "string"
+                        },
+                        "chunkSize": {
+                          "default": 512,
+                          "type": "number"
+                        },
+                        "chunkOverlap": {
+                          "default": 50,
+                          "type": "number"
+                        },
+                        "createdAt": {
+                          "type": "number"
+                        },
+                        "updatedAt": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "path",
+                        "embeddingProvider",
+                        "embeddingModel",
+                        "embeddingDimensions",
+                        "createdAt",
+                        "updatedAt"
+                      ]
+                    },
+                    "documents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "meta": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "filePath": {
+                                "type": "string"
+                              },
+                              "fileName": {
+                                "type": "string"
+                              },
+                              "fileSize": {
+                                "type": "number"
+                              },
+                              "pageCount": {
+                                "type": "number"
+                              },
+                              "status": {
+                                "type": "string",
+                                "enum": [
+                                  "pending",
+                                  "processing",
+                                  "ready",
+                                  "error"
+                                ]
+                              },
+                              "errorMessage": {
+                                "type": "string"
+                              },
+                              "createdAt": {
+                                "type": "number"
+                              },
+                              "updatedAt": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "filePath",
+                              "fileName",
+                              "fileSize",
+                              "status",
+                              "createdAt",
+                              "updatedAt"
+                            ]
+                          },
+                          "chunks": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "documentId": {
+                                  "type": "string"
+                                },
+                                "index": {
+                                  "type": "number"
+                                },
+                                "content": {
+                                  "type": "string"
+                                },
+                                "pageNumber": {
+                                  "type": "number"
+                                },
+                                "embeddingOffset": {
+                                  "type": "number"
+                                },
+                                "embeddingLength": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "documentId",
+                                "index",
+                                "content",
+                                "embeddingOffset",
+                                "embeddingLength"
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "meta",
+                          "chunks"
+                        ]
+                      }
+                    },
+                    "stats": {
+                      "type": "object",
+                      "properties": {
+                        "totalDocuments": {
+                          "type": "number"
+                        },
+                        "totalChunks": {
+                          "type": "number"
+                        },
+                        "lastSyncedAt": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "totalDocuments",
+                        "totalChunks"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "version",
+                    "config",
+                    "documents",
+                    "stats"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "description": "知识库文件夹路径",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "知识库名称",
+                    "type": "string"
+                  },
+                  "embeddingProvider": {
+                    "description": "嵌入模型提供商",
+                    "type": "string",
+                    "enum": [
+                      "openai",
+                      "local",
+                      "custom"
+                    ]
+                  },
+                  "embeddingModel": {
+                    "description": "嵌入模型 ID",
+                    "type": "string"
+                  },
+                  "embeddingDimensions": {
+                    "description": "嵌入向量维度（可选，默认使用模型默认值）",
+                    "type": "number"
+                  },
+                  "apiKey": {
+                    "description": "API 密钥（OpenAI/Custom 需要）",
+                    "type": "string"
+                  },
+                  "baseURL": {
+                    "description": "自定义 API 地址",
+                    "type": "string"
+                  },
+                  "chunkSize": {
+                    "description": "分块大小",
+                    "default": 512,
+                    "type": "number"
+                  },
+                  "chunkOverlap": {
+                    "description": "分块重叠",
+                    "default": 50,
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "path",
+                  "name",
+                  "embeddingProvider",
+                  "embeddingModel"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.knowledge.create({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/knowledge/config": {
+      "post": {
+        "operationId": "knowledge.config.set",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Set knowledge config",
+        "description": "设置全局知识库配置，供 knowledge_search 工具使用",
+        "responses": {
+          "200": {
+            "description": "配置成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "apiKey": {
+                    "type": "string"
+                  },
+                  "baseURL": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.knowledge.config.set({\n  ...\n})"
+          }
+        ]
+      },
+      "get": {
+        "operationId": "knowledge.config.get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Get knowledge config",
+        "description": "获取全局知识库配置",
+        "responses": {
+          "200": {
+            "description": "当前配置",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "apiKey": {
+                      "type": "string"
+                    },
+                    "baseURL": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.knowledge.config.get({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/knowledge/{path}/stats": {
+      "get": {
+        "operationId": "knowledge.stats",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "path",
+            "required": true
+          }
+        ],
+        "summary": "Get knowledge base stats",
+        "description": "获取知识库统计信息",
+        "responses": {
+          "200": {
+            "description": "统计信息",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "totalDocuments": {
+                      "type": "number"
+                    },
+                    "totalChunks": {
+                      "type": "number"
+                    },
+                    "pdfFileCount": {
+                      "type": "number"
+                    },
+                    "lastSyncedAt": {
+                      "type": "number"
+                    },
+                    "embeddingModel": {
+                      "type": "string"
+                    },
+                    "embeddingProvider": {
+                      "type": "string"
+                    },
+                    "chunkSize": {
+                      "type": "number"
+                    },
+                    "chunkOverlap": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "totalDocuments",
+                    "totalChunks",
+                    "pdfFileCount",
+                    "embeddingModel",
+                    "embeddingProvider",
+                    "chunkSize",
+                    "chunkOverlap"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "知识库不存在"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.knowledge.stats({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/knowledge/{path}": {
+      "get": {
+        "operationId": "knowledge.get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "path",
+            "required": true
+          }
+        ],
+        "summary": "Get knowledge base",
+        "description": "获取知识库详细信息",
+        "responses": {
+          "200": {
+            "description": "知识库信息",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "version": {
+                      "type": "number",
+                      "const": 1
+                    },
+                    "config": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "embeddingProvider": {
+                          "type": "string",
+                          "enum": [
+                            "openai",
+                            "local",
+                            "custom"
+                          ]
+                        },
+                        "embeddingModel": {
+                          "type": "string"
+                        },
+                        "embeddingDimensions": {
+                          "type": "number"
+                        },
+                        "apiKey": {
+                          "type": "string"
+                        },
+                        "baseURL": {
+                          "type": "string"
+                        },
+                        "chunkSize": {
+                          "default": 512,
+                          "type": "number"
+                        },
+                        "chunkOverlap": {
+                          "default": 50,
+                          "type": "number"
+                        },
+                        "createdAt": {
+                          "type": "number"
+                        },
+                        "updatedAt": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "path",
+                        "embeddingProvider",
+                        "embeddingModel",
+                        "embeddingDimensions",
+                        "createdAt",
+                        "updatedAt"
+                      ]
+                    },
+                    "documents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "meta": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "filePath": {
+                                "type": "string"
+                              },
+                              "fileName": {
+                                "type": "string"
+                              },
+                              "fileSize": {
+                                "type": "number"
+                              },
+                              "pageCount": {
+                                "type": "number"
+                              },
+                              "status": {
+                                "type": "string",
+                                "enum": [
+                                  "pending",
+                                  "processing",
+                                  "ready",
+                                  "error"
+                                ]
+                              },
+                              "errorMessage": {
+                                "type": "string"
+                              },
+                              "createdAt": {
+                                "type": "number"
+                              },
+                              "updatedAt": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "filePath",
+                              "fileName",
+                              "fileSize",
+                              "status",
+                              "createdAt",
+                              "updatedAt"
+                            ]
+                          },
+                          "chunks": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "documentId": {
+                                  "type": "string"
+                                },
+                                "index": {
+                                  "type": "number"
+                                },
+                                "content": {
+                                  "type": "string"
+                                },
+                                "pageNumber": {
+                                  "type": "number"
+                                },
+                                "embeddingOffset": {
+                                  "type": "number"
+                                },
+                                "embeddingLength": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "documentId",
+                                "index",
+                                "content",
+                                "embeddingOffset",
+                                "embeddingLength"
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "meta",
+                          "chunks"
+                        ]
+                      }
+                    },
+                    "stats": {
+                      "type": "object",
+                      "properties": {
+                        "totalDocuments": {
+                          "type": "number"
+                        },
+                        "totalChunks": {
+                          "type": "number"
+                        },
+                        "lastSyncedAt": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "totalDocuments",
+                        "totalChunks"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "version",
+                    "config",
+                    "documents",
+                    "stats"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "知识库不存在"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.knowledge.get({\n  ...\n})"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "knowledge.delete",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "path",
+            "required": true
+          }
+        ],
+        "summary": "Delete knowledge base",
+        "description": "删除知识库（仅删除索引，不删除原文件）",
+        "responses": {
+          "200": {
+            "description": "删除成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "知识库不存在"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.knowledge.delete({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/knowledge/{path}/config": {
+      "patch": {
+        "operationId": "knowledge.config.update",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "path",
+            "required": true
+          }
+        ],
+        "summary": "Update knowledge base config",
+        "description": "更新知识库嵌入模型配置，模型变更时会清空索引并等待重新同步",
+        "responses": {
+          "200": {
+            "description": "更新后的知识库",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "version": {
+                      "type": "number",
+                      "const": 1
+                    },
+                    "config": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "embeddingProvider": {
+                          "type": "string",
+                          "enum": [
+                            "openai",
+                            "local",
+                            "custom"
+                          ]
+                        },
+                        "embeddingModel": {
+                          "type": "string"
+                        },
+                        "embeddingDimensions": {
+                          "type": "number"
+                        },
+                        "apiKey": {
+                          "type": "string"
+                        },
+                        "baseURL": {
+                          "type": "string"
+                        },
+                        "chunkSize": {
+                          "default": 512,
+                          "type": "number"
+                        },
+                        "chunkOverlap": {
+                          "default": 50,
+                          "type": "number"
+                        },
+                        "createdAt": {
+                          "type": "number"
+                        },
+                        "updatedAt": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "path",
+                        "embeddingProvider",
+                        "embeddingModel",
+                        "embeddingDimensions",
+                        "createdAt",
+                        "updatedAt"
+                      ]
+                    },
+                    "documents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "meta": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "filePath": {
+                                "type": "string"
+                              },
+                              "fileName": {
+                                "type": "string"
+                              },
+                              "fileSize": {
+                                "type": "number"
+                              },
+                              "pageCount": {
+                                "type": "number"
+                              },
+                              "status": {
+                                "type": "string",
+                                "enum": [
+                                  "pending",
+                                  "processing",
+                                  "ready",
+                                  "error"
+                                ]
+                              },
+                              "errorMessage": {
+                                "type": "string"
+                              },
+                              "createdAt": {
+                                "type": "number"
+                              },
+                              "updatedAt": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "filePath",
+                              "fileName",
+                              "fileSize",
+                              "status",
+                              "createdAt",
+                              "updatedAt"
+                            ]
+                          },
+                          "chunks": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "documentId": {
+                                  "type": "string"
+                                },
+                                "index": {
+                                  "type": "number"
+                                },
+                                "content": {
+                                  "type": "string"
+                                },
+                                "pageNumber": {
+                                  "type": "number"
+                                },
+                                "embeddingOffset": {
+                                  "type": "number"
+                                },
+                                "embeddingLength": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "documentId",
+                                "index",
+                                "content",
+                                "embeddingOffset",
+                                "embeddingLength"
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "meta",
+                          "chunks"
+                        ]
+                      }
+                    },
+                    "stats": {
+                      "type": "object",
+                      "properties": {
+                        "totalDocuments": {
+                          "type": "number"
+                        },
+                        "totalChunks": {
+                          "type": "number"
+                        },
+                        "lastSyncedAt": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "totalDocuments",
+                        "totalChunks"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "version",
+                    "config",
+                    "documents",
+                    "stats"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "知识库不存在"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "embeddingProvider": {
+                    "type": "string",
+                    "enum": [
+                      "openai",
+                      "local",
+                      "custom"
+                    ]
+                  },
+                  "embeddingModel": {
+                    "type": "string"
+                  },
+                  "embeddingDimensions": {
+                    "type": "number"
+                  },
+                  "apiKey": {
+                    "type": "string"
+                  },
+                  "baseURL": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.knowledge.config.update({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/knowledge/{path}/import": {
+      "post": {
+        "operationId": "knowledge.import",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "path",
+            "required": true
+          }
+        ],
+        "summary": "Import files into knowledge base",
+        "description": "复制文件到知识库目录（不自动同步）",
+        "responses": {
+          "200": {
+            "description": "导入结果",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "added": {
+                      "type": "number"
+                    },
+                    "skipped": {
+                      "type": "number"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "added",
+                    "skipped",
+                    "errors"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "知识库不存在"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "paths": {
+                    "minItems": 1,
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "paths"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.knowledge.import({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/knowledge/{path}/sync": {
+      "post": {
+        "operationId": "knowledge.sync",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "path",
+            "required": true
+          }
+        ],
+        "summary": "Sync knowledge base",
+        "description": "同步知识库文件夹，处理新增的可支持文档，以 SSE 流式返回进度",
+        "responses": {
+          "200": {
+            "description": "SSE 进度流，最终事件为 complete 或 error",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "event": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "event",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "知识库不存在"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "apiKey": {
+                    "type": "string"
+                  },
+                  "baseURL": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.knowledge.sync({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/knowledge/{path}/search": {
+      "post": {
+        "operationId": "knowledge.search",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "path",
+            "required": true
+          }
+        ],
+        "summary": "Search knowledge base",
+        "description": "在知识库中搜索相关内容",
+        "responses": {
+          "200": {
+            "description": "搜索结果",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "chunk": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "documentId": {
+                            "type": "string"
+                          },
+                          "index": {
+                            "type": "number"
+                          },
+                          "content": {
+                            "type": "string"
+                          },
+                          "pageNumber": {
+                            "type": "number"
+                          },
+                          "embeddingOffset": {
+                            "type": "number"
+                          },
+                          "embeddingLength": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "documentId",
+                          "index",
+                          "content",
+                          "embeddingOffset",
+                          "embeddingLength"
+                        ]
+                      },
+                      "document": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "filePath": {
+                            "type": "string"
+                          },
+                          "fileName": {
+                            "type": "string"
+                          },
+                          "fileSize": {
+                            "type": "number"
+                          },
+                          "pageCount": {
+                            "type": "number"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "pending",
+                              "processing",
+                              "ready",
+                              "error"
+                            ]
+                          },
+                          "errorMessage": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "number"
+                          },
+                          "updatedAt": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "filePath",
+                          "fileName",
+                          "fileSize",
+                          "status",
+                          "createdAt",
+                          "updatedAt"
+                        ]
+                      },
+                      "score": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "chunk",
+                      "document",
+                      "score"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "知识库不存在"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "description": "搜索查询",
+                    "type": "string"
+                  },
+                  "topK": {
+                    "description": "返回结果数量",
+                    "default": 5,
+                    "type": "number"
+                  },
+                  "apiKey": {
+                    "type": "string"
+                  },
+                  "baseURL": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "query"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.knowledge.search({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/knowledge/{path}/document/{documentId}": {
+      "delete": {
+        "operationId": "knowledge.document.delete",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "path",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "documentId",
+            "required": true
+          }
+        ],
+        "summary": "Delete document",
+        "description": "从知识库中删除指定文档",
+        "responses": {
+          "200": {
+            "description": "删除成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "version": {
+                      "type": "number",
+                      "const": 1
+                    },
+                    "config": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "embeddingProvider": {
+                          "type": "string",
+                          "enum": [
+                            "openai",
+                            "local",
+                            "custom"
+                          ]
+                        },
+                        "embeddingModel": {
+                          "type": "string"
+                        },
+                        "embeddingDimensions": {
+                          "type": "number"
+                        },
+                        "apiKey": {
+                          "type": "string"
+                        },
+                        "baseURL": {
+                          "type": "string"
+                        },
+                        "chunkSize": {
+                          "default": 512,
+                          "type": "number"
+                        },
+                        "chunkOverlap": {
+                          "default": 50,
+                          "type": "number"
+                        },
+                        "createdAt": {
+                          "type": "number"
+                        },
+                        "updatedAt": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "path",
+                        "embeddingProvider",
+                        "embeddingModel",
+                        "embeddingDimensions",
+                        "createdAt",
+                        "updatedAt"
+                      ]
+                    },
+                    "documents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "meta": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "filePath": {
+                                "type": "string"
+                              },
+                              "fileName": {
+                                "type": "string"
+                              },
+                              "fileSize": {
+                                "type": "number"
+                              },
+                              "pageCount": {
+                                "type": "number"
+                              },
+                              "status": {
+                                "type": "string",
+                                "enum": [
+                                  "pending",
+                                  "processing",
+                                  "ready",
+                                  "error"
+                                ]
+                              },
+                              "errorMessage": {
+                                "type": "string"
+                              },
+                              "createdAt": {
+                                "type": "number"
+                              },
+                              "updatedAt": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "filePath",
+                              "fileName",
+                              "fileSize",
+                              "status",
+                              "createdAt",
+                              "updatedAt"
+                            ]
+                          },
+                          "chunks": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "documentId": {
+                                  "type": "string"
+                                },
+                                "index": {
+                                  "type": "number"
+                                },
+                                "content": {
+                                  "type": "string"
+                                },
+                                "pageNumber": {
+                                  "type": "number"
+                                },
+                                "embeddingOffset": {
+                                  "type": "number"
+                                },
+                                "embeddingLength": {
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "documentId",
+                                "index",
+                                "content",
+                                "embeddingOffset",
+                                "embeddingLength"
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "meta",
+                          "chunks"
+                        ]
+                      }
+                    },
+                    "stats": {
+                      "type": "object",
+                      "properties": {
+                        "totalDocuments": {
+                          "type": "number"
+                        },
+                        "totalChunks": {
+                          "type": "number"
+                        },
+                        "lastSyncedAt": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "totalDocuments",
+                        "totalChunks"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "version",
+                    "config",
+                    "documents",
+                    "stats"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "知识库或文档不存在"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.knowledge.document.delete({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/cron/jobs": {
+      "get": {
+        "operationId": "cron.jobs.list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "List cron jobs",
+        "responses": {
+          "200": {
+            "description": "Cron jobs with current state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "definition": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "mode": {
+                            "type": "string",
+                            "enum": [
+                              "direct",
+                              "isolated_agent",
+                              "session_agent",
+                              "agent_message"
+                            ]
+                          },
+                          "project_id": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "session_id": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "schedule_type": {
+                            "type": "string",
+                            "enum": [
+                              "cron",
+                              "interval",
+                              "once"
+                            ]
+                          },
+                          "schedule_value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "integer",
+                                "minimum": -9007199254740991,
+                                "maximum": 9007199254740991
+                              }
+                            ]
+                          },
+                          "timezone": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "payload": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            },
+                            "additionalProperties": {}
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "enabled",
+                          "mode",
+                          "schedule_type",
+                          "schedule_value",
+                          "payload"
+                        ],
+                        "additionalProperties": {}
+                      },
+                      "state": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "job_id": {
+                                "type": "string"
+                              },
+                              "enabled": {
+                                "type": "boolean"
+                              },
+                              "next_run_at": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer",
+                                    "minimum": -9007199254740991,
+                                    "maximum": 9007199254740991
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "last_run_at": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer",
+                                    "minimum": -9007199254740991,
+                                    "maximum": 9007199254740991
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "last_status": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "success",
+                                      "failed",
+                                      "skipped",
+                                      "expired"
+                                    ]
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "running": {
+                                "type": "boolean"
+                              },
+                              "start_at": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer",
+                                    "minimum": -9007199254740991,
+                                    "maximum": 9007199254740991
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "updated_at": {
+                                "type": "integer",
+                                "minimum": -9007199254740991,
+                                "maximum": 9007199254740991
+                              }
+                            },
+                            "required": [
+                              "job_id",
+                              "enabled",
+                              "next_run_at",
+                              "last_run_at",
+                              "last_status",
+                              "running",
+                              "start_at",
+                              "updated_at"
+                            ]
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "definition",
+                      "state"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.cron.jobs.list({\n  ...\n})"
+          }
+        ]
+      },
+      "post": {
+        "operationId": "cron.jobs.create",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Create cron job",
+        "responses": {
+          "200": {
+            "description": "Created cron job",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "definition": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "mode": {
+                          "type": "string",
+                          "enum": [
+                            "direct",
+                            "isolated_agent",
+                            "session_agent",
+                            "agent_message"
+                          ]
+                        },
+                        "project_id": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "session_id": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "schedule_type": {
+                          "type": "string",
+                          "enum": [
+                            "cron",
+                            "interval",
+                            "once"
+                          ]
+                        },
+                        "schedule_value": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          ]
+                        },
+                        "timezone": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "payload": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "additionalProperties": {}
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "enabled",
+                        "mode",
+                        "schedule_type",
+                        "schedule_value",
+                        "payload"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    "state": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "job_id": {
+                              "type": "string"
+                            },
+                            "enabled": {
+                              "type": "boolean"
+                            },
+                            "next_run_at": {
+                              "anyOf": [
+                                {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "last_run_at": {
+                              "anyOf": [
+                                {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "last_status": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "success",
+                                    "failed",
+                                    "skipped",
+                                    "expired"
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "running": {
+                              "type": "boolean"
+                            },
+                            "start_at": {
+                              "anyOf": [
+                                {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "updated_at": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "required": [
+                            "job_id",
+                            "enabled",
+                            "next_run_at",
+                            "last_run_at",
+                            "last_status",
+                            "running",
+                            "start_at",
+                            "updated_at"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "definition",
+                    "state"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {}
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.cron.jobs.create({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/cron/jobs/{id}": {
+      "get": {
+        "operationId": "cron.jobs.get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Get cron job",
+        "responses": {
+          "200": {
+            "description": "Cron job with current state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "definition": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "mode": {
+                          "type": "string",
+                          "enum": [
+                            "direct",
+                            "isolated_agent",
+                            "session_agent",
+                            "agent_message"
+                          ]
+                        },
+                        "project_id": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "session_id": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "schedule_type": {
+                          "type": "string",
+                          "enum": [
+                            "cron",
+                            "interval",
+                            "once"
+                          ]
+                        },
+                        "schedule_value": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          ]
+                        },
+                        "timezone": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "payload": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "additionalProperties": {}
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "enabled",
+                        "mode",
+                        "schedule_type",
+                        "schedule_value",
+                        "payload"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    "state": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "job_id": {
+                              "type": "string"
+                            },
+                            "enabled": {
+                              "type": "boolean"
+                            },
+                            "next_run_at": {
+                              "anyOf": [
+                                {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "last_run_at": {
+                              "anyOf": [
+                                {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "last_status": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "success",
+                                    "failed",
+                                    "skipped",
+                                    "expired"
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "running": {
+                              "type": "boolean"
+                            },
+                            "start_at": {
+                              "anyOf": [
+                                {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "updated_at": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "required": [
+                            "job_id",
+                            "enabled",
+                            "next_run_at",
+                            "last_run_at",
+                            "last_status",
+                            "running",
+                            "start_at",
+                            "updated_at"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "definition",
+                    "state"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.cron.jobs.get({\n  ...\n})"
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "cron.jobs.update",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Update cron job",
+        "responses": {
+          "200": {
+            "description": "Updated cron job",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "definition": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "mode": {
+                          "type": "string",
+                          "enum": [
+                            "direct",
+                            "isolated_agent",
+                            "session_agent",
+                            "agent_message"
+                          ]
+                        },
+                        "project_id": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "session_id": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "schedule_type": {
+                          "type": "string",
+                          "enum": [
+                            "cron",
+                            "interval",
+                            "once"
+                          ]
+                        },
+                        "schedule_value": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          ]
+                        },
+                        "timezone": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "payload": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "additionalProperties": {}
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "enabled",
+                        "mode",
+                        "schedule_type",
+                        "schedule_value",
+                        "payload"
+                      ],
+                      "additionalProperties": {}
+                    },
+                    "state": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "job_id": {
+                              "type": "string"
+                            },
+                            "enabled": {
+                              "type": "boolean"
+                            },
+                            "next_run_at": {
+                              "anyOf": [
+                                {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "last_run_at": {
+                              "anyOf": [
+                                {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "last_status": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "success",
+                                    "failed",
+                                    "skipped",
+                                    "expired"
+                                  ]
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "running": {
+                              "type": "boolean"
+                            },
+                            "start_at": {
+                              "anyOf": [
+                                {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "updated_at": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "required": [
+                            "job_id",
+                            "enabled",
+                            "next_run_at",
+                            "last_run_at",
+                            "last_status",
+                            "running",
+                            "start_at",
+                            "updated_at"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "definition",
+                    "state"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {}
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.cron.jobs.update({\n  ...\n})"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "cron.jobs.delete",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Delete cron job",
+        "responses": {
+          "200": {
+            "description": "Deleted cron job definition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "const": true
+                    },
+                    "job_id": {
+                      "type": "string"
+                    },
+                    "definition": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "mode": {
+                          "type": "string",
+                          "enum": [
+                            "direct",
+                            "isolated_agent",
+                            "session_agent",
+                            "agent_message"
+                          ]
+                        },
+                        "project_id": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "session_id": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "schedule_type": {
+                          "type": "string",
+                          "enum": [
+                            "cron",
+                            "interval",
+                            "once"
+                          ]
+                        },
+                        "schedule_value": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          ]
+                        },
+                        "timezone": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "payload": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "additionalProperties": {}
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "enabled",
+                        "mode",
+                        "schedule_type",
+                        "schedule_value",
+                        "payload"
+                      ],
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "job_id",
+                    "definition"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.cron.jobs.delete({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/cron/jobs/{id}/run": {
+      "post": {
+        "operationId": "cron.jobs.run",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Run cron job now",
+        "responses": {
+          "200": {
+            "description": "Cron run result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "run_id": {
+                      "type": "string"
+                    },
+                    "job_id": {
+                      "type": "string"
+                    },
+                    "started_at": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "finished_at": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success",
+                        "failed",
+                        "skipped"
+                      ]
+                    },
+                    "output_summary": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "direct",
+                        "isolated_agent",
+                        "session_agent",
+                        "agent_message"
+                      ]
+                    },
+                    "project_id": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "session_id": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "created_session_id": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "payload_snapshot": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "additionalProperties": {}
+                    },
+                    "trigger_reason": {
+                      "type": "string",
+                      "enum": [
+                        "scheduled",
+                        "manual"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "run_id",
+                    "job_id",
+                    "started_at",
+                    "finished_at",
+                    "status",
+                    "output_summary",
+                    "mode",
+                    "project_id",
+                    "session_id",
+                    "created_session_id",
+                    "payload_snapshot",
+                    "trigger_reason"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.cron.jobs.run({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/cron/jobs/{id}/runs": {
+      "get": {
+        "operationId": "cron.jobs.runs",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "count",
+            "schema": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            }
+          }
+        ],
+        "summary": "List recent cron runs for a job",
+        "responses": {
+          "200": {
+            "description": "Recent cron runs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "run_id": {
+                        "type": "string"
+                      },
+                      "job_id": {
+                        "type": "string"
+                      },
+                      "started_at": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "finished_at": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991
+                      },
+                      "status": {
+                        "type": "string",
+                        "enum": [
+                          "success",
+                          "failed",
+                          "skipped"
+                        ]
+                      },
+                      "output_summary": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "mode": {
+                        "type": "string",
+                        "enum": [
+                          "direct",
+                          "isolated_agent",
+                          "session_agent",
+                          "agent_message"
+                        ]
+                      },
+                      "project_id": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "session_id": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "created_session_id": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "payload_snapshot": {
+                        "type": "object",
+                        "propertyNames": {
+                          "type": "string"
+                        },
+                        "additionalProperties": {}
+                      },
+                      "trigger_reason": {
+                        "type": "string",
+                        "enum": [
+                          "scheduled",
+                          "manual"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "run_id",
+                      "job_id",
+                      "started_at",
+                      "finished_at",
+                      "status",
+                      "output_summary",
+                      "mode",
+                      "project_id",
+                      "session_id",
+                      "created_session_id",
+                      "payload_snapshot",
+                      "trigger_reason"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.cron.jobs.runs({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/cron/runs/{run_id}": {
+      "get": {
+        "operationId": "cron.runs.get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "run_id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Get cron run",
+        "responses": {
+          "200": {
+            "description": "Single cron run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "run_id": {
+                          "type": "string"
+                        },
+                        "job_id": {
+                          "type": "string"
+                        },
+                        "started_at": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "finished_at": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "success",
+                            "failed",
+                            "skipped"
+                          ]
+                        },
+                        "output_summary": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "mode": {
+                          "type": "string",
+                          "enum": [
+                            "direct",
+                            "isolated_agent",
+                            "session_agent",
+                            "agent_message"
+                          ]
+                        },
+                        "project_id": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "session_id": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "created_session_id": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "payload_snapshot": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "additionalProperties": {}
+                        },
+                        "trigger_reason": {
+                          "type": "string",
+                          "enum": [
+                            "scheduled",
+                            "manual"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "run_id",
+                        "job_id",
+                        "started_at",
+                        "finished_at",
+                        "status",
+                        "output_summary",
+                        "mode",
+                        "project_id",
+                        "session_id",
+                        "created_session_id",
+                        "payload_snapshot",
+                        "trigger_reason"
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.cron.runs.get({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/wechat/start": {
+      "post": {
+        "operationId": "wechat.start",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Start wechat bridge",
+        "description": "Start the wechat bridge service",
+        "responses": {
+          "200": {
+            "description": "Bridge started",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name"
+                      ]
+                    },
+                    "clientId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.wechat.start({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/wechat/retry": {
+      "post": {
+        "operationId": "wechat.retry",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Retry WeChat connection",
+        "description": "Retry WeChat connection from error state",
+        "responses": {
+          "200": {
+            "description": "Retry initiated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.wechat.retry({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/wechat/stop": {
+      "post": {
+        "operationId": "wechat.stop",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Stop wechat bridge",
+        "description": "Stop the wechat bridge service",
+        "responses": {
+          "200": {
+            "description": "Bridge stopped",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.wechat.stop({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/wechat/status": {
+      "get": {
+        "operationId": "wechat.status",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Get wechat status",
+        "description": "Get the current wechat bridge status",
+        "responses": {
+          "200": {
+            "description": "Status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "idle",
+                        "starting",
+                        "qrcode",
+                        "connected",
+                        "reconnecting",
+                        "error"
+                      ]
+                    },
+                    "qrcode": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "user": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "name"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "locked": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "lockHolder": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "error": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string"
+                            },
+                            "message": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "code",
+                            "message"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "qrcode",
+                    "user",
+                    "locked",
+                    "lockHolder",
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.wechat.status({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/wechat/events": {
+      "get": {
+        "operationId": "wechat.events",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Subscribe to wechat events",
+        "description": "Get real-time wechat events via SSE",
+        "responses": {
+          "200": {
+            "description": "Event stream",
+            "content": {
+              "text/event-stream": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.wechat.events({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/wechat/session": {
+      "delete": {
+        "operationId": "wechat.session.clear",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Clear wechat session",
+        "description": "Clear the saved wechat configuration and session data",
+        "responses": {
+          "200": {
+            "description": "Session cleared",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.wechat.session.clear({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/wechat/ping": {
+      "post": {
+        "operationId": "wechat.ping",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Ping WeChat lease",
+        "description": "Renew the WeChat lock lease or detect if stolen by another client",
+        "responses": {
+          "200": {
+            "description": "Ping result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "stolen": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "stolen"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.wechat.ping({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/feishu/start": {
+      "post": {
+        "operationId": "feishu.start",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Start feishu bridge",
+        "description": "Start the feishu bridge service",
+        "responses": {
+          "200": {
+            "description": "Bridge started",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "appId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.feishu.start({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/feishu/retry": {
+      "post": {
+        "operationId": "wechat.retry",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Retry WeChat connection",
+        "description": "Retry WeChat connection from error state",
+        "responses": {
+          "200": {
+            "description": "Retry initiated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.wechat.retry({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/feishu/stop": {
+      "post": {
+        "operationId": "feishu.stop",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Stop feishu bridge",
+        "description": "Stop the feishu bridge service",
+        "responses": {
+          "200": {
+            "description": "Bridge stopped",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.feishu.stop({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/feishu/status": {
+      "get": {
+        "operationId": "feishu.status",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Get feishu status",
+        "description": "Get the current feishu bridge status",
+        "responses": {
+          "200": {
+            "description": "Status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "idle",
+                        "starting",
+                        "qrcode",
+                        "connected",
+                        "reconnecting",
+                        "error"
+                      ]
+                    },
+                    "appId": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "hasConfig": {
+                      "type": "boolean"
+                    },
+                    "error": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string"
+                            },
+                            "message": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "code",
+                            "message"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "appId",
+                    "hasConfig",
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.feishu.status({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/feishu/events": {
+      "get": {
+        "operationId": "feishu.events",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Subscribe to feishu events",
+        "description": "Get real-time feishu events via SSE",
+        "responses": {
+          "200": {
+            "description": "Event stream",
+            "content": {
+              "text/event-stream": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.feishu.events({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/feishu/session": {
+      "delete": {
+        "operationId": "feishu.session.clear",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Clear feishu session",
+        "description": "Clear the saved feishu configuration and session data",
+        "responses": {
+          "200": {
+            "description": "Session cleared",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.feishu.session.clear({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/feishu/ping": {
+      "post": {
+        "operationId": "wechat.ping",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Ping WeChat lease",
+        "description": "Renew the WeChat lock lease or detect if stolen by another client",
+        "responses": {
+          "200": {
+            "description": "Ping result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "stolen": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "stolen"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.wechat.ping({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/qq/start": {
+      "post": {
+        "operationId": "qq.start",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Start qq bridge",
+        "description": "Start the qq bridge service",
+        "responses": {
+          "200": {
+            "description": "Bridge started",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "appId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.qq.start({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/qq/retry": {
+      "post": {
+        "operationId": "wechat.retry",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Retry WeChat connection",
+        "description": "Retry WeChat connection from error state",
+        "responses": {
+          "200": {
+            "description": "Retry initiated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.wechat.retry({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/qq/stop": {
+      "post": {
+        "operationId": "qq.stop",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Stop qq bridge",
+        "description": "Stop the qq bridge service",
+        "responses": {
+          "200": {
+            "description": "Bridge stopped",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.qq.stop({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/qq/status": {
+      "get": {
+        "operationId": "qq.status",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Get qq status",
+        "description": "Get the current qq bridge status",
+        "responses": {
+          "200": {
+            "description": "Status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "idle",
+                        "starting",
+                        "qrcode",
+                        "connected",
+                        "reconnecting",
+                        "error"
+                      ]
+                    },
+                    "appId": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "hasConfig": {
+                      "type": "boolean"
+                    },
+                    "error": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string"
+                            },
+                            "message": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "code",
+                            "message"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "appId",
+                    "hasConfig",
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.qq.status({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/qq/events": {
+      "get": {
+        "operationId": "qq.events",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Subscribe to qq events",
+        "description": "Get real-time qq events via SSE",
+        "responses": {
+          "200": {
+            "description": "Event stream",
+            "content": {
+              "text/event-stream": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.qq.events({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/qq/session": {
+      "delete": {
+        "operationId": "qq.session.clear",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Clear qq session",
+        "description": "Clear the saved qq configuration and session data",
+        "responses": {
+          "200": {
+            "description": "Session cleared",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.qq.session.clear({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mobile/qq/ping": {
+      "post": {
+        "operationId": "wechat.ping",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Ping WeChat lease",
+        "description": "Renew the WeChat lock lease or detect if stolen by another client",
+        "responses": {
+          "200": {
+            "description": "Ping result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "stolen": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "stolen"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.wechat.ping({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/reading-mode/session": {
+      "post": {
+        "operationId": "reading-mode.session.create",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Create reading mode session",
+        "responses": {
+          "200": {
+            "description": "Created session info with readingMode meta",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Session"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.reading-mode.session.create({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/reading-mode/session/from-file": {
+      "post": {
+        "operationId": "reading-mode.session.from-file",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Open reading mode from a workspace PDF file",
+        "responses": {
+          "200": {
+            "description": "Existing or newly created reading mode session",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "action": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "const": "existing"
+                        },
+                        {
+                          "type": "string",
+                          "const": "created"
+                        }
+                      ]
+                    },
+                    "session": {
+                      "$ref": "#/components/schemas/Session"
+                    }
+                  },
+                  "required": [
+                    "action",
+                    "session"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "settings": {
+                    "type": "object",
+                    "properties": {
+                      "translatePrompt": {
+                        "type": "string"
+                      },
+                      "questionPrompt": {
+                        "type": "string"
+                      },
+                      "firstReadPrompt": {
+                        "type": "string"
+                      },
+                      "contextPageRange": {
+                        "anyOf": [
+                          {
+                            "type": "number",
+                            "const": 0
+                          },
+                          {
+                            "type": "number",
+                            "const": 1
+                          },
+                          {
+                            "type": "number",
+                            "const": 2
+                          }
+                        ]
+                      },
+                      "autoFirstRead": {
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "forceNew": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "path"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.reading-mode.session.from-file({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/reading-mode/page-text": {
+      "post": {
+        "operationId": "reading-mode.page-text",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Get extracted text for reading mode PDF pages",
+        "responses": {
+          "200": {
+            "description": "Extracted page text",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "pageCount": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "pages": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "pageNumber": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0,
+                            "maximum": 9007199254740991
+                          },
+                          "text": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "pageNumber",
+                          "text"
+                        ]
+                      }
+                    },
+                    "combinedText": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "pageCount",
+                    "pages",
+                    "combinedText"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sessionID": {
+                    "type": "string",
+                    "pattern": "^ses.*"
+                  },
+                  "startPage": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "endPage": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "required": [
+                  "sessionID",
+                  "startPage",
+                  "endPage"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.reading-mode.page-text({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/reading-mode/page-pdf": {
+      "post": {
+        "operationId": "reading-mode.page-pdf",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Get a ranged PDF subdocument for reading mode",
+        "responses": {
+          "200": {
+            "description": "PDF binary for the requested page range"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sessionID": {
+                    "type": "string",
+                    "pattern": "^ses.*"
+                  },
+                  "startPage": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "endPage": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "required": [
+                  "sessionID",
+                  "startPage",
+                  "endPage"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.reading-mode.page-pdf({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/reading-mode/page-pdf-from-file": {
+      "post": {
+        "operationId": "reading-mode.page-pdf-from-file",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Get a ranged PDF subdocument for a workspace file",
+        "responses": {
+          "200": {
+            "description": "PDF binary for the requested page range"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "startPage": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "endPage": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "required": [
+                  "path",
+                  "startPage",
+                  "endPage"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.reading-mode.page-pdf-from-file({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/reading-mode/annotations": {
+      "get": {
+        "operationId": "reading-mode.annotations.get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sessionID",
+            "schema": {
+              "type": "string",
+              "pattern": "^ses.*"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Get reading mode annotations",
+        "responses": {
+          "200": {
+            "description": "Annotation file content",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.reading-mode.annotations.get({\n  ...\n})"
+          }
+        ]
+      },
+      "put": {
+        "operationId": "reading-mode.annotations.update",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Update reading mode annotations",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sessionID": {
+                    "type": "string",
+                    "pattern": "^ses.*"
+                  },
+                  "data": {}
+                },
+                "required": [
+                  "sessionID",
+                  "data"
+                ]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.reading-mode.annotations.update({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/reading-mode/pdf": {
+      "get": {
+        "operationId": "reading-mode.pdf.get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sessionID",
+            "schema": {
+              "type": "string",
+              "pattern": "^ses.*"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Get stored PDF file",
+        "responses": {
+          "200": {
+            "description": "PDF binary"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.reading-mode.pdf.get({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/reading-mode/session/{sessionID}": {
+      "patch": {
+        "operationId": "reading-mode.session.update",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string",
+              "pattern": "^ses.*"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Update reading mode session settings",
+        "responses": {
+          "200": {
+            "description": "Updated session",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Session"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "settings": {
+                    "type": "object",
+                    "properties": {
+                      "translatePrompt": {
+                        "type": "string"
+                      },
+                      "questionPrompt": {
+                        "type": "string"
+                      },
+                      "firstReadPrompt": {
+                        "type": "string"
+                      },
+                      "contextPageRange": {
+                        "anyOf": [
+                          {
+                            "type": "number",
+                            "const": 0
+                          },
+                          {
+                            "type": "number",
+                            "const": 1
+                          },
+                          {
+                            "type": "number",
+                            "const": 2
+                          }
+                        ]
+                      },
+                      "autoFirstRead": {
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "firstReadCompleted": {
+                    "type": "boolean"
+                  },
+                  "firstReadDismissed": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.reading-mode.session.update({\n  ...\n})"
           }
         ]
       }
@@ -6741,7 +17542,10 @@
             "name": "mode",
             "schema": {
               "type": "string",
-              "enum": ["git", "branch"]
+              "enum": [
+                "git",
+                "branch"
+              ]
             },
             "required": true
           }
@@ -6767,6 +17571,54 @@
           {
             "lang": "js",
             "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.vcs.diff({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/vcs/graph": {
+      "get": {
+        "operationId": "vcs.graph",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "max",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "summary": "Get VCS graph data",
+        "description": "Retrieve git log and refs data for rendering the git graph visualization.",
+        "responses": {
+          "200": {
+            "description": "VCS graph data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VcsGraphResult"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.vcs.graph({\n  ...\n})"
           }
         ]
       }
@@ -6871,7 +17723,12 @@
                   "level": {
                     "description": "Log level",
                     "type": "string",
-                    "enum": ["debug", "info", "error", "warn"]
+                    "enum": [
+                      "debug",
+                      "info",
+                      "error",
+                      "warn"
+                    ]
                   },
                   "message": {
                     "description": "Log message",
@@ -6886,7 +17743,11 @@
                     "additionalProperties": {}
                   }
                 },
-                "required": ["service", "level", "message"]
+                "required": [
+                  "service",
+                  "level",
+                  "message"
+                ]
               }
             }
           }
@@ -6985,9 +17846,49 @@
                       },
                       "content": {
                         "type": "string"
+                      },
+                      "conditions": {
+                        "type": "object",
+                        "properties": {
+                          "requires_tools": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "requires_toolsets": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "fallback_for_tools": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "fallback_for_toolsets": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "platforms": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
                       }
                     },
-                    "required": ["name", "description", "location", "content"]
+                    "required": [
+                      "name",
+                      "description",
+                      "location",
+                      "content"
+                    ]
                   }
                 }
               }
@@ -7093,6 +17994,31 @@
   },
   "components": {
     "schemas": {
+      "BadRequestError": {
+        "type": "object",
+        "properties": {
+          "data": {},
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {}
+            }
+          },
+          "success": {
+            "type": "boolean",
+            "const": false
+          }
+        },
+        "required": [
+          "data",
+          "errors",
+          "success"
+        ]
+      },
       "Event.installation.updated": {
         "type": "object",
         "properties": {
@@ -7107,10 +18033,15 @@
                 "type": "string"
               }
             },
-            "required": ["version"]
+            "required": [
+              "version"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.installation.update-available": {
         "type": "object",
@@ -7126,10 +18057,15 @@
                 "type": "string"
               }
             },
-            "required": ["version"]
+            "required": [
+              "version"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Project": {
         "type": "object",
@@ -7183,7 +18119,10 @@
                 "type": "number"
               }
             },
-            "required": ["created", "updated"]
+            "required": [
+              "created",
+              "updated"
+            ]
           },
           "sandboxes": {
             "type": "array",
@@ -7192,7 +18131,12 @@
             }
           }
         },
-        "required": ["id", "worktree", "time", "sandboxes"]
+        "required": [
+          "id",
+          "worktree",
+          "time",
+          "sandboxes"
+        ]
       },
       "Event.project.updated": {
         "type": "object",
@@ -7205,7 +18149,27 @@
             "$ref": "#/components/schemas/Project"
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.project.recent.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "project.recent.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.server.instance.disposed": {
         "type": "object",
@@ -7221,10 +18185,15 @@
                 "type": "string"
               }
             },
-            "required": ["directory"]
+            "required": [
+              "directory"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.server.connected": {
         "type": "object",
@@ -7238,7 +18207,10 @@
             "properties": {}
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.global.disposed": {
         "type": "object",
@@ -7252,7 +18224,10 @@
             "properties": {}
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.lsp.client.diagnostics": {
         "type": "object",
@@ -7271,10 +18246,16 @@
                 "type": "string"
               }
             },
-            "required": ["serverID", "path"]
+            "required": [
+              "serverID",
+              "path"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.lsp.updated": {
         "type": "object",
@@ -7288,7 +18269,10 @@
             "properties": {}
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.message.part.delta": {
         "type": "object",
@@ -7319,10 +18303,19 @@
                 "type": "string"
               }
             },
-            "required": ["sessionID", "messageID", "partID", "field", "delta"]
+            "required": [
+              "sessionID",
+              "messageID",
+              "partID",
+              "field",
+              "delta"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "PermissionRequest": {
         "type": "object",
@@ -7368,10 +18361,20 @@
                 "type": "string"
               }
             },
-            "required": ["messageID", "callID"]
+            "required": [
+              "messageID",
+              "callID"
+            ]
           }
         },
-        "required": ["id", "sessionID", "permission", "patterns", "metadata", "always"]
+        "required": [
+          "id",
+          "sessionID",
+          "permission",
+          "patterns",
+          "metadata",
+          "always"
+        ]
       },
       "Event.permission.asked": {
         "type": "object",
@@ -7384,7 +18387,10 @@
             "$ref": "#/components/schemas/PermissionRequest"
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.permission.replied": {
         "type": "object",
@@ -7406,13 +18412,24 @@
               },
               "reply": {
                 "type": "string",
-                "enum": ["once", "always", "reject"]
+                "enum": [
+                  "once",
+                  "always",
+                  "reject"
+                ]
               }
             },
-            "required": ["sessionID", "requestID", "reply"]
+            "required": [
+              "sessionID",
+              "requestID",
+              "reply"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "SessionStatus": {
         "anyOf": [
@@ -7424,7 +18441,9 @@
                 "const": "idle"
               }
             },
-            "required": ["type"]
+            "required": [
+              "type"
+            ]
           },
           {
             "type": "object",
@@ -7443,7 +18462,12 @@
                 "type": "number"
               }
             },
-            "required": ["type", "attempt", "message", "next"]
+            "required": [
+              "type",
+              "attempt",
+              "message",
+              "next"
+            ]
           },
           {
             "type": "object",
@@ -7453,7 +18477,9 @@
                 "const": "busy"
               }
             },
-            "required": ["type"]
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -7475,10 +18501,16 @@
                 "$ref": "#/components/schemas/SessionStatus"
               }
             },
-            "required": ["sessionID", "status"]
+            "required": [
+              "sessionID",
+              "status"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.session.idle": {
         "type": "object",
@@ -7495,10 +18527,47 @@
                 "pattern": "^ses.*"
               }
             },
-            "required": ["sessionID"]
+            "required": [
+              "sessionID"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.skill.saved": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "skill.saved"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses.*"
+              },
+              "actions": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "sessionID",
+              "actions"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "QuestionOption": {
         "type": "object",
@@ -7512,7 +18581,10 @@
             "type": "string"
           }
         },
-        "required": ["label", "description"]
+        "required": [
+          "label",
+          "description"
+        ]
       },
       "QuestionInfo": {
         "type": "object",
@@ -7541,7 +18613,11 @@
             "type": "boolean"
           }
         },
-        "required": ["question", "header", "options"]
+        "required": [
+          "question",
+          "header",
+          "options"
+        ]
       },
       "QuestionRequest": {
         "type": "object",
@@ -7572,10 +18648,17 @@
                 "type": "string"
               }
             },
-            "required": ["messageID", "callID"]
+            "required": [
+              "messageID",
+              "callID"
+            ]
           }
         },
-        "required": ["id", "sessionID", "questions"]
+        "required": [
+          "id",
+          "sessionID",
+          "questions"
+        ]
       },
       "Event.question.asked": {
         "type": "object",
@@ -7588,7 +18671,10 @@
             "$ref": "#/components/schemas/QuestionRequest"
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "QuestionAnswer": {
         "type": "array",
@@ -7621,10 +18707,17 @@
                 }
               }
             },
-            "required": ["sessionID", "requestID", "answers"]
+            "required": [
+              "sessionID",
+              "requestID",
+              "answers"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.question.rejected": {
         "type": "object",
@@ -7645,10 +18738,16 @@
                 "pattern": "^que.*"
               }
             },
-            "required": ["sessionID", "requestID"]
+            "required": [
+              "sessionID",
+              "requestID"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.session.compacted": {
         "type": "object",
@@ -7665,29 +18764,15 @@
                 "pattern": "^ses.*"
               }
             },
-            "required": ["sessionID"]
+            "required": [
+              "sessionID"
+            ]
           }
         },
-        "required": ["type", "properties"]
-      },
-      "Event.file.edited": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "file.edited"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "file": {
-                "type": "string"
-              }
-            },
-            "required": ["file"]
-          }
-        },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.file.watcher.updated": {
         "type": "object",
@@ -7719,10 +18804,73 @@
                 ]
               }
             },
-            "required": ["file", "event"]
+            "required": [
+              "file",
+              "event"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.file.watcher.limited": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "file.watcher.limited"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "dir": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "limit",
+                  "timeout",
+                  "error"
+                ]
+              }
+            },
+            "required": [
+              "dir",
+              "reason"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.file.edited": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "file.edited"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "file": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "file"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Todo": {
         "type": "object",
@@ -7740,7 +18888,11 @@
             "type": "string"
           }
         },
-        "required": ["content", "status", "priority"]
+        "required": [
+          "content",
+          "status",
+          "priority"
+        ]
       },
       "Event.todo.updated": {
         "type": "object",
@@ -7763,10 +18915,16 @@
                 }
               }
             },
-            "required": ["sessionID", "todos"]
+            "required": [
+              "sessionID",
+              "todos"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.tui.prompt.append": {
         "type": "object",
@@ -7782,10 +18940,15 @@
                 "type": "string"
               }
             },
-            "required": ["text"]
+            "required": [
+              "text"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.tui.command.execute": {
         "type": "object",
@@ -7826,10 +18989,15 @@
                 ]
               }
             },
-            "required": ["command"]
+            "required": [
+              "command"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.tui.toast.show": {
         "type": "object",
@@ -7849,7 +19017,12 @@
               },
               "variant": {
                 "type": "string",
-                "enum": ["info", "success", "warning", "error"]
+                "enum": [
+                  "info",
+                  "success",
+                  "warning",
+                  "error"
+                ]
               },
               "duration": {
                 "description": "Duration in milliseconds",
@@ -7857,10 +19030,16 @@
                 "type": "number"
               }
             },
-            "required": ["message", "variant"]
+            "required": [
+              "message",
+              "variant"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.tui.session.select": {
         "type": "object",
@@ -7878,10 +19057,15 @@
                 "pattern": "^ses.*"
               }
             },
-            "required": ["sessionID"]
+            "required": [
+              "sessionID"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.mcp.tools.changed": {
         "type": "object",
@@ -7897,10 +19081,15 @@
                 "type": "string"
               }
             },
-            "required": ["server"]
+            "required": [
+              "server"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.mcp.browser.open.failed": {
         "type": "object",
@@ -7919,10 +19108,16 @@
                 "type": "string"
               }
             },
-            "required": ["mcpName", "url"]
+            "required": [
+              "mcpName",
+              "url"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.command.executed": {
         "type": "object",
@@ -7949,10 +19144,87 @@
                 "pattern": "^msg.*"
               }
             },
-            "required": ["name", "sessionID", "arguments", "messageID"]
+            "required": [
+              "name",
+              "sessionID",
+              "arguments",
+              "messageID"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.session.preference.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "session.preference.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses.*"
+              },
+              "preference": {
+                "type": "object",
+                "properties": {
+                  "sessionID": {
+                    "type": "string",
+                    "pattern": "^ses.*"
+                  },
+                  "agent": {
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "object",
+                    "properties": {
+                      "providerID": {
+                        "type": "string"
+                      },
+                      "modelID": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "providerID",
+                      "modelID"
+                    ]
+                  },
+                  "variant": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "autoAccept": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "sessionID"
+                ]
+              }
+            },
+            "required": [
+              "sessionID",
+              "preference"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "FileDiff": {
         "type": "object",
@@ -7974,10 +19246,20 @@
           },
           "status": {
             "type": "string",
-            "enum": ["added", "deleted", "modified"]
+            "enum": [
+              "added",
+              "deleted",
+              "modified"
+            ]
           }
         },
-        "required": ["file", "before", "after", "additions", "deletions"]
+        "required": [
+          "file",
+          "before",
+          "after",
+          "additions",
+          "deletions"
+        ]
       },
       "Event.session.diff": {
         "type": "object",
@@ -8000,10 +19282,16 @@
                 }
               }
             },
-            "required": ["sessionID", "diff"]
+            "required": [
+              "sessionID",
+              "diff"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "ProviderAuthError": {
         "type": "object",
@@ -8022,10 +19310,16 @@
                 "type": "string"
               }
             },
-            "required": ["providerID", "message"]
+            "required": [
+              "providerID",
+              "message"
+            ]
           }
         },
-        "required": ["name", "data"]
+        "required": [
+          "name",
+          "data"
+        ]
       },
       "UnknownError": {
         "type": "object",
@@ -8041,10 +19335,15 @@
                 "type": "string"
               }
             },
-            "required": ["message"]
+            "required": [
+              "message"
+            ]
           }
         },
-        "required": ["name", "data"]
+        "required": [
+          "name",
+          "data"
+        ]
       },
       "MessageOutputLengthError": {
         "type": "object",
@@ -8058,7 +19357,10 @@
             "properties": {}
           }
         },
-        "required": ["name", "data"]
+        "required": [
+          "name",
+          "data"
+        ]
       },
       "MessageAbortedError": {
         "type": "object",
@@ -8074,10 +19376,15 @@
                 "type": "string"
               }
             },
-            "required": ["message"]
+            "required": [
+              "message"
+            ]
           }
         },
-        "required": ["name", "data"]
+        "required": [
+          "name",
+          "data"
+        ]
       },
       "StructuredOutputError": {
         "type": "object",
@@ -8096,10 +19403,16 @@
                 "type": "number"
               }
             },
-            "required": ["message", "retries"]
+            "required": [
+              "message",
+              "retries"
+            ]
           }
         },
-        "required": ["name", "data"]
+        "required": [
+          "name",
+          "data"
+        ]
       },
       "ContextOverflowError": {
         "type": "object",
@@ -8118,10 +19431,15 @@
                 "type": "string"
               }
             },
-            "required": ["message"]
+            "required": [
+              "message"
+            ]
           }
         },
-        "required": ["name", "data"]
+        "required": [
+          "name",
+          "data"
+        ]
       },
       "APIError": {
         "type": "object",
@@ -8164,10 +19482,16 @@
                 }
               }
             },
-            "required": ["message", "isRetryable"]
+            "required": [
+              "message",
+              "isRetryable"
+            ]
           }
         },
-        "required": ["name", "data"]
+        "required": [
+          "name",
+          "data"
+        ]
       },
       "Event.session.error": {
         "type": "object",
@@ -8211,7 +19535,10 @@
             }
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.vcs.branch.updated": {
         "type": "object",
@@ -8229,7 +19556,10 @@
             }
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.workspace.ready": {
         "type": "object",
@@ -8245,10 +19575,15 @@
                 "type": "string"
               }
             },
-            "required": ["name"]
+            "required": [
+              "name"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.workspace.failed": {
         "type": "object",
@@ -8264,10 +19599,15 @@
                 "type": "string"
               }
             },
-            "required": ["message"]
+            "required": [
+              "message"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Pty": {
         "type": "object",
@@ -8293,13 +19633,24 @@
           },
           "status": {
             "type": "string",
-            "enum": ["running", "exited"]
+            "enum": [
+              "running",
+              "exited"
+            ]
           },
           "pid": {
             "type": "number"
           }
         },
-        "required": ["id", "title", "command", "args", "cwd", "status", "pid"]
+        "required": [
+          "id",
+          "title",
+          "command",
+          "args",
+          "cwd",
+          "status",
+          "pid"
+        ]
       },
       "Event.pty.created": {
         "type": "object",
@@ -8315,10 +19666,15 @@
                 "$ref": "#/components/schemas/Pty"
               }
             },
-            "required": ["info"]
+            "required": [
+              "info"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.pty.updated": {
         "type": "object",
@@ -8334,10 +19690,15 @@
                 "$ref": "#/components/schemas/Pty"
               }
             },
-            "required": ["info"]
+            "required": [
+              "info"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.pty.exited": {
         "type": "object",
@@ -8357,10 +19718,16 @@
                 "type": "number"
               }
             },
-            "required": ["id", "exitCode"]
+            "required": [
+              "id",
+              "exitCode"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.pty.deleted": {
         "type": "object",
@@ -8377,10 +19744,15 @@
                 "pattern": "^pty.*"
               }
             },
-            "required": ["id"]
+            "required": [
+              "id"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.worktree.ready": {
         "type": "object",
@@ -8399,10 +19771,16 @@
                 "type": "string"
               }
             },
-            "required": ["name", "branch"]
+            "required": [
+              "name",
+              "branch"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.worktree.failed": {
         "type": "object",
@@ -8418,10 +19796,15 @@
                 "type": "string"
               }
             },
-            "required": ["message"]
+            "required": [
+              "message"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "OutputFormatText": {
         "type": "object",
@@ -8431,7 +19814,9 @@
             "const": "text"
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "JSONSchema": {
         "type": "object",
@@ -8457,7 +19842,10 @@
             "maximum": 9007199254740991
           }
         },
-        "required": ["type", "schema"]
+        "required": [
+          "type",
+          "schema"
+        ]
       },
       "OutputFormat": {
         "anyOf": [
@@ -8491,7 +19879,9 @@
                 "type": "number"
               }
             },
-            "required": ["created"]
+            "required": [
+              "created"
+            ]
           },
           "format": {
             "$ref": "#/components/schemas/OutputFormat"
@@ -8512,7 +19902,9 @@
                 }
               }
             },
-            "required": ["diffs"]
+            "required": [
+              "diffs"
+            ]
           },
           "agent": {
             "type": "string"
@@ -8527,7 +19919,10 @@
                 "type": "string"
               }
             },
-            "required": ["providerID", "modelID"]
+            "required": [
+              "providerID",
+              "modelID"
+            ]
           },
           "system": {
             "type": "string"
@@ -8545,7 +19940,14 @@
             "type": "string"
           }
         },
-        "required": ["id", "sessionID", "role", "time", "agent", "model"]
+        "required": [
+          "id",
+          "sessionID",
+          "role",
+          "time",
+          "agent",
+          "model"
+        ]
       },
       "AssistantMessage": {
         "type": "object",
@@ -8572,7 +19974,9 @@
                 "type": "number"
               }
             },
-            "required": ["created"]
+            "required": [
+              "created"
+            ]
           },
           "error": {
             "anyOf": [
@@ -8625,7 +20029,10 @@
                 "type": "string"
               }
             },
-            "required": ["cwd", "root"]
+            "required": [
+              "cwd",
+              "root"
+            ]
           },
           "summary": {
             "type": "boolean"
@@ -8658,10 +20065,18 @@
                     "type": "number"
                   }
                 },
-                "required": ["read", "write"]
+                "required": [
+                  "read",
+                  "write"
+                ]
               }
             },
-            "required": ["input", "output", "reasoning", "cache"]
+            "required": [
+              "input",
+              "output",
+              "reasoning",
+              "cache"
+            ]
           },
           "structured": {},
           "variant": {
@@ -8714,10 +20129,16 @@
                 "$ref": "#/components/schemas/Message"
               }
             },
-            "required": ["sessionID", "info"]
+            "required": [
+              "sessionID",
+              "info"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.message.removed": {
         "type": "object",
@@ -8738,10 +20159,16 @@
                 "pattern": "^msg.*"
               }
             },
-            "required": ["sessionID", "messageID"]
+            "required": [
+              "sessionID",
+              "messageID"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "TextPart": {
         "type": "object",
@@ -8781,7 +20208,9 @@
                 "type": "number"
               }
             },
-            "required": ["start"]
+            "required": [
+              "start"
+            ]
           },
           "metadata": {
             "type": "object",
@@ -8791,7 +20220,13 @@
             "additionalProperties": {}
           }
         },
-        "required": ["id", "sessionID", "messageID", "type", "text"]
+        "required": [
+          "id",
+          "sessionID",
+          "messageID",
+          "type",
+          "text"
+        ]
       },
       "SubtaskPart": {
         "type": "object",
@@ -8831,13 +20266,24 @@
                 "type": "string"
               }
             },
-            "required": ["providerID", "modelID"]
+            "required": [
+              "providerID",
+              "modelID"
+            ]
           },
           "command": {
             "type": "string"
           }
         },
-        "required": ["id", "sessionID", "messageID", "type", "prompt", "description", "agent"]
+        "required": [
+          "id",
+          "sessionID",
+          "messageID",
+          "type",
+          "prompt",
+          "description",
+          "agent"
+        ]
       },
       "ReasoningPart": {
         "type": "object",
@@ -8878,10 +20324,19 @@
                 "type": "number"
               }
             },
-            "required": ["start"]
+            "required": [
+              "start"
+            ]
           }
         },
-        "required": ["id", "sessionID", "messageID", "type", "text", "time"]
+        "required": [
+          "id",
+          "sessionID",
+          "messageID",
+          "type",
+          "text",
+          "time"
+        ]
       },
       "FilePartSourceText": {
         "type": "object",
@@ -8900,7 +20355,11 @@
             "maximum": 9007199254740991
           }
         },
-        "required": ["value", "start", "end"]
+        "required": [
+          "value",
+          "start",
+          "end"
+        ]
       },
       "FileSource": {
         "type": "object",
@@ -8916,7 +20375,11 @@
             "type": "string"
           }
         },
-        "required": ["text", "type", "path"]
+        "required": [
+          "text",
+          "type",
+          "path"
+        ]
       },
       "Range": {
         "type": "object",
@@ -8931,7 +20394,10 @@
                 "type": "number"
               }
             },
-            "required": ["line", "character"]
+            "required": [
+              "line",
+              "character"
+            ]
           },
           "end": {
             "type": "object",
@@ -8943,10 +20409,16 @@
                 "type": "number"
               }
             },
-            "required": ["line", "character"]
+            "required": [
+              "line",
+              "character"
+            ]
           }
         },
-        "required": ["start", "end"]
+        "required": [
+          "start",
+          "end"
+        ]
       },
       "SymbolSource": {
         "type": "object",
@@ -8973,7 +20445,14 @@
             "maximum": 9007199254740991
           }
         },
-        "required": ["text", "type", "path", "range", "name", "kind"]
+        "required": [
+          "text",
+          "type",
+          "path",
+          "range",
+          "name",
+          "kind"
+        ]
       },
       "ResourceSource": {
         "type": "object",
@@ -8992,7 +20471,12 @@
             "type": "string"
           }
         },
-        "required": ["text", "type", "clientName", "uri"]
+        "required": [
+          "text",
+          "type",
+          "clientName",
+          "uri"
+        ]
       },
       "FilePartSource": {
         "anyOf": [
@@ -9039,7 +20523,14 @@
             "$ref": "#/components/schemas/FilePartSource"
           }
         },
-        "required": ["id", "sessionID", "messageID", "type", "mime", "url"]
+        "required": [
+          "id",
+          "sessionID",
+          "messageID",
+          "type",
+          "mime",
+          "url"
+        ]
       },
       "ToolStatePending": {
         "type": "object",
@@ -9059,7 +20550,11 @@
             "type": "string"
           }
         },
-        "required": ["status", "input", "raw"]
+        "required": [
+          "status",
+          "input",
+          "raw"
+        ]
       },
       "ToolStateRunning": {
         "type": "object",
@@ -9092,10 +20587,16 @@
                 "type": "number"
               }
             },
-            "required": ["start"]
+            "required": [
+              "start"
+            ]
           }
         },
-        "required": ["status", "input", "time"]
+        "required": [
+          "status",
+          "input",
+          "time"
+        ]
       },
       "ToolStateCompleted": {
         "type": "object",
@@ -9137,7 +20638,10 @@
                 "type": "number"
               }
             },
-            "required": ["start", "end"]
+            "required": [
+              "start",
+              "end"
+            ]
           },
           "attachments": {
             "type": "array",
@@ -9146,7 +20650,14 @@
             }
           }
         },
-        "required": ["status", "input", "output", "title", "metadata", "time"]
+        "required": [
+          "status",
+          "input",
+          "output",
+          "title",
+          "metadata",
+          "time"
+        ]
       },
       "ToolStateError": {
         "type": "object",
@@ -9182,10 +20693,18 @@
                 "type": "number"
               }
             },
-            "required": ["start", "end"]
+            "required": [
+              "start",
+              "end"
+            ]
           }
         },
-        "required": ["status", "input", "error", "time"]
+        "required": [
+          "status",
+          "input",
+          "error",
+          "time"
+        ]
       },
       "ToolState": {
         "anyOf": [
@@ -9239,7 +20758,15 @@
             "additionalProperties": {}
           }
         },
-        "required": ["id", "sessionID", "messageID", "type", "callID", "tool", "state"]
+        "required": [
+          "id",
+          "sessionID",
+          "messageID",
+          "type",
+          "callID",
+          "tool",
+          "state"
+        ]
       },
       "StepStartPart": {
         "type": "object",
@@ -9264,7 +20791,12 @@
             "type": "string"
           }
         },
-        "required": ["id", "sessionID", "messageID", "type"]
+        "required": [
+          "id",
+          "sessionID",
+          "messageID",
+          "type"
+        ]
       },
       "StepFinishPart": {
         "type": "object",
@@ -9319,13 +20851,29 @@
                     "type": "number"
                   }
                 },
-                "required": ["read", "write"]
+                "required": [
+                  "read",
+                  "write"
+                ]
               }
             },
-            "required": ["input", "output", "reasoning", "cache"]
+            "required": [
+              "input",
+              "output",
+              "reasoning",
+              "cache"
+            ]
           }
         },
-        "required": ["id", "sessionID", "messageID", "type", "reason", "cost", "tokens"]
+        "required": [
+          "id",
+          "sessionID",
+          "messageID",
+          "type",
+          "reason",
+          "cost",
+          "tokens"
+        ]
       },
       "SnapshotPart": {
         "type": "object",
@@ -9350,7 +20898,13 @@
             "type": "string"
           }
         },
-        "required": ["id", "sessionID", "messageID", "type", "snapshot"]
+        "required": [
+          "id",
+          "sessionID",
+          "messageID",
+          "type",
+          "snapshot"
+        ]
       },
       "PatchPart": {
         "type": "object",
@@ -9381,7 +20935,14 @@
             }
           }
         },
-        "required": ["id", "sessionID", "messageID", "type", "hash", "files"]
+        "required": [
+          "id",
+          "sessionID",
+          "messageID",
+          "type",
+          "hash",
+          "files"
+        ]
       },
       "AgentPart": {
         "type": "object",
@@ -9422,10 +20983,20 @@
                 "maximum": 9007199254740991
               }
             },
-            "required": ["value", "start", "end"]
+            "required": [
+              "value",
+              "start",
+              "end"
+            ]
           }
         },
-        "required": ["id", "sessionID", "messageID", "type", "name"]
+        "required": [
+          "id",
+          "sessionID",
+          "messageID",
+          "type",
+          "name"
+        ]
       },
       "RetryPart": {
         "type": "object",
@@ -9459,10 +21030,20 @@
                 "type": "number"
               }
             },
-            "required": ["created"]
+            "required": [
+              "created"
+            ]
           }
         },
-        "required": ["id", "sessionID", "messageID", "type", "attempt", "error", "time"]
+        "required": [
+          "id",
+          "sessionID",
+          "messageID",
+          "type",
+          "attempt",
+          "error",
+          "time"
+        ]
       },
       "CompactionPart": {
         "type": "object",
@@ -9490,7 +21071,13 @@
             "type": "boolean"
           }
         },
-        "required": ["id", "sessionID", "messageID", "type", "auto"]
+        "required": [
+          "id",
+          "sessionID",
+          "messageID",
+          "type",
+          "auto"
+        ]
       },
       "Part": {
         "anyOf": [
@@ -9553,10 +21140,17 @@
                 "type": "number"
               }
             },
-            "required": ["sessionID", "part", "time"]
+            "required": [
+              "sessionID",
+              "part",
+              "time"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.message.part.removed": {
         "type": "object",
@@ -9581,14 +21175,25 @@
                 "pattern": "^prt.*"
               }
             },
-            "required": ["sessionID", "messageID", "partID"]
+            "required": [
+              "sessionID",
+              "messageID",
+              "partID"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "PermissionAction": {
         "type": "string",
-        "enum": ["allow", "deny", "ask"]
+        "enum": [
+          "allow",
+          "deny",
+          "ask"
+        ]
       },
       "PermissionRule": {
         "type": "object",
@@ -9603,7 +21208,11 @@
             "$ref": "#/components/schemas/PermissionAction"
           }
         },
-        "required": ["permission", "pattern", "action"]
+        "required": [
+          "permission",
+          "pattern",
+          "action"
+        ]
       },
       "PermissionRuleset": {
         "type": "array",
@@ -9635,6 +21244,23 @@
             "type": "string",
             "pattern": "^ses.*"
           },
+          "treeID": {
+            "type": "string",
+            "pattern": "^tre.*"
+          },
+          "forkIndex": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "forkParentSessionID": {
+            "type": "string",
+            "pattern": "^ses.*"
+          },
+          "forkAfterUserMessageID": {
+            "type": "string",
+            "pattern": "^msg.*"
+          },
           "summary": {
             "type": "object",
             "properties": {
@@ -9654,7 +21280,11 @@
                 }
               }
             },
-            "required": ["additions", "deletions", "files"]
+            "required": [
+              "additions",
+              "deletions",
+              "files"
+            ]
           },
           "share": {
             "type": "object",
@@ -9663,7 +21293,9 @@
                 "type": "string"
               }
             },
-            "required": ["url"]
+            "required": [
+              "url"
+            ]
           },
           "title": {
             "type": "string"
@@ -9687,7 +21319,10 @@
                 "type": "number"
               }
             },
-            "required": ["created", "updated"]
+            "required": [
+              "created",
+              "updated"
+            ]
           },
           "permission": {
             "$ref": "#/components/schemas/PermissionRuleset"
@@ -9710,10 +21345,116 @@
                 "type": "string"
               }
             },
-            "required": ["messageID"]
+            "required": [
+              "messageID"
+            ]
+          },
+          "readingMode": {
+            "type": "object",
+            "properties": {
+              "pdfFileName": {
+                "type": "string"
+              },
+              "pdfStorePath": {
+                "type": "string"
+              },
+              "lastReadPage": {
+                "type": "number"
+              },
+              "annotationsPath": {
+                "type": "string"
+              },
+              "source": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "const": "workspace-file"
+                      },
+                      {
+                        "type": "string",
+                        "const": "upload"
+                      }
+                    ]
+                  },
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind"
+                ]
+              },
+              "settings": {
+                "type": "object",
+                "properties": {
+                  "translatePrompt": {
+                    "type": "string"
+                  },
+                  "questionPrompt": {
+                    "type": "string"
+                  },
+                  "firstReadPrompt": {
+                    "type": "string"
+                  },
+                  "contextPageRange": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "const": 0
+                      },
+                      {
+                        "type": "number",
+                        "const": 1
+                      },
+                      {
+                        "type": "number",
+                        "const": 2
+                      }
+                    ]
+                  },
+                  "autoFirstRead": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "translatePrompt",
+                  "questionPrompt",
+                  "firstReadPrompt",
+                  "contextPageRange",
+                  "autoFirstRead"
+                ]
+              },
+              "firstReadCompleted": {
+                "type": "boolean"
+              },
+              "firstReadDismissed": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "pdfFileName",
+              "pdfStorePath",
+              "lastReadPage",
+              "annotationsPath",
+              "source",
+              "settings",
+              "firstReadCompleted",
+              "firstReadDismissed"
+            ]
           }
         },
-        "required": ["id", "slug", "projectID", "directory", "title", "version", "time"]
+        "required": [
+          "id",
+          "slug",
+          "projectID",
+          "directory",
+          "title",
+          "version",
+          "time"
+        ]
       },
       "Event.session.created": {
         "type": "object",
@@ -9733,10 +21474,16 @@
                 "$ref": "#/components/schemas/Session"
               }
             },
-            "required": ["sessionID", "info"]
+            "required": [
+              "sessionID",
+              "info"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.session.updated": {
         "type": "object",
@@ -9756,10 +21503,16 @@
                 "$ref": "#/components/schemas/Session"
               }
             },
-            "required": ["sessionID", "info"]
+            "required": [
+              "sessionID",
+              "info"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event.session.deleted": {
         "type": "object",
@@ -9779,10 +21532,16 @@
                 "$ref": "#/components/schemas/Session"
               }
             },
-            "required": ["sessionID", "info"]
+            "required": [
+              "sessionID",
+              "info"
+            ]
           }
         },
-        "required": ["type", "properties"]
+        "required": [
+          "type",
+          "properties"
+        ]
       },
       "Event": {
         "anyOf": [
@@ -9794,6 +21553,9 @@
           },
           {
             "$ref": "#/components/schemas/Event.project.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.project.recent.updated"
           },
           {
             "$ref": "#/components/schemas/Event.server.instance.disposed"
@@ -9826,6 +21588,9 @@
             "$ref": "#/components/schemas/Event.session.idle"
           },
           {
+            "$ref": "#/components/schemas/Event.skill.saved"
+          },
+          {
             "$ref": "#/components/schemas/Event.question.asked"
           },
           {
@@ -9838,10 +21603,13 @@
             "$ref": "#/components/schemas/Event.session.compacted"
           },
           {
-            "$ref": "#/components/schemas/Event.file.edited"
+            "$ref": "#/components/schemas/Event.file.watcher.updated"
           },
           {
-            "$ref": "#/components/schemas/Event.file.watcher.updated"
+            "$ref": "#/components/schemas/Event.file.watcher.limited"
+          },
+          {
+            "$ref": "#/components/schemas/Event.file.edited"
           },
           {
             "$ref": "#/components/schemas/Event.todo.updated"
@@ -9866,6 +21634,9 @@
           },
           {
             "$ref": "#/components/schemas/Event.command.executed"
+          },
+          {
+            "$ref": "#/components/schemas/Event.session.preference.updated"
           },
           {
             "$ref": "#/components/schemas/Event.session.diff"
@@ -9933,7 +21704,10 @@
             "$ref": "#/components/schemas/Event"
           }
         },
-        "required": ["directory", "payload"]
+        "required": [
+          "directory",
+          "payload"
+        ]
       },
       "SyncEvent.message.updated": {
         "type": "object",
@@ -9957,10 +21731,17 @@
                 "$ref": "#/components/schemas/Message"
               }
             },
-            "required": ["sessionID", "info"]
+            "required": [
+              "sessionID",
+              "info"
+            ]
           }
         },
-        "required": ["type", "aggregate", "data"]
+        "required": [
+          "type",
+          "aggregate",
+          "data"
+        ]
       },
       "SyncEvent.message.removed": {
         "type": "object",
@@ -9985,10 +21766,17 @@
                 "pattern": "^msg.*"
               }
             },
-            "required": ["sessionID", "messageID"]
+            "required": [
+              "sessionID",
+              "messageID"
+            ]
           }
         },
-        "required": ["type", "aggregate", "data"]
+        "required": [
+          "type",
+          "aggregate",
+          "data"
+        ]
       },
       "SyncEvent.message.part.updated": {
         "type": "object",
@@ -10015,10 +21803,18 @@
                 "type": "number"
               }
             },
-            "required": ["sessionID", "part", "time"]
+            "required": [
+              "sessionID",
+              "part",
+              "time"
+            ]
           }
         },
-        "required": ["type", "aggregate", "data"]
+        "required": [
+          "type",
+          "aggregate",
+          "data"
+        ]
       },
       "SyncEvent.message.part.removed": {
         "type": "object",
@@ -10047,10 +21843,18 @@
                 "pattern": "^prt.*"
               }
             },
-            "required": ["sessionID", "messageID", "partID"]
+            "required": [
+              "sessionID",
+              "messageID",
+              "partID"
+            ]
           }
         },
-        "required": ["type", "aggregate", "data"]
+        "required": [
+          "type",
+          "aggregate",
+          "data"
+        ]
       },
       "SyncEvent.session.created": {
         "type": "object",
@@ -10074,10 +21878,17 @@
                 "$ref": "#/components/schemas/Session"
               }
             },
-            "required": ["sessionID", "info"]
+            "required": [
+              "sessionID",
+              "info"
+            ]
           }
         },
-        "required": ["type", "aggregate", "data"]
+        "required": [
+          "type",
+          "aggregate",
+          "data"
+        ]
       },
       "SyncEvent.session.updated": {
         "type": "object",
@@ -10163,6 +21974,51 @@
                       }
                     ]
                   },
+                  "treeID": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "pattern": "^tre.*"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "forkIndex": {
+                    "anyOf": [
+                      {
+                        "type": "integer",
+                        "exclusiveMinimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "forkParentSessionID": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "pattern": "^ses.*"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "forkAfterUserMessageID": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "pattern": "^msg.*"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
                   "summary": {
                     "anyOf": [
                       {
@@ -10184,7 +22040,11 @@
                             }
                           }
                         },
-                        "required": ["additions", "deletions", "files"]
+                        "required": [
+                          "additions",
+                          "deletions",
+                          "files"
+                        ]
                       },
                       {
                         "type": "null"
@@ -10205,7 +22065,9 @@
                         ]
                       }
                     },
-                    "required": ["url"]
+                    "required": [
+                      "url"
+                    ]
                   },
                   "title": {
                     "anyOf": [
@@ -10271,7 +22133,12 @@
                         ]
                       }
                     },
-                    "required": ["created", "updated", "compacting", "archived"]
+                    "required": [
+                      "created",
+                      "updated",
+                      "compacting",
+                      "archived"
+                    ]
                   },
                   "permission": {
                     "anyOf": [
@@ -10303,7 +22170,112 @@
                             "type": "string"
                           }
                         },
-                        "required": ["messageID"]
+                        "required": [
+                          "messageID"
+                        ]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "readingMode": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "pdfFileName": {
+                            "type": "string"
+                          },
+                          "pdfStorePath": {
+                            "type": "string"
+                          },
+                          "lastReadPage": {
+                            "type": "number"
+                          },
+                          "annotationsPath": {
+                            "type": "string"
+                          },
+                          "source": {
+                            "type": "object",
+                            "properties": {
+                              "kind": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "const": "workspace-file"
+                                  },
+                                  {
+                                    "type": "string",
+                                    "const": "upload"
+                                  }
+                                ]
+                              },
+                              "path": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind"
+                            ]
+                          },
+                          "settings": {
+                            "type": "object",
+                            "properties": {
+                              "translatePrompt": {
+                                "type": "string"
+                              },
+                              "questionPrompt": {
+                                "type": "string"
+                              },
+                              "firstReadPrompt": {
+                                "type": "string"
+                              },
+                              "contextPageRange": {
+                                "anyOf": [
+                                  {
+                                    "type": "number",
+                                    "const": 0
+                                  },
+                                  {
+                                    "type": "number",
+                                    "const": 1
+                                  },
+                                  {
+                                    "type": "number",
+                                    "const": 2
+                                  }
+                                ]
+                              },
+                              "autoFirstRead": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "translatePrompt",
+                              "questionPrompt",
+                              "firstReadPrompt",
+                              "contextPageRange",
+                              "autoFirstRead"
+                            ]
+                          },
+                          "firstReadCompleted": {
+                            "type": "boolean"
+                          },
+                          "firstReadDismissed": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "pdfFileName",
+                          "pdfStorePath",
+                          "lastReadPage",
+                          "annotationsPath",
+                          "source",
+                          "settings",
+                          "firstReadCompleted",
+                          "firstReadDismissed"
+                        ]
                       },
                       {
                         "type": "null"
@@ -10318,18 +22290,30 @@
                   "workspaceID",
                   "directory",
                   "parentID",
+                  "treeID",
+                  "forkIndex",
+                  "forkParentSessionID",
+                  "forkAfterUserMessageID",
                   "summary",
                   "title",
                   "version",
                   "permission",
-                  "revert"
+                  "revert",
+                  "readingMode"
                 ]
               }
             },
-            "required": ["sessionID", "info"]
+            "required": [
+              "sessionID",
+              "info"
+            ]
           }
         },
-        "required": ["type", "aggregate", "data"]
+        "required": [
+          "type",
+          "aggregate",
+          "data"
+        ]
       },
       "SyncEvent.session.deleted": {
         "type": "object",
@@ -10353,10 +22337,17 @@
                 "$ref": "#/components/schemas/Session"
               }
             },
-            "required": ["sessionID", "info"]
+            "required": [
+              "sessionID",
+              "info"
+            ]
           }
         },
-        "required": ["type", "aggregate", "data"]
+        "required": [
+          "type",
+          "aggregate",
+          "data"
+        ]
       },
       "SyncEvent": {
         "type": "object",
@@ -10365,12 +22356,19 @@
             "$ref": "#/components/schemas/SyncEvent"
           }
         },
-        "required": ["payload"]
+        "required": [
+          "payload"
+        ]
       },
       "LogLevel": {
         "description": "Log level",
         "type": "string",
-        "enum": ["DEBUG", "INFO", "WARN", "ERROR"]
+        "enum": [
+          "DEBUG",
+          "INFO",
+          "WARN",
+          "ERROR"
+        ]
       },
       "ServerConfig": {
         "description": "Server configuration for opencode serve and web commands",
@@ -10400,13 +22398,23 @@
             "items": {
               "type": "string"
             }
+          },
+          "idleTimeout": {
+            "description": "Seconds to wait after all browser connections close before exiting (default: 60). Set to 0 to disable auto-exit.",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
           }
         },
         "additionalProperties": false
       },
       "PermissionActionConfig": {
         "type": "string",
-        "enum": ["ask", "allow", "deny"]
+        "enum": [
+          "ask",
+          "allow",
+          "deny"
+        ]
       },
       "PermissionObjectConfig": {
         "type": "object",
@@ -10477,6 +22485,9 @@
               "codesearch": {
                 "$ref": "#/components/schemas/PermissionActionConfig"
               },
+              "cron": {
+                "$ref": "#/components/schemas/PermissionRuleConfig"
+              },
               "lsp": {
                 "$ref": "#/components/schemas/PermissionRuleConfig"
               },
@@ -10534,7 +22545,11 @@
           },
           "mode": {
             "type": "string",
-            "enum": ["subagent", "primary", "all"]
+            "enum": [
+              "subagent",
+              "primary",
+              "all"
+            ]
           },
           "hidden": {
             "description": "Hide this subagent from the @ autocomplete menu (default: false, only applies to mode: subagent)",
@@ -10556,7 +22571,15 @@
               },
               {
                 "type": "string",
-                "enum": ["primary", "secondary", "accent", "success", "warning", "error", "info"]
+                "enum": [
+                  "primary",
+                  "secondary",
+                  "accent",
+                  "success",
+                  "warning",
+                  "error",
+                  "info"
+                ]
               }
             ]
           },
@@ -10642,10 +22665,15 @@
                       "properties": {
                         "field": {
                           "type": "string",
-                          "enum": ["reasoning_content", "reasoning_details"]
+                          "enum": [
+                            "reasoning_content",
+                            "reasoning_details"
+                          ]
                         }
                       },
-                      "required": ["field"],
+                      "required": [
+                        "field"
+                      ],
                       "additionalProperties": false
                     }
                   ]
@@ -10681,10 +22709,16 @@
                           "type": "number"
                         }
                       },
-                      "required": ["input", "output"]
+                      "required": [
+                        "input",
+                        "output"
+                      ]
                     }
                   },
-                  "required": ["input", "output"]
+                  "required": [
+                    "input",
+                    "output"
+                  ]
                 },
                 "limit": {
                   "type": "object",
@@ -10699,7 +22733,10 @@
                       "type": "number"
                     }
                   },
-                  "required": ["context", "output"]
+                  "required": [
+                    "context",
+                    "output"
+                  ]
                 },
                 "modalities": {
                   "type": "object",
@@ -10708,25 +22745,44 @@
                       "type": "array",
                       "items": {
                         "type": "string",
-                        "enum": ["text", "audio", "image", "video", "pdf"]
+                        "enum": [
+                          "text",
+                          "audio",
+                          "image",
+                          "video",
+                          "pdf"
+                        ]
                       }
                     },
                     "output": {
                       "type": "array",
                       "items": {
                         "type": "string",
-                        "enum": ["text", "audio", "image", "video", "pdf"]
+                        "enum": [
+                          "text",
+                          "audio",
+                          "image",
+                          "video",
+                          "pdf"
+                        ]
                       }
                     }
                   },
-                  "required": ["input", "output"]
+                  "required": [
+                    "input",
+                    "output"
+                  ]
                 },
                 "experimental": {
                   "type": "boolean"
                 },
                 "status": {
                   "type": "string",
-                  "enum": ["alpha", "beta", "deprecated"]
+                  "enum": [
+                    "alpha",
+                    "beta",
+                    "deprecated"
+                  ]
                 },
                 "options": {
                   "type": "object",
@@ -10868,7 +22924,10 @@
             "maximum": 9007199254740991
           }
         },
-        "required": ["type", "command"],
+        "required": [
+          "type",
+          "command"
+        ],
         "additionalProperties": false
       },
       "McpOAuthConfig": {
@@ -10934,13 +22993,19 @@
             "maximum": 9007199254740991
           }
         },
-        "required": ["type", "url"],
+        "required": [
+          "type",
+          "url"
+        ],
         "additionalProperties": false
       },
       "LayoutConfig": {
         "description": "@deprecated Always uses stretch layout.",
         "type": "string",
-        "enum": ["auto", "stretch"]
+        "enum": [
+          "auto",
+          "stretch"
+        ]
       },
       "Config": {
         "type": "object",
@@ -10980,7 +23045,9 @@
                   "type": "boolean"
                 }
               },
-              "required": ["template"]
+              "required": [
+                "template"
+              ]
             }
           },
           "skills": {
@@ -10996,6 +23063,32 @@
               },
               "urls": {
                 "description": "URLs to fetch skills from (e.g., https://example.com/.well-known/skills/)",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "disabled": {
+                "description": "List of skill names to deactivate",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "creation_nudge_interval": {
+                "description": "LLM steps without skill_manage before background skill review triggers (default: 10, 0 to disable)",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "max_versions": {
+                "description": "Maximum number of version snapshots kept per skill before older snapshots are pruned (default: 100)",
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 9007199254740991
+              },
+              "evolution_disabled": {
+                "description": "Skill directory paths excluded from background auto-evolution",
                 "type": "array",
                 "items": {
                   "type": "string"
@@ -11027,7 +23120,11 @@
           "share": {
             "description": "Control sharing behavior:'manual' allows manual sharing via commands, 'auto' enables automatic sharing, 'disabled' disables all sharing",
             "type": "string",
-            "enum": ["manual", "auto", "disabled"]
+            "enum": [
+              "manual",
+              "auto",
+              "disabled"
+            ]
           },
           "autoshare": {
             "description": "@deprecated Use 'share' field instead. Share newly created sessions automatically",
@@ -11054,6 +23151,13 @@
           },
           "enabled_providers": {
             "description": "When set, ONLY these providers will be enabled. All other providers will be ignored",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "disabled_models": {
+            "description": "Disable specific models in provider/model format, e.g. anthropic/claude-3-5-haiku",
             "type": "array",
             "items": {
               "type": "string"
@@ -11130,6 +23234,13 @@
               "$ref": "#/components/schemas/ProviderConfig"
             }
           },
+          "provider_remove": {
+            "description": "Remove these provider configs entirely from the config file",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "mcp": {
             "description": "MCP (Model Context Protocol) server configurations",
             "type": "object",
@@ -11155,7 +23266,9 @@
                       "type": "boolean"
                     }
                   },
-                  "required": ["enabled"],
+                  "required": [
+                    "enabled"
+                  ],
                   "additionalProperties": false
                 }
               ]
@@ -11225,7 +23338,9 @@
                           "const": true
                         }
                       },
-                      "required": ["disabled"]
+                      "required": [
+                        "disabled"
+                      ]
                     },
                     {
                       "type": "object",
@@ -11262,7 +23377,9 @@
                           "additionalProperties": {}
                         }
                       },
-                      "required": ["command"]
+                      "required": [
+                        "command"
+                      ]
                     }
                   ]
                 }
@@ -11319,6 +23436,40 @@
               }
             }
           },
+          "memory": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "description": "Enable memory tools, prompt recall, and memory reflection (default: true)",
+                "type": "boolean"
+              },
+              "memory_reflection_model": {
+                "description": "Optional model override for LLM-based memory reflection",
+                "type": "object",
+                "properties": {
+                  "providerID": {
+                    "type": "string"
+                  },
+                  "modelID": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "providerID",
+                  "modelID"
+                ]
+              }
+            }
+          },
+          "cron": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "description": "Enable cron job execution (default: true)",
+                "type": "boolean"
+              }
+            }
+          },
           "experimental": {
             "type": "object",
             "properties": {
@@ -11355,27 +23506,6 @@
         },
         "additionalProperties": false
       },
-      "BadRequestError": {
-        "type": "object",
-        "properties": {
-          "data": {},
-          "errors": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
-              "additionalProperties": {}
-            }
-          },
-          "success": {
-            "type": "boolean",
-            "const": false
-          }
-        },
-        "required": ["data", "errors", "success"]
-      },
       "OAuth": {
         "type": "object",
         "properties": {
@@ -11399,7 +23529,12 @@
             "type": "string"
           }
         },
-        "required": ["type", "refresh", "access", "expires"]
+        "required": [
+          "type",
+          "refresh",
+          "access",
+          "expires"
+        ]
       },
       "ApiAuth": {
         "type": "object",
@@ -11412,7 +23547,10 @@
             "type": "string"
           }
         },
-        "required": ["type", "key"]
+        "required": [
+          "type",
+          "key"
+        ]
       },
       "WellKnownAuth": {
         "type": "object",
@@ -11428,7 +23566,11 @@
             "type": "string"
           }
         },
-        "required": ["type", "key", "token"]
+        "required": [
+          "type",
+          "key",
+          "token"
+        ]
       },
       "Auth": {
         "anyOf": [
@@ -11441,6 +23583,83 @@
           {
             "$ref": "#/components/schemas/WellKnownAuth"
           }
+        ]
+      },
+      "ProjectRecent": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "project",
+              "directory"
+            ]
+          },
+          "projectID": {
+            "type": "string"
+          },
+          "directory": {
+            "type": "string"
+          },
+          "worktree": {
+            "type": "string"
+          },
+          "vcs": {
+            "type": "string",
+            "const": "git"
+          },
+          "name": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string"
+              },
+              "override": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              }
+            }
+          },
+          "commands": {
+            "type": "object",
+            "properties": {
+              "start": {
+                "description": "Startup script to run when creating a new workspace (worktree)",
+                "type": "string"
+              }
+            }
+          },
+          "time": {
+            "type": "object",
+            "properties": {
+              "activity": {
+                "type": "number"
+              },
+              "created": {
+                "type": "number"
+              },
+              "updated": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "activity"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "kind",
+          "directory",
+          "time"
         ]
       },
       "NotFoundError": {
@@ -11457,10 +23676,15 @@
                 "type": "string"
               }
             },
-            "required": ["message"]
+            "required": [
+              "message"
+            ]
           }
         },
-        "required": ["name", "data"]
+        "required": [
+          "name",
+          "data"
+        ]
       },
       "Model": {
         "type": "object",
@@ -11484,7 +23708,11 @@
                 "type": "string"
               }
             },
-            "required": ["id", "url", "npm"]
+            "required": [
+              "id",
+              "url",
+              "npm"
+            ]
           },
           "name": {
             "type": "string"
@@ -11526,7 +23754,13 @@
                     "type": "boolean"
                   }
                 },
-                "required": ["text", "audio", "image", "video", "pdf"]
+                "required": [
+                  "text",
+                  "audio",
+                  "image",
+                  "video",
+                  "pdf"
+                ]
               },
               "output": {
                 "type": "object",
@@ -11547,7 +23781,13 @@
                     "type": "boolean"
                   }
                 },
-                "required": ["text", "audio", "image", "video", "pdf"]
+                "required": [
+                  "text",
+                  "audio",
+                  "image",
+                  "video",
+                  "pdf"
+                ]
               },
               "interleaved": {
                 "anyOf": [
@@ -11559,15 +23799,28 @@
                     "properties": {
                       "field": {
                         "type": "string",
-                        "enum": ["reasoning_content", "reasoning_details"]
+                        "enum": [
+                          "reasoning_content",
+                          "reasoning_details"
+                        ]
                       }
                     },
-                    "required": ["field"]
+                    "required": [
+                      "field"
+                    ]
                   }
                 ]
               }
             },
-            "required": ["temperature", "reasoning", "attachment", "toolcall", "input", "output", "interleaved"]
+            "required": [
+              "temperature",
+              "reasoning",
+              "attachment",
+              "toolcall",
+              "input",
+              "output",
+              "interleaved"
+            ]
           },
           "cost": {
             "type": "object",
@@ -11588,7 +23841,10 @@
                     "type": "number"
                   }
                 },
-                "required": ["read", "write"]
+                "required": [
+                  "read",
+                  "write"
+                ]
               },
               "experimentalOver200K": {
                 "type": "object",
@@ -11609,13 +23865,24 @@
                         "type": "number"
                       }
                     },
-                    "required": ["read", "write"]
+                    "required": [
+                      "read",
+                      "write"
+                    ]
                   }
                 },
-                "required": ["input", "output", "cache"]
+                "required": [
+                  "input",
+                  "output",
+                  "cache"
+                ]
               }
             },
-            "required": ["input", "output", "cache"]
+            "required": [
+              "input",
+              "output",
+              "cache"
+            ]
           },
           "limit": {
             "type": "object",
@@ -11630,11 +23897,22 @@
                 "type": "number"
               }
             },
-            "required": ["context", "output"]
+            "required": [
+              "context",
+              "output"
+            ]
           },
           "status": {
             "type": "string",
-            "enum": ["alpha", "beta", "deprecated", "active"]
+            "enum": [
+              "alpha",
+              "beta",
+              "deprecated",
+              "active"
+            ]
+          },
+          "disabled": {
+            "type": "boolean"
           },
           "options": {
             "type": "object",
@@ -11694,7 +23972,12 @@
           },
           "source": {
             "type": "string",
-            "enum": ["env", "config", "custom", "api"]
+            "enum": [
+              "env",
+              "config",
+              "custom",
+              "api"
+            ]
           },
           "env": {
             "type": "array",
@@ -11722,7 +24005,14 @@
             }
           }
         },
-        "required": ["id", "name", "source", "env", "options", "models"]
+        "required": [
+          "id",
+          "name",
+          "source",
+          "env",
+          "options",
+          "models"
+        ]
       },
       "ToolIDs": {
         "type": "array",
@@ -11741,7 +24031,11 @@
           },
           "parameters": {}
         },
-        "required": ["id", "description", "parameters"]
+        "required": [
+          "id",
+          "description",
+          "parameters"
+        ]
       },
       "ToolList": {
         "type": "array",
@@ -11801,7 +24095,15 @@
             "type": "string"
           }
         },
-        "required": ["id", "type", "branch", "name", "directory", "extra", "projectID"]
+        "required": [
+          "id",
+          "type",
+          "branch",
+          "name",
+          "directory",
+          "extra",
+          "projectID"
+        ]
       },
       "Worktree": {
         "type": "object",
@@ -11816,7 +24118,11 @@
             "type": "string"
           }
         },
-        "required": ["name", "branch", "directory"]
+        "required": [
+          "name",
+          "branch",
+          "directory"
+        ]
       },
       "WorktreeCreateInput": {
         "type": "object",
@@ -11837,7 +24143,9 @@
             "type": "string"
           }
         },
-        "required": ["directory"]
+        "required": [
+          "directory"
+        ]
       },
       "WorktreeResetInput": {
         "type": "object",
@@ -11846,7 +24154,9 @@
             "type": "string"
           }
         },
-        "required": ["directory"]
+        "required": [
+          "directory"
+        ]
       },
       "ProjectSummary": {
         "type": "object",
@@ -11861,7 +24171,10 @@
             "type": "string"
           }
         },
-        "required": ["id", "worktree"]
+        "required": [
+          "id",
+          "worktree"
+        ]
       },
       "GlobalSession": {
         "type": "object",
@@ -11887,6 +24200,23 @@
             "type": "string",
             "pattern": "^ses.*"
           },
+          "treeID": {
+            "type": "string",
+            "pattern": "^tre.*"
+          },
+          "forkIndex": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "forkParentSessionID": {
+            "type": "string",
+            "pattern": "^ses.*"
+          },
+          "forkAfterUserMessageID": {
+            "type": "string",
+            "pattern": "^msg.*"
+          },
           "summary": {
             "type": "object",
             "properties": {
@@ -11906,7 +24236,11 @@
                 }
               }
             },
-            "required": ["additions", "deletions", "files"]
+            "required": [
+              "additions",
+              "deletions",
+              "files"
+            ]
           },
           "share": {
             "type": "object",
@@ -11915,7 +24249,9 @@
                 "type": "string"
               }
             },
-            "required": ["url"]
+            "required": [
+              "url"
+            ]
           },
           "title": {
             "type": "string"
@@ -11939,7 +24275,10 @@
                 "type": "number"
               }
             },
-            "required": ["created", "updated"]
+            "required": [
+              "created",
+              "updated"
+            ]
           },
           "permission": {
             "$ref": "#/components/schemas/PermissionRuleset"
@@ -11962,7 +24301,105 @@
                 "type": "string"
               }
             },
-            "required": ["messageID"]
+            "required": [
+              "messageID"
+            ]
+          },
+          "readingMode": {
+            "type": "object",
+            "properties": {
+              "pdfFileName": {
+                "type": "string"
+              },
+              "pdfStorePath": {
+                "type": "string"
+              },
+              "lastReadPage": {
+                "type": "number"
+              },
+              "annotationsPath": {
+                "type": "string"
+              },
+              "source": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "const": "workspace-file"
+                      },
+                      {
+                        "type": "string",
+                        "const": "upload"
+                      }
+                    ]
+                  },
+                  "path": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "kind"
+                ]
+              },
+              "settings": {
+                "type": "object",
+                "properties": {
+                  "translatePrompt": {
+                    "type": "string"
+                  },
+                  "questionPrompt": {
+                    "type": "string"
+                  },
+                  "firstReadPrompt": {
+                    "type": "string"
+                  },
+                  "contextPageRange": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "const": 0
+                      },
+                      {
+                        "type": "number",
+                        "const": 1
+                      },
+                      {
+                        "type": "number",
+                        "const": 2
+                      }
+                    ]
+                  },
+                  "autoFirstRead": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "translatePrompt",
+                  "questionPrompt",
+                  "firstReadPrompt",
+                  "contextPageRange",
+                  "autoFirstRead"
+                ]
+              },
+              "firstReadCompleted": {
+                "type": "boolean"
+              },
+              "firstReadDismissed": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "pdfFileName",
+              "pdfStorePath",
+              "lastReadPage",
+              "annotationsPath",
+              "source",
+              "settings",
+              "firstReadCompleted",
+              "firstReadDismissed"
+            ]
           },
           "project": {
             "anyOf": [
@@ -11975,7 +24412,16 @@
             ]
           }
         },
-        "required": ["id", "slug", "projectID", "directory", "title", "version", "time", "project"]
+        "required": [
+          "id",
+          "slug",
+          "projectID",
+          "directory",
+          "title",
+          "version",
+          "time",
+          "project"
+        ]
       },
       "McpResource": {
         "type": "object",
@@ -11996,7 +24442,259 @@
             "type": "string"
           }
         },
-        "required": ["name", "uri", "client"]
+        "required": [
+          "name",
+          "uri",
+          "client"
+        ]
+      },
+      "SessionTreeResult": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "tree"
+              },
+              "treeID": {
+                "type": "string",
+                "pattern": "^tre.*"
+              },
+              "sessions": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Session"
+                }
+              }
+            },
+            "required": [
+              "kind",
+              "treeID",
+              "sessions"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "legacy"
+              },
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "message"
+            ]
+          }
+        ]
+      },
+      "SessionGraphCurrent": {
+        "type": "object",
+        "properties": {
+          "sessionID": {
+            "type": "string",
+            "pattern": "^ses.*"
+          },
+          "pathNodeIDs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "latestNodeID": {
+            "type": "string"
+          },
+          "targetNodeID": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "sessionID",
+          "pathNodeIDs"
+        ]
+      },
+      "SessionGraphNode": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "anyOf": [
+              {
+                "type": "string",
+                "const": "turn"
+              },
+              {
+                "type": "string",
+                "const": "bud"
+              }
+            ]
+          },
+          "sessionID": {
+            "type": "string",
+            "pattern": "^ses.*"
+          },
+          "lane": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "row": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "time": {
+            "type": "number"
+          },
+          "label": {
+            "type": "string"
+          },
+          "userMessageID": {
+            "type": "string",
+            "pattern": "^msg.*"
+          },
+          "providerID": {
+            "type": "string"
+          },
+          "modelID": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "origin": {
+            "anyOf": [
+              {
+                "type": "string",
+                "const": "tree"
+              },
+              {
+                "type": "string",
+                "const": "external"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "kind",
+          "sessionID",
+          "lane",
+          "row",
+          "time",
+          "label",
+          "origin"
+        ]
+      },
+      "SessionGraphEdge": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "from": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          },
+          "kind": {
+            "anyOf": [
+              {
+                "type": "string",
+                "const": "continuation"
+              },
+              {
+                "type": "string",
+                "const": "branch"
+              },
+              {
+                "type": "string",
+                "const": "bud"
+              }
+            ]
+          },
+          "style": {
+            "anyOf": [
+              {
+                "type": "string",
+                "const": "solid"
+              },
+              {
+                "type": "string",
+                "const": "dashed"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "from",
+          "to",
+          "kind",
+          "style"
+        ]
+      },
+      "SessionGraphResult": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "graph"
+              },
+              "treeID": {
+                "type": "string",
+                "pattern": "^tre.*"
+              },
+              "current": {
+                "$ref": "#/components/schemas/SessionGraphCurrent"
+              },
+              "nodes": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SessionGraphNode"
+                }
+              },
+              "edges": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SessionGraphEdge"
+                }
+              }
+            },
+            "required": [
+              "kind",
+              "treeID",
+              "current",
+              "nodes",
+              "edges"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "legacy"
+              },
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "message"
+            ]
+          }
+        ]
       },
       "TextPartInput": {
         "type": "object",
@@ -12028,7 +24726,9 @@
                 "type": "number"
               }
             },
-            "required": ["start"]
+            "required": [
+              "start"
+            ]
           },
           "metadata": {
             "type": "object",
@@ -12038,7 +24738,10 @@
             "additionalProperties": {}
           }
         },
-        "required": ["type", "text"]
+        "required": [
+          "type",
+          "text"
+        ]
       },
       "FilePartInput": {
         "type": "object",
@@ -12064,7 +24767,11 @@
             "$ref": "#/components/schemas/FilePartSource"
           }
         },
-        "required": ["type", "mime", "url"]
+        "required": [
+          "type",
+          "mime",
+          "url"
+        ]
       },
       "AgentPartInput": {
         "type": "object",
@@ -12097,10 +24804,17 @@
                 "maximum": 9007199254740991
               }
             },
-            "required": ["value", "start", "end"]
+            "required": [
+              "value",
+              "start",
+              "end"
+            ]
           }
         },
-        "required": ["type", "name"]
+        "required": [
+          "type",
+          "name"
+        ]
       },
       "SubtaskPartInput": {
         "type": "object",
@@ -12132,13 +24846,21 @@
                 "type": "string"
               }
             },
-            "required": ["providerID", "modelID"]
+            "required": [
+              "providerID",
+              "modelID"
+            ]
           },
           "command": {
             "type": "string"
           }
         },
-        "required": ["type", "prompt", "description", "agent"]
+        "required": [
+          "type",
+          "prompt",
+          "description",
+          "agent"
+        ]
       },
       "ProviderAuthMethod": {
         "type": "object",
@@ -12200,10 +24922,18 @@
                           "type": "string"
                         }
                       },
-                      "required": ["key", "op", "value"]
+                      "required": [
+                        "key",
+                        "op",
+                        "value"
+                      ]
                     }
                   },
-                  "required": ["type", "key", "message"]
+                  "required": [
+                    "type",
+                    "key",
+                    "message"
+                  ]
                 },
                 {
                   "type": "object",
@@ -12233,7 +24963,10 @@
                             "type": "string"
                           }
                         },
-                        "required": ["label", "value"]
+                        "required": [
+                          "label",
+                          "value"
+                        ]
                       }
                     },
                     "when": {
@@ -12258,16 +24991,28 @@
                           "type": "string"
                         }
                       },
-                      "required": ["key", "op", "value"]
+                      "required": [
+                        "key",
+                        "op",
+                        "value"
+                      ]
                     }
                   },
-                  "required": ["type", "key", "message", "options"]
+                  "required": [
+                    "type",
+                    "key",
+                    "message",
+                    "options"
+                  ]
                 }
               ]
             }
           }
         },
-        "required": ["type", "label"]
+        "required": [
+          "type",
+          "label"
+        ]
       },
       "ProviderAuthAuthorization": {
         "type": "object",
@@ -12291,7 +25036,11 @@
             "type": "string"
           }
         },
-        "required": ["url", "method", "instructions"]
+        "required": [
+          "url",
+          "method",
+          "instructions"
+        ]
       },
       "Symbol": {
         "type": "object",
@@ -12312,10 +25061,17 @@
                 "$ref": "#/components/schemas/Range"
               }
             },
-            "required": ["uri", "range"]
+            "required": [
+              "uri",
+              "range"
+            ]
           }
         },
-        "required": ["name", "kind", "location"]
+        "required": [
+          "name",
+          "kind",
+          "location"
+        ]
       },
       "FileNode": {
         "type": "object",
@@ -12331,20 +25087,87 @@
           },
           "type": {
             "type": "string",
-            "enum": ["file", "directory"]
+            "enum": [
+              "file",
+              "directory"
+            ]
+          },
+          "symlinkTarget": {
+            "type": "string"
           },
           "ignored": {
             "type": "boolean"
           }
         },
-        "required": ["name", "path", "absolute", "type", "ignored"]
+        "required": [
+          "name",
+          "path",
+          "absolute",
+          "type",
+          "ignored"
+        ]
+      },
+      "FileMetadata": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "file",
+              "directory"
+            ]
+          },
+          "size": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "mimeType": {
+            "type": "string"
+          },
+          "previewKind": {
+            "type": "string",
+            "enum": [
+              "text",
+              "image",
+              "pdf",
+              "binary",
+              "directory"
+            ]
+          },
+          "inline": {
+            "type": "boolean"
+          },
+          "range": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "path",
+          "name",
+          "kind",
+          "size",
+          "mimeType",
+          "previewKind",
+          "inline",
+          "range"
+        ]
       },
       "FileContent": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["text", "binary"]
+            "enum": [
+              "text",
+              "binary"
+            ]
           },
           "content": {
             "type": "string"
@@ -12391,14 +25214,24 @@
                       }
                     }
                   },
-                  "required": ["oldStart", "oldLines", "newStart", "newLines", "lines"]
+                  "required": [
+                    "oldStart",
+                    "oldLines",
+                    "newStart",
+                    "newLines",
+                    "lines"
+                  ]
                 }
               },
               "index": {
                 "type": "string"
               }
             },
-            "required": ["oldFileName", "newFileName", "hunks"]
+            "required": [
+              "oldFileName",
+              "newFileName",
+              "hunks"
+            ]
           },
           "encoding": {
             "type": "string",
@@ -12408,7 +25241,10 @@
             "type": "string"
           }
         },
-        "required": ["type", "content"]
+        "required": [
+          "type",
+          "content"
+        ]
       },
       "File": {
         "type": "object",
@@ -12428,10 +25264,19 @@
           },
           "status": {
             "type": "string",
-            "enum": ["added", "deleted", "modified"]
+            "enum": [
+              "added",
+              "deleted",
+              "modified"
+            ]
           }
         },
-        "required": ["path", "added", "removed", "status"]
+        "required": [
+          "path",
+          "added",
+          "removed",
+          "status"
+        ]
       },
       "MCPStatusConnected": {
         "type": "object",
@@ -12441,7 +25286,9 @@
             "const": "connected"
           }
         },
-        "required": ["status"]
+        "required": [
+          "status"
+        ]
       },
       "MCPStatusDisabled": {
         "type": "object",
@@ -12451,7 +25298,9 @@
             "const": "disabled"
           }
         },
-        "required": ["status"]
+        "required": [
+          "status"
+        ]
       },
       "MCPStatusFailed": {
         "type": "object",
@@ -12464,7 +25313,10 @@
             "type": "string"
           }
         },
-        "required": ["status", "error"]
+        "required": [
+          "status",
+          "error"
+        ]
       },
       "MCPStatusNeedsAuth": {
         "type": "object",
@@ -12474,7 +25326,9 @@
             "const": "needs_auth"
           }
         },
-        "required": ["status"]
+        "required": [
+          "status"
+        ]
       },
       "MCPStatusNeedsClientRegistration": {
         "type": "object",
@@ -12487,7 +25341,10 @@
             "type": "string"
           }
         },
-        "required": ["status", "error"]
+        "required": [
+          "status",
+          "error"
+        ]
       },
       "MCPStatus": {
         "anyOf": [
@@ -12527,7 +25384,13 @@
             "type": "string"
           }
         },
-        "required": ["home", "state", "config", "worktree", "directory"]
+        "required": [
+          "home",
+          "state",
+          "config",
+          "worktree",
+          "directory"
+        ]
       },
       "VcsInfo": {
         "type": "object",
@@ -12539,6 +25402,134 @@
             "type": "string"
           }
         }
+      },
+      "TagRef": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "annotated": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name",
+          "annotated"
+        ]
+      },
+      "RemoteRef": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "remote": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "remote"
+        ]
+      },
+      "CommitLogItem": {
+        "type": "object",
+        "properties": {
+          "hash": {
+            "type": "string"
+          },
+          "parents": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "author": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "date": {
+            "type": "number"
+          },
+          "message": {
+            "type": "string"
+          },
+          "heads": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TagRef"
+            }
+          },
+          "remotes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RemoteRef"
+            }
+          }
+        },
+        "required": [
+          "hash",
+          "parents",
+          "author",
+          "email",
+          "date",
+          "message",
+          "heads",
+          "tags",
+          "remotes"
+        ]
+      },
+      "VcsGraphResult": {
+        "type": "object",
+        "properties": {
+          "commits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CommitLogItem"
+            }
+          },
+          "head": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "moreAvailable": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "commits",
+          "head",
+          "tags",
+          "moreAvailable"
+        ]
       },
       "Command": {
         "type": "object",
@@ -12557,7 +25548,11 @@
           },
           "source": {
             "type": "string",
-            "enum": ["command", "mcp", "skill"]
+            "enum": [
+              "command",
+              "mcp",
+              "skill"
+            ]
           },
           "template": {
             "anyOf": [
@@ -12579,7 +25574,11 @@
             }
           }
         },
-        "required": ["name", "template", "hints"]
+        "required": [
+          "name",
+          "template",
+          "hints"
+        ]
       },
       "Agent": {
         "type": "object",
@@ -12592,7 +25591,11 @@
           },
           "mode": {
             "type": "string",
-            "enum": ["subagent", "primary", "all"]
+            "enum": [
+              "subagent",
+              "primary",
+              "all"
+            ]
           },
           "native": {
             "type": "boolean"
@@ -12622,7 +25625,10 @@
                 "type": "string"
               }
             },
-            "required": ["modelID", "providerID"]
+            "required": [
+              "modelID",
+              "providerID"
+            ]
           },
           "variant": {
             "type": "string"
@@ -12643,7 +25649,12 @@
             "maximum": 9007199254740991
           }
         },
-        "required": ["name", "mode", "permission", "options"]
+        "required": [
+          "name",
+          "mode",
+          "permission",
+          "options"
+        ]
       },
       "LSPStatus": {
         "type": "object",
@@ -12670,7 +25681,12 @@
             ]
           }
         },
-        "required": ["id", "name", "root", "status"]
+        "required": [
+          "id",
+          "name",
+          "root",
+          "status"
+        ]
       },
       "FormatterStatus": {
         "type": "object",
@@ -12688,7 +25704,11 @@
             "type": "boolean"
           }
         },
-        "required": ["name", "extensions", "enabled"]
+        "required": [
+          "name",
+          "extensions",
+          "enabled"
+        ]
       }
     }
   }


### PR DESCRIPTION
### Issue for this PR

Closes #623

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

在 web-ui 侧边栏变更视图中新增 Git Graph Tab，实现基本的 git 历史可视化查看。分三个阶段：

- **后端** — 新增 GET /vcs/graph API，组合 git log + git for-each-ref 数据
- **图布局模型** — 基于 vscode-git-graph determinePath 算法的纯函数 lane 分配 + 12 色调色板颜色回收
- **渲染 + Tab 集成** — SolidJS SVG+HTML 双层渲染，接入 side panel Tab 系统

### How did you verify your code works?

- 手动追踪多种 git 拓扑场景验证 lane 分配算法
- bun typecheck 通过（opencode + app 包）
- SDK 重新生成并包含 vcs.graph() 客户端方法

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR