### PR TITLE
fix: support pty websocket under base path

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -52,45 +52,6 @@ function baseStrip(path: string, base: string) {
   return undefined
 }
 
-const api = [
-  "/agent",
-  "/auth",
-  "/command",
-  "/config",
-  "/cron",
-  "/database",
-  "/doc",
-  "/event",
-  "/experimental",
-  "/file",
-  "/find",
-  "/formatter",
-  "/global",
-  "/instance",
-  "/knowledge",
-  "/log",
-  "/lsp",
-  "/mcp",
-  "/memory",
-  "/mobile",
-  "/path",
-  "/permission",
-  "/project",
-  "/project-directory-meta",
-  "/provider",
-  "/pty",
-  "/question",
-  "/reading-mode",
-  "/session",
-  "/skill",
-  "/tui",
-  "/vcs",
-]
-
-function routed(path: string) {
-  return api.some((route) => path === route || path.startsWith(`${route}/`))
-}
-
 function baseInject(html: string, base: string) {
   const tag = `<base href="${baseHref(base)}"><script>globalThis.__AETHER_BASE_PATH__=${JSON.stringify(base)}</script>`
   return html.includes("<head>") ? html.replace("<head>", `<head>${tag}`) : `${tag}${html}`
@@ -177,7 +138,7 @@ import { EventRoutes } from "./routes/event"
 import { InstanceBootstrap } from "../project/bootstrap"
 import { NotFoundError } from "../storage/db"
 import type { ContentfulStatusCode } from "hono/utils/http-status"
-import { websocket, type BunWebSocketData } from "hono/bun"
+import { websocket } from "hono/bun"
 import { HTTPException } from "hono/http-exception"
 import { errors } from "./error"
 import { Filesystem } from "@/util/filesystem"
@@ -969,22 +930,11 @@ export namespace Server {
   }) {
     const app = createApp(opts)
     const bp = basePath()
-    const baseFetch =
-      bp === "/"
-        ? app.fetch
-        : async (req: Request, server: Bun.Server<BunWebSocketData>): Promise<Response> => {
-            const url = new URL(req.url)
-            const stripped = baseStrip(url.pathname, bp)
-            if (stripped !== undefined && routed(stripped)) {
-              url.pathname = stripped
-              req = new Request(url.toString(), req)
-            }
-            return app.fetch(req, server)
-          }
+    const root = bp === "/" ? app : new Hono<ServerEnv>().route(bp, app).route("/", app)
     const args = {
       hostname: opts.hostname,
       idleTimeout: 0,
-      fetch: baseFetch,
+      fetch: root.fetch,
       websocket: websocket,
       // Raise body limit to 1 GB to support large PDF uploads (default is 128 MB)
       maxRequestBodySize: 1024 * 1024 * 1024,

--- a/packages/opencode/test/server/server-web-cache.test.ts
+++ b/packages/opencode/test/server/server-web-cache.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, test } from "bun:test"
 import { mkdir, writeFile } from "node:fs/promises"
 import path from "node:path"
+import { setTimeout as sleep } from "node:timers/promises"
 import { Server } from "../../src/server/server"
 import { tmpdir } from "../fixture/fixture"
+
+const wait = async (fn: () => boolean, ms = 5000) => {
+  const end = Date.now() + ms
+  while (Date.now() < end) {
+    if (fn()) return
+    await sleep(25)
+  }
+  throw new Error("timeout waiting for server event")
+}
 
 describe("web cache headers", () => {
   test("serves hashed assets as immutable", async () => {
@@ -86,6 +96,58 @@ describe("web cache headers", () => {
       expect(await route.text()).toContain(`<base href="/aether/">`)
     } finally {
       Object.defineProperty(process, "execPath", { value: old, configurable: true })
+      if (env === undefined) {
+        delete process.env.VITE_BASE_PATH
+      } else {
+        process.env.VITE_BASE_PATH = env
+      }
+    }
+  })
+
+  test("upgrades pty websocket under runtime base path", async () => {
+    if (process.platform === "win32") return
+
+    await using tmp = await tmpdir({ git: true })
+
+    const env = process.env.VITE_BASE_PATH
+    process.env.VITE_BASE_PATH = "/aether"
+    const server = Server.listen({ port: 0, hostname: "127.0.0.1" })
+    const root = `http://127.0.0.1:${server.port}/aether`
+    const query = `directory=${encodeURIComponent(tmp.path)}`
+    let ws: WebSocket | undefined
+    let id: string | undefined
+
+    try {
+      const res = await fetch(`${root}/pty?${query}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ command: "cat", title: "base" }),
+      })
+      expect(res.status).toBe(200)
+
+      const data = (await res.json()) as { id?: unknown }
+      if (typeof data.id !== "string") throw new Error("missing pty id")
+      id = data.id
+
+      let open = false
+      let closed = false
+      ws = new WebSocket(`ws://127.0.0.1:${server.port}/aether/pty/${id}/connect?${query}&cursor=0`)
+      ws.addEventListener("open", () => {
+        open = true
+      })
+      ws.addEventListener("close", () => {
+        closed = true
+      })
+      ws.addEventListener("error", () => {
+        closed = true
+      })
+
+      await wait(() => open || closed)
+      expect(open).toBe(true)
+    } finally {
+      ws?.close()
+      if (id) await fetch(`${root}/pty/${id}?${query}`, { method: "DELETE" }).catch(() => undefined)
+      await server.stop(true)
       if (env === undefined) {
         delete process.env.VITE_BASE_PATH
       } else {


### PR DESCRIPTION
### Issue for this PR

Closes #678

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes PTY WebSocket connections when the packaged web UI is served under a non-root `VITE_BASE_PATH`.

The previous `Server.listen()` base path handling stripped the prefix by rebuilding the incoming `Request` before passing it to Hono. That is fine for normal HTTP routes, but breaks Bun/Hono WebSocket upgrade because the upgrade needs the original request object.

This PR mounts the same Hono app at both the configured base path and `/` instead. That lets `/aether/pty/:id/connect` route directly to the existing PTY WebSocket handler without cloning the request, while preserving unprefixed compatibility.

It also adds a real `Server.listen()` regression test that creates a PTY session and verifies WebSocket upgrade succeeds at `/aether/pty/:id/connect`.

### How did you verify your code works?

- `bun install --frozen-lockfile`
- `bun test test/server/server-web-cache.test.ts`
- `bun typecheck`
- `git diff --check`
- `git push` pre-push hook ran `bun turbo typecheck` successfully

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR