### PR TITLE
fix(ui): 修复聊天数学公式渲染兼容性问题

### DIFF
--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -380,14 +380,29 @@ const katexMacros: Record<string, string> = {
   "\\slashed": "\\not\\!#1",
 }
 
-function renderMathInText(text: string): string {
-  let result = text
+export function decodeMath(text: string) {
+  return text
+    .replace(/&amp;/g, "&")
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+}
+
+export function normalizeMath(text: string) {
+  return text
+    .replace(/\\\(((?:\\.|[^\\])*?)\\\)/g, (_, math) => `$${math}$`)
+    .replace(/\\\[\s*([\s\S]*?)\s*\\\]/g, (_, math) => `\n$$\n${math}\n$$\n`)
+}
+
+export function renderMathInText(text: string): string {
+  let result = normalizeMath(text)
 
   // Display math: $$...$$
   const displayMathRegex = /\$\$([\s\S]*?)\$\$/g
   result = result.replace(displayMathRegex, (_, math) => {
     try {
-      return katex.renderToString(math, {
+      return katex.renderToString(decodeMath(math), {
         displayMode: true,
         throwOnError: false,
         macros: katexMacros,
@@ -401,7 +416,7 @@ function renderMathInText(text: string): string {
   const inlineMathRegex = /(?<!\$)\$(?!\$)((?:[^$\\]|\\.)+?)\$(?!\$)/g
   result = result.replace(inlineMathRegex, (_, math) => {
     try {
-      return katex.renderToString(math, {
+      return katex.renderToString(decodeMath(math), {
         displayMode: false,
         throwOnError: false,
         macros: katexMacros,
@@ -522,9 +537,10 @@ export const { use: useMarked, provider: MarkedProvider } = createSimpleContext(
       const nativeParser = props.nativeParser
       return {
         async parse(markdown: string): Promise<string> {
-          const raw = await nativeParser(markdown)
+          const input = normalizeMath(markdown)
+          const raw = await nativeParser(input)
           const html =
-            hasMarkdownHints(markdown) && !hasStructuredMarkup(raw) ? await jsParser.parse(markdown) : raw
+            hasMarkdownHints(input) && !hasStructuredMarkup(raw) ? await jsParser.parse(input) : raw
           const withMath = renderMathExpressions(html)
           return highlightCodeBlocks(withMath)
         },
@@ -533,7 +549,7 @@ export const { use: useMarked, provider: MarkedProvider } = createSimpleContext(
 
     return {
       async parse(markdown: string): Promise<string> {
-        const html = await jsParser.parse(markdown)
+        const html = await jsParser.parse(normalizeMath(markdown))
         return renderMathExpressions(html)
       },
     }

--- a/packages/ui/src/context/marked.vitest.ts
+++ b/packages/ui/src/context/marked.vitest.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest"
+import { decodeMath, normalizeMath, renderMathInText } from "./marked"
+
+describe("marked math", () => {
+  test("decodes html entities inside math", () => {
+    expect(decodeMath("a &amp; b")).toBe("a & b")
+    expect(decodeMath(String.raw`k&#39; &lt; \Lambda &quot;x&quot; &gt; 0`)).toBe(String.raw`k' < \Lambda "x" > 0`)
+  })
+
+  test("normalizes tex delimiters", () => {
+    expect(normalizeMath(String.raw`consider \(SO(2)\)`)).toBe("consider $SO(2)$")
+    expect(normalizeMath(String.raw`\[
+a+b
+\]`)).toContain("$$\na+b\n$$")
+  })
+
+  test("renders matrix formulas without leaking html entities", () => {
+    const html = renderMathInText(String.raw`
+$$
+\begin{pmatrix}
+\cos\theta &amp; -\sin\theta \\
+\sin\theta &amp; \cos\theta
+\end{pmatrix}
+$$
+`)
+    const root = document.createElement("div")
+    root.innerHTML = html
+    const text = root.querySelector(".katex-html")?.textContent ?? ""
+
+    expect(html).toContain("katex-display")
+    expect(text).toContain("cos")
+    expect(text).toContain("sin")
+    expect(text).not.toContain("amp;")
+  })
+
+  test("renders long formulas with primes and inequalities", () => {
+    const html = renderMathInText(String.raw`
+$$
+S=\int_{|k&#39;|&lt;b\Lambda}\frac{\mathrm{d}^d k&#39;}{(2\pi)^d}\phi&#39;(-k&#39;)\phi&#39;(k&#39;)
+$$
+`)
+    const root = document.createElement("div")
+    root.innerHTML = html
+    const text = root.querySelector(".katex-html")?.textContent ?? ""
+
+    expect(html).toContain("katex-display")
+    expect(text).toContain("′")
+    expect(text).toContain("<")
+    expect(text).not.toContain("&#39;")
+    expect(text).not.toContain("&lt;")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #658

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

修复聊天消息中的数学公式渲染兼容性问题。这个改动补了两层处理：一是在数学渲染前把 `\(...\)` 和 `\[...\]` 规范化成当前渲染链稳定支持的 `$...$` 和 `$$...$$`；二是在送入 KaTeX 前解码公式里的 HTML 实体，避免矩阵、长公式和带 prime / 不等式的公式因为 `&amp;`、`&#39;`、`&lt;` 等内容而显示异常。之所以有效，是因为桌面端会先经过 `nativeParser`，现在在进入这个解析入口前就先完成了数学规范化，后续 KaTeX 拿到的也是未被污染的公式内容。

### How did you verify your code works?

- 运行 `bun run test:unit -- src/context/marked.vitest.ts`
- 运行 `bun typecheck`
- 在聊天界面手动验证复杂长公式、矩阵公式和 `\[...\]` 块公式可以正常显示

### Screenshots / recordings

未修复前：
<img width="1095" height="1104" alt="image" src="https://github.com/user-attachments/assets/00ab006b-d811-4392-8c46-09aed16a13a5" />

修复后：
<img width="1099" height="370" alt="image" src="https://github.com/user-attachments/assets/51e00789-d7dd-4d74-82ae-6c1def19e853" />



本地已手动验证 UI 渲染结果。

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR