### PR TITLE
fix(log): redirect session activity logs to dedicated file under cache

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -14,7 +14,6 @@ import { writeHeapSnapshot } from "node:v8"
 
 await Log.init({
   print: process.argv.includes("--print-logs"),
-  dev: Installation.isLocal(),
   level: (() => {
     if (Installation.isLocal()) return "DEBUG"
     return "INFO"

--- a/packages/opencode/src/global/index.ts
+++ b/packages/opencode/src/global/index.ts
@@ -18,7 +18,7 @@ export namespace Global {
     },
     data,
     bin: path.join(cache, "bin"),
-    log: path.join(data, "log"),
+    log: path.join(cache, "log"),
     cache,
     config,
     state,

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -69,7 +69,6 @@ let cli = yargs(hideBin(process.argv))
     await Global.ensureDirs()
     await Log.init({
       print: process.argv.includes("--print-logs"),
-      dev: Installation.isLocal(),
       level: (() => {
         if (opts.logLevel) return opts.logLevel as Log.Level
         if (Installation.isLocal()) return "DEBUG"

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -378,7 +378,7 @@ export namespace SessionPrompt {
       }
 
       step++
-      console.log(`\n${"-".repeat(60)} step ${step} ${"-".repeat(60)}\n`)
+      Log.activity(`${"-".repeat(60)} step ${step} ${"-".repeat(60)}`)
       if (step === 1)
         ensureTitle({
           session,
@@ -651,9 +651,9 @@ export namespace SessionPrompt {
       await Plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
       const patch = await SkillRefresh.patch(sessionID)
-      console.log(`[skill refresh] step=${step} hasPatch=${patch ? 1 : 0}`)
+      Log.activity(`[skill refresh] step=${step} hasPatch=${patch ? 1 : 0}`)
       if (patch) {
-        console.log(`[skill refresh] injecting synthetic user message step=${step} names=${patch.names.join(", ")}`)
+        Log.activity(`[skill refresh] injecting synthetic user message step=${step} names=${patch.names.join(", ")}`)
         const msg: MessageV2.User = {
           id: MessageID.ascending(),
           sessionID,
@@ -756,7 +756,7 @@ export namespace SessionPrompt {
       // Build system prompt, adding structured output instruction if needed
       const skills = await SystemPrompt.skills(agent, new Set(Object.keys(tools)), new Set())
       const _skillNames = skills ? [...skills.matchAll(/<name>(.*?)<\/name>/g)].map((m) => m[1]) : []
-      console.log(`[skills] ${_skillNames.length > 0 ? _skillNames.join(", ") : "(none)"}`)
+      Log.activity(`[skills] ${_skillNames.length > 0 ? _skillNames.join(", ") : "(none)"}`)
       const system = [
         ...(await SystemPrompt.environment(model)),
         ...(skills ? [skills] : []),
@@ -799,18 +799,16 @@ export namespace SessionPrompt {
       if (!isSkillReviewSession && skillManageAvailable && hadToolCalls) {
         const assistantParts = await MessageV2.parts(processor.message.id)
         const toolNames = assistantParts.filter((p) => p.type === "tool").map((p) => (p as MessageV2.ToolPart).tool)
-        console.log(`[tools] step=${step} tools=[${toolNames.join(", ")}]`)
+        Log.activity(`[tools] step=${step} tools=[${toolNames.join(", ")}]`)
         const calledSkillManage = toolNames.includes("skill_manage")
-        console.log(
-          `[skill manage] step=${step} called=${calledSkillManage ? 1 : 0} count_before=${_skillCounters.get(sessionID) ?? 0}`,
-        )
+        Log.activity(`[skill manage] step=${step} called=${calledSkillManage ? 1 : 0} count_before=${_skillCounters.get(sessionID) ?? 0}`)
         if (calledSkillManage) {
           // mirrors Hermes L7868: reset to 0 inside _execute_tool_calls
           // then L9110: +1 unconditionally after → net result is 1, not 0
           _skillCounters.set(sessionID, 0)
         }
         _skillCounters.set(sessionID, (_skillCounters.get(sessionID) ?? 0) + 1) // always +1 per step, mirrors Hermes L9110
-        console.log(`[skill counter] count=${_skillCounters.get(sessionID)}`)
+        Log.activity(`[skill counter] count=${_skillCounters.get(sessionID)}`)
       }
 
       const parts = await MessageV2.parts(processor.message.id)
@@ -818,9 +816,7 @@ export namespace SessionPrompt {
         .filter((p) => p.type === "text")
         .map((p) => (p as MessageV2.TextPart).text.trim())
         .join("\n")
-      console.log(
-        `[assistant] step=${step} finish=${processor.message.finish ?? "(none)"} error=${processor.message.error ? 1 : 0} parts=${parts.length} textChars=${text.length}`,
-      )
+      Log.activity(`[assistant] step=${step} finish=${processor.message.finish ?? "(none)"} error=${processor.message.error ? 1 : 0} parts=${parts.length} textChars=${text.length}`)
 
       // If structured output was captured, save it and exit immediately
       // This takes priority because the StructuredOutput tool was called successfully
@@ -886,9 +882,7 @@ export namespace SessionPrompt {
       _finalResponse &&
       !abort.aborted
 
-    console.log(
-      `[skill review check] count=${_skillCounters.get(sessionID)} threshold=${skillNudgeInterval} finalResponse=${_finalResponse} aborted=${abort.aborted} isReview=${isSkillReviewSession} should=${_shouldReviewSkills}`,
-    )
+    Log.activity(`[skill review check] count=${_skillCounters.get(sessionID)} threshold=${skillNudgeInterval} finalResponse=${_finalResponse} aborted=${abort.aborted} isReview=${isSkillReviewSession} should=${_shouldReviewSkills}`)
 
     if (_shouldReviewSkills) {
       _skillCounters.set(sessionID, 0) // reset immediately, mirrors Hermes L11833
@@ -914,9 +908,7 @@ export namespace SessionPrompt {
         .filter((p) => p.type === "text")
         .map((p) => (p as MessageV2.TextPart).text.trim())
         .join("\n")
-      console.log(
-        `[final return] role=${item.info.role} id=${item.info.id} parts=${item.parts.length} textChars=${txt.length} finalResponse=${_finalResponse ? 1 : 0}`,
-      )
+      Log.activity(`[final return] role=${item.info.role} id=${item.info.id} parts=${item.parts.length} textChars=${txt.length} finalResponse=${_finalResponse ? 1 : 0}`)
       return item
     }
     throw new Error("Impossible")

--- a/packages/opencode/src/session/skill-dirty.ts
+++ b/packages/opencode/src/session/skill-dirty.ts
@@ -1,4 +1,5 @@
 import { SessionID } from "./schema"
+import { Log } from "../util/log"
 
 const state = new Map<string, Set<string>>()
 
@@ -18,23 +19,19 @@ export namespace SkillDirty {
     }
     if (cur.size === 0) return
     state.set(id, cur)
-    console.log(
-      `[skill dirty state] op=add session=${id} names=[${names.join(", ")}] before=${before} after=${cur.size} ts=${Date.now()}`,
-    )
+    Log.activity(`[skill dirty state] op=add session=${id} names=[${names.join(", ")}] before=${before} after=${cur.size} ts=${Date.now()}`)
   }
 
   export function take(sessionID: SessionID | string) {
     const id = key(sessionID)
     const cur = state.get(id)
     if (!cur || cur.size === 0) {
-      console.log(`[skill dirty state] op=take session=${id} names=[] before=0 after=0 ts=${Date.now()}`)
+      Log.activity(`[skill dirty state] op=take session=${id} names=[] before=0 after=0 ts=${Date.now()}`)
       return [] as string[]
     }
     const names = [...cur]
     state.delete(id)
-    console.log(
-      `[skill dirty state] op=take session=${id} names=[${names.join(", ")}] before=${names.length} after=0 ts=${Date.now()}`,
-    )
+    Log.activity(`[skill dirty state] op=take session=${id} names=[${names.join(", ")}] before=${names.length} after=0 ts=${Date.now()}`)
     return names
   }
 

--- a/packages/opencode/src/session/skill-evolution.ts
+++ b/packages/opencode/src/session/skill-evolution.ts
@@ -125,7 +125,7 @@ export async function spawnBackgroundReview(input: {
       ],
     })
 
-    console.log(`[skill review] started childSession=${childSession.id} model=${model.providerID}/${model.modelID}`)
+    Log.activity(`[skill review] started childSession=${childSession.id} model=${model.providerID}/${model.modelID}`)
 
     const reviewPrompt = await buildReviewPrompt(messages)
 
@@ -169,15 +169,14 @@ export async function spawnBackgroundReview(input: {
 
     if (actions.length > 0) {
       SkillDirty.add(sessionID, [...names])
-      console.log(`[skill review] ${reviewText || ""}`)
-      console.log(`[skill review] 💾 ${actions.join(", ")}`)
+      Log.activity(`[skill review] ${reviewText || ""}`)
+      Log.activity(`[skill review] 💾 ${actions.join(", ")}`)
       await Bus.publish(Event.SkillSaved, { sessionID, actions })
-      log.info("skill review saved", { actions })
     } else {
-      console.log(`[skill review] ${reviewText || "nothing to save"}`)
+      Log.activity(`[skill review] ${reviewText || "nothing to save"}`)
     }
   } catch (err) {
-    console.log(`[skill review] error: ${err}`)
+    Log.activity(`[skill review] error: ${err}`)
     log.error("failed to spawn background skill review", { error: err })
   }
 }

--- a/packages/opencode/src/session/skill-refresh.ts
+++ b/packages/opencode/src/session/skill-refresh.ts
@@ -1,6 +1,7 @@
 import { ConfigMarkdown } from "../config/markdown"
 import { Skill } from "../skill"
 import { SkillDirty } from "./skill-dirty"
+import { Log } from "../util/log"
 
 type Entry = {
   name: string
@@ -42,8 +43,8 @@ export namespace SkillRefresh {
       )
     }
     if (list.length === 0) return
-    console.log(`[skill dirty] reload session=${sessionID} skills=${names.join(", ")}`)
-    console.log(`[skill dirty] patch built session=${sessionID} skills=${names.join(", ")} blocks=${list.length}`)
+    Log.activity(`[skill dirty] reload session=${sessionID} skills=${names.join(", ")}`)
+    Log.activity(`[skill dirty] patch built session=${sessionID} skills=${names.join(", ")} blocks=${list.length}`)
     return {
       names,
       text: [

--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -44,7 +44,6 @@ export namespace Log {
 
   export interface Options {
     print: boolean
-    dev?: boolean
     level?: Level
   }
 
@@ -63,10 +62,11 @@ export namespace Log {
     if (initialized) return
     initialized = true
     cleanup(Global.Path.log)
+    initActivity(Global.Path.log)
     if (options.print) return
     logpath = path.join(
       Global.Path.log,
-      options.dev ? "dev.log" : new Date().toISOString().split(".")[0].replace(/:/g, "") + ".log",
+      new Date().toISOString().split(".")[0].replace(/:/g, "") + ".log",
     )
     await fs.truncate(logpath).catch(() => {})
     const stream = createWriteStream(logpath, { flags: "a" })
@@ -90,6 +90,37 @@ export namespace Log {
 
     const filesToDelete = files.slice(0, -10)
     await Promise.all(filesToDelete.map((file) => fs.unlink(file).catch(() => {})))
+  }
+
+  let activityWrite = (_msg: string) => {}
+
+  function initActivity(dir: string) {
+    const today = new Date().toISOString().slice(0, 10)
+    const filePath = path.join(dir, `activity-${today}.log`)
+    const stream = createWriteStream(filePath, { flags: "a" })
+    activityWrite = (msg) => stream.write(new Date().toISOString().slice(11, 19) + " " + msg + "\n")
+    cleanupActivity(dir).catch(() => {})
+  }
+
+  async function cleanupActivity(dir: string) {
+    const files = await Glob.scan("activity-????-??-??.log", {
+      cwd: dir,
+      absolute: true,
+      include: "file",
+    })
+    const cutoff = Date.now() - 7 * 24 * 60 * 60 * 1000
+    await Promise.all(
+      files
+        .filter((f) => {
+          const date = path.basename(f).slice("activity-".length, -".log".length)
+          return new Date(date).getTime() < cutoff
+        })
+        .map((f) => fs.unlink(f).catch(() => {})),
+    )
+  }
+
+  export function activity(msg: string) {
+    activityWrite(msg)
   }
 
   function formatError(error: Error, depth = 0): string {

--- a/packages/opencode/test/preload.ts
+++ b/packages/opencode/test/preload.ts
@@ -105,7 +105,6 @@ await Global.ensureDirs()
 
 Log.init({
   print: false,
-  dev: true,
   level: "DEBUG",
 })
 


### PR DESCRIPTION
Fixes #644

## 变更内容

### 问题
session 相关日志（skill dirty/refresh、assistant step 等）直接 `console.log` 到 stderr，后端终端被刷屏，且与系统日志混在一起无法区分。

### 解决方式

**新增 `Log.activity(msg)`**：写入独立的 `~/.cache/aether/log/activity-YYYY-MM-DD.log`，格式保持原来的紧凑风格：
```
14:52:11 [skill dirty state] op=take session=ses_xxx names=[] before=0 after=0
14:52:11 [skill refresh] step=1 hasPatch=0
14:52:11 [skills] academic-researcher, arxiv-search, ...
14:52:11 [assistant] step=1 finish=stop error=0 parts=3 textChars=3
```

**日志路径调整**：`~/.local/share/aether/log/` → `~/.cache/aether/log/`，符合 XDG 规范。

**自动清理**：activity 日志保留 7 天，启动时触发清理。主系统日志保留最近 10 个文件。

**统一文件命名**：移除开发模式的 `dev.log`，统一使用时间戳命名。

## 测试

- [x] TypeScript 类型检查通过
- [x] 后端终端无日志输出
- [x] `~/.cache/aether/log/activity-*.log` 正常写入