### PR TITLE
fix(session): recover stuck DB artifacts when stop button is pressed

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -1755,7 +1755,6 @@ export namespace Session {
     const msgs = await MessageV2.filterCompacted(MessageV2.stream(sessionID))
     const now = Date.now()
     for (const msg of msgs) {
-      let needsMessageUpdate = false
       for (const part of msg.parts) {
         if (part.type === "tool" && part.state.status !== "completed" && part.state.status !== "error") {
           await updatePart({
@@ -1770,10 +1769,9 @@ export namespace Session {
               },
             },
           })
-          needsMessageUpdate = true
         }
       }
-      if (needsMessageUpdate && msg.info.role === "assistant" && msg.info.time.completed === undefined) {
+      if (msg.info.role === "assistant" && msg.info.time.completed === undefined) {
         await updateMessage({ ...msg.info, time: { ...msg.info.time, completed: now } })
       }
     }

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -1751,6 +1751,34 @@ export namespace Session {
     },
   )
 
+  export async function recoverStuckParts(sessionID: SessionID) {
+    const msgs = await MessageV2.filterCompacted(MessageV2.stream(sessionID))
+    const now = Date.now()
+    for (const msg of msgs) {
+      let needsMessageUpdate = false
+      for (const part of msg.parts) {
+        if (part.type === "tool" && part.state.status !== "completed" && part.state.status !== "error") {
+          await updatePart({
+            ...part,
+            state: {
+              status: "error",
+              input: part.state.input,
+              error: "Tool execution was interrupted",
+              time: {
+                start: part.state.status === "running" ? part.state.time.start : now,
+                end: now,
+              },
+            },
+          })
+          needsMessageUpdate = true
+        }
+      }
+      if (needsMessageUpdate && msg.info.role === "assistant" && msg.info.time.completed === undefined) {
+        await updateMessage({ ...msg.info, time: { ...msg.info.time, completed: now } })
+      }
+    }
+  }
+
   export class BusyError extends Error {
     constructor(public readonly sessionID: string) {
       super(`Session ${sessionID} is busy`)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -275,12 +275,12 @@ export namespace SessionPrompt {
     const match = s[sessionID]
     if (!match) {
       await SessionStatus.set(sessionID, { type: "idle" })
-      return
+    } else {
+      match.abort.abort()
+      delete s[sessionID]
+      await SessionStatus.set(sessionID, { type: "idle" })
     }
-    match.abort.abort()
-    delete s[sessionID]
-    await SessionStatus.set(sessionID, { type: "idle" })
-    return
+    await Session.recoverStuckParts(sessionID)
   }
 
   export const LoopInput = z.object({


### PR DESCRIPTION
### Issue for this PR

Closes #639

### Type of change

- [x] Bug fix

### What does this PR do?

After a hard kill (SIGKILL, OOM, crash), two DB artifacts remain stuck:
- ToolParts in `pending`/`running` state
- Assistant messages missing `time.completed`

UI `busy()` checks `assistant.time.completed !== number` and treats the session as permanently busy, blocking send/stop in a deadlock loop.

This PR adds `Session.recoverStuckParts()` which is called at the end of `SessionPrompt.cancel()` (what the stop button invokes). It transitions stuck ToolParts to `error` and sets `time.completed` on any assistant message missing it. The original cancel logic (abort signal + SessionStatus idle) is unchanged — `recoverStuckParts` is appended after both branches complete.

### How did you verify your code works?

- `bun typecheck` passes in `packages/opencode`
- Diagnosed two real stuck sessions in `aether-local.db`:
  - "Aether.vbs 无法打开诊断" — bash tool stuck in `pending` + assistant message with no parts and no `time.completed`
  - "11+1 calculation" — empty assistant message missing `time.completed` (no stuck tool parts)
- Verified stop button successfully recovered the first session after deploying the fix

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR