### PR TITLE
fix(desktop-electron): set Windows-safe sidecar version for predev

### DIFF
--- a/packages/desktop-electron/scripts/predev.ts
+++ b/packages/desktop-electron/scripts/predev.ts
@@ -4,6 +4,11 @@ import { copyBinaryToSidecarFolder, getCurrentSidecar, windowsify } from "./util
 
 await $`bun ./scripts/copy-icons.ts ${process.env.OPENCODE_CHANNEL ?? "dev"}`
 
+if (process.platform === "win32" && !process.env.OPENCODE_VERSION) {
+  // Bun rejects preview versions in Windows executable metadata during local predev builds.
+  process.env.OPENCODE_VERSION = (await Bun.file(new URL("../package.json", import.meta.url)).json()).version
+}
+
 const RUST_TARGET = Bun.env.RUST_TARGET
 
 const sidecarConfig = getCurrentSidecar(RUST_TARGET)


### PR DESCRIPTION
### Issue for this PR

Closes #663

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes the Windows `desktop-electron` dev flow when `predev` builds the `packages/opencode` sidecar with a preview version like `0.0.0-dev-...`.

On Windows, Bun rejects that preview version when it is used as the executable metadata version during the sidecar build. This caused `bun run --cwd packages/desktop-electron dev` to fail before Electron could start.

The fix is scoped to `packages/desktop-electron/scripts/predev.ts`: on Windows, if `OPENCODE_VERSION` is not already set, `predev` now supplies the package version so the local sidecar build uses a Windows-safe version string.

### How did you verify your code works?

I ran `bun run --cwd packages/desktop-electron predev` on Windows and confirmed the sidecar build completed successfully.

The smoke test also passed:
`dist/aether-windows-x64/bin/aether --version`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR