### PR TITLE
fix: gate web-update and /upgrade endpoints with OPENCODE_DISABLE_AUTOUPDATE

### DIFF
--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -8,6 +8,7 @@ import { GlobalBus } from "@/bus/global"
 import { AsyncQueue } from "@/util/queue"
 import { Installation } from "@/installation"
 import { Instance } from "../../project/instance"
+import { Flag } from "../../flag/flag"
 import { Log } from "../../util/log"
 import { lazy } from "../../util/lazy"
 import { Config } from "../../config/config"
@@ -629,6 +630,7 @@ export const GlobalRoutes = lazy(() =>
         }),
       ),
       async (c) => {
+        if (Flag.OPENCODE_DISABLE_AUTOUPDATE) return c.json({ success: false, error: "Auto-update is disabled" }, 400)
         const method = await Installation.method()
         if (method === "unknown") {
           return c.json({ success: false, error: "Unknown installation method" }, 400)

--- a/packages/opencode/src/server/web-update.ts
+++ b/packages/opencode/src/server/web-update.ts
@@ -7,6 +7,7 @@ import z from "zod"
 import { Global } from "@/global"
 import { Installation } from "@/installation"
 import { ConfigPaths } from "../config/paths"
+import { Flag } from "../flag/flag"
 import { Log } from "../util/log"
 
 const log = Log.create({ service: "server" })
@@ -745,6 +746,19 @@ export async function readWebCurrentVersion() {
 }
 
 export async function webCheck(os: z.infer<typeof WebUpdateOS>) {
+  if (Flag.OPENCODE_DISABLE_AUTOUPDATE) {
+    return {
+      currentVersion: await readWebCurrentVersion(),
+      remoteVersion: "",
+      updateAvailable: false,
+      downloaded: false,
+      status: "available" as const,
+      workDir: getWorkDir(os) ?? "",
+      updateAction: undefined,
+      updateError: undefined,
+      checkError: undefined,
+    }
+  }
   const currentVersion = await readWebCurrentVersion()
   const workDir = getWorkDir(os) ?? ""
   try {
@@ -797,6 +811,7 @@ export async function webCheck(os: z.infer<typeof WebUpdateOS>) {
 }
 
 export async function downloadWebUpdate(input: z.infer<typeof WebUpdateDownloadInput>) {
+  if (Flag.OPENCODE_DISABLE_AUTOUPDATE) return failRes("Auto-update is disabled")
   const os = input.os
   const version = input.version
   const force = input.force
@@ -879,6 +894,7 @@ export async function downloadWebUpdate(input: z.infer<typeof WebUpdateDownloadI
 }
 
 export async function installWebUpdate(input: z.infer<typeof WebUpdateInstallInput>) {
+  if (Flag.OPENCODE_DISABLE_AUTOUPDATE) return failRes("Auto-update is disabled")
   const os = input.os
   const version = input.version
   const workDir = getWorkDir(os)


### PR DESCRIPTION
### Issue for this PR

Closes #660

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `OPENCODE_DISABLE_AUTOUPDATE` env var was only checked in the CLI/TUI upgrade path (`cli/upgrade.ts`). This PR extends the gate to:
- `webCheck()` — returns `updateAvailable: false` when flag is set
- `downloadWebUpdate()` — returns error when flag is set  
- `installWebUpdate()` — returns error when flag is set
- `POST /upgrade` — returns 400 error when flag is set

This ensures auto-update is fully disabled across all paths when deploying in managed cluster environments.

### How did you verify your code works?

Reviewed via `git diff`; changes are 4 minimal early-return guards with no new logic or side effects.

### Screenshots / recordings

Not applicable.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR