### PR TITLE
fix: sidebar conversation tree shows (no text) when skill-refresh injects synthetic user message

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -666,7 +666,6 @@ export namespace SessionPrompt {
           variant: lastUser.variant,
         }
         await Session.updateMessage(msg)
-        lastUser = msg
         const part = {
           id: PartID.ascending(),
           messageID: msg.id,


### PR DESCRIPTION
### Issue for this PR

Closes #667

### Type of change

- [x] Bug fix

### What does this PR do?

When a skill-refresh injects a synthetic user message between the real user message and the assistant response, the sidebar conversation tree shows "(no text)" for that turn instead of the actual user text.

Root cause: `prompt.ts:669` replaces `lastUser` with the synthetic skill-inject message. This causes:
1. `parentID` on the assistant message (L693) points to the synthetic msg instead of the real user msg
2. `collectCompletedTurns` requires `assistant.parentID === user.id` to form a CompletedTurn — the real user msg has no matching assistant child → skipped
3. The synthetic msg has an assistant child → forms a CompletedTurn, but `extractUserLabel` filters out `synthetic=true` parts → returns "(no text)"
4. Memory auto-recall (`lastUserText` at L746-747) uses skill-inject text instead of real user text

Fix: remove `lastUser = msg` at line 669. The synthetic message is still pushed into `msgs` (L683-686) for LLM context, but `lastUser` remains the real user message so `parentID`, `lastUserText`, and other downstream references point correctly.

### How did you verify your code works?

- `bun typecheck` passes in packages/opencode
- DB query confirmed the root cause: assistant `parentID` points to synthetic msg with `synthetic=true` parts while real user msg has no assistant children
- Verified that all downstream uses of `lastUser` (parentID, variant, format, model, tools, LLM user param) work correctly with the real user message — the synthetic msg copies `agent/model/variant` from `lastUser`, so removing the replacement has no negative effect on those fields

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR