### PR TITLE
fix(app): always search files on @ mention, even for empty query

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -595,7 +595,6 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       const open = recent()
       const seen = new Set(open)
       const pinned: AtOption[] = open.map((path) => ({ type: "file", path, display: path, recent: true }))
-      if (!query.trim()) return [...agents, ...pinned]
       const paths = await files.searchFilesAndDirectories(query)
       const fileOptions: AtOption[] = paths
         .filter((path) => !seen.has(path))


### PR DESCRIPTION
### Issue for this PR

Closes #436

### Type of change

- [x] Bug fix

### What does this PR do?

Removes the early-return guard in `prompt-input.tsx` that skipped `files.searchFilesAndDirectories()` when `query` is empty. This caused the `@` mention dropdown to only show agents and pinned (open-tab) files, never searching the full project. The backend already handles empty queries, and the TUI autocomplete doesn't have this short-circuit — this aligns the web behavior with both.

### How did you verify your code works?

Rebased onto `upstream/dev`, confirmed the single-line deletion compiles cleanly with existing type checks.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR