### PR TITLE
feat(knowledge): 知识库状态持久化迁移到统一 JSON 文件，解决跨端口丢失

### DIFF
--- a/packages/app/src/context/knowledge.tsx
+++ b/packages/app/src/context/knowledge.tsx
@@ -1,6 +1,5 @@
-import { createContext, useContext, createSignal, Component, JSX, onMount } from "solid-js"
+import { createContext, useContext, createSignal, Component, JSX, onMount, createEffect, on } from "solid-js"
 import { createStore } from "solid-js/store"
-import { Persist, persisted } from "@/utils/persist"
 import { useGlobalSDK } from "./global-sdk"
 import { useServer } from "./server"
 
@@ -25,7 +24,7 @@ export interface KnowledgeConfig {
 
 // 上次使用的配置
 export interface LastConfig {
-  provider: string  // provider ID, e.g. "openai", "siliconflow", "local"
+  provider: string // provider ID, e.g. "openai", "siliconflow", "local"
   model: string
   apiKey: string
   baseURL: string
@@ -152,7 +151,38 @@ export const KnowledgeProvider: Component<{ children: JSX.Element }> = (props) =
   const sdk = useGlobalSDK()
   const server = useServer()
 
-  const [state, setState] = persisted(Persist.global("knowledge-state"), createStore<KnowledgeState>(DEFAULT_STATE))
+  const [state, setState] = createStore<KnowledgeState>({ ...DEFAULT_STATE })
+
+  let initDone = false
+  let saveTimer: ReturnType<typeof setTimeout>
+
+  const loadState = async () => {
+    try {
+      const resp = await fetchApi("/knowledge/state")
+      if (resp.ok) {
+        const remote = await resp.json()
+        if (remote.knowledgeBases?.length > 0) setState(remote)
+        return remote.knowledgeBases?.length > 0
+      }
+    } catch {}
+    return false
+  }
+
+  const saveState = () => {
+    clearTimeout(saveTimer)
+    saveTimer = setTimeout(() => {
+      fetchApi("/knowledge/state", {
+        method: "POST",
+        body: JSON.stringify({
+          data: {
+            knowledgeBases: state.knowledgeBases,
+            activeIds: state.activeIds,
+            lastConfig: state.lastConfig,
+          },
+        }),
+      }).catch(() => {})
+    }, 500)
+  }
 
   const [models] = createSignal<EmbeddingModel[]>([
     {
@@ -265,11 +295,62 @@ export const KnowledgeProvider: Component<{ children: JSX.Element }> = (props) =
     }
   }
 
-  onMount(() => {
+  onMount(async () => {
+    const hasRemote = await loadState()
+    initDone = true
+
+    if (!hasRemote) {
+      // 尝试从 .aether-kb 目录扫描恢复
+      try {
+        const resp = await fetchApi("/knowledge/discover")
+        if (resp.ok) {
+          const { found } = await resp.json()
+          if (found?.length > 0) {
+            for (const item of found) {
+              const id = generateId()
+              setState("knowledgeBases", (list) => [
+                ...list,
+                {
+                  id,
+                  path: item.path,
+                  name: item.config?.name ?? item.path.split("/").pop() ?? "Recovered KB",
+                  providerID: "",
+                  embeddingProvider: item.config?.embeddingProvider ?? "custom",
+                  embeddingModel: item.config?.embeddingModel ?? "",
+                  embeddingDimensions: item.config?.embeddingDimensions,
+                  apiKey: item.config?.apiKey ?? "",
+                  baseURL: item.config?.baseURL ?? "",
+                  chunkSize: item.config?.chunkSize ?? 500,
+                  chunkOverlap: item.config?.chunkOverlap ?? 50,
+                } as KnowledgeConfig,
+              ])
+            }
+            saveState()
+          }
+        }
+      } catch {}
+    }
+
     if (state.knowledgeBases.length > 0) {
       refreshAllStats()
     }
   })
+
+  // 状态变更时自动持久化
+  createEffect(
+    on(
+      () => ({
+        knowledgeBases: state.knowledgeBases,
+        activeIds: state.activeIds,
+        lastConfig: state.lastConfig,
+      }),
+      () => {
+        if (!initDone) return
+        saveState()
+      },
+      { defer: true },
+    ),
+  )
 
   const loadKnowledgeBase = async (path: string): Promise<KnowledgeIndexData | null> => {
     const encodedPath = encodeURIComponent(path)

--- a/packages/desktop-electron/src/main/paths.ts
+++ b/packages/desktop-electron/src/main/paths.ts
@@ -28,6 +28,13 @@ export function userDataDir() {
   return join(app.getPath("appData"), id(APP_IDS))
 }
 
+export function aetherDataDir() {
+  const home = app.getPath("home")
+  if (process.platform === "darwin") return join(home, ".local", "share", "aether")
+  if (process.platform === "win32") return join(process.env.LOCALAPPDATA || join(home, "AppData", "Local"), "aether")
+  return join(home, ".local", "share", "aether")
+}
+
 export function legacyUserDataDir() {
   return join(app.getPath("appData"), id(LEGACY_APP_IDS))
 }

--- a/packages/desktop-electron/src/main/persist.ts
+++ b/packages/desktop-electron/src/main/persist.ts
@@ -1,7 +1,7 @@
 import { copyFileSync, existsSync, mkdirSync, rmSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { legacyStoreName, storeName } from "./persist-names"
-import { legacyUserDataDir, userDataDir } from "./paths"
+import { legacyUserDataDir, userDataDir, aetherDataDir } from "./paths"
 
 let ready = false
 
@@ -16,19 +16,27 @@ function copy(src: string, dst: string) {
 function storeSources(name: string) {
   const cur = userDataDir()
   const old = legacyUserDataDir()
+  const aether = aetherDataDir()
   const next = storeName(name)
   const prev = legacyStoreName(name)
-  return [
+  const sources = [
     join(cur, next),
     ...(prev ? [join(cur, prev)] : []),
     join(old, next),
     ...(prev ? [join(old, prev)] : []),
   ]
+  // 如果全局 store 目标目录不同于 old userDataDir，从旧 userDataDir 复制
+  if (aether !== cur && next === "aether.global.dat") {
+    sources.push(join(cur, next))
+    if (prev) sources.push(join(cur, prev))
+  }
+  return sources
 }
 
 export function ensureStoreFile(name: string) {
   const next = storeName(name)
-  const file = join(userDataDir(), next)
+  const cwd = next === "aether.global.dat" ? aetherDataDir() : userDataDir()
+  const file = join(cwd, next)
   if (existsSync(file)) return next
   const seen = new Set<string>()
   for (const src of storeSources(name)) {

--- a/packages/desktop-electron/src/main/store.ts
+++ b/packages/desktop-electron/src/main/store.ts
@@ -1,15 +1,19 @@
 import Store from "electron-store"
 import { SETTINGS_STORE } from "./constants"
 import { ensureDesktopPersist, ensureStoreFile } from "./persist"
-import { userDataDir } from "./paths"
+import { userDataDir, aetherDataDir } from "./paths"
 
 const cache = new Map<string, Store>()
+
+const GLOBAL_STORE_NAME = "aether.global.dat"
 
 export function getStore(name = SETTINGS_STORE) {
   const cached = cache.get(name)
   if (cached) return cached
   ensureDesktopPersist()
-  const next = new Store({ name: ensureStoreFile(name), fileExtension: "", cwd: userDataDir() })
+  const nextName = ensureStoreFile(name)
+  const cwd = nextName === GLOBAL_STORE_NAME ? aetherDataDir() : userDataDir()
+  const next = new Store({ name: nextName, fileExtension: "", cwd })
   cache.set(name, next)
   return next
 }

--- a/packages/opencode/src/server/routes/knowledge.ts
+++ b/packages/opencode/src/server/routes/knowledge.ts
@@ -8,10 +8,21 @@ import { KnowledgeIndexSchema, SearchResultSchema, EmbeddingModelInfoSchema } fr
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
 import { Log } from "../../util/log"
+import { Filesystem } from "../../util/filesystem"
 import { setKnowledgeConfig, getKnowledgeConfig } from "../../tool/knowledge"
 import path from "path"
+import os from "os"
+import { readdir, mkdir } from "fs/promises"
 
 const log = Log.create({ service: "knowledge" })
+
+function dataDir() {
+  const home = os.homedir()
+  if (process.platform === "darwin") return path.join(home, ".local", "share", "aether")
+  if (process.platform === "win32")
+    return path.join(process.env.LOCALAPPDATA || path.join(home, "AppData", "Local"), "aether")
+  return path.join(home, ".local", "share", "aether")
+}
 
 // 请求/响应 schemas
 const CreateKnowledgeBaseSchema = z.object({
@@ -73,6 +84,164 @@ export const KnowledgeRoutes = lazy(() =>
       async (c) => {
         const models = Knowledge.listModels()
         return c.json(models)
+      },
+    )
+    // 扫描恢复已有知识库
+    .get(
+      "/discover",
+      describeRoute({
+        summary: "Discover existing knowledge bases",
+        description: "扫描桌面和文稿目录，发现已存在的 .aether-kb 知识库索引并返回",
+        operationId: "knowledge.discover",
+        responses: {
+          200: {
+            description: "发现的知识库列表",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.object({
+                    found: z.array(
+                      z.object({
+                        path: z.string(),
+                        config: z.object({
+                          name: z.string(),
+                          embeddingProvider: z.string(),
+                          embeddingModel: z.string(),
+                          embeddingDimensions: z.number().optional(),
+                          apiKey: z.string().optional(),
+                          baseURL: z.string().optional(),
+                          chunkSize: z.number().optional(),
+                          chunkOverlap: z.number().optional(),
+                        }),
+                      }),
+                    ),
+                  }),
+                ),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        const home = os.homedir()
+        const search = ["Desktop", "Documents"].map((d) => path.join(home, d))
+        const found: Array<{ path: string; config: Record<string, unknown> }> = []
+        const seen = new Set<string>()
+
+        async function scan(dir: string, depth: number) {
+          if (depth <= 0 || seen.has(dir)) return
+          seen.add(dir)
+          try {
+            const index = await Storage.loadIndex(dir)
+            if (index) {
+              found.push({
+                path: dir,
+                config: {
+                  name: index.config?.name ?? path.basename(dir),
+                  embeddingProvider: index.config?.embeddingProvider ?? "custom",
+                  embeddingModel: index.config?.embeddingModel ?? "",
+                  embeddingDimensions: index.config?.embeddingDimensions,
+                  apiKey: index.config?.apiKey,
+                  baseURL: index.config?.baseURL,
+                  chunkSize: index.config?.chunkSize,
+                  chunkOverlap: index.config?.chunkOverlap,
+                },
+              })
+              return
+            }
+            const entries = await readdir(dir, { withFileTypes: true })
+            for (const entry of entries) {
+              if (!entry.isDirectory()) continue
+              if (entry.name.startsWith(".")) continue
+              await scan(path.join(dir, entry.name), depth - 1)
+            }
+          } catch {
+            // skip inaccessible directories
+          }
+        }
+
+        for (const dir of search) {
+          await scan(dir, 6)
+        }
+
+        if (found.length === 0) {
+          await scan(home, 4)
+        }
+
+        return c.json({ found })
+      },
+    )
+    // 获取/保存全局知识库状态（统一持久化到 ~/.local/share/aether/aether.global.dat）
+    .get(
+      "/state",
+      describeRoute({
+        summary: "Get knowledge base state",
+        description: "获取全局知识库状态列表",
+        operationId: "knowledge.state.get",
+        responses: {
+          200: {
+            description: "知识库状态",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.object({
+                    knowledgeBases: z.array(z.any()),
+                    activeIds: z.array(z.string()),
+                    lastConfig: z.any().optional(),
+                  }),
+                ),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        const file = path.join(dataDir(), "aether.global.dat")
+        try {
+          let store: Record<string, unknown> = {}
+          try {
+            store = await Filesystem.readJson(file)
+          } catch {}
+          return c.json(store["knowledge-state"] ?? { knowledgeBases: [], activeIds: [] })
+        } catch {
+          return c.json({ knowledgeBases: [], activeIds: [] })
+        }
+      },
+    )
+    .post(
+      "/state",
+      describeRoute({
+        summary: "Save knowledge base state",
+        description: "保存全局知识库状态列表",
+        operationId: "knowledge.state.post",
+        responses: {
+          200: {
+            description: "保存成功",
+            content: {
+              "application/json": {
+                schema: resolver(z.object({ ok: z.boolean() })),
+              },
+            },
+          },
+        },
+      }),
+      validator("json", z.object({ data: z.any() })),
+      async (c) => {
+        const { data } = c.req.valid("json")
+        const dir = dataDir()
+        const file = path.join(dir, "aether.global.dat")
+        await mkdir(dir, { recursive: true })
+        try {
+          let store: Record<string, unknown> = {}
+          try {
+            store = await Filesystem.readJson(file)
+          } catch {}
+          store["knowledge-state"] = data
+          await Filesystem.writeJson(file, store)
+          return c.json({ ok: true })
+        } catch {
+          return c.json({ error: "Failed to save state" }, 500)
+        }
       },
     )
     // 创建知识库


### PR DESCRIPTION
### Issue for this PR

Closes #665

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

当前知识库状态持久化分散在 localStorage 和 electron-store，导致换端口后丢失、Desktop 与会话数据不在同目录。本次 PR 统一到后端管理的 aether.global.dat JSON 文件。

后端: 新增 /knowledge/discover (扫描 .aether-kb) + /knowledge/state (GET/POST 读写 JSON)
前端: 移除 persisted() 改用后端 API，空列表时自动 discover 恢复
Desktop: aetherDataDir() + getStore 重定向 + 旧路径迁移

### How did you verify your code works?

curl 验证 API 正常，换端口重启知识库列表不丢失

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR