### PR TITLE
Fix Electron desktop packaging and display identity

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,8 +51,6 @@ jobs:
 
   build-electron:
     # Electron build stays available, but is opt-in via workflow_dispatch input.
-    # To upload Electron artifacts again, also re-add build-electron under
-    # publish.needs below.
     if: github.repository == 'Science-Discovery/Aether' && inputs.release_electron
     needs: release
     strategy:
@@ -230,11 +228,17 @@ jobs:
           if-no-files-found: error
 
   publish:
-    if: github.repository == 'Science-Discovery/Aether'
+    if: >
+      always() &&
+      github.repository == 'Science-Discovery/Aether' &&
+      needs.release.result == 'success' &&
+      needs.build-web-mac.result == 'success' &&
+      needs.build-web-linux.result == 'success' &&
+      needs.build-web-windows.result == 'success' &&
+      (!inputs.release_electron || needs.build-electron.result == 'success')
     needs:
       - release
-      # Electron release artifacts are temporarily disabled in this workflow.
-      # - build-electron
+      - build-electron
       - build-web-mac
       - build-web-linux
       - build-web-windows

--- a/packages/desktop-electron/electron-builder.config.ts
+++ b/packages/desktop-electron/electron-builder.config.ts
@@ -32,19 +32,19 @@ const getBase = (): Configuration => ({
     },
     {
       from: "../../.opencode/skills",
-      to: ".opencode/skills",
+      to: ".aether/skills",
     },
     {
       from: "../../.opencode/agent",
-      to: ".opencode/agent",
+      to: ".aether/agent",
     },
     {
       from: "../../.opencode/command",
-      to: ".opencode/command",
+      to: ".aether/command",
     },
     {
       from: "../../.opencode/themes",
-      to: ".opencode/themes",
+      to: ".aether/themes",
     },
     {
       from: "../../Aether-wechat-bridge",

--- a/packages/desktop-electron/electron-builder.config.ts
+++ b/packages/desktop-electron/electron-builder.config.ts
@@ -70,7 +70,7 @@ const getBase = (): Configuration => ({
     target: ["dmg"],
   },
   protocols: {
-    name: "Aether",
+    name: "Aether Desktop",
     schemes: ["aether"],
   },
   win: {
@@ -98,28 +98,32 @@ function getConfig() {
       return {
         ...base,
         appId: "com.aether.desktop.dev",
-        productName: "Aether Dev",
-        rpm: { packageName: "aether-dev" },
+        productName: "Aether Desktop Dev",
+        protocols: { name: "Aether Desktop Dev", schemes: ["aether"] },
+        deb: { packageName: "aether-desktop-dev" },
+        rpm: { packageName: "aether-desktop-dev" },
       }
     }
     case "beta": {
       return {
         ...base,
         appId: "com.aether.desktop.beta",
-        productName: "Aether Beta",
-        protocols: { name: "Aether Beta", schemes: ["aether"] },
+        productName: "Aether Desktop Beta",
+        protocols: { name: "Aether Desktop Beta", schemes: ["aether"] },
         publish: { provider: "github", owner: "anomalyco", repo: "aether-beta", channel: "latest" },
-        rpm: { packageName: "aether-beta" },
+        deb: { packageName: "aether-desktop-beta" },
+        rpm: { packageName: "aether-desktop-beta" },
       }
     }
     case "prod": {
       return {
         ...base,
         appId: "com.aether.desktop",
-        productName: "Aether",
-        protocols: { name: "Aether", schemes: ["aether"] },
+        productName: "Aether Desktop",
+        protocols: { name: "Aether Desktop", schemes: ["aether"] },
         publish: { provider: "github", owner: "Science-Discovery", repo: "Aether", channel: updater },
-        rpm: { packageName: "aether" },
+        deb: { packageName: "aether-desktop" },
+        rpm: { packageName: "aether-desktop" },
       }
     }
   }

--- a/packages/desktop-electron/src/main/cli.ts
+++ b/packages/desktop-electron/src/main/cli.ts
@@ -217,7 +217,6 @@ export function spawnCommand(args: string, extraEnv: Record<string, string>) {
     OPENCODE_EXPERIMENTAL_ICON_DISCOVERY: "true",
     OPENCODE_EXPERIMENTAL_FILEWATCHER: "true",
     OPENCODE_CLIENT: "desktop",
-    XDG_STATE_HOME: userDataDir(),
     ...extraEnv,
   }
 

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -73,7 +73,7 @@ function setupApp() {
   }
 
   app.on("second-instance", (_event: Event, argv: string[]) => {
-    const urls = argv.filter((arg: string) => arg.startsWith("opencode://"))
+    const urls = argv.filter((arg: string) => arg.startsWith("aether://"))
     if (urls.length) {
       logger.log("deep link received via second-instance", { urls })
       emitDeepLinks(urls)
@@ -104,7 +104,7 @@ function setupApp() {
 
   void app.whenReady().then(async () => {
     // migrate()
-    app.setAsDefaultProtocolClient("opencode")
+    app.setAsDefaultProtocolClient("aether")
     setDockIcon()
     setupAutoUpdater()
     syncCli()

--- a/packages/desktop-electron/src/main/menu.ts
+++ b/packages/desktop-electron/src/main/menu.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, Menu, shell } from "electron"
+import { app, BrowserWindow, Menu, shell } from "electron"
 
 import { UPDATER_ENABLED } from "./constants"
 import { createMainWindow } from "./windows"
@@ -16,7 +16,7 @@ export function createMenu(deps: Deps) {
 
   const template: Electron.MenuItemConstructorOptions[] = [
     {
-      label: "Aether",
+      label: app.getName(),
       submenu: [
         { role: "about" },
         {

--- a/packages/desktop-electron/src/main/menu.ts
+++ b/packages/desktop-electron/src/main/menu.ts
@@ -16,17 +16,13 @@ export function createMenu(deps: Deps) {
 
   const template: Electron.MenuItemConstructorOptions[] = [
     {
-      label: "OpenCode",
+      label: "Aether",
       submenu: [
         { role: "about" },
         {
           label: "Check for Updates...",
           enabled: UPDATER_ENABLED,
           click: () => deps.checkForUpdates(),
-        },
-        {
-          label: "Install CLI...",
-          click: () => deps.installCli(),
         },
         {
           label: "Reload Webview",

--- a/packages/desktop-electron/src/main/paths.ts
+++ b/packages/desktop-electron/src/main/paths.ts
@@ -3,9 +3,9 @@ import { join } from "node:path"
 import { CHANNEL } from "./constants"
 
 const APP_NAMES: Record<string, string> = {
-  dev: "Aether Dev",
-  beta: "Aether Beta",
-  prod: "Aether",
+  dev: "Aether Desktop Dev",
+  beta: "Aether Desktop Beta",
+  prod: "Aether Desktop",
 }
 
 const APP_IDS: Record<string, string> = {

--- a/packages/desktop-electron/src/main/persist.ts
+++ b/packages/desktop-electron/src/main/persist.ts
@@ -1,6 +1,6 @@
-import { cpSync, copyFileSync, existsSync, mkdirSync, rmSync } from "node:fs"
+import { copyFileSync, existsSync, mkdirSync, rmSync } from "node:fs"
 import { dirname, join } from "node:path"
-import { APP, LEGACY_APP, legacyStoreName, storeName } from "./persist-names"
+import { legacyStoreName, storeName } from "./persist-names"
 import { legacyUserDataDir, userDataDir } from "./paths"
 
 let ready = false
@@ -10,14 +10,6 @@ function copy(src: string, dst: string) {
   if (existsSync(dst)) return false
   mkdirSync(dirname(dst), { recursive: true })
   copyFileSync(src, dst)
-  return true
-}
-
-function copyDir(src: string, dst: string) {
-  if (!existsSync(src)) return false
-  if (existsSync(dst)) return false
-  mkdirSync(dirname(dst), { recursive: true })
-  cpSync(src, dst, { recursive: true })
   return true
 }
 
@@ -47,14 +39,6 @@ export function ensureStoreFile(name: string) {
   return next
 }
 
-function ensureState() {
-  const next = join(userDataDir(), APP)
-  if (existsSync(next)) return
-  for (const src of [join(userDataDir(), LEGACY_APP), join(legacyUserDataDir(), APP), join(legacyUserDataDir(), LEGACY_APP)]) {
-    if (copyDir(src, next)) return
-  }
-}
-
 function ensureDefault() {
   copy(join(legacyUserDataDir(), "default.dat"), join(userDataDir(), "default.dat"))
 }
@@ -63,7 +47,6 @@ export function ensureDesktopPersist() {
   if (ready) return
   mkdirSync(userDataDir(), { recursive: true })
   ensureDefault()
-  ensureState()
   ready = true
 }
 

--- a/packages/desktop-electron/src/main/windows.ts
+++ b/packages/desktop-electron/src/main/windows.ts
@@ -66,7 +66,7 @@ export function createMainWindow(globals: Globals) {
     width: state.width,
     height: state.height,
     show: true,
-    title: "OpenCode",
+    title: app.getName(),
     icon: iconPath(),
     backgroundColor,
     ...(process.platform === "darwin"

--- a/packages/opencode/launcher/aether-protocol-handler.sh
+++ b/packages/opencode/launcher/aether-protocol-handler.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 dir="$(cd "$(dirname "$0")" && pwd)"
-portfile="$HOME/.local/share/aether/serve-port"
+portfile="${XDG_DATA_HOME:-$HOME/.local/share}/aether/serve-port"
 port=""
 if [ -f "$portfile" ]; then
   port="$(head -1 "$portfile" 2>/dev/null || true)"


### PR DESCRIPTION
### Issue for this PR

Closes #629

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Maintains the Electron desktop release path across Windows, macOS, and Linux.

This PR:
- makes the publish workflow only require Electron artifacts when Electron release is selected
- aligns Electron sidecar persistence with the Web version user-level persistence directories
- updates Electron packaged default resources from `.opencode` targets to `.aether`
- switches Electron protocol/menu handling to `aether`
- disables the stale macOS Install CLI menu entry
- fixes Linux Web protocol handling to respect `XDG_DATA_HOME`
- renames the Electron app display name to `Aether Desktop` to distinguish it from Web distributions

### How did you verify your code works?

- `bun typecheck` in `packages/desktop-electron`
- `bun test src/main/persist-names.test.ts` in `packages/desktop-electron`
- `bash -n packages/opencode/launcher/aether-protocol-handler.sh`
- `git diff --check`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR