### PR TITLE
fix(opencode): force exit when lease orphaned but SSE stuck by Chrome connection pooling

### DIFF
--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -77,10 +77,28 @@ export const WebCommand = cmd({
     // Disable by setting idleTimeout to 0 (always-on daemon mode).
     if (IDLE_TIMEOUT_MS > 0) {
       let everConnected = false
+      let leaseEverActive = false
       let exitTimer: ReturnType<typeof setTimeout> | null = null
+      let leaseOrphanTimer: ReturnType<typeof setTimeout> | null = null
       const connectionChecker = setInterval(() => {
         const active = (server as any).pendingRequests as number
-        if (active > 0 || sse > 0 || Lease.count() > 0) {
+        const leaseCount = Lease.count()
+        if (leaseCount > 0) leaseEverActive = true
+
+        // Safety net: lease confirms browser gone (no ping for 30s TTL),
+        // but Chrome connection pooling keeps sse/pending stuck.
+        // Force exit after grace period regardless of sse/active state.
+        if (leaseEverActive && leaseCount === 0 && (active > 0 || sse > 0)) {
+          leaseOrphanTimer ??= setTimeout(() => {
+            clearInterval(connectionChecker)
+            void gracefulShutdown(server)
+          }, 30_000)
+        } else if (leaseOrphanTimer !== null) {
+          clearTimeout(leaseOrphanTimer)
+          leaseOrphanTimer = null
+        }
+
+        if (active > 0 || sse > 0 || leaseCount > 0) {
           everConnected = true
           if (exitTimer !== null) {
             clearTimeout(exitTimer)


### PR DESCRIPTION
### Issue for this PR

Closes #655

### Type of change

- [x] Bug fix

### What does this PR do?

Chrome's connection pooling keeps stale TCP connections alive after browser tabs close on Windows. This prevents Bun from detecting SSE disconnect, so `sseConnectionCount` and `pendingRequests` remain >0 indefinitely. The `connectionChecker` in `web.ts` then never triggers `gracefulShutdown`, causing zombie processes that consume ~400-800MB each.

Fix: add a "lease orphan" safety net. When `Lease.count() === 0` for 30s after a browser was actively pinging (`leaseEverActive`), the server forces exit regardless of stuck `sse/pendingRequests`. Lease is the authoritative signal because the client pings every 10s; if no ping arrives for 30s (TTL) + 30s (grace), the browser is definitively gone.

### How did you verify your code works?

- `bun typecheck` passes in `packages/opencode`
- Verified root cause: Chrome PID keeps 6 established TCP connections to port 19527 after tabs closed, keeping `sse/pendingRequests` stuck while `Lease.count()` is 0

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR