### PR TITLE
feat(mobile): 连接界面改进 — 重新扫码/重新配置、取消回退、自动连接

### DIFF
--- a/packages/app/src/components/dialog-mobile.tsx
+++ b/packages/app/src/components/dialog-mobile.tsx
@@ -68,6 +68,8 @@ export const DialogMobile: Component<Props> = (props) => {
 
   const doStart = () => {
     if (p() === "feishu" || p() === "qq") {
+      if (prevStatus() === "connected")
+        return stopBridge(p()).then(() => startBridge(p(), false, undefined, false, inputAppId(), inputAppSecret()))
       return startBridge(p(), false, undefined, false, inputAppId(), inputAppSecret())
     }
     return startBridge("wechat", true, currentModelStr() as string | undefined)


### PR DESCRIPTION
### Issue for this PR

Closes #632

### Type of change

- [x] New feature

### What does this PR do?

移动端连接界面6项改进（微信/QQ/飞书通用）：

1. 微信 idle 界面已有旧凭证时，添加"重新扫码"按钮（与QQ/飞书的"重新配置"对应）
2. 微信/QQ/飞书已连接界面的"切换账号/切换应用"改为"重新扫码/重新配置"
3. 从 connected 进入重新配置/重新扫码后取消，回到 connected 而非 idle
4. QQ/飞书从 connected 重新配置提交时先 stop 旧桥接，避免 "already running" 冲突
5. 已连接界面添加"启动时自动连接"开关（localStorage 持久化），连接成功默认开启，断开连接自动关闭，启动 Aether 时自动连接
6. 微信重新扫码通过 `start(rescan=true)` 跳过恢复旧 session 但不删除 `ilink_state.json`，取消后仍可恢复旧连接

### How did you verify your code works?

- `bun typecheck` 通过（packages/app 和 packages/opencode）
- 手动测试微信/QQ/飞书连接、重新配置、取消回退流程

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR