### PR TITLE
fix(app): prevent browser autofill and implement localStorage credential auto-fill

### DIFF
--- a/packages/app/src/components/dialog-login.tsx
+++ b/packages/app/src/components/dialog-login.tsx
@@ -7,6 +7,22 @@ import { createStore } from "solid-js/store"
 import { useAuth } from "@/context/auth"
 import { useLanguage } from "@/context/language"
 
+const CRED_KEY = "opencode:creds:login"
+
+function loadCreds() {
+  try {
+    const raw = localStorage.getItem(CRED_KEY)
+    if (!raw) return null
+    return JSON.parse(raw) as { email: string; password: string }
+  } catch {
+    return null
+  }
+}
+
+function saveCreds(email: string, password: string) {
+  localStorage.setItem(CRED_KEY, JSON.stringify({ email, password }))
+}
+
 export function DialogLogin() {
   const dialog = useDialog()
   const auth = useAuth()
@@ -16,9 +32,10 @@ export function DialogLogin() {
   })
   let run = 0
 
+  const saved = loadCreds()
   const [form, setForm] = createStore({
-    email: "",
-    password: "",
+    email: saved?.email ?? "",
+    password: saved?.password ?? "",
     emailErr: undefined as string | undefined,
     passwordErr: undefined as string | undefined,
     submitting: false,
@@ -49,6 +66,7 @@ export function DialogLogin() {
 
     try {
       await auth.login(form.email.trim(), form.password)
+      saveCreds(form.email.trim(), form.password)
       dialog.close()
       showToast({
         variant: "success",
@@ -82,10 +100,18 @@ export function DialogLogin() {
 
   return (
     <Dialog title={language.t("auth.login.title")} fit>
-      <form onSubmit={handleSubmit} class="flex flex-col gap-4 pl-6 pr-2.5 pb-3">
+      <form onSubmit={handleSubmit} class="flex flex-col gap-4 pl-6 pr-2.5 pb-3" autocomplete="off">
+        <div class="sr-only" aria-hidden="true">
+          <input type="text" name="username" tabIndex={-1} autocomplete="username" />
+          <input type="password" name="password" tabIndex={-1} autocomplete="current-password" />
+        </div>
         <TextField
           autofocus
           type="email"
+          name="login-email-x9"
+          autocomplete="off"
+          data-1p-ignore
+          data-lpignore="true"
           label={language.t("auth.login.email.label")}
           placeholder={language.t("auth.login.email.placeholder")}
           value={form.email}
@@ -99,6 +125,10 @@ export function DialogLogin() {
         />
         <TextField
           type="password"
+          name="login-pwd-x9"
+          autocomplete="off"
+          data-1p-ignore
+          data-lpignore="true"
           label={language.t("auth.login.password.label")}
           placeholder={language.t("auth.login.password.placeholder")}
           value={form.password}

--- a/packages/app/src/components/dialog-mobile.tsx
+++ b/packages/app/src/components/dialog-mobile.tsx
@@ -60,13 +60,12 @@ export const DialogMobile: Component<Props> = (props) => {
   const server = useServer()
   const models = useModels()
   const language = useLanguage()
-  const savedCreds = () => loadMobileCreds(p())
-  const [inputAppId, setInputAppId] = createSignal(savedCreds()?.appId ?? "")
-  const [inputAppSecret, setInputAppSecret] = createSignal(savedCreds()?.appSecret ?? "")
+  const p = () => props.platform
+  const saved = loadMobileCreds(p())
+  const [inputAppId, setInputAppId] = createSignal(saved?.appId ?? "")
+  const [inputAppSecret, setInputAppSecret] = createSignal(saved?.appSecret ?? "")
   const [steps, setSteps] = createStore({ 1: false, 2: false, 3: false, 4: false, 5: false })
   const [prevStatus, setPrevStatus] = createSignal<MobileStatus>("idle")
-
-  const p = () => props.platform
 
   const authHeaders = (): HeadersInit => {
     const s = server.current?.http

--- a/packages/app/src/components/dialog-mobile.tsx
+++ b/packages/app/src/components/dialog-mobile.tsx
@@ -32,6 +32,22 @@ import {
   type MobileStatus,
 } from "@/context/mobile"
 
+const CRED_KEY = (p: MobilePlatform) => `opencode:creds:mobile:${p}`
+
+function loadMobileCreds(p: MobilePlatform) {
+  try {
+    const raw = localStorage.getItem(CRED_KEY(p))
+    if (!raw) return null
+    return JSON.parse(raw) as { appId: string; appSecret: string }
+  } catch {
+    return null
+  }
+}
+
+function saveMobileCreds(p: MobilePlatform, appId: string, appSecret: string) {
+  localStorage.setItem(CRED_KEY(p), JSON.stringify({ appId, appSecret }))
+}
+
 interface Props {
   platform: MobilePlatform
 }
@@ -44,8 +60,9 @@ export const DialogMobile: Component<Props> = (props) => {
   const server = useServer()
   const models = useModels()
   const language = useLanguage()
-  const [inputAppId, setInputAppId] = createSignal("")
-  const [inputAppSecret, setInputAppSecret] = createSignal("")
+  const savedCreds = () => loadMobileCreds(p())
+  const [inputAppId, setInputAppId] = createSignal(savedCreds()?.appId ?? "")
+  const [inputAppSecret, setInputAppSecret] = createSignal(savedCreds()?.appSecret ?? "")
   const [steps, setSteps] = createStore({ 1: false, 2: false, 3: false, 4: false, 5: false })
   const [prevStatus, setPrevStatus] = createSignal<MobileStatus>("idle")
 
@@ -68,6 +85,7 @@ export const DialogMobile: Component<Props> = (props) => {
 
   const doStart = () => {
     if (p() === "feishu" || p() === "qq") {
+      saveMobileCreds(p(), inputAppId(), inputAppSecret())
       return startBridge(p(), false, undefined, false, inputAppId(), inputAppSecret())
     }
     return startBridge("wechat", true, currentModelStr() as string | undefined)
@@ -170,13 +188,20 @@ export const DialogMobile: Component<Props> = (props) => {
             <Show when={p() === "feishu" || p() === "qq"}>
               <div class="flex flex-col gap-4 w-full">
                 <div class="w-full flex flex-col gap-3">
+                  <div class="sr-only" aria-hidden="true">
+                    <input type="text" name="username" tabIndex={-1} autocomplete="username" />
+                    <input type="password" name="password" tabIndex={-1} autocomplete="current-password" />
+                  </div>
                   <div class="flex flex-col gap-1">
                     <label class="text-12-medium text-text-base">App ID</label>
                     <input
                       type="text"
+                      name={`mobile-appid-${p()}`}
                       value={inputAppId()}
                       onInput={(e) => setInputAppId(e.currentTarget.value)}
                       autocomplete="off"
+                      data-1p-ignore
+                      data-lpignore="true"
                       placeholder={p() === "qq" ? "10xxxxxx" : "cli_xxxxxxxx"}
                       class="w-full px-3 py-2 rounded-md border border-border-base bg-surface-base text-text-base text-13-regular focus:outline-none focus:border-border-focus"
                     />
@@ -185,9 +210,12 @@ export const DialogMobile: Component<Props> = (props) => {
                     <label class="text-12-medium text-text-base">App Secret</label>
                     <input
                       type="password"
+                      name={`mobile-secret-${p()}`}
                       value={inputAppSecret()}
                       onInput={(e) => setInputAppSecret(e.currentTarget.value)}
-                      autocomplete="new-password"
+                      autocomplete="off"
+                      data-1p-ignore
+                      data-lpignore="true"
                       placeholder={language.t(`${p()}.enterAppSecret`)}
                       class="w-full px-3 py-2 rounded-md border border-border-base bg-surface-base text-text-base text-13-regular focus:outline-none focus:border-border-focus"
                     />

--- a/packages/app/src/components/dialog-register.tsx
+++ b/packages/app/src/components/dialog-register.tsx
@@ -105,10 +105,18 @@ export function DialogRegister() {
 
   return (
     <Dialog title={language.t("auth.register.title")} fit>
-      <form onSubmit={handleSubmit} class="flex flex-col gap-4 pl-6 pr-2.5 pb-3">
+      <form onSubmit={handleSubmit} class="flex flex-col gap-4 pl-6 pr-2.5 pb-3" autocomplete="off">
+        <div class="sr-only" aria-hidden="true">
+          <input type="text" name="username" tabIndex={-1} autocomplete="username" />
+          <input type="password" name="password" tabIndex={-1} autocomplete="current-password" />
+        </div>
         <TextField
           autofocus
           type="email"
+          name="reg-email-x9"
+          autocomplete="off"
+          data-1p-ignore
+          data-lpignore="true"
           label={language.t("auth.register.email.label")}
           placeholder={language.t("auth.register.email.placeholder")}
           value={form.email}
@@ -122,6 +130,10 @@ export function DialogRegister() {
         />
         <TextField
           type="password"
+          name="reg-pwd-x9"
+          autocomplete="off"
+          data-1p-ignore
+          data-lpignore="true"
           label={language.t("auth.register.password.label")}
           placeholder={language.t("auth.register.password.placeholder")}
           value={form.password}
@@ -136,6 +148,10 @@ export function DialogRegister() {
         />
         <TextField
           type="password"
+          name="reg-confirm-x9"
+          autocomplete="off"
+          data-1p-ignore
+          data-lpignore="true"
           label={language.t("auth.register.confirm.label")}
           placeholder={language.t("auth.register.confirm.placeholder")}
           value={form.confirm}
@@ -149,6 +165,10 @@ export function DialogRegister() {
         />
         <TextField
           type="text"
+          name="reg-name-x9"
+          autocomplete="off"
+          data-1p-ignore
+          data-lpignore="true"
           label={language.t("auth.register.name.label")}
           placeholder={language.t("auth.register.name.placeholder")}
           value={form.name}


### PR DESCRIPTION
### Issue for this PR

Closes #634

### Type of change

- [x] Bug fix

### What does this PR do?

修复侧边栏登录、QQ配置、飞书配置对话框中浏览器/密码管理器自动填充混乱的问题。

方案采用多层防御：
1. 在每个表单内添加隐藏的 honeypot `<input>`，吸引浏览器自动填充到隐藏字段而非真实输入框
2. 真实输入使用 `autocomplete="off"` + `data-1p-ignore` + `data-lpignore="true"` + 非标准 `name` 属性，阻止 Chrome/Firefox/1Password/LastPass 自动填充
3. 用 localStorage 替代浏览器自动填充，登录成功/QQ/飞书连接成功时保存凭据，下次打开对话框时自动加载已保存的凭据

涉及文件：
- `dialog-login.tsx` — 禁止浏览器自动填充 + localStorage 保存/加载登录凭据
- `dialog-mobile.tsx` — 禁止浏览器自动填充 + localStorage 保存/加载 QQ/飞书 App ID/App Secret
- `dialog-register.tsx` — 禁止浏览器自动填充（注册不需要本地保存）

### How did you verify your code works?

- `bun typecheck` 通过
- 本地开发环境实际打开登录/QQ/飞书配置对话框，确认浏览器不再自动填充，且 localStorage 保存的凭据能正确自动填入

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR