### PR TITLE
fix(app): guard against undefined commits/parents in git-graph layout

### DIFF
--- a/packages/app/src/pages/session/git-graph/model.ts
+++ b/packages/app/src/pages/session/git-graph/model.ts
@@ -58,16 +58,16 @@ const idx = (commits: CommitLogItem[]) => {
   return map
 }
 
-export function computeGraphLayout(commits: CommitLogItem[], head: string | null): GraphView {
+export function computeGraphLayout(commits: CommitLogItem[] | undefined | null, head: string | null): GraphView {
+  if (!commits || commits.length === 0) return { nodes: [], edges: [], lanes: 0 }
   const n = commits.length
-  if (n === 0) return { nodes: [], edges: [], lanes: 0 }
 
   const lookup = idx(commits)
   const slot = commits.map(() => ({ lane: -1, nextX: 0, parent: 0 }))
   const bag: { end: number }[] = []
 
   for (let i = 0; i < n; i++) {
-    while (slot[i].parent < commits[i].parents.length) {
+    while (slot[i].parent < (commits[i].parents?.length ?? 0)) {
       const parentHash = commits[i].parents[slot[i].parent]
       const parentRow = lookup.get(parentHash)
 
@@ -156,8 +156,8 @@ export function computeGraphLayout(commits: CommitLogItem[], head: string | null
 
   const edges: GraphEdge[] = []
   for (let i = 0; i < n; i++) {
-    for (let p = 0; p < commits[i].parents.length; p++) {
-      const parentRow = lookup.get(commits[i].parents[p])
+    for (let p = 0; p < (commits[i].parents?.length ?? 0); p++) {
+      const parentRow = lookup.get(commits[i].parents![p])
       if (parentRow === undefined) continue
       edges.push({
         fromRow: i,


### PR DESCRIPTION
### Issue for this PR

Closes #637

### Type of change

- [x] Bug fix

### What does this PR do?

`computeGraphLayout` crashed with `TypeError: Cannot read properties of undefined (reading 'length')` when `commits` or `parents` were undefined/null. This PR:
1. Accepts `undefined | null` commits parameter, returns empty result early
2. Uses optional chaining (`parents?.length ?? 0`) to guard against undefined `parents`

### How did you verify your code works?

- `bun typecheck` passes in `packages/app`
- Changes are purely null guards, logic semantics unchanged

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR