### PR TITLE
fix: exempt PWA manifest and favicon paths from basicAuth

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -203,6 +203,18 @@ import { Cron } from "@/cron"
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
 
+const NO_AUTH_PATHS = new Set([
+  "/site.webmanifest",
+  "/favicon-96x96-v3.png",
+  "/favicon-v3.svg",
+  "/favicon-v3.ico",
+  "/apple-touch-icon-v3.png",
+  "/oc-theme-preload.js",
+  "/web-app-manifest-192x192.png",
+  "/web-app-manifest-512x512.png",
+  "/social-share.png",
+])
+
 const csp = (hash = "") =>
   `default-src 'self'; script-src 'self' 'wasm-unsafe-eval'${hash ? ` 'sha256-${hash}'` : ""}; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:`
 
@@ -283,6 +295,10 @@ export namespace Server {
         // Allow CORS preflight requests to succeed without auth.
         // Browser clients sending Authorization headers will preflight with OPTIONS.
         if (c.req.method === "OPTIONS") return next()
+        // PWA manifest, favicons, and theme preload are fetched by the browser
+        // automatically without Authorization headers. Exempt them from basicAuth
+        // since they contain no sensitive data.
+        if (NO_AUTH_PATHS.has(c.req.path)) return next()
         const password = Flag.OPENCODE_SERVER_PASSWORD
         if (!password) return next()
         const username = Flag.OPENCODE_SERVER_USERNAME ?? "opencode"


### PR DESCRIPTION
### Issue for this PR

Closes #674

### Type of change

- [x] Bug fix

### What does this PR do?

When the Aether web server is deployed behind a reverse proxy (e.g. SCOW) with `OPENCODE_SERVER_PASSWORD` enabled, the browser automatically fetches `/site.webmanifest`, favicons, and theme resources without `Authorization` headers. The `basicAuth` middleware rejects these requests with 401.

These paths contain no sensitive data (just icons, manifest, and a theme-preload script), so this PR exempts them from basicAuth by adding a `NO_AUTH_PATHS` set that skips auth for these specific paths. The base path interceptor already strips `VITE_BASE_PATH` before Hono routing, so the exempted paths work correctly regardless of deployment prefix.

### How did you verify your code works?

- `bun typecheck` passes for both `packages/opencode` and `packages/app`
- The exempted paths are exact matches (no regex), matching the static file paths listed in `index.html`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR