### PR TITLE
fix: electron-vite renderer base override causing white screen on file:// protocol

### DIFF
--- a/packages/app/vite.js
+++ b/packages/app/vite.js
@@ -36,7 +36,7 @@ function stripGitBashPrefix(path) {
 
 function readBasePath() {
   const raw = process.env.VITE_BASE_PATH
-  if (!raw) return "/"
+  if (!raw) return
   if (raw === "." || raw === "./") return "./"
   if (/^[A-Za-z]:[\\/]/.test(raw)) {
     const recovered = stripGitBashPrefix(raw)
@@ -74,7 +74,7 @@ export default [
       if (routerBase !== "/") console.log(`[opencode] base path: ${routerBase}`)
       env.VITE_BASE_PATH = routerBase
       return {
-        base: basePath,
+        ...(basePath ? { base: basePath } : {}),
         define: Object.fromEntries(Object.entries(env).map(([k, v]) => [`import.meta.env.${k}`, JSON.stringify(v)])),
         resolve: {
           alias: {


### PR DESCRIPTION
### Issue for this PR

Closes #676

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**问题**：Electron 桌面版 `electron-vite build` 后打开应用出现白屏。

**根因**：`packages/app/vite.js` 的插件在 `config()` 钩子中无条件返回 `base: "/"`，覆盖了 electron-vite 内部 `enforce: 'pre'` 插件为生产环境设置的 `base: "./"`。构建产物中 JS/CSS 使用绝对路径（`/assets/...`），在 Electron 的 `file://` 协议下无法正确加载。

**修复**（两行改动）：
1. `readBasePath()`：当 `VITE_BASE_PATH` 环境变量未设置时返回 `undefined`，不再返回 `"/"`
2. `config()` 返回值：使用 `...(basePath ? { base: basePath } : {})`，只在显式配置了 `VITE_BASE_PATH` 时才设置 `base`

**影响分析**：

| 场景 | 修改前 | 修改后 |
|---|---|---|
| Electron 构建（无 VITE_BASE_PATH）| base = "/" → 白屏 | base = "./"（electron-vite 默认）→ 正常 |
| Web 构建（无 VITE_BASE_PATH）| base = "/"（Vite 默认）| base = "/"（Vite 默认，不变）|
| 子路径部署（有 VITE_BASE_PATH）| base = "<配置值>" | base = "<配置值>"（不变）|

### How did you verify your code works?

1. 修复后执行 `electron-vite build`，验证 `out/renderer/index.html` 中资源路径变为相对路径 `./assets/...`
2. 打包并安装 .dmg，确认应用正常显示，不再白屏
3. `bun turbo typecheck` 全部通过

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR