### PR TITLE
feat(memory): add modular durable memory system

### DIFF
--- a/docs/memory-system.zh-CN.md
+++ b/docs/memory-system.zh-CN.md
@@ -490,4 +490,3 @@ bun run --cwd packages/opencode typecheck
 bun run --cwd packages/app ./script/vitest.ts run --config ./vitest.config.ts src/components/settings-memory.vitest.tsx
 bun run --cwd packages/app typecheck
 ```
-

--- a/docs/memory-system.zh-CN.md
+++ b/docs/memory-system.zh-CN.md
@@ -1,0 +1,493 @@
+# Aether Memory 系统（当前实现）
+
+本文描述当前代码中已经落地的 memory 基础设施实现，目标代码范围主要在：
+
+- `packages/opencode/src/memory/`
+- `packages/opencode/src/tool/memory.ts`
+- `packages/opencode/src/server/routes/memory.ts`
+- `packages/opencode/src/server/server.ts`
+- `packages/opencode/src/cron/index.ts`
+- `packages/app/src/components/settings-memory.tsx`
+
+本文只描述**当前已经实现**的能力、接口和边界。
+
+## 0. 当前已实现功能总览
+
+当前已经落地的 memory 功能可以直接概括为：
+
+- 单一长期记忆文件 `AETHER_MEMORY.md`
+- 按 channel 隔离的 `memory.db` 原始事件与反思日志
+- 三种长期记忆类型：
+  - `preference`
+  - `fact`
+  - `task`
+- 两种长期记忆 scope：
+  - `global`
+  - `project:<project_id>`
+- 四个 agent 工具：
+  - `memory_search`
+  - `memory_remember`
+  - `memory_forget`
+  - `memory_reflect`
+- `/memory` HTTP API
+- Settings > Memory 管理页
+- shortcut 目录注入
+- quick reflection 与 daily reflection
+- 首次初始化导入旧 session 的用户消息
+- built-in daily reflection cron direct action
+- `stop()` / `purge()` 生命周期接口
+
+当前**还没有**落地的部分：
+
+- 向量库或 embedding 检索
+- 多 Markdown 长期记忆源
+- 直接编辑 `AETHER_MEMORY.md` 的前端编辑器
+- session 级长期记忆 scope
+- hard delete 历史原始事件
+- 并行扫描历史 session
+
+## 1. 设计目标
+
+当前 memory 系统被实现为一层**模块化长期记忆基础设施**，而不是把历史 session 当作可随时读取的记忆库。
+
+设计目标是：
+
+- 正常对话时不读取旧 session transcript
+- Agent 只通过 `memory_search` 获取长期记忆正文
+- 长期记忆最终集中到一个 Markdown 文件中，便于检查、备份和迁移
+- 原始写入、forget 请求和 reflection 运行记录进入 SQLite，便于审计和补跑
+- 显式记忆尽快跨 session 可见
+- 低信号消息不过度触发 LLM reflection
+- daily reflection 能整理重复、相似和冲突记忆
+- 尽量减少对 agent/session 主链路的侵入
+
+当前版本定位为：
+
+- 本地单用户长期记忆系统
+- Markdown 作为长期事实源
+- SQLite 作为事件日志和运行日志
+- Tool/API/UI 三种入口共享同一套 `Memory` service
+
+## 2. 整体架构
+
+当前实现可分成 5 层：
+
+1. **Markdown 长期记忆层**
+   - `AETHER_MEMORY.md`
+   - 保存可搜索的长期记忆和 shortcut 目录
+
+2. **Event / Run Log 层**
+   - `<channel>/memory.db`
+   - 保存 `memory_event`、`reflection_run` 和 `memory_setting`
+
+3. **Memory Service 层**
+   - 负责 remember、forget、search、reflect、initialize、startup catch-up
+
+4. **Agent / API 适配层**
+   - `memory_*` agent tools
+   - `/memory` HTTP routes
+
+5. **UI / Cron 集成层**
+   - Settings > Memory
+   - daily reflection cron direct action
+
+```mermaid
+flowchart TD
+  User["用户消息或工具调用"] --> Service["Memory service"]
+  Service --> DB["<channel>/memory.db"]
+  Service --> Reflect["quick/daily reflection"]
+  Reflect --> MD["AETHER_MEMORY.md"]
+  MD --> Search["memory_search"]
+  Search --> Agent["Agent"]
+  MD --> Shortcut["Shortcut Directory"]
+  Shortcut --> Prompt["极小 system prompt 注入"]
+  Cron["Daily reflection cron"] --> Reflect
+  UI["Settings > Memory"] --> Service
+```
+
+## 2.1 核心代码入口
+
+当前最关键的入口文件是：
+
+- `packages/opencode/src/memory/index.ts`
+  - 核心 memory service 实现
+- `packages/opencode/src/memory/markdown.ts`
+  - `AETHER_MEMORY.md` parse / render
+- `packages/opencode/src/memory/search.ts`
+  - Markdown 记忆检索
+- `packages/opencode/src/memory/gate.ts`
+  - quick reflection 确定性 gate
+- `packages/opencode/src/memory/schema.sql.ts`
+  - SQLite 表定义
+- `packages/opencode/src/memory/installer.ts`
+  - memory 安装、daily cron 注册、startup catch-up
+- `packages/opencode/src/memory/plugin.ts`
+  - shortcut prompt 注入
+- `packages/opencode/src/tool/memory.ts`
+  - agent tools
+- `packages/opencode/src/server/routes/memory.ts`
+  - `/memory` HTTP 路由
+- `packages/app/src/components/settings-memory.tsx`
+  - Settings > Memory UI
+
+## 3. 持久化结构
+
+### 3.1 `memory.db`
+
+原始事件与 reflection 运行记录保存在当前 channel 下：
+
+```text
+<channel>/memory.db
+```
+
+`memory.db` 不是长期记忆事实源，也不是正常对话时的搜索目标。它主要用于：
+
+- 记录 `remember` / `forget` 原始请求
+- 记录 quick/daily/manual reflection 输入和结果
+- 标记事件状态
+- 支持 missed daily reflection 补跑
+- 支持首次初始化导入旧 session 后继续走同一套 reflection 链路
+
+核心表：
+
+- `memory_event`
+- `reflection_run`
+- `memory_setting`
+
+`memory_event.status` 当前可能值包括：
+
+- `new`
+- `pending_important`
+- `applied`
+- `ignored`
+- `deleted`
+- `forgot`
+- `deprecated`
+- `superseded`
+
+### 3.2 `AETHER_MEMORY.md`
+
+长期记忆保存在全局 memory 数据目录下：
+
+```text
+<global-memory-data-dir>/AETHER_MEMORY.md
+```
+
+它是当前唯一长期记忆事实源。`memory_search` 只搜索这个文件，不读取旧 session 文件，也不读取 `memory.db` raw event。
+
+当前 Markdown 顶层结构固定为：
+
+```text
+# Aether Memory
+
+<!--
+schema_version: 1
+updated_at: ...
+source: memory.db
+search_target: true
+-->
+
+## Shortcut Directory
+
+---
+
+## Preferences
+
+---
+
+## Facts
+
+---
+
+## Tasks
+```
+
+长期记忆 block 示例：
+
+```text
+### PREF-answer-language
+- type: preference
+- scope: global
+- memory: 用户偏好默认用中文回答。
+- confidence: 0.95
+- weight: 0.9
+- evidence: 用户明确要求默认中文回答。
+- updated_at: 2026-05-13T00:00:00.000Z
+- status: active
+```
+
+## 4. 记忆类型与 scope
+
+### 4.1 type
+
+当前只允许三种长期记忆类型：
+
+- `preference`
+  - 用户偏好、表达方式、工作方式、稳定画像
+- `fact`
+  - 较稳定的客观事实、项目事实、环境事实
+- `task`
+  - 持续任务、长期待办、需要后续跟进的事项
+
+### 4.2 scope
+
+当前只允许两类长期记忆 scope：
+
+- `global`
+  - 跨项目成立的用户偏好、事实或任务
+- `project:<project_id>`
+  - 只对某个 project 成立的事实、偏好或任务
+
+`memory_search` 会把当前 project 作为排序加权信号，而不是默认硬过滤。当前 project scoped 记忆在相关查询中会优先于 global 记忆。
+
+## 5. Agent 工具
+
+### 5.1 `memory_search`
+
+用途：
+
+- 搜索长期记忆
+- 只读 `AETHER_MEMORY.md`
+- 返回按相关度、scope、权重和新近程度排序的结果
+
+参数：
+
+- `query`
+- `types?`
+- `limit?`
+- `currentProjectID?`
+
+### 5.2 `memory_remember`
+
+用途：
+
+- 记录用户明确要求记住的内容
+- 写入当前 channel 的 `memory.db`
+- 触发 quick reflection
+- quick reflection 通过后才会更新 `AETHER_MEMORY.md`
+
+参数：
+
+- `text`
+- `type?`
+- `project_id?`
+
+注意：
+
+- `memory_remember` 不直接 raw edit Markdown。
+- Agent 不能绕过 service 直接写长期记忆文件。
+
+### 5.3 `memory_forget`
+
+用途：
+
+- 按自然语言 query 或 memory id 查找并删除长期记忆
+- 删除通过 Memory service 完成
+- 未找到匹配时不会写永久禁止项
+
+参数：
+
+- `query?`
+- `ids?`
+- `type?`
+
+当前实现是 tombstone / service 删除语义，不做历史 raw event 的 hard delete。
+
+### 5.4 `memory_reflect`
+
+用途：
+
+- 手动触发 reflection
+- 默认是 quick reflection
+- 用户明确要求全局/每日/完整整理时可使用 daily mode
+
+参数：
+
+- `mode?`
+  - `quick`
+  - `daily`
+  - `manual`
+- `reason?`
+
+## 6. Reflection 链路
+
+### 6.1 Quick Reflection
+
+Quick reflection 主要处理当前 channel 中需要尽快判断的事件。
+
+触发来源：
+
+- `memory_remember`
+- 显式或高置信用户输入
+- memory 工具入口前的 pending 处理
+
+资源控制：
+
+- 每条用户消息可以先入库
+- 但是否调用 LLM 由 `shouldQuickReflect()` gate 决定
+- 低信号一次性问题不会立即触发 LLM
+
+### 6.2 Daily Reflection
+
+Daily reflection 用于全局整理和压缩长期记忆。
+
+触发来源：
+
+- built-in daily reflection cron
+- Settings > Memory 手动按钮
+- `memory_reflect` 明确指定 daily
+- startup catch-up
+
+Daily reflection 会顺序扫描所有发现到的 channel `memory.db`，汇总 pending event 后更新同一个 `AETHER_MEMORY.md`。
+
+### 6.3 Startup Catch-up
+
+server 启动安装 memory 时会调用 `Memory.startupCatchup()`。
+
+如果当天尚未有成功 daily reflection，且 memory 与 daily reflection 都开启，会在后台触发一次 daily reflection。该补跑不阻塞 server 启动。
+
+## 7. Daily Reflection Cron
+
+Memory 系统复用 cron 的 direct action 能力。
+
+内置 action：
+
+```text
+memory.reflect.daily
+```
+
+内置 job id：
+
+```text
+builtin.memory.daily_reflect
+```
+
+默认调度时间：
+
+```text
+0 3 * * *
+```
+
+Settings > Memory 中的 daily reflection 开关和时间会同步到该 cron job。若用户已经自定义过该内置 job，安装时默认保留已有定义；显式更新设置时才会重新同步。
+
+## 8. HTTP API
+
+当前 `/memory` 路由提供：
+
+- `GET /memory/status`
+  - 查询 memory 状态、Markdown 是否存在、条目数量、初始化状态等
+- `POST /memory/search`
+  - 调用 `Memory.search`
+- `POST /memory/reflect`
+  - 调用 `Memory.reflect`
+- `POST /memory/initialize/start`
+  - 启动一次性历史 session 初始化
+- `POST /memory/initialize/cancel`
+  - 取消初始化
+- `POST /memory/daily-reflect/sync`
+  - 按配置同步 built-in daily reflection cron job
+
+这些 API 主要供 Settings UI 使用。Agent 正常应通过 `memory_*` tools 访问 memory 能力。
+
+## 9. Settings > Memory
+
+当前 UI 已实现：
+
+- memory 总开关
+- daily reflection 开关
+- daily reflection 时间设置
+- 初始化导入旧 session
+- 初始化进度展示
+- memory 状态卡片
+- 手动 search
+- 手动 quick/daily reflect
+
+初始化导入旧 session 时：
+
+- 逐个 session 串行扫描
+- 主要分析用户消息
+- 将候选内容写入 `memory.db`
+- 再通过 reflection 生成长期 Markdown
+- 不使用多线程并发扫描
+
+## 10. Prompt 注入策略
+
+当前 memory 系统不把完整长期记忆注入 system prompt。
+
+注入内容只包含 `Shortcut Directory` 的精简提示：
+
+- shortcut
+- triggers
+- instruction
+
+这些内容只用于提醒 Agent 判断是否应该调用 `memory_search`。Agent 不应把 shortcut 当作完整事实使用。
+
+## 11. 生命周期接口
+
+`installMemory()` 返回：
+
+- `service`
+- `start()`
+- `stop()`
+- `purge()`
+
+语义：
+
+- `start()`
+  - 同步 daily reflection job
+  - 执行 startup catch-up 检查
+- `stop()`
+  - 停止 memory 侧后台状态
+  - 不删除数据
+- `purge()`
+  - 删除全局 `AETHER_MEMORY.md`
+  - 删除 reflection state
+  - 删除各 channel 下的 `memory.db` 及 WAL/SHM 文件
+
+## 12. 当前侵入式修改
+
+除新增 memory 模块、文档和测试外，当前实现对主干文件有以下接入点：
+
+- `packages/opencode/src/server/server.ts`
+  - 挂载 `/memory` route
+  - server 启动时安装 memory
+
+- `packages/opencode/src/tool/registry.ts`
+  - 注册 `memory_search`、`memory_remember`、`memory_forget`、`memory_reflect`
+
+- `packages/opencode/src/plugin/index.ts`
+  - 注册 memory plugin，注入 shortcut prompt
+
+- `packages/opencode/src/config/config.ts`
+  - 增加 memory 配置项
+
+- `packages/opencode/src/cron/index.ts`
+  - 支持 memory direct action 所需的 direct handler 机制
+
+- `packages/app/src/context/global-sdk.tsx`
+  - 注册 memory client helper
+
+- `packages/app/src/utils/server.ts`
+  - 增加 memory API client helper
+
+- `packages/app/src/components/dialog-settings.tsx`
+  - 增加 Settings > Memory tab
+
+这些修改的目的都是把 memory 作为可安装模块暴露给 server、agent tools、settings UI 和 cron direct action，而不是改写 SessionPrompt 主循环。
+
+## 13. 测试
+
+当前 memory 相关测试主要在：
+
+- `packages/opencode/test/memory/memory.test.ts`
+- `packages/app/src/components/settings-memory.vitest.tsx`
+
+建议本地验证命令：
+
+```bash
+bun run --cwd packages/opencode test test/memory/memory.test.ts test/cron/cron.test.ts --timeout 60000
+bun run --cwd packages/opencode typecheck
+bun run --cwd packages/app ./script/vitest.ts run --config ./vitest.config.ts src/components/settings-memory.vitest.tsx
+bun run --cwd packages/app typecheck
+```
+

--- a/packages/app/src/components/dialog-settings.tsx
+++ b/packages/app/src/components/dialog-settings.tsx
@@ -10,6 +10,7 @@ import { SettingsProviders } from "./settings-providers"
 import { SettingsModels } from "./settings-models"
 import { SettingsKnowledge } from "./settings-knowledge"
 import { SettingsCron } from "./settings-cron"
+import { SettingsMemory } from "./settings-memory"
 
 export const DialogSettings: Component = () => {
   const language = useLanguage()
@@ -55,6 +56,10 @@ export const DialogSettings: Component = () => {
                       <Icon name="task" />
                       {language.t("settings.tab.cron")}
                     </Tabs.Trigger>
+                    <Tabs.Trigger value="memory">
+                      <Icon name="brain" />
+                      Memory
+                    </Tabs.Trigger>
                   </div>
                 </div>
               </div>
@@ -81,6 +86,9 @@ export const DialogSettings: Component = () => {
         </Tabs.Content>
         <Tabs.Content value="cron" class="no-scrollbar">
           <SettingsCron />
+        </Tabs.Content>
+        <Tabs.Content value="memory" class="no-scrollbar">
+          <SettingsMemory />
         </Tabs.Content>
       </Tabs>
     </Dialog>

--- a/packages/app/src/components/settings-memory.tsx
+++ b/packages/app/src/components/settings-memory.tsx
@@ -1,0 +1,284 @@
+import { type Component, For, Show, createMemo, createResource, createSignal, onCleanup } from "solid-js"
+import { Button } from "@opencode-ai/ui/button"
+import { Switch } from "@opencode-ai/ui/switch"
+import { showToast } from "@opencode-ai/ui/toast"
+import { useGlobalSDK } from "@/context/global-sdk"
+import { useGlobalSync } from "@/context/global-sync"
+
+type MemorySearchResult = {
+  id: string
+  type: "preference" | "fact" | "task"
+  scope: string
+  memory: string
+  confidence: number
+  weight: number
+  score: number
+  ranking_note: string
+}
+
+function numberValue(input: unknown) {
+  return typeof input === "number" && Number.isFinite(input) ? input : 0
+}
+
+function stringValue(input: unknown) {
+  return typeof input === "string" ? input : ""
+}
+
+export const SettingsMemory: Component = () => {
+  const sdk = useGlobalSDK()
+  const globalSync = useGlobalSync()
+  const [searchText, setSearchText] = createSignal("")
+  const [searching, setSearching] = createSignal(false)
+  const [reflecting, setReflecting] = createSignal(false)
+  const [initializing, setInitializing] = createSignal(false)
+  const [results, setResults] = createSignal<MemorySearchResult[]>([])
+
+  const [status, statusActions] = createResource(async () => {
+    const result = await sdk.client.memory.status()
+    return result.data ?? {}
+  })
+  let progressTimer: ReturnType<typeof setInterval> | undefined
+
+  const stopProgressPolling = () => {
+    if (!progressTimer) return
+    clearInterval(progressTimer)
+    progressTimer = undefined
+  }
+
+  const startProgressPolling = () => {
+    stopProgressPolling()
+    progressTimer = setInterval(() => {
+      void statusActions.refetch()
+    }, 1500)
+  }
+
+  onCleanup(stopProgressPolling)
+
+  const configMemory = createMemo(() => {
+    const config = globalSync.data.config as Record<string, unknown>
+    return typeof config.memory === "object" && config.memory ? (config.memory as Record<string, unknown>) : {}
+  })
+
+  const memoryEnabled = createMemo(() => configMemory().enabled !== false)
+  const dailyReflect = createMemo(() => {
+    const daily = configMemory().dailyReflect
+    return typeof daily === "object" && daily ? (daily as Record<string, unknown>) : {}
+  })
+  const dailyEnabled = createMemo(() => dailyReflect().enabled !== false)
+  const dailyTime = createMemo(() => stringValue(dailyReflect().time) || "03:00")
+  const initialization = createMemo(() => {
+    const value = status()?.initialization
+    return typeof value === "object" && value ? (value as Record<string, unknown>) : {}
+  })
+  const initializationStatus = createMemo(() => stringValue(initialization().status) || "idle")
+  const initializationStarted = createMemo(() => initializationStatus() !== "idle")
+
+  const updateMemoryConfig = async (patch: Record<string, unknown>) => {
+    ;(globalSync.set as (...input: unknown[]) => unknown)("config", (prev: unknown) => ({
+      ...(prev as Record<string, unknown>),
+      memory: {
+        ...(((prev as Record<string, unknown>).memory as Record<string, unknown> | undefined) ?? {}),
+        ...patch,
+      },
+    }))
+    await globalSync.updateConfig({ memory: patch } as Parameters<typeof globalSync.updateConfig>[0])
+    await statusActions.refetch()
+  }
+
+  const updateDailyConfig = async (patch: Record<string, unknown>) => {
+    const next = {
+      ...dailyReflect(),
+      ...patch,
+    }
+    await updateMemoryConfig({ dailyReflect: next })
+    await sdk.client.memory.dailyReflect.sync()
+  }
+
+  const runSearch = async () => {
+    const query = searchText().trim()
+    if (!query) return
+    setSearching(true)
+    await sdk.client.memory
+      .search({ query, limit: 5 })
+      .then((result) => {
+        setResults(((result.data?.results as MemorySearchResult[] | undefined) ?? []) as MemorySearchResult[])
+      })
+      .catch((error: unknown) => {
+        showToast({ title: "Memory search failed", description: error instanceof Error ? error.message : String(error) })
+      })
+      .finally(() => setSearching(false))
+  }
+
+  const runReflect = async (mode: "quick" | "daily") => {
+    setReflecting(true)
+    await sdk.client.memory
+      .reflect({ mode, reason: "settings-memory" })
+      .then((result) => {
+        showToast({ title: "Memory reflection finished", description: String(result.data?.summary ?? "") })
+        void statusActions.refetch()
+      })
+      .catch((error: unknown) => {
+        showToast({ title: "Memory reflection failed", description: error instanceof Error ? error.message : String(error) })
+      })
+      .finally(() => setReflecting(false))
+  }
+
+  const startInitialize = async () => {
+    setInitializing(true)
+    startProgressPolling()
+    showToast({ title: "Memory initialization started", description: "Progress is shown in Settings > Memory." })
+    await sdk.client.memory.initialize
+      .start()
+      .then((result) => {
+        const scanned = numberValue(result.data?.scanned)
+        const imported = numberValue(result.data?.imported)
+        showToast({ title: "Memory initialization finished", description: `Scanned ${scanned} session(s), imported ${imported} event(s).` })
+        void statusActions.refetch()
+      })
+      .catch((error: unknown) => {
+        showToast({ title: "Memory initialization failed", description: error instanceof Error ? error.message : String(error) })
+      })
+      .finally(() => {
+        stopProgressPolling()
+        setInitializing(false)
+        void statusActions.refetch()
+      })
+  }
+
+  return (
+    <div class="flex h-full flex-col overflow-y-auto no-scrollbar px-4 pb-10 sm:px-10 sm:pb-10">
+      <div class="sticky top-0 z-10 bg-[linear-gradient(to_bottom,var(--surface-stronger-non-alpha)_calc(100%_-_24px),transparent)]">
+        <div class="flex items-start justify-between gap-4 pt-6 pb-8 max-w-[920px]">
+          <div>
+            <h2 class="text-16-medium text-text-strong">Memory</h2>
+            <p class="text-14-regular text-text-weak mt-1">
+              Manage Aether long-term memory, daily reflection, and real search behavior.
+            </p>
+          </div>
+          <Button size="small" variant="secondary" onClick={() => statusActions.refetch()}>
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      <div class="flex w-full max-w-[920px] flex-col gap-5">
+        <div class="rounded-lg border border-border-weak-base bg-surface-raised-base p-4 flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <div class="text-14-medium text-text-strong">Import previous conversations</div>
+            <div class="text-12-regular text-text-weak">
+              Scan old sessions serially and extract useful long-term memories. This is visible even after initialization so you can recover from a failed or empty import.
+            </div>
+            <div class="mt-2 text-11-regular text-text-dim">
+              {status()?.markdown_exists
+                ? "Current memory file exists; imported items will be merged through reflection."
+                : status()?.has_history_sessions
+                  ? "Historical sessions detected."
+                  : "No historical sessions were detected yet; running import is safe and will report zero if none exist."}
+            </div>
+            <Show when={initializationStarted()}>
+              <div class="mt-3 rounded-md border border-border-weak-base bg-surface-base px-3 py-2 text-12-regular text-text-weak">
+                <div class="flex flex-wrap gap-x-4 gap-y-1">
+                  <span>Status: {initializationStatus()}</span>
+                  <span>Scanned: {numberValue(initialization().scanned)}</span>
+                  <span>Imported: {numberValue(initialization().imported)}</span>
+                </div>
+                <Show when={stringValue(initialization().current_session_id)}>
+                  <div class="mt-1 truncate">Current session: {stringValue(initialization().current_session_id)}</div>
+                </Show>
+              </div>
+            </Show>
+          </div>
+          <Button size="small" disabled={initializing()} onClick={startInitialize}>
+            {initializing() ? "Importing..." : "Import memories"}
+          </Button>
+        </div>
+
+        <section class="rounded-lg border border-border-weak-base bg-surface-raised-base p-4 flex flex-col gap-3">
+          <div class="flex items-center justify-between gap-4">
+            <div>
+              <div class="text-14-medium text-text-strong">Memory enabled</div>
+              <div class="text-12-regular text-text-weak">Disable this to stop memory hooks, tools, and reflection.</div>
+            </div>
+            <Switch checked={memoryEnabled()} onChange={(enabled) => updateMemoryConfig({ enabled })} />
+          </div>
+          <div class="flex items-center justify-between gap-4">
+            <div>
+              <div class="text-14-medium text-text-strong">Daily reflection</div>
+              <div class="text-12-regular text-text-weak">Scheduled daily reflection can be disabled without disabling manual reflection.</div>
+            </div>
+            <Switch checked={dailyEnabled()} onChange={(enabled) => updateDailyConfig({ enabled })} />
+          </div>
+          <label class="flex items-center justify-between gap-4">
+            <span class="text-13-regular text-text-weak">Daily time</span>
+            <input
+              class="h-9 w-32 rounded-md border border-border-base bg-surface-base px-3 text-14-regular text-text-strong focus:outline-none focus:ring-2 focus:ring-border-focus"
+              type="time"
+              value={dailyTime()}
+              onChange={(event) => updateDailyConfig({ time: event.currentTarget.value })}
+            />
+          </label>
+        </section>
+
+      <section class="grid grid-cols-2 gap-3">
+        <div class="rounded-lg border border-border-weak-base bg-surface-raised-base p-3">
+          <div class="text-11-medium text-text-weak uppercase tracking-[0.04em]">Long-term memories</div>
+          <div class="pt-1 text-15-medium text-text-strong">{numberValue(status()?.memory_count)}</div>
+        </div>
+        <div class="rounded-lg border border-border-weak-base bg-surface-raised-base p-3">
+          <div class="text-11-medium text-text-weak uppercase tracking-[0.04em]">Shortcuts</div>
+          <div class="pt-1 text-15-medium text-text-strong">{numberValue(status()?.shortcut_count)}</div>
+        </div>
+      </section>
+
+      <section class="rounded-lg border border-border-weak-base bg-surface-raised-base p-4 flex flex-col gap-3">
+        <div>
+          <div class="text-14-medium text-text-strong">Search test</div>
+          <div class="text-12-regular text-text-weak">This calls the same memory_search logic available to agents.</div>
+        </div>
+        <div class="flex gap-2">
+          <input
+            class="h-9 flex-1 rounded-md border border-border-base bg-surface-base px-3 text-14-regular text-text-strong placeholder:text-text-weak focus:outline-none focus:ring-2 focus:ring-border-focus"
+            value={searchText()}
+            placeholder="Search memory..."
+            onInput={(event) => setSearchText(event.currentTarget.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") void runSearch()
+            }}
+          />
+          <Button size="small" disabled={searching()} onClick={runSearch}>
+            {searching() ? "Searching..." : "Search"}
+          </Button>
+        </div>
+        <div class="flex flex-col gap-2">
+          <For each={results()}>
+            {(item) => (
+              <div class="rounded-md border border-border-weak-base bg-surface-base p-3">
+                <div class="text-12-medium text-text-strong">
+                  {item.id} · {item.type} · {item.scope}
+                </div>
+                <div class="text-13-regular text-text-base mt-1">{item.memory}</div>
+                <div class="text-11-regular text-text-weak mt-1">{item.ranking_note}</div>
+              </div>
+            )}
+          </For>
+        </div>
+      </section>
+
+      <section class="rounded-lg border border-border-weak-base bg-surface-raised-base p-4 flex items-center justify-between gap-4">
+        <div>
+          <div class="text-14-medium text-text-strong">Manual reflection</div>
+          <div class="text-12-regular text-text-weak">Quick is lightweight. Daily-style performs global organization.</div>
+        </div>
+        <div class="flex gap-2">
+          <Button size="small" variant="secondary" disabled={reflecting()} onClick={() => runReflect("quick")}>
+            Quick reflect
+          </Button>
+          <Button size="small" disabled={reflecting()} onClick={() => runReflect("daily")}>
+            Daily reflect
+          </Button>
+        </div>
+      </section>
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/components/settings-memory.vitest.tsx
+++ b/packages/app/src/components/settings-memory.vitest.tsx
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import { render } from "solid-js/web"
+
+const state = vi.hoisted(() => ({
+  configUpdates: [] as Array<{ memory?: Record<string, unknown> }>,
+  statusCalls: 0,
+  searchCalls: [] as Array<{ query: string; limit?: number }>,
+  reflectCalls: [] as Array<{ mode: string; reason?: string }>,
+  syncCalls: 0,
+  initializeCalls: 0,
+  toasts: [] as Array<{ title?: string; description?: string }>,
+  status: {
+    needs_initialization: true,
+    has_history_sessions: true,
+    memory_count: 2,
+    shortcut_count: 1,
+  } as Record<string, unknown>,
+  searchResults: [
+    {
+      id: "PREF-answer-language",
+      type: "preference",
+      scope: "global",
+      memory: "用户偏好默认用中文回答。",
+      confidence: 0.95,
+      weight: 0.9,
+      score: 1,
+      ranking_note: "结果按相关度、scope、权重和新近程度综合排序。",
+    },
+  ],
+}))
+
+vi.mock("@/context/global-sync", async () => {
+  const { createStore } = await import("solid-js/store")
+  const [data, setData] = createStore({
+    config: {
+      memory: {
+        enabled: true,
+        dailyReflect: {
+          enabled: true,
+          time: "03:00",
+        },
+      },
+    },
+  })
+  return {
+    useGlobalSync: () => ({
+      data,
+      set: (...input: unknown[]) => (setData as (...args: unknown[]) => unknown)(...input),
+      updateConfig: async (config: { memory?: Record<string, unknown> }) => {
+        state.configUpdates.push(config)
+        if (config.memory) {
+          setData("config", "memory", (prev) => ({ ...prev, ...config.memory }))
+        }
+        return data.config
+      },
+    }),
+  }
+})
+
+vi.mock("@/context/global-sdk", () => ({
+  useGlobalSDK: () => ({
+    client: {
+      memory: {
+        status: async () => {
+          state.statusCalls += 1
+          return { data: state.status }
+        },
+        search: async (input: { query: string; limit?: number }) => {
+          state.searchCalls.push(input)
+          return { data: { results: state.searchResults } }
+        },
+        reflect: async (input: { mode: string; reason?: string }) => {
+          state.reflectCalls.push(input)
+          return { data: { summary: `reflected ${input.mode}` } }
+        },
+        dailyReflect: {
+          sync: async () => {
+            state.syncCalls += 1
+            return { data: { ok: true } }
+          },
+        },
+        initialize: {
+          start: async () => {
+            state.initializeCalls += 1
+            return { data: { status: "succeeded", scanned: 1, imported: 1 } }
+          },
+          cancel: async () => ({ data: { ok: true } }),
+        },
+      },
+    },
+  }),
+}))
+
+vi.mock("@opencode-ai/ui/button", () => ({
+  Button: (props: { children?: unknown; disabled?: boolean; onClick?: () => void; "data-testid"?: string }) => (
+    <button type="button" data-testid={props["data-testid"]} disabled={props.disabled} onClick={props.onClick}>
+      {props.children}
+    </button>
+  ),
+}))
+
+vi.mock("@opencode-ai/ui/switch", () => ({
+  Switch: (props: { checked?: boolean; disabled?: boolean; onChange?: (checked: boolean) => void }) => (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={props.checked ? "true" : "false"}
+      disabled={props.disabled}
+      onClick={() => props.onChange?.(!props.checked)}
+    />
+  ),
+}))
+
+vi.mock("@opencode-ai/ui/toast", () => ({
+  showToast: (input: { title?: string; description?: string }) => {
+    state.toasts.push(input)
+  },
+}))
+
+import { SettingsMemory } from "./settings-memory"
+
+function mount() {
+  const host = document.createElement("div")
+  document.body.append(host)
+  const off = render(() => <SettingsMemory />, host)
+  return { host, off }
+}
+
+async function flush() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ""
+  state.configUpdates = []
+  state.statusCalls = 0
+  state.searchCalls = []
+  state.reflectCalls = []
+  state.syncCalls = 0
+  state.initializeCalls = 0
+  state.toasts = []
+  state.status = {
+    needs_initialization: true,
+    has_history_sessions: true,
+    memory_count: 2,
+    shortcut_count: 1,
+  }
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  document.body.innerHTML = ""
+})
+
+describe("settings memory", () => {
+  test("renders status and allows one-time initialization", async () => {
+    const { host, off } = mount()
+    await flush()
+
+    expect(host.textContent).toContain("Import previous conversations")
+    expect(host.textContent).toContain("Historical sessions detected")
+    expect(host.textContent).toContain("Long-term memories")
+    expect(host.textContent).toContain("2")
+
+    const initialize = [...host.querySelectorAll("button")].find((button) => button.textContent === "Import memories")
+    initialize?.click()
+    await flush()
+
+    expect(state.initializeCalls).toBe(1)
+    expect(state.toasts.some((toast) => toast.title === "Memory initialization started")).toBe(true)
+
+    off()
+  })
+
+  test("shows initialization progress from status", async () => {
+    state.status = {
+      needs_initialization: true,
+      has_history_sessions: true,
+      memory_count: 0,
+      shortcut_count: 0,
+      initialization: {
+        status: "running",
+        scanned: 7,
+        imported: 2,
+        current_session_id: "session-progress",
+      },
+    }
+    const { host, off } = mount()
+    await flush()
+
+    expect(host.textContent).toContain("Status: running")
+    expect(host.textContent).toContain("Scanned: 7")
+    expect(host.textContent).toContain("Imported: 2")
+    expect(host.textContent).toContain("session-progress")
+
+    off()
+  })
+
+  test("keeps import action visible even when status does not request initialization", async () => {
+    state.status = {
+      needs_initialization: false,
+      has_history_sessions: false,
+      markdown_exists: true,
+      memory_count: 1,
+      shortcut_count: 0,
+    }
+    const { host, off } = mount()
+    await flush()
+
+    expect(host.textContent).toContain("Import previous conversations")
+    expect(host.textContent).toContain("Import memories")
+    expect(host.textContent).toContain("Current memory file exists")
+
+    off()
+  })
+
+  test("updates global memory and daily reflection settings", async () => {
+    const { host, off } = mount()
+    await flush()
+
+    const switches = [...host.querySelectorAll('[role="switch"]')] as HTMLButtonElement[]
+    switches[0]?.click()
+    switches[1]?.click()
+    await flush()
+
+    expect(state.configUpdates).toContainEqual({ memory: { enabled: false } })
+    expect(state.configUpdates.some((item) => item.memory?.dailyReflect)).toBe(true)
+    expect(state.syncCalls).toBe(1)
+
+    off()
+  })
+
+  test("searches memory and runs manual reflection through SDK methods", async () => {
+    const { host, off } = mount()
+    await flush()
+
+    const input = host.querySelector("input[placeholder='Search memory...']") as HTMLInputElement
+    input.value = "中文回答"
+    input.dispatchEvent(new Event("input", { bubbles: true }))
+    const search = [...host.querySelectorAll("button")].find((button) => button.textContent === "Search")
+    search?.click()
+    await flush()
+
+    expect(state.searchCalls).toEqual([{ query: "中文回答", limit: 5 }])
+    expect(host.textContent).toContain("PREF-answer-language")
+
+    const quick = [...host.querySelectorAll("button")].find((button) => button.textContent === "Quick reflect")
+    quick?.click()
+    await flush()
+
+    expect(state.reflectCalls).toContainEqual({ mode: "quick", reason: "settings-memory" })
+    expect(state.toasts.some((toast) => toast.title === "Memory reflection finished")).toBe(true)
+
+    off()
+  })
+})

--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -1,9 +1,16 @@
 import type { Event } from "@opencode-ai/sdk/v2/client"
 import { createSimpleContext } from "@opencode-ai/ui/context"
+import { showToast } from "@opencode-ai/ui/toast"
 import { createGlobalEmitter } from "@solid-primitives/event-bus"
 import { batch, onCleanup } from "solid-js"
 import z from "zod"
-import { type AppClient, addCronMethods, addProjectDeleteMethod, createSdkForServer } from "@/utils/server"
+import {
+  type AppClient,
+  addCronMethods,
+  addMemoryMethods,
+  addProjectDeleteMethod,
+  createSdkForServer,
+} from "@/utils/server"
 import { useLanguage } from "./language"
 import { usePlatform } from "./platform"
 import { useServer } from "./server"
@@ -11,6 +18,8 @@ import { useServer } from "./server"
 const abortError = z.object({
   name: z.literal("AbortError"),
 })
+
+let memoryInitializationToastShown = false
 
 export type GlobalSDKValue = {
   url: string
@@ -227,7 +236,20 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       throwOnError: true,
     })
     addCronMethods(sdk, server.current.http.url, authHeader(server.current.http), { throwOnError: true })
+    addMemoryMethods(sdk, server.current.http.url, authHeader(server.current.http), { throwOnError: true })
     addProjectDeleteMethod(sdk, server.current.http.url, authHeader(server.current.http), { throwOnError: true })
+    if (!memoryInitializationToastShown) {
+      memoryInitializationToastShown = true
+      void sdk.memory.status().then((result) => {
+        const data = result.data ?? {}
+        if (data.needs_initialization && data.has_history_sessions) {
+          showToast({
+            title: "Memory initialization available",
+            description: "Open Settings > Memory to import useful memories from previous conversations.",
+          })
+        }
+      })
+    }
 
     return {
       url: currentServer.http.url,
@@ -242,6 +264,7 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
           ...opts,
         })
         addCronMethods(c, s.http.url, authHeader(s.http), { throwOnError: opts.throwOnError })
+        addMemoryMethods(c, s.http.url, authHeader(s.http), { throwOnError: opts.throwOnError })
         addProjectDeleteMethod(c, s.http.url, authHeader(s.http), { throwOnError: opts.throwOnError })
         return c
       },

--- a/packages/app/src/utils/server.ts
+++ b/packages/app/src/utils/server.ts
@@ -20,6 +20,7 @@ type CronScheduleType = "cron" | "interval" | "once"
 type CronLastStatus = "success" | "failed" | "skipped" | "expired" | null
 type CronRunStatus = "success" | "failed" | "skipped"
 type CronTriggerReason = "scheduled" | "manual"
+type MemoryType = "preference" | "fact" | "task"
 type CronDefinition = {
   id: string
   name: string
@@ -130,6 +131,31 @@ export type AppClient = Base & {
     }
     runs: {
       get(input: { runID: string }): Req<CronRun | null>
+    }
+  }
+  memory: {
+    status(): Req<Record<string, unknown>>
+    search(input: { query: string; types?: MemoryType[]; limit?: number; currentProjectID?: string }): Req<{
+      results: Array<{
+        id: string
+        type: MemoryType
+        scope: string
+        memory: string
+        confidence: number
+        weight: number
+        score: number
+        markdown: string
+        ranking_note: string
+      }>
+      ranking_note: string
+    }>
+    reflect(input?: { mode?: "quick" | "daily" | "manual"; reason?: string }): Req<Record<string, unknown>>
+    dailyReflect: {
+      sync(): Req<Record<string, unknown>>
+    }
+    initialize: {
+      start(): Req<Record<string, unknown>>
+      cancel(): Req<{ ok: boolean }>
     }
   }
   config: Base["config"] & {
@@ -335,5 +361,77 @@ export function addCronMethods(
     },
   }
   safeAssign(client, "cron", cronMethods)
+  return client
+}
+
+export function addMemoryMethods(
+  client: AppClient,
+  baseUrl: string,
+  auth?: Record<string, string>,
+  options?: RequestHelperOptions,
+): AppClient {
+  const headers: Record<string, string> = { "Content-Type": "application/json", ...auth }
+  const memoryMethods = {
+    async status() {
+      return requestJSON<Record<string, unknown>>(`${baseUrl}/memory/status`, { headers }, options)
+    },
+    async search(input: { query: string; types?: MemoryType[]; limit?: number; currentProjectID?: string }) {
+      return requestJSON(
+        `${baseUrl}/memory/search`,
+        {
+          method: "POST",
+          headers,
+          body: JSON.stringify(input),
+        },
+        options,
+      )
+    },
+    async reflect(input?: { mode?: "quick" | "daily" | "manual"; reason?: string }) {
+      return requestJSON<Record<string, unknown>>(
+        `${baseUrl}/memory/reflect`,
+        {
+          method: "POST",
+          headers,
+          body: JSON.stringify(input ?? {}),
+        },
+        options,
+      )
+    },
+    dailyReflect: {
+      async sync() {
+        return requestJSON<Record<string, unknown>>(
+          `${baseUrl}/memory/daily-reflect/sync`,
+          {
+            method: "POST",
+            headers,
+          },
+          options,
+        )
+      },
+    },
+    initialize: {
+      async start() {
+        return requestJSON<Record<string, unknown>>(
+          `${baseUrl}/memory/initialize/start`,
+          {
+            method: "POST",
+            headers,
+          },
+          options,
+        )
+      },
+      async cancel() {
+        return requestJSON<{ ok: boolean }>(
+          `${baseUrl}/memory/initialize/cancel`,
+          {
+            method: "POST",
+            headers,
+          },
+          options,
+        )
+      },
+    },
+  }
+  safeAssign(client, "memory", memoryMethods)
   return client
 }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1295,6 +1295,31 @@ export namespace Config {
           enabled: z.boolean().optional().describe("Enable cron job execution (default: true)"),
         })
         .optional(),
+      memory: z
+        .object({
+          enabled: z.boolean().optional().describe("Enable memory hooks and tools (default: true)"),
+          quickReflect: z.boolean().optional().describe("Enable lightweight quick reflection (default: true)"),
+          dailyReflect: z
+            .object({
+              enabled: z.boolean().optional().describe("Enable scheduled daily memory reflection (default: true)"),
+              time: z.string().optional().describe("Daily memory reflection time in HH:mm format (default: 03:00)"),
+              timezone: z.string().optional().describe("Daily memory reflection timezone. Defaults to the system timezone."),
+            })
+            .optional(),
+          search: z
+            .object({
+              defaultLimit: z.number().int().positive().optional(),
+              maxLimit: z.number().int().positive().optional(),
+            })
+            .optional(),
+          reflection: z
+            .object({
+              maxInputTokens: z.number().int().positive().optional(),
+              maxOutputTokens: z.number().int().positive().optional(),
+            })
+            .optional(),
+        })
+        .optional(),
       experimental: z
         .object({
           disable_paste_summary: z.boolean().optional(),

--- a/packages/opencode/src/cron/index.ts
+++ b/packages/opencode/src/cron/index.ts
@@ -1271,6 +1271,30 @@ export namespace Cron {
     }
   })
 
+  export async function ensureJob(input: Record<string, unknown>) {
+    await ensureJobDir()
+    const id = assertNonBlankString(input.id, "id")
+    const filePath = path.join(jobsDir(), `${id}.json`)
+    const existing = await fs
+      .stat(filePath)
+      .then(() => true)
+      .catch(() => false)
+    if (existing) return getJob(id)
+    const definition = parseDefinition(input, id)
+    await writeJobFile(definition)
+    const now = Date.now()
+    const state = reconcileState({
+      previous: undefined,
+      definition,
+      now,
+    })
+    upsertState(state)
+    return {
+      definition,
+      state: toState(state),
+    }
+  }
+
   export const assist = fn(AssistInput, async (input) => {
     const selected = input.selected_id ? (await getJob(input.selected_id)).definition : undefined
     const result = await assistant({

--- a/packages/opencode/src/memory/gate.ts
+++ b/packages/opencode/src/memory/gate.ts
@@ -1,0 +1,51 @@
+export type QuickReflectGateInput = {
+  text: string
+  intent: "explicit" | "observed"
+  op: "remember" | "forget"
+  shortcutTriggers?: string[]
+}
+
+export type QuickReflectGateDecision = {
+  shouldRun: boolean
+  priority: "normal" | "important"
+  reason: string
+}
+
+const REMEMBER_RE = /(记住|以后都|别忘了|remember|keep in mind|please note)/i
+const FORGET_RE = /(忘掉|忘记|不要记得|别记|forget|don't remember|do not remember)/i
+const PREFERENCE_RE = /(我.{0,16}(喜欢|偏好|希望|倾向|常用|主要用|习惯|要求|强调|建议)|默认|以后|prefer|preference|by default|always)/i
+const PROJECT_RE = /(这个项目|当前项目|此 repo|这个 repo|this project|current project|this repo)/i
+const TASK_RE = /(待办|之后|每天|定期|继续|follow up|todo|remind|schedule|daily)/i
+const SENSITIVE_RE = /(身份证|护照|银行卡|信用卡|密码|住址|家庭住址|电话号码|手机号|phone number|address|password|credit card|passport|ssn|social security|diagnosed|病史|诊断|宗教|政治倾向)/i
+
+export function hasRememberIntent(text: string) {
+  return REMEMBER_RE.test(text)
+}
+
+export function hasForgetIntent(text: string) {
+  return FORGET_RE.test(text)
+}
+
+export function hasSensitiveSignal(text: string) {
+  return SENSITIVE_RE.test(text)
+}
+
+export function shouldQuickReflect(input: QuickReflectGateInput): QuickReflectGateDecision {
+  const text = input.text.trim()
+  if (!text) return { shouldRun: false, priority: "normal", reason: "empty" }
+  if (input.op === "forget" || hasForgetIntent(text)) {
+    return { shouldRun: true, priority: "important", reason: "explicit forget intent" }
+  }
+  if (input.intent === "explicit" || hasRememberIntent(text)) {
+    return { shouldRun: true, priority: "important", reason: "explicit remember intent" }
+  }
+  if (hasSensitiveSignal(text)) return { shouldRun: false, priority: "normal", reason: "sensitive observed signal" }
+  if (PROJECT_RE.test(text)) return { shouldRun: true, priority: "normal", reason: "project-scoped signal" }
+  if (PREFERENCE_RE.test(text)) return { shouldRun: true, priority: "normal", reason: "preference signal" }
+  if (TASK_RE.test(text)) return { shouldRun: true, priority: "normal", reason: "persistent task signal" }
+  const shortcutTriggers = input.shortcutTriggers ?? []
+  if (shortcutTriggers.some((trigger) => text.toLowerCase().includes(trigger.toLowerCase()))) {
+    return { shouldRun: true, priority: "normal", reason: "shortcut trigger" }
+  }
+  return { shouldRun: false, priority: "normal", reason: "low signal" }
+}

--- a/packages/opencode/src/memory/index.ts
+++ b/packages/opencode/src/memory/index.ts
@@ -1,0 +1,1334 @@
+import fs from "fs/promises"
+import { mkdirSync } from "fs"
+import path from "path"
+import { Database as BunSqlite } from "bun:sqlite"
+import { ulid } from "ulid"
+import z from "zod"
+import { generateObject, streamObject, type ModelMessage } from "ai"
+import { Global } from "@/global"
+import { Database } from "@/storage/db"
+import { Config } from "@/config/config"
+import { Session } from "@/session"
+import { Instance } from "@/project/instance"
+import { Provider } from "@/provider/provider"
+import { ProviderTransform } from "@/provider/transform"
+import { Auth } from "@/auth"
+import { Lock } from "@/util/lock"
+import {
+  emptyMemoryDocument,
+  parseMemoryMarkdown,
+  renderMemoryDocument,
+  type MemoryBlock,
+  type MemoryDocument,
+  type MemoryScope,
+  type MemoryType,
+} from "./markdown"
+import { searchMemoryDocument, type MemorySearchInput } from "./search"
+import { hasForgetIntent, hasSensitiveSignal, shouldQuickReflect } from "./gate"
+
+type Role = "user" | "assistant" | "system" | "tool"
+type EventStatus =
+  | "new"
+  | "pending_important"
+  | "applied"
+  | "ignored"
+  | "deleted"
+  | "forgot"
+  | "deprecated"
+  | "superseded"
+
+type MemoryEvent = {
+  id: string
+  created_at: number
+  op: "remember" | "forget"
+  type: MemoryType | null
+  intent: "explicit" | "observed"
+  raw_text: string
+  channel_id: string | null
+  project_id: string | null
+  session_id: string | null
+  message_id: string | null
+  role: Role | null
+  source_json: string
+  candidate_key: string | null
+  candidate_summary: string | null
+  confidence_hint: number | null
+  status: EventStatus
+  reflected_at: number | null
+  result_json: string | null
+}
+
+type Paths = {
+  globalMemoryDir: string
+  channelRootDir: string
+  channelID: string
+}
+
+type SessionForInitialization = {
+  channelID: string
+  projectID?: string
+  sessionID: string
+  messages: Array<{ role: "user" | "assistant"; text: string; createdAt: number }>
+}
+
+type InitializerCandidate = {
+  text: string
+  type?: MemoryType
+  scope?: MemoryScope
+}
+
+type ReflectionCandidate = {
+  eventID: string
+  type: MemoryType
+  scope: MemoryScope
+  memory: string
+  confidence: number
+  weight: number
+  evidence: string
+}
+
+let overridePaths: Paths | undefined
+let documentCache: { path: string; mtimeMs: number; doc: MemoryDocument } | undefined
+let db: BunSqlite | undefined
+let initializeCancelled = false
+let scannerForTest: (() => AsyncGenerator<SessionForInitialization>) | undefined
+let extractorForTest: ((session: SessionForInitialization) => Promise<InitializerCandidate[]>) | undefined
+let startupCatchupStarted = false
+let reflectorForTest:
+  | ((input: { events: MemoryEvent[]; doc: MemoryDocument; mode: "quick" | "daily" | "manual" }) => Promise<ReflectionCandidate[]>)
+  | undefined
+
+const ReflectionOutput = z.object({
+  candidates: z.array(
+    z.object({
+      event_id: z.string(),
+      type: z.enum(["preference", "fact", "task"]),
+      scope: z.string(),
+      memory: z.string().min(1),
+      confidence: z.number().min(0).max(1).optional(),
+      weight: z.number().min(0).max(1).optional(),
+      evidence: z.string().optional(),
+    }),
+  ),
+})
+
+const InitializationOutput = z.object({
+  candidates: z.array(
+    z.object({
+      type: z.enum(["preference", "fact", "task"]),
+      scope: z.string(),
+      memory: z.string().min(1),
+      evidence: z.string().optional(),
+    }),
+  ),
+})
+
+const ForgetDecisionOutput = z.object({
+  delete_ids: z.array(z.string()),
+  keep_ids: z.array(z.string()).optional(),
+  reason: z.string().optional(),
+})
+
+function defaultPaths(): Paths {
+  return {
+    globalMemoryDir: path.join(Global.Path.data, "memory"),
+    channelRootDir: Global.Path.data,
+    channelID: path.basename(Database.channelDir()),
+  }
+}
+
+function paths() {
+  return overridePaths ?? defaultPaths()
+}
+
+function currentChannelDir() {
+  const p = paths()
+  return path.join(p.channelRootDir, p.channelID)
+}
+
+function dbPath(channelID = paths().channelID) {
+  return path.join(paths().channelRootDir, channelID, "memory.db")
+}
+
+function mdPath() {
+  return path.join(paths().globalMemoryDir, "AETHER_MEMORY.md")
+}
+
+function statePath() {
+  return path.join(paths().globalMemoryDir, "reflection-state.json")
+}
+
+function memoryLockPath() {
+  return path.join(paths().globalMemoryDir, "AETHER_MEMORY.lock")
+}
+
+async function ensureDirs() {
+  await fs.mkdir(paths().globalMemoryDir, { recursive: true })
+  await fs.mkdir(currentChannelDir(), { recursive: true })
+}
+
+function initDb(sqlite: BunSqlite) {
+  sqlite.exec("PRAGMA journal_mode = WAL")
+  sqlite.exec("PRAGMA synchronous = NORMAL")
+  sqlite.exec("PRAGMA busy_timeout = 5000")
+  sqlite.exec(`CREATE TABLE IF NOT EXISTS memory_event (
+    id TEXT PRIMARY KEY,
+    created_at INTEGER NOT NULL,
+    op TEXT NOT NULL CHECK (op IN ('remember', 'forget')),
+    type TEXT CHECK (type IN ('preference', 'fact', 'task')),
+    intent TEXT NOT NULL CHECK (intent IN ('explicit', 'observed')),
+    raw_text TEXT NOT NULL,
+    channel_id TEXT,
+    project_id TEXT,
+    session_id TEXT,
+    message_id TEXT,
+    role TEXT CHECK (role IN ('user', 'assistant', 'system', 'tool')),
+    source_json TEXT NOT NULL,
+    candidate_key TEXT,
+    candidate_summary TEXT,
+    confidence_hint REAL,
+    status TEXT NOT NULL DEFAULT 'new'
+      CHECK (status IN ('new', 'pending_important', 'applied', 'ignored', 'deleted', 'forgot', 'deprecated', 'superseded')),
+    reflected_at INTEGER,
+    result_json TEXT
+  )`)
+  sqlite.exec("CREATE INDEX IF NOT EXISTS memory_event_created_idx ON memory_event(created_at)")
+  sqlite.exec("CREATE INDEX IF NOT EXISTS memory_event_status_idx ON memory_event(status)")
+  sqlite.exec("CREATE INDEX IF NOT EXISTS memory_event_candidate_key_idx ON memory_event(candidate_key)")
+  sqlite.exec("CREATE INDEX IF NOT EXISTS memory_event_project_created_idx ON memory_event(project_id, created_at)")
+  sqlite.exec("CREATE INDEX IF NOT EXISTS memory_event_session_created_idx ON memory_event(session_id, created_at)")
+  sqlite.exec(`CREATE TABLE IF NOT EXISTS reflection_run (
+    id TEXT PRIMARY KEY,
+    mode TEXT NOT NULL CHECK (mode IN ('quick', 'daily', 'manual')),
+    started_at INTEGER NOT NULL,
+    completed_at INTEGER,
+    model TEXT,
+    input_event_ids_json TEXT,
+    md_before_hash TEXT,
+    md_after_hash TEXT,
+    summary_json TEXT,
+    error TEXT
+  )`)
+  sqlite.exec("CREATE TABLE IF NOT EXISTS memory_setting (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+  return sqlite
+}
+
+function openDb() {
+  if (db) return db
+  mkdirSync(path.dirname(dbPath()), { recursive: true })
+  const sqlite = initDb(new BunSqlite(dbPath(), { create: true }))
+  db = sqlite
+  return sqlite
+}
+
+function openDbForChannel(channelID: string) {
+  if (channelID === paths().channelID) return { database: openDb(), close: () => undefined }
+  mkdirSync(path.dirname(dbPath(channelID)), { recursive: true })
+  const database = initDb(new BunSqlite(dbPath(channelID), { create: true }))
+  return {
+    database,
+    close: () => database.close(),
+  }
+}
+
+function invalidateDocumentCache() {
+  documentCache = undefined
+}
+
+async function readDocument() {
+  return readDocumentWithOptions({ createIfMissing: true })
+}
+
+async function readDocumentWithOptions(input: { createIfMissing: boolean }) {
+  await ensureDirs()
+  const file = mdPath()
+  const stat = await fs.stat(file).catch(() => undefined)
+  if (!stat) {
+    const doc = emptyMemoryDocument()
+    if (input.createIfMissing) await writeDocument(doc)
+    return doc
+  }
+  if (documentCache && documentCache.path === file && documentCache.mtimeMs === stat.mtimeMs) return documentCache.doc
+  const doc = parseMemoryMarkdown(await fs.readFile(file, "utf8"))
+  documentCache = { path: file, mtimeMs: stat.mtimeMs, doc }
+  return doc
+}
+
+async function writeDocument(doc: MemoryDocument) {
+  await ensureDirs()
+  using _ = await Lock.write(memoryLockPath())
+  const file = mdPath()
+  const tmp = `${file}.${process.pid}.${Date.now()}.tmp`
+  const rendered = renderMemoryDocument({ ...doc, updated_at: new Date().toISOString() })
+  parseMemoryMarkdown(rendered)
+  await fs.writeFile(tmp, rendered)
+  await fs.rename(tmp, file)
+  invalidateDocumentCache()
+}
+
+function insertEvent(input: {
+  op: "remember" | "forget"
+  type?: MemoryType | null
+  intent?: "explicit" | "observed"
+  text: string
+  status?: EventStatus
+  source: {
+    createdAt: number
+    channelID?: string
+    projectID?: string
+    sessionID?: string
+    messageID?: string
+    role?: Role
+    [key: string]: unknown
+  }
+  result?: unknown
+}) {
+  const event = {
+    id: `mem_${ulid()}`,
+    created_at: input.source.createdAt,
+    op: input.op,
+    type: input.type ?? null,
+    intent: input.intent ?? "observed",
+    raw_text: input.text,
+    channel_id: input.source.channelID ?? paths().channelID,
+    project_id: input.source.projectID ?? null,
+    session_id: input.source.sessionID ?? null,
+    message_id: input.source.messageID ?? null,
+    role: input.source.role ?? null,
+    source_json: JSON.stringify(input.source),
+    candidate_key: null,
+    candidate_summary: null,
+    confidence_hint: null,
+    status: input.status ?? "new",
+    reflected_at: null,
+    result_json: input.result ? JSON.stringify(input.result) : null,
+  }
+  openDb()
+    .prepare(
+      `INSERT INTO memory_event (
+        id, created_at, op, type, intent, raw_text, channel_id, project_id, session_id, message_id, role,
+        source_json, candidate_key, candidate_summary, confidence_hint, status, reflected_at, result_json
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      event.id,
+      event.created_at,
+      event.op,
+      event.type,
+      event.intent,
+      event.raw_text,
+      event.channel_id,
+      event.project_id,
+      event.session_id,
+      event.message_id,
+      event.role,
+      event.source_json,
+      event.candidate_key,
+      event.candidate_summary,
+      event.confidence_hint,
+      event.status,
+      event.reflected_at,
+      event.result_json,
+    )
+  return event
+}
+
+function sessionHasMemorySignal(session: SessionForInitialization) {
+  const userText = session.messages
+    .filter((message) => message.role === "user")
+    .map((message) => message.text)
+    .join("\n")
+  return shouldQuickReflect({ text: userText, intent: "observed", op: "remember", shortcutTriggers: [] }).shouldRun
+}
+
+function sessionLooksWorthLLMInitialization(session: SessionForInitialization) {
+  const userMessages = session.messages.filter((message) => message.role === "user" && message.text.trim())
+  if (userMessages.length === 0) return false
+  const text = userMessages.map((message) => message.text).join("\n")
+  if (hasSensitiveSignal(text)) return false
+  if (text.length >= 120) return true
+  if (userMessages.length >= 2) return true
+  return /(我|my|prefer|preference|project|项目|默认|以后|喜欢|偏好|希望|倾向|常用|习惯|每天|定期|提醒|remember)/i.test(text)
+}
+
+function extractRuleMemoryCandidates(session: SessionForInitialization): InitializerCandidate[] {
+  const candidates: InitializerCandidate[] = []
+  for (const message of session.messages) {
+    if (message.role !== "user") continue
+    const decision = shouldQuickReflect({
+      text: message.text,
+      intent: "observed",
+      op: "remember",
+      shortcutTriggers: [],
+    })
+    if (!decision.shouldRun) continue
+    const text = sanitizeMemoryText(message.text)
+    if (!text || hasSensitiveSignal(text)) continue
+    const type = classifyType(text)
+    candidates.push({
+      text,
+      type,
+      scope: inferScope({ text, type, projectID: session.projectID }),
+    })
+  }
+  return candidates.slice(0, 8)
+}
+
+async function extractMemoryCandidates(session: SessionForInitialization): Promise<InitializerCandidate[]> {
+  const ruleCandidates = extractRuleMemoryCandidates(session)
+  if (ruleCandidates.length > 0) return ruleCandidates
+  if (!sessionLooksWorthLLMInitialization(session)) return []
+  return llmInitializeExtractor(session).catch(() => [])
+}
+
+async function sleep(ms: number) {
+  await new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function readReflectionState(): Promise<Record<string, unknown>> {
+  return fs
+    .readFile(statePath(), "utf8")
+    .then((text) => JSON.parse(text) as Record<string, unknown>)
+    .catch(() => ({}))
+}
+
+async function writeReflectionState(patch: Record<string, unknown>) {
+  await ensureDirs()
+  const current = await readReflectionState()
+  await fs.writeFile(statePath(), JSON.stringify({ ...current, ...patch }, null, 2))
+}
+
+function dateKey(time: number) {
+  return new Date(time).toISOString().slice(0, 10)
+}
+
+function textFromMessage(message: { parts?: Array<{ type?: string; text?: string }>; info?: { role?: string } }) {
+  return (message.parts ?? [])
+    .filter((part) => part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("\n")
+    .trim()
+}
+
+async function* defaultSessionScanner(): AsyncGenerator<SessionForInitialization> {
+  for (const listed of Session.listGlobal({ limit: 500, archivedMode: "exclude" })) {
+    const project = listed.project
+    const messages = await Instance.provide({
+      directory: listed.directory,
+      create: false,
+      project: project
+        ? {
+            id: project.id,
+            worktree: project.worktree,
+            time: { created: Date.now(), updated: Date.now() },
+            sandboxes: [],
+          }
+        : undefined,
+      worktree: project?.worktree,
+      fn: () => Session.messages({ sessionID: listed.id }).catch(() => []),
+    })
+    yield {
+      channelID: paths().channelID,
+      projectID: listed.projectID,
+      sessionID: listed.id,
+      messages: messages
+        .map((message) => ({
+          role: message.info.role,
+          text: textFromMessage(message),
+          createdAt: message.info.time.created,
+        }))
+        .filter(
+          (message): message is { role: "user" | "assistant"; text: string; createdAt: number } =>
+            (message.role === "user" || message.role === "assistant") && Boolean(message.text),
+        ),
+    }
+  }
+}
+
+function classifyType(text: string, hinted?: MemoryType | null): MemoryType {
+  if (hinted) return hinted
+  if (/(待办|之后|每天|定期|提醒|继续|follow up|todo|remind|schedule|daily)/i.test(text)) return "task"
+  if (/(我喜欢|我偏好|我希望|默认|以后|倾向|prefer|preference|by default|always)/i.test(text)) return "preference"
+  return "fact"
+}
+
+function inferScope(input: { text: string; type: MemoryType; projectID?: string | null; sourceJson?: string }): MemoryScope {
+  const sourceScope = (() => {
+    if (!input.sourceJson) return undefined
+    try {
+      const parsed = JSON.parse(input.sourceJson) as { scope?: string }
+      return typeof parsed.scope === "string" ? parsed.scope : undefined
+    } catch {
+      return undefined
+    }
+  })()
+  if (sourceScope === "global" || sourceScope?.startsWith("project:")) return sourceScope as MemoryScope
+  if (input.projectID && /(这个项目|当前项目|此 repo|这个 repo|this project|current project|this repo)/i.test(input.text)) {
+    return `project:${input.projectID}`
+  }
+  if (input.type === "task" && input.projectID) return `project:${input.projectID}`
+  return "global"
+}
+
+function sanitizeMemoryText(text: string) {
+  return text
+    .replace(/^\s*(请|麻烦)?\s*(记住|remember|keep in mind|please note)[：:\s]*/i, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 240)
+}
+
+function prefixForType(type: MemoryType) {
+  if (type === "preference") return "PREF"
+  if (type === "task") return "TASK"
+  return "FACT"
+}
+
+function candidateKey(input: Pick<ReflectionCandidate, "type" | "scope" | "memory">) {
+  return `${input.type}:${input.scope}:${input.memory.toLowerCase().replace(/\s+/g, " ").slice(0, 96)}`
+}
+
+function memoryTopic(input: string) {
+  const text = input.toLowerCase()
+  if (/(回答|回复|answer|response|verbose|concise|详细|简短|短回答|长回答)/i.test(text)) return "response-style"
+  if (/(中文|英文|language|chinese|english)/i.test(text)) return "language"
+  if (/(bun|node|typescript|javascript|runtime)/i.test(text)) return "runtime"
+  return text.replace(/[^\p{L}\p{N}]+/gu, " ").split(/\s+/).filter(Boolean).slice(0, 4).join(" ")
+}
+
+function conflictsWith(existing: MemoryBlock, candidate: ReflectionCandidate) {
+  if (existing.status !== "active") return false
+  if (existing.id === candidate.eventID) return false
+  if (existing.type !== candidate.type || existing.scope !== candidate.scope) return false
+  const topic = memoryTopic(candidate.memory)
+  if (!topic || topic !== memoryTopic(existing.memory)) return false
+  if (existing.memory === candidate.memory) return false
+  return true
+}
+
+function buildShortcut(candidate: ReflectionCandidate) {
+  const words = candidate.memory
+    .split(/[\s,，;；、|/\\]+/g)
+    .map((item) => item.trim())
+    .filter((item) => item.length >= 2)
+    .slice(0, 6)
+  return {
+    shortcut: `${candidate.type}:${candidate.scope}`,
+    triggers: [...new Set(words.length ? words : [candidate.type])],
+    types: [candidate.type],
+    target_ids: [] as string[],
+    weight: Math.max(0.5, candidate.weight),
+    instruction: `Call memory_search before tasks related to ${candidate.type} ${candidate.scope}.`,
+  }
+}
+
+function reflectEvent(event: MemoryEvent): ReflectionCandidate | undefined {
+  if (event.op !== "remember") return
+  const text = sanitizeMemoryText(event.raw_text)
+  if (!text) return
+  if (event.intent !== "explicit" && hasSensitiveSignal(text)) return
+  const type = classifyType(text, event.type)
+  return {
+    eventID: event.id,
+    type,
+    scope: inferScope({ text, type, projectID: event.project_id, sourceJson: event.source_json }),
+    memory: text,
+    confidence: event.intent === "explicit" ? 0.9 : 0.68,
+    weight: event.intent === "explicit" ? 0.86 : 0.55,
+    evidence: event.intent === "explicit" ? "用户明确请求记住。" : "从用户会话中提取到的长期信号。",
+  }
+}
+
+async function deterministicReflector(input: { events: MemoryEvent[] }) {
+  return input.events.map(reflectEvent).filter((item) => item !== undefined)
+}
+
+function compactDocForLLM(doc: MemoryDocument) {
+  return {
+    shortcuts: doc.shortcuts.slice(0, 50).map((shortcut) => ({
+      shortcut: shortcut.shortcut,
+      triggers: shortcut.triggers,
+      types: shortcut.types,
+      weight: shortcut.weight,
+    })),
+    memories: doc.memories.slice(0, 200).map((memory) => ({
+      id: memory.id,
+      type: memory.type,
+      scope: memory.scope,
+      memory: memory.memory,
+      confidence: memory.confidence,
+      weight: memory.weight,
+      status: memory.status,
+    })),
+  }
+}
+
+function clamp01(value: unknown, fallback: number) {
+  return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.min(1, value)) : fallback
+}
+
+function normalizeLLMScope(value: string, fallback: MemoryScope) {
+  if (value === "global") return value
+  if (/^project:[A-Za-z0-9_.:-]+$/.test(value)) return value as MemoryScope
+  return fallback
+}
+
+async function llmReflector(input: {
+  events: MemoryEvent[]
+  doc: MemoryDocument
+  mode: "quick" | "daily" | "manual"
+}): Promise<ReflectionCandidate[]> {
+  if (!input.events.length) return []
+  const model = await Provider.defaultModel()
+  const resolved = await Provider.getModel(model.providerID, model.modelID)
+  const language = await Provider.getLanguage(resolved)
+  const system = [
+    "You are Aether's memory reflection engine.",
+    "Convert raw memory events into durable long-term memory candidates.",
+    "Return only JSON that matches the schema.",
+    "Allowed memory types: preference, fact, task.",
+    "Allowed scopes: global or project:<project_id>.",
+    "Do not create a candidate for one-off questions, transient chat, or low-confidence guesses.",
+    "Do not create a candidate from sensitive observed data such as IDs, passwords, addresses, phone numbers, medical, political, or religious information unless the user explicitly asked to remember it.",
+    "Prefer global for user-level preferences and profile-like facts.",
+    "Prefer project:<project_id> for project constraints, project facts, and project tasks.",
+    "Merge duplicates conceptually by returning the cleanest concise memory text.",
+    input.mode === "quick"
+      ? "Quick mode: analyze only the provided user-origin memory events and decide whether each event is worth writing as durable memory."
+      : "Heavy mode: organize memories by topic. For each type/scope/topic combination, emit at most one candidate. When multiple events or existing memories concern the same theme, merge complementary details into one coherent topical memory instead of separate fragmented entries.",
+    input.mode === "quick"
+      ? "Quick mode: do not rely on current memory context; it is intentionally omitted to save tokens."
+      : "Heavy mode: use current_memory to group related preferences, facts, and tasks under stable themes such as response style, language, tools, project workflow, research interests, and recurring tasks. If two candidate memories would share the same theme, combine them before returning JSON.",
+    "Do not expose raw event IDs inside memory or evidence; use event_id only in the structured field.",
+  ].join("\n")
+  const userMessage: ModelMessage = {
+    role: "user",
+    content: JSON.stringify(
+      {
+        mode: input.mode,
+        current_memory: input.mode === "quick" ? { shortcuts: [], memories: [] } : compactDocForLLM(input.doc),
+        events: input.events.map((event) => ({
+          id: event.id,
+          op: event.op,
+          type_hint: event.type,
+          intent: event.intent,
+          raw_text: event.raw_text,
+          channel_id: event.channel_id,
+          project_id: event.project_id,
+          session_id: event.session_id,
+          role: event.role,
+          created_at: event.created_at,
+        })),
+      },
+      null,
+      2,
+    ),
+  }
+  const params = {
+    model: language,
+    temperature: 0,
+    schema: ReflectionOutput,
+    messages: [
+      { role: "system", content: system },
+      userMessage,
+    ],
+  } satisfies Parameters<typeof generateObject>[0]
+
+  const authInfo = await Auth.get(model.providerID)
+  const object =
+    model.providerID === "openai" && authInfo?.type === "oauth"
+      ? await (async () => {
+          const result = streamObject({
+            ...params,
+            messages: [userMessage],
+            providerOptions: ProviderTransform.providerOptions(resolved, {
+              store: false,
+              instructions: system,
+            }),
+            onError: () => {},
+          })
+          for await (const part of result.fullStream) {
+            if (part.type === "error") throw part.error
+          }
+          return result.object
+        })()
+      : await generateObject(params).then((result) => result.object)
+
+  const byID = new Map(input.events.map((event) => [event.id, event]))
+  return object.candidates
+    .map((candidate) => {
+      const event = byID.get(candidate.event_id)
+      if (!event) return
+      const type = classifyType(candidate.memory, candidate.type)
+      const fallbackScope = inferScope({ text: candidate.memory, type, projectID: event.project_id, sourceJson: event.source_json })
+      return {
+        eventID: event.id,
+        type,
+        scope: normalizeLLMScope(candidate.scope, fallbackScope),
+        memory: sanitizeMemoryText(candidate.memory),
+        confidence: clamp01(candidate.confidence, event.intent === "explicit" ? 0.86 : 0.68),
+        weight: clamp01(candidate.weight, event.intent === "explicit" ? 0.82 : 0.55),
+        evidence: (candidate.evidence || (event.intent === "explicit" ? "用户明确请求记住。" : "由 LLM 反思提取。")).slice(0, 180),
+      } satisfies ReflectionCandidate
+    })
+    .filter((item): item is ReflectionCandidate => item !== undefined && item.memory.length > 0)
+}
+
+async function llmInitializeExtractor(session: SessionForInitialization): Promise<InitializerCandidate[]> {
+  const model = await Provider.defaultModel()
+  const resolved = await Provider.getModel(model.providerID, model.modelID)
+  const language = await Provider.getLanguage(resolved)
+  const system = [
+    "You are Aether's one-time memory initialization extractor.",
+    "Read one historical session and extract only stable, useful long-term memory candidates.",
+    "Return only JSON that matches the schema.",
+    "Allowed memory types: preference, fact, task.",
+    "Allowed scopes: global or project:<project_id>.",
+    "Only user messages are provided. Do not infer memories that require unavailable assistant context.",
+    "Do not record one-off questions, transient commands, ordinary chat, tool outputs, or completed reminders.",
+    "Do not record sensitive data such as IDs, passwords, addresses, phone numbers, medical, political, or religious information.",
+    "Prefer global for user-level preferences and profile-like facts.",
+    "Prefer project:<project_id> for project constraints, project facts, and project tasks.",
+    "Keep each memory concise and self-contained.",
+  ].join("\n")
+  const messages = session.messages
+    .filter((message) => message.role === "user")
+    .slice(-30)
+    .map((message) => ({
+      role: message.role,
+      created_at: message.createdAt,
+      text: message.text.slice(0, 1200),
+    }))
+  const userMessage: ModelMessage = {
+    role: "user",
+    content: JSON.stringify(
+      {
+        channel_id: session.channelID,
+        project_id: session.projectID,
+        session_id: session.sessionID,
+        messages,
+      },
+      null,
+      2,
+    ),
+  }
+  const params = {
+    model: language,
+    temperature: 0,
+    schema: InitializationOutput,
+    messages: [
+      { role: "system", content: system },
+      userMessage,
+    ],
+  } satisfies Parameters<typeof generateObject>[0]
+  const authInfo = await Auth.get(model.providerID)
+  const object =
+    model.providerID === "openai" && authInfo?.type === "oauth"
+      ? await (async () => {
+          const result = streamObject({
+            ...params,
+            messages: [userMessage],
+            providerOptions: ProviderTransform.providerOptions(resolved, {
+              store: false,
+              instructions: system,
+            }),
+            onError: () => {},
+          })
+          for await (const part of result.fullStream) {
+            if (part.type === "error") throw part.error
+          }
+          return result.object
+        })()
+      : await generateObject(params).then((result) => result.object)
+
+  return object.candidates
+    .map((candidate): InitializerCandidate | undefined => {
+      const type = classifyType(candidate.memory, candidate.type)
+      const text = sanitizeMemoryText(candidate.memory)
+      if (!text || hasSensitiveSignal(text)) return
+      return {
+        text,
+        type,
+        scope: normalizeLLMScope(candidate.scope, inferScope({ text, type, projectID: session.projectID })),
+      } satisfies InitializerCandidate
+    })
+    .filter((item): item is InitializerCandidate => item !== undefined)
+    .slice(0, 8)
+}
+
+async function llmForgetDecide(input: { query: string; candidates: MemoryBlock[] }) {
+  const model = await Provider.defaultModel()
+  const resolved = await Provider.getModel(model.providerID, model.modelID)
+  const language = await Provider.getLanguage(resolved)
+  const system = [
+    "You decide which long-term memory blocks should be forgotten.",
+    "Return only JSON that matches the schema.",
+    "Delete only memories clearly targeted by the user's forget request.",
+    "If the request is ambiguous or no candidate truly matches, return an empty delete_ids array.",
+  ].join("\n")
+  const userMessage: ModelMessage = {
+    role: "user",
+    content: JSON.stringify(
+      {
+        request: input.query,
+        candidates: input.candidates.map((candidate) => ({
+          id: candidate.id,
+          type: candidate.type,
+          scope: candidate.scope,
+          memory: candidate.memory,
+          evidence: candidate.evidence,
+        })),
+      },
+      null,
+      2,
+    ),
+  }
+  const params = {
+    model: language,
+    temperature: 0,
+    schema: ForgetDecisionOutput,
+    messages: [
+      { role: "system", content: system },
+      userMessage,
+    ],
+  } satisfies Parameters<typeof generateObject>[0]
+  const authInfo = await Auth.get(model.providerID)
+  const result =
+    model.providerID === "openai" && authInfo?.type === "oauth"
+      ? await (async () => {
+          const stream = streamObject({
+            ...params,
+            messages: [userMessage],
+            providerOptions: ProviderTransform.providerOptions(resolved, {
+              store: false,
+              instructions: system,
+            }),
+            onError: () => {},
+          })
+          for await (const part of stream.fullStream) {
+            if (part.type === "error") throw part.error
+          }
+          return stream.object
+        })()
+      : await generateObject(params).then((output) => output.object)
+  const allowed = new Set(input.candidates.map((candidate) => candidate.id))
+  const deleteIDs = result.delete_ids.filter((id) => allowed.has(id))
+  const keepIDs = (result.keep_ids ?? []).filter((id) => allowed.has(id))
+  return {
+    deleteIDs,
+    keepIDs,
+    reason: result.reason ?? "LLM forget decision",
+  }
+}
+
+async function defaultForgetDecision(input: { query: string; candidates: MemoryBlock[] }) {
+  try {
+    return await llmForgetDecide(input)
+  } catch {
+    return { deleteIDs: input.candidates.map((candidate) => candidate.id), keepIDs: [], reason: "matched candidates" }
+  }
+}
+
+async function runReflector(input: { events: MemoryEvent[]; doc: MemoryDocument; mode: "quick" | "daily" | "manual" }) {
+  if (reflectorForTest) return reflectorForTest(input)
+  try {
+    return await llmReflector(input)
+  } catch (error) {
+    if (input.mode === "quick") throw error
+    // Keep full reflection usable when model configuration is unavailable; the
+    // deterministic fallback preserves the same schema boundary for scheduled maintenance.
+  }
+  return deterministicReflector(input)
+}
+
+function mergeCandidates(doc: MemoryDocument, candidates: ReflectionCandidate[]) {
+  const now = new Date().toISOString()
+  const byKey = new Map<string, MemoryBlock>()
+  for (const memory of doc.memories) byKey.set(candidateKey(memory), memory)
+  const updatedIDs: string[] = []
+  const eventResults: Record<string, string> = {}
+  let shortcutChanged = false
+
+  for (const candidate of candidates) {
+    const key = candidateKey(candidate)
+    const existing = byKey.get(key)
+    if (existing) {
+      existing.confidence = Math.max(existing.confidence, candidate.confidence)
+      existing.weight = Math.max(existing.weight, candidate.weight)
+      existing.evidence = candidate.evidence
+      existing.updated_at = now
+      existing.status = "active"
+      updatedIDs.push(existing.id)
+      eventResults[candidate.eventID] = existing.id
+      continue
+    }
+    for (const memory of doc.memories) {
+      if (!conflictsWith(memory, candidate)) continue
+      memory.status = "deprecated"
+      memory.updated_at = now
+      shortcutChanged = true
+    }
+    const id = `${prefixForType(candidate.type)}-${ulid()}`
+    const block: MemoryBlock = {
+      id,
+      type: candidate.type,
+      scope: candidate.scope,
+      memory: candidate.memory,
+      confidence: candidate.confidence,
+      weight: candidate.weight,
+      evidence: candidate.evidence,
+      updated_at: now,
+      status: "active",
+    }
+    doc.memories.push(block)
+    byKey.set(key, block)
+    updatedIDs.push(id)
+    eventResults[candidate.eventID] = id
+
+    const shortcut = buildShortcut(candidate)
+    const existingShortcut = doc.shortcuts.find(
+      (item) => item.shortcut === shortcut.shortcut && item.instruction === shortcut.instruction,
+    )
+    if (existingShortcut) {
+      const activeIDs = new Set(doc.memories.filter((memory) => memory.status === "active").map((memory) => memory.id))
+      existingShortcut.target_ids = existingShortcut.target_ids.filter((target) => activeIDs.has(target))
+      if (!existingShortcut.target_ids.includes(id)) existingShortcut.target_ids.push(id)
+      shortcutChanged = true
+      existingShortcut.triggers = [...new Set([...existingShortcut.triggers, ...shortcut.triggers])].slice(0, 12)
+      existingShortcut.weight = Math.max(existingShortcut.weight, shortcut.weight)
+    } else {
+      shortcut.target_ids.push(id)
+      doc.shortcuts.push(shortcut)
+      shortcutChanged = true
+    }
+  }
+
+  return { updatedIDs: [...new Set(updatedIDs)], eventResults, shortcutChanged }
+}
+
+async function memoryChannels() {
+  await ensureDirs()
+  const found = new Set<string>([paths().channelID])
+  const entries = await fs.readdir(paths().channelRootDir, { withFileTypes: true }).catch(() => [])
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    const file = dbPath(entry.name)
+    if (await fs.stat(file).catch(() => undefined)) found.add(entry.name)
+  }
+  return [...found].sort()
+}
+
+async function pendingEvents(input: { mode: "quick" | "daily" | "manual"; eventIDs?: string[] }) {
+  if (input.eventIDs?.length) {
+    const database = openDb()
+    const placeholders = input.eventIDs.map(() => "?").join(", ")
+    return database
+      .prepare(`SELECT * FROM memory_event WHERE id IN (${placeholders}) ORDER BY created_at ASC, id ASC`)
+      .all(...input.eventIDs) as MemoryEvent[]
+  }
+  const limit = input.mode === "quick" ? 20 : 200
+  const rows: MemoryEvent[] = []
+  const channels = input.mode === "daily" ? await memoryChannels() : [paths().channelID]
+  for (const channelID of channels) {
+    const handle = openDbForChannel(channelID)
+    try {
+      const next = handle.database
+        .prepare(
+          `SELECT * FROM memory_event
+           WHERE op = 'remember' AND status IN ('new', 'pending_important')
+           ORDER BY created_at ASC, id ASC
+           LIMIT ?`,
+        )
+        .all(limit) as MemoryEvent[]
+      rows.push(...next.map((event) => ({ ...event, channel_id: event.channel_id ?? channelID })))
+    } finally {
+      handle.close()
+    }
+  }
+  return rows.sort((a, b) => a.created_at - b.created_at || a.id.localeCompare(b.id)).slice(0, limit)
+}
+
+function updateEventStatus(event: MemoryEvent, input: { status: EventStatus; reflectedAt: number; result: unknown }) {
+  const handle = openDbForChannel(event.channel_id ?? paths().channelID)
+  try {
+    handle.database
+      .prepare("UPDATE memory_event SET status = ?, reflected_at = ?, result_json = ? WHERE id = ?")
+      .run(input.status, input.reflectedAt, JSON.stringify(input.result), event.id)
+  } finally {
+    handle.close()
+  }
+}
+
+export namespace Memory {
+  export function configureForTest(input: Paths) {
+    overridePaths = input
+    stop()
+    reflectorForTest = (reflectInput) => deterministicReflector(reflectInput)
+  }
+
+  export async function stop() {
+    db?.close()
+    db = undefined
+    invalidateDocumentCache()
+    initializeCancelled = false
+    startupCatchupStarted = false
+    scannerForTest = undefined
+    extractorForTest = undefined
+  }
+
+  export async function purge() {
+    await stop()
+    await fs.rm(paths().globalMemoryDir, { recursive: true, force: true })
+    await fs.rm(dbPath(), { force: true }).catch(() => undefined)
+    await fs.rm(`${dbPath()}-wal`, { force: true }).catch(() => undefined)
+    await fs.rm(`${dbPath()}-shm`, { force: true }).catch(() => undefined)
+  }
+
+  export async function status() {
+    const stat = await fs.stat(mdPath()).catch(() => undefined)
+    const doc = await readDocumentWithOptions({ createIfMissing: false })
+    const cfg = await Config.get().catch(() => ({} as Awaited<ReturnType<typeof Config.get>>))
+    const state = await readReflectionState()
+    const hasHistorySessions = Boolean(Session.listGlobal({ limit: 1, archivedMode: "exclude" }).next().value)
+    return {
+      enabled: cfg.memory?.enabled ?? true,
+      dailyReflectEnabled: cfg.memory?.dailyReflect?.enabled ?? true,
+      dailyReflectTime: cfg.memory?.dailyReflect?.time ?? "03:00",
+      markdown_exists: Boolean(stat),
+      markdown_updated_at: stat?.mtimeMs ?? null,
+      memory_count: doc.memories.length,
+      shortcut_count: doc.shortcuts.length,
+      needs_initialization: !stat,
+      has_history_sessions: hasHistorySessions,
+      initialization: state.initialization ?? { status: "idle" },
+    }
+  }
+
+  export async function writeDocumentForTest(doc: MemoryDocument) {
+    await writeDocument(doc)
+  }
+
+  export async function eventsForTest(): Promise<MemoryEvent[]> {
+    return openDb().prepare("SELECT * FROM memory_event ORDER BY created_at ASC, id ASC").all() as MemoryEvent[]
+  }
+
+  export function setSessionScannerForTest(scanner: () => AsyncGenerator<SessionForInitialization>) {
+    scannerForTest = scanner
+  }
+
+  export function setInitializerExtractorForTest(extractor: (session: SessionForInitialization) => Promise<InitializerCandidate[]>) {
+    extractorForTest = extractor
+  }
+
+  export function setReflectorForTest(
+    reflector: (input: { events: MemoryEvent[]; doc: MemoryDocument; mode: "quick" | "daily" | "manual" }) => Promise<ReflectionCandidate[]>,
+  ) {
+    reflectorForTest = reflector
+  }
+
+  export async function search(input: MemorySearchInput) {
+    const doc = await readDocument()
+    return {
+      results: searchMemoryDocument(doc, input),
+      ranking_note: "结果按相关度、scope、权重和新近程度综合排序。",
+    }
+  }
+
+  export async function remember(input: {
+    text: string
+    type?: MemoryType
+    intent: "explicit" | "observed"
+    source: Parameters<typeof insertEvent>[0]["source"]
+  }) {
+    if (!(await isEnabled())) return { eventID: "", status: "ignored" as const, reason: "memory disabled" }
+    await ensureDirs()
+    const gate = shouldQuickReflect({ text: input.text, intent: input.intent, op: "remember", shortcutTriggers: [] })
+    const event = insertEvent({
+      op: "remember",
+      type: input.type,
+      intent: input.intent,
+      text: input.text,
+      status: gate.shouldRun ? "new" : "ignored",
+      source: input.source,
+    })
+    if (gate.priority === "important") {
+      openDb().prepare("UPDATE memory_event SET status = ? WHERE id = ?").run("pending_important", event.id)
+      const reflected = await reflect({ mode: "quick", reason: gate.reason, eventIDs: [event.id] }).catch((error) => ({
+        changed: false,
+        summary: error instanceof Error ? error.message : String(error),
+      }))
+      return {
+        eventID: event.id,
+        status: reflected.changed ? ("applied" as const) : ("queued" as const),
+        reason: reflected.changed ? gate.reason : `${gate.reason}; quick LLM reflection did not apply a memory yet: ${reflected.summary}`,
+      }
+    }
+    return { eventID: event.id, status: gate.shouldRun ? ("queued" as const) : ("ignored" as const), reason: gate.reason }
+  }
+
+  export async function forget(input: {
+    query?: string
+    ids?: string[]
+    type?: MemoryType
+    source: Parameters<typeof insertEvent>[0]["source"]
+    decide?: (input: {
+      query: string
+      candidates: MemoryBlock[]
+    }) => Promise<{ deleteIDs: string[]; keepIDs: string[]; reason: string }>
+  }) {
+    if (!(await isEnabled())) return { eventID: "", deletedIDs: [], status: "not_found" as const }
+    const doc = await readDocument()
+    let candidates = input.ids?.length
+      ? doc.memories.filter((memory) => input.ids!.includes(memory.id))
+      : searchMemoryDocument(doc, { query: input.query ?? "", types: input.type ? [input.type] : undefined, limit: 10 })
+    const broadFallback = !candidates.length && !input.ids?.length && Boolean(input.query)
+    if (broadFallback) {
+      candidates = doc.memories
+        .filter((memory) => memory.status === "active")
+        .filter((memory) => !input.type || memory.type === input.type)
+        .slice(0, 20)
+    }
+    if (!candidates.length) {
+      return { eventID: "", deletedIDs: [], status: "not_found" as const }
+    }
+    const decision = input.decide
+      ? await input.decide({ query: input.query ?? input.ids?.join(", ") ?? "", candidates })
+      : broadFallback
+        ? await llmForgetDecide({ query: input.query ?? input.ids?.join(", ") ?? "", candidates }).catch(() => ({
+            deleteIDs: [],
+            keepIDs: candidates.map((candidate) => candidate.id),
+            reason: "No keyword candidates and LLM forget decision failed.",
+          }))
+        : await defaultForgetDecision({ query: input.query ?? input.ids?.join(", ") ?? "", candidates })
+    const deleteSet = new Set(decision.deleteIDs)
+    const deletedIDs = doc.memories.filter((memory) => deleteSet.has(memory.id)).map((memory) => memory.id)
+    if (!deletedIDs.length) return { eventID: "", deletedIDs: [], status: "not_found" as const }
+    const next = {
+      ...doc,
+      memories: doc.memories.filter((memory) => !deleteSet.has(memory.id)),
+      shortcuts: doc.shortcuts
+        .map((shortcut) => ({
+          ...shortcut,
+          target_ids: shortcut.target_ids.filter((id) => !deleteSet.has(id)),
+        }))
+        .filter((shortcut) => shortcut.target_ids.length > 0),
+    }
+    await writeDocument(next)
+    const event = insertEvent({
+      op: "forget",
+      intent: "explicit",
+      text: input.query ?? deletedIDs.join(", "),
+      status: "forgot",
+      source: input.source,
+      result: { deletedIDs, reason: decision.reason },
+    })
+    return { eventID: event.id, deletedIDs, status: "deleted" as const }
+  }
+
+  export async function reflect(input: {
+    mode: "quick" | "daily" | "manual"
+    reason?: string
+    eventIDs?: string[]
+  }) {
+    if (!(await isEnabled())) {
+      return { runID: "", changed: false, updatedIDs: [], deletedIDs: [], shortcutChanged: false, summary: "Memory is disabled." }
+    }
+    const cfg = await Config.get().catch(() => ({} as Awaited<ReturnType<typeof Config.get>>))
+    if (input.mode === "daily" && input.reason === "cron" && cfg.memory?.dailyReflect?.enabled === false) {
+      return {
+        runID: "",
+        changed: false,
+        updatedIDs: [],
+        deletedIDs: [],
+        shortcutChanged: false,
+        summary: "Daily memory reflection is disabled.",
+      }
+    }
+    const started = Date.now()
+    const id = `refl_${ulid()}`
+    const events = await pendingEvents({ mode: input.mode, eventIDs: input.eventIDs })
+    const before = await readDocument()
+    const candidates = await runReflector({ events, doc: before, mode: input.mode })
+    const next: MemoryDocument = {
+      ...before,
+      shortcuts: before.shortcuts.map((shortcut) => ({ ...shortcut, target_ids: [...shortcut.target_ids] })),
+      memories: before.memories.map((memory) => ({ ...memory })),
+    }
+    const merged = mergeCandidates(next, candidates)
+    const changed = merged.updatedIDs.length > 0
+    if (changed) await writeDocument(next)
+    const now = Date.now()
+    for (const event of events) {
+      const memoryID = merged.eventResults[event.id]
+      updateEventStatus(event, {
+        status: memoryID ? "applied" : "ignored",
+        reflectedAt: now,
+        result: { memoryID: memoryID ?? null, runID: id },
+      })
+    }
+    openDb()
+      .prepare(
+        "INSERT INTO reflection_run (id, mode, started_at, completed_at, input_event_ids_json, summary_json) VALUES (?, ?, ?, ?, ?, ?)",
+      )
+      .run(
+        id,
+        input.mode,
+        started,
+        Date.now(),
+        JSON.stringify(events.map((event) => event.id)),
+        JSON.stringify({ reason: input.reason ?? "", updatedIDs: merged.updatedIDs }),
+      )
+    if (input.mode === "daily") {
+      await writeReflectionState({
+        last_successful_daily_reflect_at: Date.now(),
+        last_daily_reflect_run_id: id,
+      })
+    }
+    return {
+      runID: id,
+      changed,
+      updatedIDs: merged.updatedIDs,
+      deletedIDs: [],
+      shortcutChanged: merged.shortcutChanged,
+      summary: changed ? `Applied ${merged.updatedIDs.length} memory update(s).` : "No changes.",
+    }
+  }
+
+  export async function initialize(input: { confirm: boolean }) {
+    if (!(await isEnabled())) return { status: "cancelled" as const, scanned: 0, imported: 0 }
+    if (!input.confirm) return { status: "cancelled" as const, scanned: 0, imported: 0 }
+    initializeCancelled = false
+    await ensureDirs()
+    const startedAt = Date.now()
+    let scanned = 0
+    let imported = 0
+    const writeInitializationProgress = (patch: Record<string, unknown> = {}) =>
+      writeReflectionState({
+        initialization: {
+          status: "running",
+          started_at: startedAt,
+          updated_at: Date.now(),
+          scanned,
+          imported,
+          ...patch,
+        },
+      })
+
+    await writeInitializationProgress()
+    const scanner = scannerForTest ?? defaultSessionScanner
+    for await (const session of scanner()) {
+      if (initializeCancelled) break
+      scanned++
+      if (!sessionHasMemorySignal(session)) {
+        await writeInitializationProgress({
+          current_session_id: session.sessionID,
+          current_project_id: session.projectID ?? null,
+        })
+        await sleep(250)
+        continue
+      }
+      const candidates = extractorForTest ? await extractorForTest(session) : await extractMemoryCandidates(session)
+      for (const candidate of candidates) {
+        insertEvent({
+          op: "remember",
+          type: candidate.type,
+          intent: "observed",
+          text: candidate.text,
+          status: "new",
+          source: {
+            createdAt: Date.now(),
+            channelID: session.channelID,
+            projectID: session.projectID,
+            sessionID: session.sessionID,
+            role: "user",
+            scope: candidate.scope,
+          },
+        })
+        imported++
+      }
+      await writeInitializationProgress({
+        current_session_id: session.sessionID,
+        current_project_id: session.projectID ?? null,
+      })
+      await sleep(250)
+    }
+    if (imported > 0) {
+      await writeInitializationProgress({ status: "reflecting" })
+      await reflect({ mode: "daily", reason: "initialize" })
+    }
+    const status = initializeCancelled ? ("cancelled" as const) : ("succeeded" as const)
+    await writeReflectionState({
+      initialization: {
+        status,
+        started_at: startedAt,
+        completed_at: Date.now(),
+        scanned,
+        imported,
+      },
+    })
+    return { status, scanned, imported }
+  }
+
+  export async function startupCatchup() {
+    if (startupCatchupStarted) return { started: false, reason: "already checked this startup" }
+    startupCatchupStarted = true
+    if (!(await isEnabled())) return { started: false, reason: "memory disabled" }
+    const cfg = await Config.get().catch(() => ({} as Awaited<ReturnType<typeof Config.get>>))
+    if (cfg.memory?.dailyReflect?.enabled === false) return { started: false, reason: "daily reflect disabled" }
+    const state = await readReflectionState()
+    const last = typeof state.last_successful_daily_reflect_at === "number" ? state.last_successful_daily_reflect_at : 0
+    if (last && dateKey(last) === dateKey(Date.now())) return { started: false, reason: "already reflected today" }
+    void reflect({ mode: "daily", reason: "startup-catchup" })
+      .then((result) =>
+        writeReflectionState({
+          last_startup_catchup_at: Date.now(),
+          last_startup_catchup_result: result.summary,
+        }),
+      )
+      .catch((error) =>
+        writeReflectionState({
+          last_startup_catchup_at: Date.now(),
+          last_startup_catchup_result: error instanceof Error ? error.message : String(error),
+        }),
+      )
+    return { started: true, reason: "scheduled" }
+  }
+
+  export async function cancelInitialize() {
+    initializeCancelled = true
+    return { ok: true }
+  }
+
+  export function detectForgetIntent(text: string) {
+    return hasForgetIntent(text)
+  }
+
+  export async function isEnabled() {
+    const cfg = await Config.get().catch(() => ({} as Awaited<ReturnType<typeof Config.get>>))
+    return cfg.memory?.enabled ?? true
+  }
+
+  export async function shortcutSystemPrompt() {
+    if (!(await isEnabled())) return undefined
+    const doc = await readDocument()
+    if (!doc.shortcuts.length) return undefined
+    const lines = [
+      "<user_memory_shortcuts>",
+      "These are memory shortcuts, not full memories. Use them only to decide whether memory_search is needed.",
+      "",
+    ]
+    for (const shortcut of doc.shortcuts) {
+      lines.push(
+        `- shortcut: ${shortcut.shortcut}`,
+        `  triggers: ${shortcut.triggers.join(", ")}`,
+        `  instruction: ${shortcut.instruction}`,
+        "",
+      )
+    }
+    lines.push(
+      "If a shortcut matches the current task, call memory_search. Do not treat shortcut text as factual memory.",
+      "</user_memory_shortcuts>",
+    )
+    return lines.join("\n")
+  }
+}

--- a/packages/opencode/src/memory/installer.ts
+++ b/packages/opencode/src/memory/installer.ts
@@ -1,0 +1,73 @@
+import { Cron } from "@/cron"
+import { Config } from "@/config/config"
+import { Memory } from "."
+
+export const MEMORY_DAILY_REFLECT_ACTION = "memory.reflect.daily"
+export const MEMORY_DAILY_REFLECT_JOB_ID = "builtin.memory.daily_reflect"
+
+export type InstalledMemory = {
+  service: typeof Memory
+  start(): Promise<void>
+  stop(): Promise<void>
+  purge(): Promise<void>
+}
+
+function scheduleFromTime(time: string | undefined) {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(time ?? "")
+  const hour = match ? Number(match[1]) : 3
+  const minute = match ? Number(match[2]) : 0
+  if (!Number.isInteger(hour) || !Number.isInteger(minute) || hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+    return "0 3 * * *"
+  }
+  return `${minute} ${hour} * * *`
+}
+
+export async function syncDailyReflectJob(input?: { preserveExisting?: boolean }) {
+  const cfg = await Config.get().catch(() => ({} as Awaited<ReturnType<typeof Config.get>>))
+  const enabled = (cfg.memory?.enabled ?? true) && (cfg.memory?.dailyReflect?.enabled ?? true)
+  const schedule = scheduleFromTime(cfg.memory?.dailyReflect?.time)
+  const existing = await Cron.getJob(MEMORY_DAILY_REFLECT_JOB_ID).catch(() => undefined)
+  if (existing && input?.preserveExisting !== false) return existing
+  if (existing) {
+    return Cron.updateJob({
+      id: MEMORY_DAILY_REFLECT_JOB_ID,
+      patch: {
+        enabled,
+        schedule_value: schedule,
+      },
+    })
+  }
+  return Cron.ensureJob({
+    id: MEMORY_DAILY_REFLECT_JOB_ID,
+    name: "Daily memory reflection",
+    enabled,
+    mode: "direct",
+    project_id: null,
+    session_id: null,
+    schedule_type: "cron",
+    schedule_value: schedule,
+    payload: {
+      action: MEMORY_DAILY_REFLECT_ACTION,
+    },
+  })
+}
+
+export async function installMemory(): Promise<InstalledMemory> {
+  Cron.registerDirectAction(MEMORY_DAILY_REFLECT_ACTION, async () => {
+    const result = await Memory.reflect({ mode: "daily", reason: "cron" })
+    return {
+      output_summary: result.summary,
+    }
+  })
+  await syncDailyReflectJob({ preserveExisting: true })
+  await Memory.startupCatchup()
+  return {
+    service: Memory,
+    start: async () => {
+      await syncDailyReflectJob({ preserveExisting: true })
+      await Memory.startupCatchup()
+    },
+    stop: Memory.stop,
+    purge: Memory.purge,
+  }
+}

--- a/packages/opencode/src/memory/markdown.ts
+++ b/packages/opencode/src/memory/markdown.ts
@@ -1,0 +1,217 @@
+export type MemoryType = "preference" | "fact" | "task"
+export type MemoryScope = "global" | `project:${string}`
+export type MemoryStatus = "active" | "deprecated"
+
+export type MemoryBlock = {
+  id: string
+  type: MemoryType
+  scope: MemoryScope
+  memory: string
+  confidence: number
+  weight: number
+  evidence: string
+  updated_at: string
+  status: MemoryStatus
+}
+
+export type Shortcut = {
+  shortcut: string
+  triggers: string[]
+  types: MemoryType[]
+  target_ids: string[]
+  weight: number
+  instruction: string
+}
+
+export type MemoryDocument = {
+  schema_version: number
+  updated_at: string
+  shortcuts: Shortcut[]
+  memories: MemoryBlock[]
+}
+
+const SECTION_BY_TYPE: Record<MemoryType, string> = {
+  preference: "Preferences",
+  fact: "Facts",
+  task: "Tasks",
+}
+
+export function emptyMemoryDocument(): MemoryDocument {
+  return {
+    schema_version: 1,
+    updated_at: new Date().toISOString(),
+    shortcuts: [],
+    memories: [],
+  }
+}
+
+function parseList(value: string) {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+function parseField(line: string) {
+  const match = /^\s*(?:-\s*)?([^:]+):\s*(.*)$/.exec(line)
+  if (!match) return
+  return [match[1]!.trim(), match[2]!.trim()] as const
+}
+
+function sectionOf(id: string) {
+  if (id.startsWith("PREF-")) return "preference"
+  if (id.startsWith("FACT-")) return "fact"
+  if (id.startsWith("TASK-")) return "task"
+  return undefined
+}
+
+export function parseMemoryMarkdown(input: string): MemoryDocument {
+  const doc = emptyMemoryDocument()
+  const lines = input.replace(/\r\n/g, "\n").split("\n")
+  let section = ""
+  let currentShortcut: Partial<Shortcut> | undefined
+  let currentMemory: Partial<MemoryBlock> & { id?: string } | undefined
+  const flushShortcut = () => {
+    if (!currentShortcut?.shortcut) return
+    doc.shortcuts.push({
+      shortcut: currentShortcut.shortcut,
+      triggers: currentShortcut.triggers ?? [],
+      types: currentShortcut.types ?? [],
+      target_ids: currentShortcut.target_ids ?? [],
+      weight: currentShortcut.weight ?? 0,
+      instruction: currentShortcut.instruction ?? "",
+    })
+    currentShortcut = undefined
+  }
+  const flushMemory = () => {
+    if (!currentMemory?.id) return
+    const inferred = sectionOf(currentMemory.id)
+    if (!currentMemory.type && inferred) currentMemory.type = inferred
+    if (
+      currentMemory.type &&
+      currentMemory.scope &&
+      currentMemory.memory &&
+      currentMemory.evidence &&
+      currentMemory.updated_at &&
+      currentMemory.status
+    ) {
+      doc.memories.push({
+        id: currentMemory.id,
+        type: currentMemory.type,
+        scope: currentMemory.scope,
+        memory: currentMemory.memory,
+        confidence: Number(currentMemory.confidence ?? 0),
+        weight: Number(currentMemory.weight ?? 0),
+        evidence: currentMemory.evidence,
+        updated_at: currentMemory.updated_at,
+        status: currentMemory.status,
+      })
+    }
+    currentMemory = undefined
+  }
+
+  for (const line of lines) {
+    const h2 = /^##\s+(.+)$/.exec(line)
+    if (h2) {
+      flushShortcut()
+      flushMemory()
+      section = h2[1]!.trim()
+      continue
+    }
+
+    const h3 = /^###\s+(.+)$/.exec(line)
+    if (h3) {
+      flushShortcut()
+      flushMemory()
+      currentMemory = { id: h3[1]!.trim() }
+      continue
+    }
+
+    if (section === "Shortcut Directory" && line.startsWith("- shortcut:")) {
+      flushShortcut()
+      currentShortcut = { shortcut: line.replace("- shortcut:", "").trim() }
+      continue
+    }
+
+    const field = parseField(line)
+    if (!field) continue
+    const [key, value] = field
+    if (section === "Shortcut Directory" && currentShortcut) {
+      if (key === "triggers") currentShortcut.triggers = parseList(value)
+      if (key === "types") currentShortcut.types = parseList(value) as MemoryType[]
+      if (key === "target_ids") currentShortcut.target_ids = parseList(value)
+      if (key === "weight") currentShortcut.weight = Number(value)
+      if (key === "instruction") currentShortcut.instruction = value
+      continue
+    }
+    if (currentMemory) {
+      if (key === "type") currentMemory.type = value as MemoryType
+      if (key === "scope") currentMemory.scope = value as MemoryScope
+      if (key === "memory") currentMemory.memory = value
+      if (key === "confidence") currentMemory.confidence = Number(value)
+      if (key === "weight") currentMemory.weight = Number(value)
+      if (key === "evidence") currentMemory.evidence = value
+      if (key === "updated_at") currentMemory.updated_at = value
+      if (key === "status") currentMemory.status = value as MemoryStatus
+    }
+  }
+  flushShortcut()
+  flushMemory()
+  return doc
+}
+
+function fmtNumber(value: number) {
+  return Number.isFinite(value) ? String(Math.max(0, Math.min(1, value))) : "0"
+}
+
+export function renderMemoryDocument(input: MemoryDocument): string {
+  const now = input.updated_at || new Date().toISOString()
+  const lines: string[] = [
+    "# Aether Memory",
+    "",
+    "<!--",
+    `schema_version: ${input.schema_version || 1}`,
+    `updated_at: ${now}`,
+    "source: memory.db",
+    "search_target: true",
+    "-->",
+    "",
+    "## Shortcut Directory",
+    "",
+    "> 这部分会被注入 system prompt。它不是完整记忆，只帮助 Agent 判断是否调用 memory.search。",
+    "",
+  ]
+
+  for (const shortcut of input.shortcuts) {
+    lines.push(
+      `- shortcut: ${shortcut.shortcut}`,
+      `  triggers: ${shortcut.triggers.join(", ")}`,
+      `  types: ${shortcut.types.join(", ")}`,
+      `  target_ids: ${shortcut.target_ids.join(", ")}`,
+      `  weight: ${fmtNumber(shortcut.weight)}`,
+      `  instruction: ${shortcut.instruction}`,
+      "",
+    )
+  }
+
+  for (const type of ["preference", "fact", "task"] as const) {
+    lines.push("---", "", `## ${SECTION_BY_TYPE[type]}`, "")
+    const memories = input.memories.filter((item) => item.type === type)
+    for (const memory of memories) {
+      lines.push(
+        `### ${memory.id}`,
+        `- type: ${memory.type}`,
+        `- scope: ${memory.scope}`,
+        `- memory: ${memory.memory}`,
+        `- confidence: ${fmtNumber(memory.confidence)}`,
+        `- weight: ${fmtNumber(memory.weight)}`,
+        `- evidence: ${memory.evidence}`,
+        `- updated_at: ${memory.updated_at}`,
+        `- status: ${memory.status}`,
+        "",
+      )
+    }
+  }
+
+  return lines.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd() + "\n"
+}

--- a/packages/opencode/src/memory/plugin.ts
+++ b/packages/opencode/src/memory/plugin.ts
@@ -1,0 +1,47 @@
+import type { Hooks, PluginInput } from "@opencode-ai/plugin"
+import { Memory } from "."
+
+function textFromParts(parts: Array<{ type?: string; text?: string }>) {
+  return parts
+    .filter((part) => part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("\n")
+    .trim()
+}
+
+export async function MemoryPlugin(input: PluginInput): Promise<Hooks> {
+  return {
+    async "chat.message"(ctx, output) {
+      const text = textFromParts(output.parts as Array<{ type?: string; text?: string }>)
+      if (!text) return
+      if (Memory.detectForgetIntent(text)) {
+        await Memory.forget({
+          query: text,
+          source: {
+            createdAt: Date.now(),
+            projectID: input.project.id,
+            sessionID: ctx.sessionID,
+            messageID: ctx.messageID,
+            role: "user",
+          },
+        })
+        return
+      }
+      await Memory.remember({
+        text,
+        intent: "observed",
+        source: {
+          createdAt: Date.now(),
+          projectID: input.project.id,
+          sessionID: ctx.sessionID,
+          messageID: ctx.messageID,
+          role: "user",
+        },
+      })
+    },
+    async "experimental.chat.system.transform"(_ctx, output) {
+      const prompt = await Memory.shortcutSystemPrompt()
+      if (prompt) output.system.push(prompt)
+    },
+  }
+}

--- a/packages/opencode/src/memory/schema.sql.ts
+++ b/packages/opencode/src/memory/schema.sql.ts
@@ -1,0 +1,53 @@
+import { index, integer, real, sqliteTable, text } from "drizzle-orm/sqlite-core"
+
+export const MemoryEventTable = sqliteTable(
+  "memory_event",
+  {
+    id: text().primaryKey(),
+    created_at: integer().notNull(),
+    op: text().$type<"remember" | "forget">().notNull(),
+    type: text().$type<"preference" | "fact" | "task" | null>(),
+    intent: text().$type<"explicit" | "observed">().notNull(),
+    raw_text: text().notNull(),
+    channel_id: text(),
+    project_id: text(),
+    session_id: text(),
+    message_id: text(),
+    role: text().$type<"user" | "assistant" | "system" | "tool" | null>(),
+    source_json: text().notNull(),
+    candidate_key: text(),
+    candidate_summary: text(),
+    confidence_hint: real(),
+    status: text()
+      .$type<"new" | "pending_important" | "applied" | "ignored" | "deleted" | "forgot" | "deprecated" | "superseded">()
+      .notNull()
+      .default("new"),
+    reflected_at: integer(),
+    result_json: text(),
+  },
+  (table) => [
+    index("memory_event_created_idx").on(table.created_at),
+    index("memory_event_status_idx").on(table.status),
+    index("memory_event_candidate_key_idx").on(table.candidate_key),
+    index("memory_event_project_created_idx").on(table.project_id, table.created_at),
+    index("memory_event_session_created_idx").on(table.session_id, table.created_at),
+  ],
+)
+
+export const ReflectionRunTable = sqliteTable("reflection_run", {
+  id: text().primaryKey(),
+  mode: text().$type<"quick" | "daily" | "manual">().notNull(),
+  started_at: integer().notNull(),
+  completed_at: integer(),
+  model: text(),
+  input_event_ids_json: text(),
+  md_before_hash: text(),
+  md_after_hash: text(),
+  summary_json: text(),
+  error: text(),
+})
+
+export const MemorySettingTable = sqliteTable("memory_setting", {
+  key: text().primaryKey(),
+  value: text().notNull(),
+})

--- a/packages/opencode/src/memory/search.ts
+++ b/packages/opencode/src/memory/search.ts
@@ -1,0 +1,128 @@
+import type { MemoryBlock, MemoryDocument, MemoryType } from "./markdown"
+
+export type MemorySearchInput = {
+  query: string
+  types?: MemoryType[]
+  limit?: number
+  currentProjectID?: string
+}
+
+export type MemorySearchResult = MemoryBlock & {
+  score: number
+  markdown: string
+  ranking_note: string
+}
+
+const SPLIT_RE = /[\s,，;；、|/\\]+/g
+
+export function splitSearchTerms(query: string) {
+  return query
+    .split(SPLIT_RE)
+    .map((term) => term.trim())
+    .filter(Boolean)
+}
+
+function normalizeEnglish(input: string) {
+  return input.toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, " ")
+}
+
+function hasCjk(input: string) {
+  return /[\u3400-\u9fff]/.test(input)
+}
+
+function ngrams(input: string, size: number) {
+  const chars = Array.from(input.replace(/\s/g, ""))
+  const out = new Set<string>()
+  for (let i = 0; i <= chars.length - size; i++) out.add(chars.slice(i, i + size).join(""))
+  return out
+}
+
+function overlap(a: Set<string>, b: Set<string>) {
+  if (!a.size || !b.size) return 0
+  let hits = 0
+  for (const item of a) if (b.has(item)) hits++
+  return hits / Math.max(a.size, b.size)
+}
+
+function textScore(term: string, target: string) {
+  const lowerTerm = normalizeEnglish(term)
+  const lowerTarget = normalizeEnglish(target)
+  let score = 0
+  if (lowerTarget.includes(lowerTerm)) score = Math.max(score, 1)
+  const tokens = lowerTarget.split(/\s+/).filter(Boolean)
+  if (tokens.some((token) => token === lowerTerm)) score = Math.max(score, 1)
+  if (tokens.some((token) => token.startsWith(lowerTerm))) score = Math.max(score, 0.75)
+
+  if (hasCjk(term)) {
+    if (target.includes(term)) score = Math.max(score, 1)
+    score = Math.max(score, overlap(ngrams(term, 2), ngrams(target, 2)) * 0.85)
+    score = Math.max(score, overlap(ngrams(term, 3), ngrams(target, 3)))
+  }
+  return score
+}
+
+function scopeRelevance(scope: string, currentProjectID?: string) {
+  if (scope === "global") return 0.65
+  if (currentProjectID && scope === `project:${currentProjectID}`) return 1
+  return 0.2
+}
+
+function recencyScore(updatedAt: string) {
+  const time = Date.parse(updatedAt)
+  if (!Number.isFinite(time)) return 0.4
+  const ageDays = Math.max(0, (Date.now() - time) / 86_400_000)
+  return Math.max(0.1, 1 - ageDays / 365)
+}
+
+function renderSnippet(memory: MemoryBlock) {
+  return [
+    `### ${memory.id}`,
+    `- type: ${memory.type}`,
+    `- scope: ${memory.scope}`,
+    `- memory: ${memory.memory}`,
+    `- confidence: ${memory.confidence}`,
+    `- weight: ${memory.weight}`,
+    `- evidence: ${memory.evidence}`,
+    `- updated_at: ${memory.updated_at}`,
+    `- status: ${memory.status}`,
+  ].join("\n")
+}
+
+export function searchMemoryDocument(doc: MemoryDocument, input: MemorySearchInput): MemorySearchResult[] {
+  const limit = Math.max(0, input.limit ?? 5)
+  if (limit <= 0) return []
+  const terms = splitSearchTerms(input.query)
+  if (!terms.length) return []
+  const allowed = input.types ? new Set(input.types) : undefined
+  const shortcutTargets = new Map<string, number>()
+  for (const shortcut of doc.shortcuts) {
+    const haystack = [shortcut.shortcut, ...shortcut.triggers, shortcut.instruction].join(" ")
+    const matched = terms.some((term) => textScore(term, haystack) > 0)
+    if (!matched) continue
+    for (const id of shortcut.target_ids) shortcutTargets.set(id, Math.max(shortcutTargets.get(id) ?? 0, shortcut.weight || 0.8))
+  }
+
+  return doc.memories
+    .filter((memory) => memory.status === "active")
+    .filter((memory) => !allowed || allowed.has(memory.type))
+    .map((memory) => {
+      const haystack = [memory.id, memory.type, memory.scope, memory.memory, memory.evidence].join(" ")
+      const match = Math.max(...terms.map((term) => textScore(term, haystack)), 0)
+      const shortcut = shortcutTargets.get(memory.id) ?? 0
+      const scope = scopeRelevance(memory.scope, input.currentProjectID)
+      const recency = recencyScore(memory.updated_at)
+      const score = match * 0.45 + shortcut * 0.25 + memory.weight * 0.2 + recency * 0.05 + scope * 0.05
+      return {
+        ...memory,
+        matched: match > 0 || shortcut > 0,
+        score,
+        markdown: renderSnippet(memory),
+        ranking_note: "结果按相关度、scope、权重和新近程度综合排序。",
+      }
+    })
+    .filter((memory) => memory.matched)
+    .filter((memory) => memory.score > 0.05)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map(({ matched, ...memory }) => memory)
+}

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -14,6 +14,7 @@ import { PoeAuthPlugin } from "opencode-poe-auth"
 import { Effect, Layer, ServiceMap, Stream } from "effect"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
+import { MemoryPlugin } from "@/memory/plugin"
 
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
@@ -44,7 +45,13 @@ export namespace Plugin {
   export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/Plugin") {}
 
   // Built-in plugins that are directly imported (not installed from npm)
-  const INTERNAL_PLUGINS: PluginInstance[] = [CodexAuthPlugin, CopilotAuthPlugin, GitlabAuthPlugin, PoeAuthPlugin]
+  const INTERNAL_PLUGINS: PluginInstance[] = [
+    CodexAuthPlugin,
+    CopilotAuthPlugin,
+    GitlabAuthPlugin,
+    PoeAuthPlugin,
+    MemoryPlugin,
+  ]
 
   // Old npm package names for plugins that are now built-in — skip if users still have them in config
   const DEPRECATED_PLUGIN_PACKAGES = ["opencode-openai-codex-auth", "opencode-copilot-auth"]

--- a/packages/opencode/src/server/routes/memory.ts
+++ b/packages/opencode/src/server/routes/memory.ts
@@ -1,0 +1,108 @@
+import { Hono } from "hono"
+import { describeRoute, resolver, validator } from "hono-openapi"
+import z from "zod"
+import { lazy } from "@/util/lazy"
+import { Memory } from "@/memory"
+import { syncDailyReflectJob } from "@/memory/installer"
+
+const SearchBody = z.object({
+  query: z.string().min(1),
+  types: z.array(z.enum(["preference", "fact", "task"])).optional(),
+  limit: z.number().int().optional(),
+  currentProjectID: z.string().optional(),
+})
+
+const ReflectBody = z.object({
+  mode: z.enum(["quick", "daily", "manual"]).optional(),
+  reason: z.string().optional(),
+})
+
+export const MemoryRoutes = lazy(() =>
+  new Hono()
+    .get(
+      "/status",
+      describeRoute({
+        summary: "Get memory system status",
+        operationId: "memory.status",
+        responses: {
+          200: {
+            description: "Memory status",
+            content: { "application/json": { schema: resolver(z.record(z.string(), z.unknown())) } },
+          },
+        },
+      }),
+      async (c) => c.json(await Memory.status()),
+    )
+    .post(
+      "/search",
+      describeRoute({
+        summary: "Search long-term memory",
+        operationId: "memory.search",
+        responses: {
+          200: {
+            description: "Memory search result",
+            content: { "application/json": { schema: resolver(z.record(z.string(), z.unknown())) } },
+          },
+        },
+      }),
+      validator("json", SearchBody),
+      async (c) => c.json(await Memory.search(c.req.valid("json"))),
+    )
+    .post(
+      "/reflect",
+      describeRoute({
+        summary: "Run memory reflection",
+        operationId: "memory.reflect",
+        responses: {
+          200: {
+            description: "Memory reflection result",
+            content: { "application/json": { schema: resolver(z.record(z.string(), z.unknown())) } },
+          },
+        },
+      }),
+      validator("json", ReflectBody),
+      async (c) => c.json(await Memory.reflect({ mode: c.req.valid("json").mode ?? "quick", reason: c.req.valid("json").reason })),
+    )
+    .post(
+      "/initialize/start",
+      describeRoute({
+        summary: "Start one-time memory initialization",
+        operationId: "memory.initialize.start",
+        responses: {
+          200: {
+            description: "Initialization result",
+            content: { "application/json": { schema: resolver(z.record(z.string(), z.unknown())) } },
+          },
+        },
+      }),
+      async (c) => c.json(await Memory.initialize({ confirm: true })),
+    )
+    .post(
+      "/initialize/cancel",
+      describeRoute({
+        summary: "Cancel memory initialization",
+        operationId: "memory.initialize.cancel",
+        responses: {
+          200: {
+            description: "Cancel result",
+            content: { "application/json": { schema: resolver(z.object({ ok: z.boolean() })) } },
+          },
+        },
+      }),
+      async (c) => c.json(await Memory.cancelInitialize()),
+    )
+    .post(
+      "/daily-reflect/sync",
+      describeRoute({
+        summary: "Sync daily memory reflection cron job from config",
+        operationId: "memory.dailyReflect.sync",
+        responses: {
+          200: {
+            description: "Synced cron job",
+            content: { "application/json": { schema: resolver(z.record(z.string(), z.unknown())) } },
+          },
+        },
+      }),
+      async (c) => c.json(await syncDailyReflectJob({ preserveExisting: false })),
+    ),
+)

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -154,12 +154,14 @@ import { WeChatManager } from "@/mobile/wechat"
 import { ReadingModeRoutes } from "./routes/reading-mode"
 import { DatabaseRoutes } from "./routes/database"
 import { CronRoutes } from "./routes/cron"
+import { MemoryRoutes } from "./routes/memory"
 import { VoiceRoutes } from "./routes/voice"
 import { MDNS } from "./mdns"
 import { lazy } from "@/util/lazy"
 import { initProjectors } from "./projectors"
 import { SessionPreference } from "@/session/preference"
 import { Cron } from "@/cron"
+import { installMemory } from "@/memory/installer"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -195,6 +197,9 @@ export namespace Server {
     SessionPreference.clear()
     void Cron.start().catch((error) => {
       log.error("cron start failed", { error })
+    })
+    void installMemory().catch((error) => {
+      log.error("memory install failed", { error })
     })
     const app = new Hono<ServerEnv>()
     const corsware = cors({
@@ -470,6 +475,7 @@ export namespace Server {
       .route("/tui", TuiRoutes())
       .route("/knowledge", KnowledgeRoutes())
       .route("/cron", CronRoutes())
+      .route("/memory", MemoryRoutes())
       .route("/voice", VoiceRoutes())
       .route("/mobile/wechat", createMobileRoutes("wechat"))
       .route("/mobile/feishu", createMobileRoutes("feishu"))

--- a/packages/opencode/src/tool/memory.ts
+++ b/packages/opencode/src/tool/memory.ts
@@ -1,0 +1,123 @@
+import z from "zod"
+import { Memory } from "@/memory"
+import { Tool } from "./tool"
+
+const MemoryType = z.enum(["preference", "fact", "task"])
+
+function renderResults(results: Awaited<ReturnType<typeof Memory.search>>["results"]) {
+  if (!results.length) return '<memory_search results="0">No matching long-term memories.</memory_search>'
+  return [
+    `<memory_search results="${results.length}">`,
+    ...results.map((item) =>
+      [
+        `  <memory id="${item.id}" type="${item.type}" scope="${item.scope}" confidence="${item.confidence}" weight="${item.weight}">`,
+        `    ${item.memory}`,
+        "  </memory>",
+      ].join("\n"),
+    ),
+    "</memory_search>",
+    "Results are ranked by relevance, scope, weight, and recency. These are long-term memory evidence; raw event ids are not exposed.",
+  ].join("\n")
+}
+
+export const MemorySearchTool = Tool.define("memory_search", {
+  description: [
+    "Search Aether long-term memory. Use this when a memory shortcut suggests relevant user preferences, facts, or tasks.",
+    "Search only reads AETHER_MEMORY.md and does not read raw session files or memory.db events.",
+  ].join("\n"),
+  parameters: z.object({
+    query: z.string().min(1),
+    types: z.array(MemoryType).optional(),
+    limit: z.number().int().optional(),
+    currentProjectID: z.string().optional(),
+  }),
+  async execute(input) {
+    const result = await Memory.search(input)
+    return {
+      title: `${result.results.length} memory result${result.results.length === 1 ? "" : "s"}`,
+      output: renderResults(result.results),
+      metadata: {
+        count: result.results.length,
+        ids: result.results.map((item) => item.id),
+      },
+    }
+  },
+})
+
+export const MemoryRememberTool = Tool.define("memory_remember", {
+  description:
+    "Record a user-requested memory. Explicit memories are immediately passed to quick LLM reflection, which may write the accepted memory into AETHER_MEMORY.md.",
+  parameters: z.object({
+    text: z.string().min(1),
+    type: MemoryType.optional(),
+    project_id: z.string().optional(),
+  }),
+  async execute(input, ctx) {
+    const result = await Memory.remember({
+      text: input.text,
+      type: input.type,
+      intent: "explicit",
+      source: {
+        createdAt: Date.now(),
+        projectID: input.project_id,
+        sessionID: ctx.sessionID,
+        messageID: ctx.messageID,
+        role: "user",
+      },
+    })
+    return {
+      title: `Memory event ${result.status}`,
+      output: `Memory event ${result.eventID} ${result.status}.${result.reason ? ` Reason: ${result.reason}` : ""}`,
+      metadata: result,
+    }
+  },
+})
+
+export const MemoryForgetTool = Tool.define("memory_forget", {
+  description: "Forget matching long-term memories. Natural-language requests are searched first, then matching Markdown memory blocks are deleted through MemoryService.",
+  parameters: z.object({
+    query: z.string().min(1).optional(),
+    ids: z.array(z.string().min(1)).optional(),
+    type: MemoryType.optional(),
+  }),
+  async execute(input, ctx) {
+    const result = await Memory.forget({
+      query: input.query,
+      ids: input.ids,
+      type: input.type,
+      source: {
+        createdAt: Date.now(),
+        sessionID: ctx.sessionID,
+        messageID: ctx.messageID,
+        role: "user",
+      },
+    })
+    return {
+      title: result.status === "deleted" ? "Memory forgotten" : "No matching memory",
+      output:
+        result.status === "deleted"
+          ? `Deleted memory ids: ${result.deletedIDs.join(", ")}`
+          : "No matching long-term memory was found. No tombstone was recorded.",
+      metadata: result,
+    }
+  },
+})
+
+export const MemoryReflectTool = Tool.define("memory_reflect", {
+  description: [
+    "Run memory reflection. Defaults to quick LLM reflection over user memory events only.",
+    "Use mode=daily only when the user explicitly asks for full/global/daily memory reflection.",
+  ].join("\n"),
+  parameters: z.object({
+    mode: z.enum(["quick", "daily", "manual"]).optional(),
+    reason: z.string().optional(),
+  }),
+  async execute(input) {
+    const result = await Memory.reflect({ mode: input.mode ?? "quick", reason: input.reason ?? "tool" })
+    return {
+      title: `Memory reflect: ${result.summary}`,
+      output: result.summary,
+      metadata: result,
+    }
+  },
+})

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -38,6 +38,7 @@ import {
   CronSetGlobalEnabledTool,
   CronUpdateTool,
 } from "./cron"
+import { MemoryForgetTool, MemoryReflectTool, MemoryRememberTool, MemorySearchTool } from "./memory"
 import { Glob } from "../util/glob"
 import { pathToFileURL } from "url"
 import { Effect, Layer, ServiceMap } from "effect"
@@ -148,6 +149,10 @@ export namespace ToolRegistry {
           CronRunNowTool,
           CronRunsTool,
           CronSetGlobalEnabledTool,
+          MemoryRememberTool,
+          MemoryForgetTool,
+          MemorySearchTool,
+          MemoryReflectTool,
           KnowledgeTool,
           ...(Flag.OPENCODE_EXPERIMENTAL_LSP_TOOL ? [LspTool] : []),
           ...(cfg.experimental?.batch_tool === true ? [BatchTool] : []),

--- a/packages/opencode/test/memory/memory.test.ts
+++ b/packages/opencode/test/memory/memory.test.ts
@@ -1,0 +1,711 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { tmpdir } from "../fixture/fixture"
+import { Memory } from "../../src/memory"
+import { installMemory } from "../../src/memory/installer"
+import { Cron } from "../../src/cron"
+import { MemoryReflectTool, MemorySearchTool } from "../../src/tool/memory"
+import { ToolRegistry } from "../../src/tool/registry"
+import { Instance } from "../../src/project/instance"
+import { parseMemoryMarkdown, renderMemoryDocument } from "../../src/memory/markdown"
+import { searchMemoryDocument } from "../../src/memory/search"
+import { shouldQuickReflect } from "../../src/memory/gate"
+
+describe("memory markdown", () => {
+  test("round trips fixed memory block fields without task-specific extras", () => {
+    const doc = parseMemoryMarkdown(`# Aether Memory
+
+## Shortcut Directory
+
+- shortcut: response-style
+  triggers: language, answer style
+  types: preference
+  target_ids: PREF-answer-language
+  weight: 0.9
+  instruction: Search response style preferences before answering.
+
+## Preferences
+
+### PREF-answer-language
+- type: preference
+- scope: global
+- memory: 用户偏好默认用中文回答。
+- confidence: 0.95
+- weight: 0.9
+- evidence: 用户明确要求默认中文回答。
+- updated_at: 2026-05-13T00:00:00.000Z
+- status: active
+
+## Facts
+
+## Tasks
+`)
+
+    expect(doc.memories).toHaveLength(1)
+    expect(doc.memories[0]).toMatchObject({
+      id: "PREF-answer-language",
+      type: "preference",
+      scope: "global",
+      memory: "用户偏好默认用中文回答。",
+      status: "active",
+    })
+    expect(Object.keys(doc.memories[0])).not.toContain("task_status")
+
+    const rendered = renderMemoryDocument(doc)
+    expect(rendered).toContain("- scope: global")
+    expect(rendered).not.toContain("task_status")
+
+    const reparsed = parseMemoryMarkdown(rendered)
+    expect(reparsed.shortcuts[0]).toMatchObject({
+      shortcut: "response-style",
+      triggers: ["language", "answer style"],
+      types: ["preference"],
+      target_ids: ["PREF-answer-language"],
+      weight: 0.9,
+    })
+  })
+})
+
+describe("memory search", () => {
+  const doc = parseMemoryMarkdown(`# Aether Memory
+
+## Shortcut Directory
+
+- shortcut: response-style
+  triggers: 中文, answer style, language
+  types: preference
+  target_ids: PREF-answer-language
+  weight: 0.9
+  instruction: Search response style preferences before answering.
+
+## Preferences
+
+### PREF-answer-language
+- type: preference
+- scope: global
+- memory: 用户偏好默认用中文回答。
+- confidence: 0.95
+- weight: 0.9
+- evidence: 用户明确要求默认中文回答。
+- updated_at: 2026-05-13T00:00:00.000Z
+- status: active
+
+### PREF-project-runtime
+- type: preference
+- scope: project:project-x
+- memory: 这个项目默认使用 Bun。
+- confidence: 0.93
+- weight: 0.92
+- evidence: 用户明确说这个项目以后都用 Bun。
+- updated_at: 2026-05-13T00:00:00.000Z
+- status: active
+
+## Facts
+
+## Tasks
+`)
+
+  test("splits common separators and returns any keyword match", () => {
+    const results = searchMemoryDocument(doc, {
+      query: "English, 中文; latex",
+      currentProjectID: "project-y",
+      limit: 5,
+    })
+
+    expect(results.map((item) => item.id)).toContain("PREF-answer-language")
+    expect(results[0].ranking_note).toContain("scope")
+  })
+
+  test("boosts current project scoped memory over global memory", () => {
+    const results = searchMemoryDocument(doc, {
+      query: "项目 Bun",
+      currentProjectID: "project-x",
+      limit: 5,
+    })
+
+    expect(results[0].id).toBe("PREF-project-runtime")
+  })
+
+  test("does not return unrelated memories from weight or recency alone", () => {
+    const results = searchMemoryDocument(doc, {
+      query: "EdgeSimUniqueNoMatch",
+      currentProjectID: "project-x",
+      limit: 5,
+    })
+
+    expect(results).toHaveLength(0)
+  })
+})
+
+describe("quick reflect gate", () => {
+  test("marks explicit remember as important", () => {
+    const decision = shouldQuickReflect({
+      text: "请记住我默认喜欢中文回答",
+      intent: "explicit",
+      op: "remember",
+      shortcutTriggers: [],
+    })
+
+    expect(decision).toEqual({
+      shouldRun: true,
+      priority: "important",
+      reason: expect.stringContaining("explicit"),
+    })
+  })
+
+  test("skips low-signal one-off questions", () => {
+    const decision = shouldQuickReflect({
+      text: "这个命令是什么意思？",
+      intent: "observed",
+      op: "remember",
+      shortcutTriggers: [],
+    })
+
+    expect(decision.shouldRun).toBe(false)
+  })
+
+  test("skips sensitive observed signals unless explicitly requested", () => {
+    const observed = shouldQuickReflect({
+      text: "我的身份证号是 1234567890",
+      intent: "observed",
+      op: "remember",
+      shortcutTriggers: [],
+    })
+    expect(observed).toEqual({
+      shouldRun: false,
+      priority: "normal",
+      reason: "sensitive observed signal",
+    })
+
+    const explicit = shouldQuickReflect({
+      text: "请记住我的电话号码只用于测试",
+      intent: "explicit",
+      op: "remember",
+      shortcutTriggers: [],
+    })
+    expect(explicit.shouldRun).toBe(true)
+  })
+
+  test("queues observed emphasis or requirement wording for LLM filtering", () => {
+    const decision = shouldQuickReflect({
+      text: "我强调过，做每日反思时不要把同主题偏好拆成很多条。",
+      intent: "observed",
+      op: "remember",
+      shortcutTriggers: [],
+    })
+
+    expect(decision).toEqual({
+      shouldRun: true,
+      priority: "normal",
+      reason: "preference signal",
+    })
+  })
+})
+
+describe("memory service", () => {
+  let tmp: Awaited<ReturnType<typeof tmpdir>>
+
+  beforeEach(async () => {
+    tmp = await tmpdir()
+    Memory.configureForTest({
+      globalMemoryDir: path.join(tmp.path, "global-memory"),
+      channelRootDir: path.join(tmp.path, "channels"),
+      channelID: "latest",
+    })
+    await Memory.purge()
+  })
+
+  afterEach(async () => {
+    await Memory.stop()
+    await tmp?.[Symbol.asyncDispose]()
+  })
+
+  test("forget deletes matching markdown block and records a tombstone only after a match", async () => {
+    await Memory.writeDocumentForTest(
+      parseMemoryMarkdown(`# Aether Memory
+
+## Shortcut Directory
+
+- shortcut: response-style
+  triggers: 中文, answer style
+  types: preference
+  target_ids: PREF-answer-language
+  weight: 0.9
+  instruction: Search response style preferences before answering.
+
+## Preferences
+
+### PREF-answer-language
+- type: preference
+- scope: global
+- memory: 用户偏好默认用中文回答。
+- confidence: 0.95
+- weight: 0.9
+- evidence: 用户明确要求默认中文回答。
+- updated_at: 2026-05-13T00:00:00.000Z
+- status: active
+
+## Facts
+
+## Tasks
+`),
+    )
+
+    const deleted = await Memory.forget({
+      query: "忘掉中文回答这个偏好",
+      source: { createdAt: Date.now(), role: "user" },
+      decide: async () => ({ deleteIDs: ["PREF-answer-language"], keepIDs: [], reason: "user requested forget" }),
+    })
+
+    expect(deleted.status).toBe("deleted")
+    expect(deleted.deletedIDs).toEqual(["PREF-answer-language"])
+    expect((await Memory.search({ query: "中文回答" })).results).toHaveLength(0)
+    expect((await Memory.status()).shortcut_count).toBe(0)
+
+    const events = await Memory.eventsForTest()
+    expect(events.some((event) => event.op === "forget" && event.status === "forgot")).toBe(true)
+
+    const notFound = await Memory.forget({
+      query: "忘掉不存在的东西",
+      source: { createdAt: Date.now(), role: "user" },
+      decide: async () => ({ deleteIDs: [], keepIDs: [], reason: "not found" }),
+    })
+    expect(notFound.status).toBe("not_found")
+  })
+
+  test("status does not create markdown before initialization", async () => {
+    const before = await Memory.status()
+    expect(before.markdown_exists).toBe(false)
+    expect(before.needs_initialization).toBe(true)
+
+    const markdownPath = path.join(tmp.path, "global-memory", "AETHER_MEMORY.md")
+    expect(await fs.stat(markdownPath).catch(() => undefined)).toBeUndefined()
+  })
+
+  test("explicit remember is quickly reflected into searchable markdown", async () => {
+    const remembered = await Memory.remember({
+      text: "请记住我默认喜欢中文回答",
+      type: "preference",
+      intent: "explicit",
+      source: { createdAt: Date.now(), role: "user", projectID: "project-a" },
+    })
+
+    expect(remembered.status).toBe("applied")
+    const found = await Memory.search({ query: "中文回答", limit: 5 })
+    expect(found.results).toHaveLength(1)
+    expect(found.results[0]?.type).toBe("preference")
+    expect(found.results[0]?.scope).toBe("global")
+
+    const events = await Memory.eventsForTest()
+    expect(events[0]?.status).toBe("applied")
+  })
+
+  test("low-signal observed events are not left pending for daily reflection", async () => {
+    const remembered = await Memory.remember({
+      text: "这个命令是什么意思？",
+      intent: "observed",
+      source: { createdAt: Date.now(), role: "user", projectID: "project-a" },
+    })
+
+    expect(remembered.status).toBe("ignored")
+    const reflected = await Memory.reflect({ mode: "daily", reason: "test" })
+    expect(reflected.changed).toBe(false)
+    const events = await Memory.eventsForTest()
+    expect(events[0]?.status).toBe("ignored")
+  })
+
+  test("forget can fall back to LLM decision when keyword search finds no candidate", async () => {
+    await Memory.writeDocumentForTest(
+      parseMemoryMarkdown(`# Aether Memory
+
+## Shortcut Directory
+
+## Preferences
+
+### PREF-temporary-test
+- type: preference
+- scope: global
+- memory: User has a temporary testing preference that should be deleted later.
+- confidence: 0.9
+- weight: 0.8
+- evidence: The user explicitly requested a temporary testing preference.
+- updated_at: 2026-05-13T00:00:00.000Z
+- status: active
+
+## Facts
+
+## Tasks
+`),
+    )
+
+    const deleted = await Memory.forget({
+      query: "忘掉测试偏好",
+      source: { createdAt: Date.now(), role: "user" },
+      decide: async ({ candidates }) => ({
+        deleteIDs: candidates.map((candidate) => candidate.id),
+        keepIDs: [],
+        reason: "semantic fallback matched translated query",
+      }),
+    })
+
+    expect(deleted.status).toBe("deleted")
+    expect(deleted.deletedIDs).toEqual(["PREF-temporary-test"])
+  })
+
+  test("observed sensitive information is not reflected into long-term markdown", async () => {
+    await Memory.remember({
+      text: "我的身份证号是 1234567890",
+      intent: "observed",
+      source: { createdAt: Date.now(), role: "user" },
+    })
+
+    const reflected = await Memory.reflect({ mode: "daily", reason: "test" })
+    expect(reflected.changed).toBe(false)
+    expect((await Memory.search({ query: "身份证", limit: 5 })).results).toHaveLength(0)
+  })
+
+  test("new response-style preference deprecates the older conflicting preference", async () => {
+    await Memory.writeDocumentForTest(
+      parseMemoryMarkdown(`# Aether Memory
+
+## Shortcut Directory
+
+- shortcut: preference:global
+  triggers: 回答, 详细
+  types: preference
+  target_ids: PREF-old-response-style
+  weight: 0.8
+  instruction: Call memory_search before response-style tasks.
+
+## Preferences
+
+### PREF-old-response-style
+- type: preference
+- scope: global
+- memory: 用户偏好回答写得详细一些。
+- confidence: 0.9
+- weight: 0.8
+- evidence: 用户曾经要求详细回答。
+- updated_at: 2026-05-12T00:00:00.000Z
+- status: active
+
+## Facts
+
+## Tasks
+`),
+    )
+
+    await Memory.remember({
+      text: "以后回答请简短一点，先给结论",
+      type: "preference",
+      intent: "explicit",
+      source: { createdAt: Date.now(), role: "user" },
+    })
+
+    const concise = await Memory.search({ query: "简短 结论", limit: 5 })
+    const detailed = await Memory.search({ query: "详细", limit: 5 })
+
+    expect(concise.results[0]?.memory).toContain("简短")
+    expect(detailed.results.some((memory) => memory.id === "PREF-old-response-style")).toBe(false)
+  })
+
+  test("project task memory is scoped to the current project when reflected", async () => {
+    await Memory.remember({
+      text: "请记住这个项目每天检查一次 cron 运行状态",
+      type: "task",
+      intent: "explicit",
+      source: { createdAt: Date.now(), role: "user", projectID: "project-a" },
+    })
+
+    const currentProject = await Memory.search({ query: "cron 状态", currentProjectID: "project-a", limit: 5 })
+    const otherProject = await Memory.search({ query: "cron 状态", currentProjectID: "project-b", limit: 5 })
+
+    expect(currentProject.results[0]?.scope).toBe("project:project-a")
+    expect(currentProject.results[0]!.score).toBeGreaterThan(otherProject.results[0]!.score)
+  })
+
+  test("daily reflection scans pending events from all channel memory databases", async () => {
+    Memory.configureForTest({
+      globalMemoryDir: path.join(tmp.path, "global-memory"),
+      channelRootDir: path.join(tmp.path, "channels"),
+      channelID: "older",
+    })
+    await Memory.remember({
+      text: "我希望所有项目默认先给结论",
+      type: "preference",
+      intent: "observed",
+      source: { createdAt: Date.now(), role: "user", channelID: "older" },
+    })
+
+    Memory.configureForTest({
+      globalMemoryDir: path.join(tmp.path, "global-memory"),
+      channelRootDir: path.join(tmp.path, "channels"),
+      channelID: "latest",
+    })
+    const reflected = await Memory.reflect({ mode: "daily", reason: "test" })
+
+    expect(reflected.changed).toBe(true)
+    const found = await Memory.search({ query: "先给结论", limit: 5 })
+    expect(found.results[0]?.memory).toContain("先给结论")
+  })
+
+  test("startup catchup schedules one missed daily reflection in the background", async () => {
+    await Memory.remember({
+      text: "我希望回答先给简短结论",
+      type: "preference",
+      intent: "observed",
+      source: { createdAt: Date.now(), role: "user" },
+    })
+
+    const scheduled = await Memory.startupCatchup()
+    expect(scheduled.started).toBe(true)
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    const found = await Memory.search({ query: "简短结论", limit: 5 })
+    expect(found.results[0]?.memory).toContain("简短结论")
+
+    const second = await Memory.startupCatchup()
+    expect(second.started).toBe(false)
+  })
+
+  test("shortcut system prompt excludes target ids and memory bodies", async () => {
+    await Memory.writeDocumentForTest(
+      parseMemoryMarkdown(`# Aether Memory
+
+## Shortcut Directory
+
+- shortcut: response-style
+  triggers: 中文, answer style
+  types: preference
+  target_ids: PREF-answer-language
+  weight: 0.9
+  instruction: Search response style preferences before answering.
+
+## Preferences
+
+### PREF-answer-language
+- type: preference
+- scope: global
+- memory: 用户偏好默认用中文回答。
+- confidence: 0.95
+- weight: 0.9
+- evidence: 用户明确要求默认中文回答。
+- updated_at: 2026-05-13T00:00:00.000Z
+- status: active
+
+## Facts
+
+## Tasks
+`),
+    )
+
+    const prompt = await Memory.shortcutSystemPrompt()
+    expect(prompt).toContain("response-style")
+    expect(prompt).toContain("memory_search")
+    expect(prompt).not.toContain("PREF-answer-language")
+    expect(prompt).not.toContain("用户偏好默认用中文回答")
+  })
+
+  test("initialize scans sessions serially and stops after cancellation", async () => {
+    const visited: string[] = []
+    Memory.setSessionScannerForTest(async function* () {
+      yield {
+        channelID: "latest",
+        projectID: "project-a",
+        sessionID: "one",
+        messages: [{ role: "user" as const, text: "请记住我喜欢中文回答", createdAt: 1 }],
+      }
+      yield {
+        channelID: "latest",
+        projectID: "project-a",
+        sessionID: "two",
+        messages: [{ role: "user" as const, text: "普通一次性问题", createdAt: 2 }],
+      }
+    })
+
+    Memory.setInitializerExtractorForTest(async (session) => {
+      visited.push(session.sessionID)
+      await Memory.cancelInitialize()
+      return [
+        {
+          text: "用户偏好默认用中文回答。",
+          type: "preference" as const,
+          scope: "global" as const,
+        },
+      ]
+    })
+
+    const result = await Memory.initialize({ confirm: true })
+
+    expect(result.status).toBe("cancelled")
+    expect(visited).toEqual(["one"])
+    expect((await Memory.eventsForTest()).length).toBe(1)
+  })
+
+  test("initialize imports matching user messages with the production extractor", async () => {
+    Memory.setSessionScannerForTest(async function* () {
+      yield {
+        channelID: "latest",
+        projectID: "project-a",
+        sessionID: "one",
+        messages: [
+          { role: "user" as const, text: "请记住我偏好先给结论再展开", createdAt: 1 },
+          { role: "assistant" as const, text: "好的。", createdAt: 2 },
+        ],
+      }
+      yield {
+        channelID: "latest",
+        projectID: "project-a",
+        sessionID: "two",
+        messages: [{ role: "user" as const, text: "这个命令是什么意思？", createdAt: 3 }],
+      }
+    })
+
+    const result = await Memory.initialize({ confirm: true })
+
+    expect(result).toEqual({ status: "succeeded", scanned: 2, imported: 1 })
+    const events = await Memory.eventsForTest()
+    expect(events).toHaveLength(1)
+    expect(events[0]?.raw_text).toContain("先给结论")
+
+    const found = await Memory.search({ query: "先给结论", limit: 5 })
+    expect(found.results[0]?.memory).toContain("先给结论")
+
+    const current = await Memory.status()
+    expect(current.initialization).toMatchObject({ status: "succeeded", scanned: 2, imported: 1 })
+  })
+
+  test("initialize recognizes natural preference wording from user messages", async () => {
+    Memory.setSessionScannerForTest(async function* () {
+      yield {
+        channelID: "latest",
+        projectID: "project-a",
+        sessionID: "mathematica",
+        messages: [
+          {
+            role: "user" as const,
+            text: "你知道么，我很喜欢用Mathematica来编写程序。我觉得它的代码很实用，且富有美感",
+            createdAt: 1,
+          },
+        ],
+      }
+    })
+
+    const result = await Memory.initialize({ confirm: true })
+
+    expect(result).toEqual({ status: "succeeded", scanned: 1, imported: 1 })
+    const found = await Memory.search({ query: "Mathematica 编写程序", limit: 5 })
+    expect(found.results[0]?.memory).toContain("Mathematica")
+  })
+
+  test("quick remember can write through reflection while daily reflection can consolidate topics", async () => {
+    const seenModes: string[] = []
+    Memory.setReflectorForTest(async ({ events, mode }) => {
+      seenModes.push(mode)
+      return events.map((event) => ({
+        eventID: event.id,
+        type: "preference" as const,
+        scope: "global" as const,
+        memory:
+          mode === "daily"
+            ? "用户在回答风格主题下偏好中文、先给结论，并保留必要解释。"
+            : event.raw_text.replace(/^请记住/, "").trim(),
+        confidence: 0.9,
+        weight: 0.86,
+        evidence: mode === "daily" ? "按主题合并生成。" : "quick LLM reflection accepted.",
+      }))
+    })
+
+    const remembered = await Memory.remember({
+      text: "请记住我希望默认用中文回答",
+      type: "preference",
+      intent: "explicit",
+      source: { createdAt: Date.now(), role: "user" },
+    })
+    expect(remembered.status).toBe("applied")
+    expect(seenModes).toEqual(["quick"])
+    expect((await Memory.search({ query: "中文回答", limit: 5 })).results).toHaveLength(1)
+
+    await Memory.remember({
+      text: "我希望回答先给结论",
+      type: "preference",
+      intent: "observed",
+      source: { createdAt: Date.now(), role: "user" },
+    })
+    const reflected = await Memory.reflect({ mode: "daily", reason: "test" })
+
+    expect(reflected.changed).toBe(true)
+    expect(seenModes).toContain("daily")
+    const found = await Memory.search({ query: "回答风格 中文 结论", limit: 5 })
+    expect(found.results[0]?.memory).toContain("回答风格")
+  })
+})
+
+describe("memory agent tools", () => {
+  test("tool registry exposes memory tools", async () => {
+    await using tmp = await tmpdir()
+    const ids = await Instance.provide({ directory: tmp.path, fn: () => ToolRegistry.ids() })
+    expect(ids).toContain("memory_search")
+    expect(ids).toContain("memory_reflect")
+  })
+
+  test("memory_search tool returns markdown memory block ids", async () => {
+    await using tmp = await tmpdir()
+    Memory.configureForTest({
+      globalMemoryDir: path.join(tmp.path, "global-memory"),
+      channelRootDir: path.join(tmp.path, "channels"),
+      channelID: "latest",
+    })
+    await Memory.purge()
+    await Memory.writeDocumentForTest(
+      parseMemoryMarkdown(`# Aether Memory
+
+## Shortcut Directory
+
+## Preferences
+
+### PREF-answer-language
+- type: preference
+- scope: global
+- memory: 用户偏好默认用中文回答。
+- confidence: 0.95
+- weight: 0.9
+- evidence: 用户明确要求默认中文回答。
+- updated_at: 2026-05-13T00:00:00.000Z
+- status: active
+
+## Facts
+
+## Tasks
+`),
+    )
+
+    const tool = await MemorySearchTool.init()
+    const result = await tool.execute({ query: "中文回答" }, {} as any)
+    expect(result.output).toContain("PREF-answer-language")
+    expect(result.output).not.toContain("memory_event")
+
+    const reflect = await MemoryReflectTool.init()
+    const reflected = await reflect.execute({ mode: "quick" }, {} as any)
+    expect(reflected.output).toContain("No changes")
+  })
+})
+
+describe("memory installer", () => {
+  test("registers daily reflect direct action and creates builtin cron job once", async () => {
+    await installMemory()
+    const job = await Cron.getJob("builtin.memory.daily_reflect")
+    expect(job.definition.payload).toEqual({ action: "memory.reflect.daily" })
+    expect(job.definition.schedule_value).toBe("0 3 * * *")
+
+    await Cron.updateJob({ id: "builtin.memory.daily_reflect", patch: { schedule_value: "0 4 * * *" } })
+    await installMemory()
+    const preserved = await Cron.getJob("builtin.memory.daily_reflect")
+    expect(preserved.definition.schedule_value).toBe("0 4 * * *")
+
+    await Cron.runJobNow({ id: "builtin.memory.daily_reflect" })
+    const runs = await Cron.listRuns({ id: "builtin.memory.daily_reflect", count: 1 })
+    expect(runs[0]?.status).toBe("success")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #757

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a modular durable memory system on top of the current `dev` branch.

The implementation keeps long-term memory in a single structured `AETHER_MEMORY.md` file and stores raw remember/forget events plus reflection logs in per-channel `memory.db` files. Agents recall memory through `memory_search` rather than reading old session transcripts or raw memory event logs.

Main changes:

- Adds `preference`, `fact`, and `task` long-term memory blocks with `global` and `project:<project_id>` scopes.
- Adds `memory_search`, `memory_remember`, `memory_forget`, and `memory_reflect` tools.
- Adds quick reflection for explicit/high-signal memory events and daily reflection through the existing cron direct-action infrastructure.
- Adds startup catch-up for missed daily reflection.
- Adds one-time historical session initialization that scans sessions serially and imports useful user-message memories through the same event/reflection path.
- Adds Settings > Memory for status, initialization, search, daily reflection config, and manual reflection.
- Adds `docs/memory-system.zh-CN.md` describing the current implementation, storage layout, APIs, tools, and integration boundaries.

Invasive integration points outside the new memory module:

- `packages/opencode/src/server/server.ts`: installs memory and mounts `/memory` routes.
- `packages/opencode/src/tool/registry.ts`: exposes memory tools to agents.
- `packages/opencode/src/plugin/index.ts`: registers the memory shortcut prompt plugin.
- `packages/opencode/src/config/config.ts`: adds memory configuration.
- `packages/opencode/src/cron/index.ts`: supports the direct-action path used by daily reflection.
- `packages/app/src/context/global-sdk.tsx` and `packages/app/src/utils/server.ts`: add memory client helpers.
- `packages/app/src/components/dialog-settings.tsx`: adds the Memory settings tab.

### How did you verify your code works?

Ran locally:

```bash
PATH=/home/liuyuanche/.bun/bin:$PATH bun run --cwd packages/opencode test test/memory/memory.test.ts test/cron/cron.test.ts --timeout 60000
PATH=/home/liuyuanche/.bun/bin:$PATH bun run --cwd packages/opencode typecheck
PATH=/home/liuyuanche/.bun/bin:$PATH bun run --cwd packages/app ./script/vitest.ts run --config ./vitest.config.ts src/components/settings-memory.vitest.tsx
PATH=/home/liuyuanche/.bun/bin:$PATH bun run --cwd packages/app typecheck
git diff --check
```

Results:

- memory + cron tests: 51 passed, 0 failed
- Settings Memory Vitest: 5 passed, 0 failed
- `packages/opencode` typecheck: passed
- `packages/app` typecheck: passed
- diff check: passed

### Screenshots / recordings

Not included. The UI change is a Settings > Memory panel and is covered by component tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
