### PR TITLE
fix(mobile): stop old bridge before starting new one from connected state

### DIFF
--- a/packages/app/src/components/dialog-mobile.tsx
+++ b/packages/app/src/components/dialog-mobile.tsx
@@ -68,6 +68,8 @@ export const DialogMobile: Component<Props> = (props) => {
 
   const doStart = () => {
     if (p() === "feishu" || p() === "qq") {
+      if (prevStatus() === "connected")
+        return stopBridge(p()).then(() => startBridge(p(), false, undefined, false, inputAppId(), inputAppSecret()))
       return startBridge(p(), false, undefined, false, inputAppId(), inputAppSecret())
     }
     return startBridge("wechat", true, currentModelStr() as string | undefined)


### PR DESCRIPTION
## Summary

When reconfiguring QQ/Feishu (or rescanning WeChat) from the connected state, the old bridge was still running. Submitting new credentials via `startBridge` conflicted with the existing bridge, causing an "already running" error.

This fix stops the old bridge first when `doStart` is called with `prevStatus === "connected"` for QQ/Feishu, matching the same pattern already used for WeChat's rescan flow. If the new connection fails, the old config remains saved (`hasConfig` stays true), so the user can reconnect with old credentials.