### PR TITLE
fix: set Windows PE metadata for standalone binary

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -229,7 +229,12 @@ for (const item of targets) {
       target: name.replace(pkg.name, "bun") as any,
       outfile: `dist/${name}/bin/aether`,
       execArgv: [`--user-agent=aether/${Script.version}`, "--use-system-ca", "--"],
-      windows: {},
+      windows: {
+        description: "Aether",
+        title: "Aether",
+        publisher: "Science Discovery",
+        version: Script.version,
+      },
     },
     entrypoints: ["./src/index.ts", parserWorker, workerPath],
     define: {


### PR DESCRIPTION
### Issue for this PR

Closes #653

### Type of change

- [x] Bug fix

### What does this PR do?

Set Windows PE metadata (FileDescription, ProductName, CompanyName, FileVersion) in `compile.windows` so that `aether.exe` displays "Aether" instead of "Bun" in Task Manager's Name column.

Previously `compile.windows` was `{}`, causing the compiled exe to inherit Bun runtime's default PE metadata.

### How did you verify your code works?

- Reviewed Bun's `compile.windows` type definition to confirm supported fields
- Confirmed no other build/CD/packing scripts need changes (PE metadata is embedded at compile time)
- Verified change is isolated to `build.ts:232` only

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR