### PR TITLE
Improve git graph alignment and inline details

### DIFF
--- a/packages/app/src/pages/session/git-graph/columns.ts
+++ b/packages/app/src/pages/session/git-graph/columns.ts
@@ -1,0 +1,99 @@
+export type Column = "graph" | "description" | "author" | "date" | "commit"
+
+export type Columns = Record<Column, number>
+
+export const COLUMN_MIN = 40
+export const GRAPH_MIN = 64
+export const GRAPH_MAX_RATIO = 0.333
+
+export const fitColumns = (cols: Columns, width: number): Columns => {
+  const total = cols.graph + cols.description + cols.author + cols.date + cols.commit
+  if (width <= 0 || total === width) return cols
+
+  if (total < width) {
+    return { ...cols, description: cols.description + width - total }
+  }
+
+  const min = COLUMN_MIN * 4 + GRAPH_MIN
+  if (width < min) {
+    const scale = width / min
+    return {
+      graph: GRAPH_MIN * scale,
+      description: COLUMN_MIN * scale,
+      author: COLUMN_MIN * scale,
+      date: COLUMN_MIN * scale,
+      commit: COLUMN_MIN * scale,
+    }
+  }
+
+  const next = { ...cols }
+  const reduce = (col: Column, min: number, amount: number) => {
+    const value = Math.max(min, next[col] - amount)
+    const used = next[col] - value
+    next[col] = value
+    return amount - used
+  }
+
+  const rest = (["description", "graph", "author", "date", "commit"] as const).reduce(
+    (amount, col) => reduce(col, col === "graph" ? GRAPH_MIN : COLUMN_MIN, amount),
+    total - width,
+  )
+
+  if (rest <= 0) return next
+
+  return {
+    graph: GRAPH_MIN,
+    description: COLUMN_MIN,
+    author: COLUMN_MIN,
+    date: COLUMN_MIN,
+    commit: COLUMN_MIN,
+  }
+}
+
+const narrow = (width: number) => {
+  if (width <= 700) return 80
+  if (width <= 775) return 90
+  if (width <= 850) return 100
+  return 112
+}
+
+export const autoColumns = (width: number, graphWidth: number): Columns => {
+  if (width <= 0) return { graph: 0, description: 0, author: 0, date: 0, commit: 0 }
+
+  const author = narrow(width)
+  const date = Math.min(96, narrow(width))
+  const commit = 74
+  const max = Math.max(GRAPH_MIN, Math.round(width * GRAPH_MAX_RATIO))
+  const graph = Math.min(Math.max(graphWidth, GRAPH_MIN), max)
+
+  return fitColumns(
+    {
+      graph,
+      description: Math.max(COLUMN_MIN, width - graph - author - date - commit),
+      author,
+      date,
+      commit,
+    },
+    width,
+  )
+}
+
+export const template = (cols: Columns) =>
+  `${cols.graph}px minmax(0, ${cols.description}px) ${cols.author}px ${cols.date}px ${cols.commit}px`
+
+export const resizeColumns = (cols: Columns, left: Column, right: Column, delta: number, width: number): Columns => {
+  const min = (col: Column) => (col === "graph" ? GRAPH_MIN : COLUMN_MIN)
+  const grow = Math.max(min(left), cols[left] + delta)
+  const diff = grow - cols[left]
+  const shrink = Math.max(min(right), cols[right] - diff)
+  const actual = cols[right] - shrink
+
+  return fitColumns(
+    {
+      ...cols,
+      [left]: cols[left] + actual,
+      [right]: shrink,
+    },
+    width,
+  )
+}

--- a/packages/app/src/pages/session/git-graph/detail.tsx
+++ b/packages/app/src/pages/session/git-graph/detail.tsx
@@ -27,7 +27,14 @@ const isBinary = (f: VcsFileChange) => f.additions === null && f.deletions === n
 
 const formatStat = (val: number | null, prefix: string) => (val !== null ? `${prefix}${val}` : "-")
 
-export function CommitDetail(props: { hash: string; parentHash: string | null; onClose: () => void }) {
+export function CommitDetail(props: {
+  hash: string
+  parentHash: string | null
+  height?: number
+  class?: string
+  onClose: () => void
+  onResizeStart?: (event: MouseEvent) => void
+}) {
   const sdk = useSDK()
   const lang = useLanguage()
   const fileComponent = useFileComponent()
@@ -55,6 +62,7 @@ export function CommitDetail(props: { hash: string; parentHash: string | null; o
   })
 
   const fileLabel = (f: VcsFileChange) => (f.status === "R" && f.oldFilePath ? `${f.oldFilePath} → ${f.file}` : f.file)
+  const size = () => (props.height === undefined ? { "max-height": "40%" } : { height: `${props.height}px` })
 
   const onFileClick = async (f: VcsFileChange) => {
     setSelectedFile(f)
@@ -77,7 +85,10 @@ export function CommitDetail(props: { hash: string; parentHash: string | null; o
   }
 
   return (
-    <div class="border-t border-border-weaker-base bg-surface-base flex flex-col" style={{ "max-height": "40%" }}>
+    <div
+      class={`border-t border-border-weaker-base bg-surface-base flex flex-col min-h-0 overflow-hidden ${props.class ?? ""}`}
+      style={size()}
+    >
       <div class="flex items-center justify-between px-3 py-1.5 border-b border-border-weaker-base shrink-0">
         <span class="text-12-regular text-text-weaker">{t("session.tab.gitGraph.commitDetails")}</span>
         <IconButton icon="close-small" variant="ghost" class="h-5 w-5" onClick={props.onClose} />
@@ -92,7 +103,7 @@ export function CommitDetail(props: { hash: string; parentHash: string | null; o
         }
       >
         {(d) => (
-          <div class="flex flex-col min-h-0 overflow-hidden">
+          <div class="flex flex-1 flex-col min-h-0 overflow-hidden">
             <div
               class="px-3 py-2 space-y-1.5 text-xs text-text-base overflow-y-auto shrink-0"
               style={{ "max-height": "40%" }}
@@ -208,6 +219,14 @@ export function CommitDetail(props: { hash: string; parentHash: string | null; o
               </div>
             </Show>
           </div>
+        )}
+      </Show>
+      <Show when={props.onResizeStart}>
+        {(start) => (
+          <div
+            class="h-1 shrink-0 cursor-row-resize bg-border-weaker-base hover:bg-border-strong"
+            onMouseDown={(event) => start()(event)}
+          />
         )}
       </Show>
     </div>

--- a/packages/app/src/pages/session/git-graph/graph-svg.tsx
+++ b/packages/app/src/pages/session/git-graph/graph-svg.tsx
@@ -1,0 +1,107 @@
+import { For, Show } from "solid-js"
+import type { GraphLine, GraphNode } from "./model"
+import {
+  GRAPH_DOT_RADIUS,
+  GRAPH_HEAD_RADIUS,
+  GRAPH_LINE_WIDTH,
+  GRAPH_SHADOW,
+  GRAPH_SHADOW_WIDTH,
+  UNCOMMITTED_COLOR,
+  color,
+  linePath,
+  xForLane,
+  yForRow,
+} from "./style"
+
+export function GitGraphSvg(props: {
+  nodes: GraphNode[]
+  lines: GraphLine[]
+  visibleWidth: number
+  height: number
+  onNodeEnter: (node: GraphNode, event: MouseEvent) => void
+  onNodeMove: (event: MouseEvent) => void
+  onNodeLeave: () => void
+  onNodeClick?: (hash: string) => void
+  onNodeContextMenu?: (hash: string, event: MouseEvent) => void
+}) {
+  return (
+    <svg
+      class="pointer-events-none absolute left-0 top-0 z-20"
+      width={props.visibleWidth}
+      height={props.height}
+      viewBox={`0 0 ${props.visibleWidth} ${props.height}`}
+      preserveAspectRatio="none"
+      style="overflow:hidden"
+    >
+      <For each={props.lines}>
+        {(line) => (
+          <path
+            d={linePath(line)}
+            fill="none"
+            stroke={GRAPH_SHADOW}
+            stroke-width={GRAPH_SHADOW_WIDTH}
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            opacity="0.9"
+          />
+        )}
+      </For>
+
+      <For each={props.lines}>
+        {(line) => (
+          <path
+            d={linePath(line)}
+            fill="none"
+            stroke={line.committed ? color(line.colorIndex) : UNCOMMITTED_COLOR}
+            stroke-width={GRAPH_LINE_WIDTH}
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        )}
+      </For>
+
+      <For each={props.nodes}>
+        {(node) => {
+          const cx = () => xForLane(node.lane)
+          const cy = () => yForRow(node.row)
+          const c = () => color(node.colorIndex)
+          const fill = () => (node.isHead || node.isUncommitted ? "var(--background-base)" : c())
+          const stroke = () => (node.isUncommitted ? UNCOMMITTED_COLOR : node.isHead ? c() : "var(--background-base)")
+
+          return (
+            <>
+              <circle
+                cx={cx()}
+                cy={cy()}
+                r={node.isHead ? GRAPH_HEAD_RADIUS : GRAPH_DOT_RADIUS}
+                fill={fill()}
+                stroke={stroke()}
+                stroke-width={node.isHead ? 2 : 1}
+                style="pointer-events:auto;cursor:pointer"
+                onMouseEnter={(event) => props.onNodeEnter(node, event)}
+                onMouseMove={props.onNodeMove}
+                onMouseLeave={props.onNodeLeave}
+                onClick={() => props.onNodeClick?.(node.hash)}
+                onContextMenu={(event) => {
+                  event.preventDefault()
+                  props.onNodeContextMenu?.(node.hash, event)
+                }}
+              />
+              <Show when={node.isUncommitted}>
+                <circle
+                  cx={cx()}
+                  cy={cy()}
+                  r="2"
+                  fill="transparent"
+                  stroke={UNCOMMITTED_COLOR}
+                  stroke-width="1"
+                  pointer-events="none"
+                />
+              </Show>
+            </>
+          )
+        }}
+      </For>
+    </svg>
+  )
+}

--- a/packages/app/src/pages/session/git-graph/graph-svg.tsx
+++ b/packages/app/src/pages/session/git-graph/graph-svg.tsx
@@ -1,5 +1,5 @@
 import { For, Show } from "solid-js"
-import type { GraphLine, GraphNode } from "./model"
+import { expandedY, type GraphLine, type GraphNode } from "./model"
 import {
   GRAPH_DOT_RADIUS,
   GRAPH_HEAD_RADIUS,
@@ -10,7 +10,6 @@ import {
   color,
   linePath,
   xForLane,
-  yForRow,
 } from "./style"
 
 export function GitGraphSvg(props: {
@@ -18,12 +17,16 @@ export function GitGraphSvg(props: {
   lines: GraphLine[]
   visibleWidth: number
   height: number
+  expandedRow?: number | null
+  expandedHeight?: number
   onNodeEnter: (node: GraphNode, event: MouseEvent) => void
   onNodeMove: (event: MouseEvent) => void
   onNodeLeave: () => void
   onNodeClick?: (hash: string) => void
   onNodeContextMenu?: (hash: string, event: MouseEvent) => void
 }) {
+  const y = (row: number) => expandedY(row, props.expandedRow, props.expandedHeight ?? 0)
+
   return (
     <svg
       class="pointer-events-none absolute left-0 top-0 z-20"
@@ -36,7 +39,7 @@ export function GitGraphSvg(props: {
       <For each={props.lines}>
         {(line) => (
           <path
-            d={linePath(line)}
+            d={linePath(line, y)}
             fill="none"
             stroke={GRAPH_SHADOW}
             stroke-width={GRAPH_SHADOW_WIDTH}
@@ -50,7 +53,7 @@ export function GitGraphSvg(props: {
       <For each={props.lines}>
         {(line) => (
           <path
-            d={linePath(line)}
+            d={linePath(line, y)}
             fill="none"
             stroke={line.committed ? color(line.colorIndex) : UNCOMMITTED_COLOR}
             stroke-width={GRAPH_LINE_WIDTH}
@@ -63,7 +66,7 @@ export function GitGraphSvg(props: {
       <For each={props.nodes}>
         {(node) => {
           const cx = () => xForLane(node.lane)
-          const cy = () => yForRow(node.row)
+          const cy = () => y(node.row)
           const c = () => color(node.colorIndex)
           const fill = () => (node.isHead || node.isUncommitted ? "var(--background-base)" : c())
           const stroke = () => (node.isUncommitted ? UNCOMMITTED_COLOR : node.isHead ? c() : "var(--background-base)")

--- a/packages/app/src/pages/session/git-graph/layout.ts
+++ b/packages/app/src/pages/session/git-graph/layout.ts
@@ -1,0 +1,175 @@
+import type { CommitLogItem } from "@opencode-ai/sdk/v2"
+import type { GraphLine, GraphNode, GraphView } from "./model"
+
+const PENDING = "UNCOMMITTED"
+
+type Vertex = {
+  commit: CommitLogItem
+  row: number
+  parents: (number | null)[]
+  used: Set<number>
+  lane: number
+  branch: number | null
+  colorIndex: number
+  next: number
+  parent: number
+}
+
+type Branch = {
+  colorIndex: number
+  end: number
+  lines: GraphLine[]
+}
+
+const idx = (commits: CommitLogItem[]) => {
+  const map = new Map<string, number>()
+  for (let i = 0; i < commits.length; i++) map.set(commits[i].hash, i)
+  return map
+}
+
+const color = (bag: { end: number }[], start: number) => {
+  for (let i = 0; i < bag.length; i++) {
+    if (start > bag[i].end) {
+      bag[i].end = start
+      return i
+    }
+  }
+  bag.push({ end: start })
+  return bag.length - 1
+}
+
+const take = (v: Vertex, lane?: number) => {
+  if (lane !== undefined && !v.used.has(lane)) {
+    v.used.add(lane)
+    v.next = Math.max(v.next, lane + 1)
+    return lane
+  }
+
+  while (v.used.has(v.next)) v.next++
+  v.used.add(v.next)
+  return v.next++
+}
+
+export const layout = (commits: CommitLogItem[], head: string | null): GraphView => {
+  const lookup = idx(commits)
+  const bag: { end: number }[] = []
+  const branches: Branch[] = []
+
+  const vertices: Vertex[] = commits.map((commit, row) => ({
+    commit,
+    row,
+    parents: commit.parents.map((p) => lookup.get(p) ?? null),
+    used: new Set<number>(),
+    lane: -1,
+    branch: null,
+    colorIndex: 0,
+    next: 0,
+    parent: 0,
+  }))
+
+  const branch = (start: number) => {
+    branches.push({ colorIndex: color(bag, start), end: start, lines: [] })
+    return branches.length - 1
+  }
+
+  const place = (v: Vertex, b: number, lane?: number) => {
+    if (v.branch !== null) return
+    v.branch = b
+    v.colorIndex = branches[b].colorIndex
+    if (lane !== undefined && v.used.has(lane)) {
+      v.lane = lane
+      v.next = Math.max(v.next, lane + 1)
+      return
+    }
+    v.lane = take(v, lane)
+  }
+
+  const add = (b: number, a: { row: number; lane: number }, z: { row: number; lane: number }, committed: boolean) => {
+    branches[b].end = Math.max(branches[b].end, z.row)
+    bag[branches[b].colorIndex].end = branches[b].end
+    branches[b].lines.push({
+      branch: b,
+      colorIndex: branches[b].colorIndex,
+      fromRow: a.row,
+      toRow: z.row,
+      fromLane: a.lane,
+      toLane: z.lane,
+      committed,
+      lockedFirst: a.lane === z.lane,
+    })
+  }
+
+  const ensure = (v: Vertex) => {
+    if (v.branch !== null) return v.branch
+    const b = branch(v.row)
+    place(v, b)
+    return b
+  }
+
+  const route = (v: Vertex, at: number) => {
+    const row = v.parents[at]
+    if (row === null || row === undefined) {
+      v.parent++
+      return
+    }
+
+    const target = vertices[row]
+    const first = at === 0
+    const b = first ? ensure(v) : target.branch ?? branch(v.row)
+    if (!first && v.branch === null) ensure(v)
+
+    const committed = v.commit.hash !== PENDING
+    const start = { row: v.row, lane: v.lane }
+    let last = start
+
+    for (let i = v.row + 1; i <= row; i++) {
+      const next = vertices[i]
+      const end = i === row
+      const lane =
+        end && next.branch !== null
+          ? next.lane
+          : end
+            ? next.used.has(last.lane)
+              ? take(next)
+              : take(next, last.lane)
+            : take(next, last.lane)
+
+      add(b, last, { row: i, lane }, committed)
+
+      if (end && next.branch === null) place(next, b, lane)
+      last = { row: i, lane }
+    }
+
+    v.parent++
+  }
+
+  for (let i = 0; i < vertices.length; i++) {
+    const v = vertices[i]
+    ensure(v)
+    while (v.parent < v.parents.length) route(v, v.parent)
+  }
+
+  const nodes: GraphNode[] = vertices.map((v) => ({
+    hash: v.commit.hash,
+    row: v.row,
+    lane: v.lane >= 0 ? v.lane : 0,
+    colorIndex: v.colorIndex,
+    isHead: v.commit.hash === head,
+    isUncommitted: v.commit.hash === PENDING,
+    message: v.commit.message,
+    author: v.commit.author,
+    date: v.commit.date,
+    heads: v.commit.heads,
+    tags: v.commit.tags,
+    remotes: v.commit.remotes,
+  }))
+
+  const lines = branches.flatMap((b) => b.lines)
+  const lanes = Math.max(
+    0,
+    ...vertices.map((v) => Math.max(v.lane, ...Array.from(v.used))),
+    ...lines.flatMap((line) => [line.fromLane, line.toLane]),
+  )
+
+  return { nodes, lines, lanes: lanes + 1 }
+}

--- a/packages/app/src/pages/session/git-graph/layout.ts
+++ b/packages/app/src/pages/session/git-graph/layout.ts
@@ -1,4 +1,5 @@
 import type { CommitLogItem } from "@opencode-ai/sdk/v2"
+import { LANE_GAP, RAIL_PAD } from "./model"
 import type { GraphLine, GraphNode, GraphView } from "./model"
 
 const PENDING = "UNCOMMITTED"
@@ -7,7 +8,7 @@ type Vertex = {
   commit: CommitLogItem
   row: number
   parents: (number | null)[]
-  used: Set<number>
+  connections: ({ target: number | null; branch: number } | undefined)[]
   lane: number
   branch: number | null
   colorIndex: number
@@ -38,16 +39,21 @@ const color = (bag: { end: number }[], start: number) => {
   return bag.length - 1
 }
 
-const take = (v: Vertex, lane?: number) => {
-  if (lane !== undefined && !v.used.has(lane)) {
-    v.used.add(lane)
-    v.next = Math.max(v.next, lane + 1)
-    return lane
-  }
+const point = (v: Vertex) => ({ row: v.row, lane: v.lane })
 
-  while (v.used.has(v.next)) v.next++
-  v.used.add(v.next)
-  return v.next++
+const slot = (v: Vertex) => ({ row: v.row, lane: v.next })
+
+const parent = (v: Vertex) => (v.parent < v.parents.length ? v.parents[v.parent] : undefined)
+
+const reserve = (v: Vertex, lane: number, target: number | null, branch: number) => {
+  if (lane !== v.next) return
+  v.connections[lane] = { target, branch }
+  v.next = lane + 1
+}
+
+const found = (v: Vertex, target: number | null, branch: number) => {
+  const lane = v.connections.findIndex((c) => c?.target === target && c.branch === branch)
+  return lane === -1 ? null : { row: v.row, lane }
 }
 
 export const layout = (commits: CommitLogItem[], head: string | null): GraphView => {
@@ -59,7 +65,7 @@ export const layout = (commits: CommitLogItem[], head: string | null): GraphView
     commit,
     row,
     parents: commit.parents.map((p) => lookup.get(p) ?? null),
-    used: new Set<number>(),
+    connections: [],
     lane: -1,
     branch: null,
     colorIndex: 0,
@@ -72,19 +78,20 @@ export const layout = (commits: CommitLogItem[], head: string | null): GraphView
     return branches.length - 1
   }
 
-  const place = (v: Vertex, b: number, lane?: number) => {
+  const place = (v: Vertex, b: number, lane: number) => {
     if (v.branch !== null) return
     v.branch = b
     v.colorIndex = branches[b].colorIndex
-    if (lane !== undefined && v.used.has(lane)) {
-      v.lane = lane
-      v.next = Math.max(v.next, lane + 1)
-      return
-    }
-    v.lane = take(v, lane)
+    v.lane = lane
   }
 
-  const add = (b: number, a: { row: number; lane: number }, z: { row: number; lane: number }, committed: boolean) => {
+  const add = (
+    b: number,
+    a: { row: number; lane: number },
+    z: { row: number; lane: number },
+    committed: boolean,
+    locked: boolean,
+  ) => {
     branches[b].end = Math.max(branches[b].end, z.row)
     bag[branches[b].colorIndex].end = branches[b].end
     branches[b].lines.push({
@@ -95,58 +102,91 @@ export const layout = (commits: CommitLogItem[], head: string | null): GraphView
       fromLane: a.lane,
       toLane: z.lane,
       committed,
-      lockedFirst: a.lane === z.lane,
+      lockedFirst: locked,
     })
   }
 
-  const ensure = (v: Vertex) => {
-    if (v.branch !== null) return v.branch
-    const b = branch(v.row)
-    place(v, b)
-    return b
-  }
+  const normal = (start: number) => {
+    const b = branch(start)
+    let v = vertices[start]
+    let row = parent(v)
+    let last = v.branch === null ? slot(v) : point(v)
 
-  const route = (v: Vertex, at: number) => {
-    const row = v.parents[at]
-    if (row === null || row === undefined) {
+    place(v, b, last.lane)
+    reserve(v, last.lane, v.row, b)
+
+    if (row === undefined) return
+
+    if (row === null) {
       v.parent++
       return
     }
 
+    for (let i = start + 1; i < vertices.length; i++) {
+      const cur = vertices[i]
+      const target = i === row ? cur : null
+      const end = target !== null && target.branch !== null ? point(target) : slot(cur)
+
+      add(b, last, end, v.commit.hash !== PENDING, last.lane < end.lane)
+      reserve(cur, end.lane, row, b)
+      last = end
+
+      if (target === null) continue
+
+      v.parent++
+      const set = target.branch !== null
+      place(target, b, end.lane)
+      v = target
+      row = parent(v)
+
+      if (row === undefined || set) return
+      if (row === null) {
+        v.parent++
+        return
+      }
+    }
+  }
+
+  const merge = (v: Vertex, row: number) => {
     const target = vertices[row]
-    const first = at === 0
-    const b = first ? ensure(v) : target.branch ?? branch(v.row)
-    if (!first && v.branch === null) ensure(v)
+    const b = target.branch!
+    let last = point(v)
 
-    const committed = v.commit.hash !== PENDING
-    const start = { row: v.row, lane: v.lane }
-    let last = start
+    for (let i = v.row + 1; i < vertices.length; i++) {
+      const cur = vertices[i]
+      const hit = found(cur, row, b)
+      const end = hit ?? slot(cur)
 
-    for (let i = v.row + 1; i <= row; i++) {
-      const next = vertices[i]
-      const end = i === row
-      const lane =
-        end && next.branch !== null
-          ? next.lane
-          : end
-            ? next.used.has(last.lane)
-              ? take(next)
-              : take(next, last.lane)
-            : take(next, last.lane)
+      add(b, last, end, v.commit.hash !== PENDING, hit !== null || cur === target || last.lane < end.lane)
+      reserve(cur, end.lane, row, b)
+      last = end
 
-      add(b, last, { row: i, lane }, committed)
-
-      if (end && next.branch === null) place(next, b, lane)
-      last = { row: i, lane }
+      if (hit === null) continue
+      v.parent++
+      return
     }
 
     v.parent++
   }
 
-  for (let i = 0; i < vertices.length; i++) {
+  const determine = (start: number) => {
+    const v = vertices[start]
+    const row = parent(v)
+    if (row !== undefined && row !== null && v.parents.length > 1 && v.branch !== null && vertices[row].branch !== null) {
+      merge(v, row)
+      return
+    }
+
+    normal(start)
+  }
+
+  for (let i = 0; i < vertices.length; ) {
     const v = vertices[i]
-    ensure(v)
-    while (v.parent < v.parents.length) route(v, v.parent)
+    if (parent(v) !== undefined || v.branch === null) {
+      determine(i)
+      continue
+    }
+    i++
   }
 
   const nodes: GraphNode[] = vertices.map((v) => ({
@@ -165,11 +205,14 @@ export const layout = (commits: CommitLogItem[], head: string | null): GraphView
   }))
 
   const lines = branches.flatMap((b) => b.lines)
-  const lanes = Math.max(
+  const lane = Math.max(
     0,
-    ...vertices.map((v) => Math.max(v.lane, ...Array.from(v.used))),
+    ...vertices.map((v) => Math.max(v.lane, v.next - 1)),
     ...lines.flatMap((line) => [line.fromLane, line.toLane]),
   )
+  const next = Math.max(1, ...vertices.map((v) => v.next))
+  const graphWidth = RAIL_PAD * 2 + Math.max(0, next - 1) * LANE_GAP
+  const widthsAtRows = vertices.map((v) => RAIL_PAD + v.next * LANE_GAP - 2)
 
-  return { nodes, lines, lanes: lanes + 1 }
+  return { nodes, lines, lanes: lane + 1, graphWidth, widthsAtRows }
 }

--- a/packages/app/src/pages/session/git-graph/model.test.ts
+++ b/packages/app/src/pages/session/git-graph/model.test.ts
@@ -1,7 +1,7 @@
 import type { CommitLogItem } from "@opencode-ai/sdk/v2"
 import { describe, expect, test } from "bun:test"
 import { autoColumns, resizeColumns } from "./columns"
-import { computeGraphLayout, LANE_GAP, RAIL_PAD, UNCOMMITTED } from "./model"
+import { computeGraphLayout, expandedY, LANE_GAP, RAIL_PAD, ROW_HEIGHT, UNCOMMITTED } from "./model"
 import { refsFor } from "./refs"
 
 const item = (input: {
@@ -226,5 +226,17 @@ describe("git graph columns", () => {
 
     expect(Math.round(total(next))).toBe(500)
     expect(next.description).toBeGreaterThanOrEqual(40)
+  })
+})
+
+describe("expandedY", () => {
+  test("offsets only rows below the expanded row", () => {
+    expect(expandedY(0, 1, 200)).toBe(ROW_HEIGHT / 2)
+    expect(expandedY(1, 1, 200)).toBe(ROW_HEIGHT + ROW_HEIGHT / 2)
+    expect(expandedY(2, 1, 200)).toBe(2 * ROW_HEIGHT + ROW_HEIGHT / 2 + 200)
+  })
+
+  test("matches normal row positions without an expanded row", () => {
+    expect(expandedY(2, null, 200)).toBe(2 * ROW_HEIGHT + ROW_HEIGHT / 2)
   })
 })

--- a/packages/app/src/pages/session/git-graph/model.test.ts
+++ b/packages/app/src/pages/session/git-graph/model.test.ts
@@ -1,8 +1,16 @@
 import type { CommitLogItem } from "@opencode-ai/sdk/v2"
 import { describe, expect, test } from "bun:test"
-import { computeGraphLayout, UNCOMMITTED } from "./model"
+import { autoColumns, resizeColumns } from "./columns"
+import { computeGraphLayout, LANE_GAP, RAIL_PAD, UNCOMMITTED } from "./model"
+import { refsFor } from "./refs"
 
-const item = (input: { hash: string; parents?: string[]; heads?: string[] }): CommitLogItem => ({
+const item = (input: {
+  hash: string
+  parents?: string[]
+  heads?: string[]
+  tags?: { name: string; annotated: boolean }[]
+  remotes?: { name: string; remote: string | null }[]
+}): CommitLogItem => ({
   hash: input.hash,
   parents: input.parents ?? [],
   author: "Test",
@@ -10,8 +18,8 @@ const item = (input: { hash: string; parents?: string[]; heads?: string[] }): Co
   date: 1,
   message: input.hash,
   heads: input.heads ?? [],
-  tags: [],
-  remotes: [],
+  tags: input.tags ?? [],
+  remotes: input.remotes ?? [],
 })
 
 describe("computeGraphLayout", () => {
@@ -85,6 +93,7 @@ describe("computeGraphLayout", () => {
     )
 
     expect(new Set(graph.lines.map((line) => line.branch)).size).toBeGreaterThanOrEqual(2)
+    expect(graph.graphWidth).toBeLessThanOrEqual(RAIL_PAD * 2 + LANE_GAP)
     expect(graph.lines).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ fromRow: 0, toRow: 1 }),
@@ -114,5 +123,108 @@ describe("computeGraphLayout", () => {
     )
 
     expect(graph.nodes[0]?.colorIndex).toBe(graph.nodes[2]?.colorIndex)
+  })
+
+  test("reports graph width from occupied connection slots", () => {
+    const graph = computeGraphLayout(
+      [item({ hash: "cccc", parents: ["aaaa"] }), item({ hash: "bbbb" }), item({ hash: "aaaa" })],
+      "cccc",
+    )
+
+    expect(graph.graphWidth).toBeLessThanOrEqual(RAIL_PAD * 2 + LANE_GAP)
+    expect(graph.widthsAtRows).toHaveLength(graph.nodes.length)
+  })
+
+  test("keeps a first-parent chain on the leftmost lane", () => {
+    const graph = computeGraphLayout(
+      [
+        item({ hash: "dddd", parents: ["cccc"] }),
+        item({ hash: "cccc", parents: ["bbbb"] }),
+        item({ hash: "bbbb", parents: ["aaaa"] }),
+        item({ hash: "aaaa" }),
+      ],
+      "dddd",
+    )
+
+    expect(graph.nodes.map((node) => node.lane)).toEqual([0, 0, 0, 0])
+    expect(graph.graphWidth).toBe(RAIL_PAD * 2)
+  })
+})
+
+describe("git graph refs", () => {
+  test("combines local and matching remote branch labels", () => {
+    const graph = computeGraphLayout(
+      [
+        item({
+          hash: "bbbb",
+          heads: ["dev"],
+          remotes: [
+            { name: "origin/dev", remote: "origin" },
+            { name: "upstream/main", remote: "upstream" },
+          ],
+          tags: [{ name: "v1", annotated: true }],
+        }),
+      ],
+      "bbbb",
+    )
+    const refs = refsFor(graph.nodes[0]!, "dev")
+
+    expect(refs).toEqual([
+      expect.objectContaining({
+        kind: "head",
+        name: "dev",
+        full: "dev",
+        active: true,
+        remotes: [{ name: "origin", full: "origin/dev" }],
+      }),
+      expect.objectContaining({ kind: "remote", name: "upstream/main", full: "upstream/main", remote: "upstream" }),
+      expect.objectContaining({ kind: "tag", name: "v1", full: "v1", annotated: true }),
+    ])
+  })
+
+  test("keeps semantic fields for branch remote and tag labels", () => {
+    const graph = computeGraphLayout(
+      [
+        item({
+          hash: "bbbb",
+          heads: ["dev"],
+          remotes: [{ name: "origin/dev", remote: "origin" }],
+          tags: [{ name: "v1", annotated: false }],
+        }),
+      ],
+      "bbbb",
+    )
+    const refs = refsFor(graph.nodes[0]!, "dev")
+
+    expect(refs[0]).toEqual(
+      expect.objectContaining({
+        kind: "head",
+        name: "dev",
+        full: "dev",
+        remotes: [{ name: "origin", full: "origin/dev" }],
+      }),
+    )
+    expect(refs[1]).toEqual(expect.objectContaining({ kind: "tag", name: "v1", full: "v1", annotated: false }))
+  })
+})
+
+describe("git graph columns", () => {
+  const total = (cols: ReturnType<typeof autoColumns>) =>
+    cols.graph + cols.description + cols.author + cols.date + cols.commit
+
+  test("keeps auto columns within the available width", () => {
+    const cols = autoColumns(230, 1000)
+
+    expect(Math.round(total(cols))).toBe(230)
+    expect(cols.graph).toBeLessThanOrEqual(Math.round(230 * 0.333))
+    expect(cols.description).toBeGreaterThan(0)
+  })
+
+  test("resizes adjacent columns without changing total width", () => {
+    const cols = autoColumns(500, 120)
+    const next = resizeColumns(cols, "graph", "description", 1000, 500)
+
+    expect(Math.round(total(next))).toBe(500)
+    expect(next.description).toBeGreaterThanOrEqual(40)
   })
 })

--- a/packages/app/src/pages/session/git-graph/model.test.ts
+++ b/packages/app/src/pages/session/git-graph/model.test.ts
@@ -48,13 +48,71 @@ describe("computeGraphLayout", () => {
 
     expect(graph.nodes[0]?.isUncommitted).toBe(true)
     expect(graph.nodes[1]?.isHead).toBe(true)
-    expect(graph.edges).toEqual(
+    expect(graph.lines).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           fromRow: 0,
           toRow: 1,
+          committed: false,
         }),
       ]),
     )
+  })
+
+  test("splits a skipped parent edge into row segments", () => {
+    const graph = computeGraphLayout(
+      [item({ hash: "cccc", parents: ["aaaa"] }), item({ hash: "bbbb" }), item({ hash: "aaaa" })],
+      "cccc",
+    )
+
+    expect(graph.lines).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ fromRow: 0, toRow: 1 }),
+        expect.objectContaining({ fromRow: 1, toRow: 2 }),
+      ]),
+    )
+  })
+
+  test("keeps a simple merge as two logical branches", () => {
+    const graph = computeGraphLayout(
+      [
+        item({ hash: "merge", parents: ["main", "side"] }),
+        item({ hash: "main", parents: ["base"] }),
+        item({ hash: "side", parents: ["base"] }),
+        item({ hash: "base" }),
+      ],
+      "merge",
+    )
+
+    expect(new Set(graph.lines.map((line) => line.branch)).size).toBeGreaterThanOrEqual(2)
+    expect(graph.lines).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ fromRow: 0, toRow: 1 }),
+        expect.objectContaining({ fromRow: 1, toRow: 2 }),
+        expect.objectContaining({ fromRow: 2, toRow: 3 }),
+      ]),
+    )
+  })
+
+  test("ignores missing parents without dropping the node", () => {
+    const graph = computeGraphLayout([item({ hash: "bbbb", parents: ["missing"] })], "bbbb")
+
+    expect(graph.nodes).toHaveLength(1)
+    expect(graph.nodes[0]?.lane).toBe(0)
+    expect(graph.lines).toHaveLength(0)
+  })
+
+  test("reuses color indexes after a branch has ended", () => {
+    const graph = computeGraphLayout(
+      [
+        item({ hash: "bbbb", parents: ["aaaa"] }),
+        item({ hash: "aaaa" }),
+        item({ hash: "dddd", parents: ["cccc"] }),
+        item({ hash: "cccc" }),
+      ],
+      "bbbb",
+    )
+
+    expect(graph.nodes[0]?.colorIndex).toBe(graph.nodes[2]?.colorIndex)
   })
 })

--- a/packages/app/src/pages/session/git-graph/model.test.ts
+++ b/packages/app/src/pages/session/git-graph/model.test.ts
@@ -1,0 +1,60 @@
+import type { CommitLogItem } from "@opencode-ai/sdk/v2"
+import { describe, expect, test } from "bun:test"
+import { computeGraphLayout, UNCOMMITTED } from "./model"
+
+const item = (input: { hash: string; parents?: string[]; heads?: string[] }): CommitLogItem => ({
+  hash: input.hash,
+  parents: input.parents ?? [],
+  author: "Test",
+  email: "test@example.com",
+  date: 1,
+  message: input.hash,
+  heads: input.heads ?? [],
+  tags: [],
+  remotes: [],
+})
+
+describe("computeGraphLayout", () => {
+  test("marks only the node matching the head hash", () => {
+    const graph = computeGraphLayout(
+      [item({ hash: "bbbb", parents: ["aaaa"], heads: ["dev"] }), item({ hash: "aaaa" })],
+      "bbbb",
+    )
+
+    expect(graph.nodes.map((node) => [node.hash, node.isHead])).toEqual([
+      ["bbbb", true],
+      ["aaaa", false],
+    ])
+  })
+
+  test("does not treat a branch name as a head hash", () => {
+    const graph = computeGraphLayout(
+      [item({ hash: "bbbb", parents: ["aaaa"], heads: ["dev"] }), item({ hash: "aaaa" })],
+      "dev",
+    )
+
+    expect(graph.nodes.some((node) => node.isHead)).toBe(false)
+  })
+
+  test("supports an uncommitted node parented to head", () => {
+    const graph = computeGraphLayout(
+      [
+        item({ hash: UNCOMMITTED, parents: ["bbbb"] }),
+        item({ hash: "bbbb", parents: ["aaaa"], heads: ["dev"] }),
+        item({ hash: "aaaa" }),
+      ],
+      "bbbb",
+    )
+
+    expect(graph.nodes[0]?.isUncommitted).toBe(true)
+    expect(graph.nodes[1]?.isHead).toBe(true)
+    expect(graph.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          fromRow: 0,
+          toRow: 1,
+        }),
+      ]),
+    )
+  })
+})

--- a/packages/app/src/pages/session/git-graph/model.ts
+++ b/packages/app/src/pages/session/git-graph/model.ts
@@ -1,4 +1,5 @@
 import type { CommitLogItem } from "@opencode-ai/sdk/v2"
+import { layout } from "./layout"
 
 export const PALETTE = [
   "#0085d9",
@@ -36,146 +37,24 @@ export type GraphNode = {
   remotes: { name: string; remote: string | null }[]
 }
 
-export type GraphEdge = {
+export type GraphLine = {
+  branch: number
+  colorIndex: number
   fromRow: number
   toRow: number
   fromLane: number
   toLane: number
-  isMerge: boolean
+  committed: boolean
+  lockedFirst: boolean
 }
 
 export type GraphView = {
   nodes: GraphNode[]
-  edges: GraphEdge[]
+  lines: GraphLine[]
   lanes: number
 }
 
-const available = (bag: { end: number }[], start: number) => {
-  for (let i = 0; i < bag.length; i++) {
-    if (start > bag[i].end) return i
-  }
-  bag.push({ end: 0 })
-  return bag.length - 1
-}
-
-const idx = (commits: CommitLogItem[]) => {
-  const map = new Map<string, number>()
-  for (let i = 0; i < commits.length; i++) map.set(commits[i].hash, i)
-  return map
-}
-
 export function computeGraphLayout(commits: CommitLogItem[] | undefined | null, head: string | null): GraphView {
-  if (!commits || commits.length === 0) return { nodes: [], edges: [], lanes: 0 }
-  const n = commits.length
-
-  const lookup = idx(commits)
-  const slot = commits.map(() => ({ lane: -1, nextX: 0, parent: 0 }))
-  const bag: { end: number }[] = []
-
-  for (let i = 0; i < n; i++) {
-    while (slot[i].parent < (commits[i].parents?.length ?? 0)) {
-      const parentHash = commits[i].parents[slot[i].parent]
-      const parentRow = lookup.get(parentHash)
-
-      if (parentRow === undefined) {
-        slot[i].parent++
-        continue
-      }
-
-      const here = slot[i]
-      const there = slot[parentRow]
-      const isMerge = slot[i].parent > 0
-
-      if (here.lane !== -1 && there.lane !== -1 && isMerge) {
-        for (let j = i + 1; j < n; j++) {
-          if (j === parentRow) {
-            slot[i].parent++
-            break
-          }
-          slot[j].nextX++
-        }
-        continue
-      }
-
-      const laneIdx = available(bag, i)
-      let cur = i
-      let target = parentRow
-
-      if (here.lane === -1) {
-        here.lane = laneIdx
-        here.nextX++
-      }
-
-      for (let j = i + 1; j < n; j++) {
-        const s = slot[j]
-
-        if (j === target) {
-          const wasLaned = s.lane !== -1
-          if (s.lane === -1) s.lane = laneIdx
-          bag[laneIdx] = { end: j }
-          s.nextX++
-
-          slot[cur].parent++
-
-          if (wasLaned) {
-            slot[i].parent++
-            break
-          }
-
-          cur = target
-          if (slot[cur].parent >= commits[cur].parents.length) break
-
-          const next = commits[cur].parents[slot[cur].parent]
-          const nxt = lookup.get(next)
-          if (nxt === undefined) {
-            slot[i].parent++
-            break
-          }
-          target = nxt
-        } else {
-          s.nextX++
-        }
-      }
-
-      bag[laneIdx] = { end: Math.max(bag[laneIdx].end, i) }
-    }
-  }
-
-  const lanes = bag.length || 1
-  const color = (l: number) => l % PALETTE.length
-
-  const nodes: GraphNode[] = commits.map((c, i) => {
-    const lane = slot[i].lane >= 0 ? slot[i].lane : 0
-    return {
-      hash: c.hash,
-      row: i,
-      lane,
-      colorIndex: color(lane),
-      isHead: c.hash === head,
-      isUncommitted: c.hash === UNCOMMITTED,
-      message: c.message,
-      author: c.author,
-      date: c.date,
-      heads: c.heads,
-      tags: c.tags,
-      remotes: c.remotes,
-    }
-  })
-
-  const edges: GraphEdge[] = []
-  for (let i = 0; i < n; i++) {
-    for (let p = 0; p < (commits[i].parents?.length ?? 0); p++) {
-      const parentRow = lookup.get(commits[i].parents![p])
-      if (parentRow === undefined) continue
-      edges.push({
-        fromRow: i,
-        toRow: parentRow,
-        fromLane: slot[i].lane >= 0 ? slot[i].lane : 0,
-        toLane: slot[parentRow].lane >= 0 ? slot[parentRow].lane : 0,
-        isMerge: p > 0,
-      })
-    }
-  }
-
-  return { nodes, edges, lanes }
+  if (!commits || commits.length === 0) return { nodes: [], lines: [], lanes: 0 }
+  return layout(commits, head)
 }

--- a/packages/app/src/pages/session/git-graph/model.ts
+++ b/packages/app/src/pages/session/git-graph/model.ts
@@ -52,9 +52,11 @@ export type GraphView = {
   nodes: GraphNode[]
   lines: GraphLine[]
   lanes: number
+  graphWidth: number
+  widthsAtRows: number[]
 }
 
 export function computeGraphLayout(commits: CommitLogItem[] | undefined | null, head: string | null): GraphView {
-  if (!commits || commits.length === 0) return { nodes: [], lines: [], lanes: 0 }
+  if (!commits || commits.length === 0) return { nodes: [], lines: [], lanes: 0, graphWidth: 0, widthsAtRows: [] }
   return layout(commits, head)
 }

--- a/packages/app/src/pages/session/git-graph/model.ts
+++ b/packages/app/src/pages/session/git-graph/model.ts
@@ -60,3 +60,9 @@ export function computeGraphLayout(commits: CommitLogItem[] | undefined | null, 
   if (!commits || commits.length === 0) return { nodes: [], lines: [], lanes: 0, graphWidth: 0, widthsAtRows: [] }
   return layout(commits, head)
 }
+
+export function expandedY(row: number, expandedRow: number | null | undefined, height: number) {
+  const base = row * ROW_HEIGHT + ROW_HEIGHT / 2
+  if (expandedRow === null || expandedRow === undefined || row <= expandedRow) return base
+  return base + height
+}

--- a/packages/app/src/pages/session/git-graph/refs.tsx
+++ b/packages/app/src/pages/session/git-graph/refs.tsx
@@ -1,0 +1,152 @@
+import { For, Show } from "solid-js"
+import type { GraphNode } from "./model"
+
+type Head = {
+  kind: "head"
+  name: string
+  full: string
+  active: boolean
+  remotes: { name: string; full: string }[]
+}
+
+type Remote = {
+  kind: "remote"
+  name: string
+  full: string
+  remote: string | null
+}
+
+type Tag = {
+  kind: "tag"
+  name: string
+  full: string
+  annotated: boolean
+}
+
+export type Ref = Head | Remote | Tag
+
+const title = (item: Ref) => {
+  if (item.kind === "head" && item.remotes.length > 0) return `${item.full} (${item.remotes.map((r) => r.full).join(", ")})`
+  if (item.kind === "tag") return `${item.full}${item.annotated ? " (annotated)" : ""}`
+  return item.full
+}
+
+const chip = (item: Ref) => ({
+  "border-accent-base/70 bg-accent-base/10 text-text-base": item.kind === "head" && item.active,
+  "border-border-weaker-base bg-surface-base text-text-base": item.kind === "head" && !item.active,
+  "border-border-weaker-base bg-surface-base text-text-weaker": item.kind === "remote",
+  "border-border-weaker-base bg-surface-base text-text-weak": item.kind === "tag",
+})
+
+const icon = (item: Ref) => ({
+  "bg-accent-base text-surface-base": item.kind === "head" && item.active,
+  "bg-text-weaker text-surface-base": item.kind !== "head" || !item.active,
+})
+
+export const refsFor = (node: GraphNode, branch: string | null | undefined) => {
+  const heads: Head[] = node.heads.map((name) => ({
+    kind: "head" as const,
+    name,
+    full: name,
+    active: name === branch,
+    remotes: [],
+  }))
+  const map = new Map(heads.map((head, idx) => [head.name, idx]))
+  const remotes = node.remotes.flatMap((remote) => {
+    if (remote.remote !== null && remote.name.startsWith(`${remote.remote}/`)) {
+      const name = remote.name.slice(remote.remote.length + 1)
+      const idx = map.get(name)
+      if (idx !== undefined) {
+        heads[idx]!.remotes.push({ name: remote.remote, full: remote.name })
+        return []
+      }
+    }
+
+    return [{ kind: "remote" as const, name: remote.name, full: remote.name, remote: remote.remote }]
+  })
+  const tags = node.tags.map((tag) => ({
+    kind: "tag" as const,
+    name: tag.name,
+    full: tag.name,
+    annotated: tag.annotated,
+  }))
+
+  return [...heads.sort((a, z) => Number(z.active) - Number(a.active)), ...remotes, ...tags]
+}
+
+function BranchIcon() {
+  return (
+    <svg class="size-3" viewBox="0 0 20 20" aria-hidden="true">
+      <path
+        d="M6.3 3.3a1.8 1.8 0 1 1 0 3.6 1.8 1.8 0 0 1 0-3.6Zm0 9.9a1.8 1.8 0 1 1 0 3.6 1.8 1.8 0 0 1 0-3.6Zm7.4-9.9a1.8 1.8 0 1 1 0 3.6 1.8 1.8 0 0 1 0-3.6ZM6.3 6.9v6.3m7.4-6.3v4.3a3 3 0 0 1-3 3H8.1"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.4"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  )
+}
+
+function TagIcon() {
+  return (
+    <svg class="size-3" viewBox="0 0 20 20" aria-hidden="true">
+      <path
+        d="M3.5 4.5v5.1l6.9 6.9 5.1-5.1-6.9-6.9H3.5Zm3.7 3.7h.1"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.4"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  )
+}
+
+export function RefChip(props: { item: Ref }) {
+  return (
+    <span
+      class="inline-flex h-[18px] max-w-48 shrink-0 items-center overflow-hidden rounded-[5px] border text-[11px] leading-none"
+      classList={chip(props.item)}
+      data-git-graph-ref-kind={props.item.kind}
+      data-fullref={props.item.full}
+      data-remote={props.item.kind === "remote" ? (props.item.remote ?? "") : undefined}
+      data-tagtype={props.item.kind === "tag" ? (props.item.annotated ? "annotated" : "lightweight") : undefined}
+      title={title(props.item)}
+    >
+      <span class="flex h-full w-[18px] shrink-0 items-center justify-center" classList={icon(props.item)}>
+        <Show when={props.item.kind === "tag"} fallback={<BranchIcon />}>
+          <TagIcon />
+        </Show>
+      </span>
+      <span class="truncate px-1.5" classList={{ "font-semibold": props.item.kind === "head" && props.item.active }}>
+        {props.item.name}
+      </span>
+      <For each={props.item.kind === "head" ? props.item.remotes : []}>
+        {(remote) => (
+          <span
+            class="h-full shrink-0 border-l border-current/25 px-1 italic leading-[17px] text-text-weaker"
+            data-git-graph-ref-remote={remote.name}
+            data-fullref={remote.full}
+            title={remote.full}
+          >
+            {remote.name}
+          </span>
+        )}
+      </For>
+    </span>
+  )
+}
+
+export function RefLabels(props: { node: GraphNode; currentBranch: string | null | undefined }) {
+  const refs = () => refsFor(props.node, props.currentBranch)
+
+  return (
+    <Show when={refs().length > 0}>
+      <span class="flex min-w-0 shrink-0 items-center gap-1">
+        <For each={refs()}>{(ref) => <RefChip item={ref} />}</For>
+      </span>
+    </Show>
+  )
+}

--- a/packages/app/src/pages/session/git-graph/render.tsx
+++ b/packages/app/src/pages/session/git-graph/render.tsx
@@ -1,6 +1,6 @@
 import { For, Show, createMemo, createSignal } from "solid-js"
 import { Portal } from "solid-js/web"
-import { PALETTE, ROW_HEIGHT, LANE_GAP, RAIL_PAD, type GraphEdge, type GraphNode } from "./model"
+import { PALETTE, ROW_HEIGHT, LANE_GAP, RAIL_PAD, type GraphLine, type GraphNode } from "./model"
 
 const DELTA = ROW_HEIGHT * 0.8
 
@@ -26,13 +26,13 @@ const formatDate = (date: number) => {
   return d.toLocaleDateString() + " " + d.toLocaleTimeString()
 }
 
-const edgePath = (edge: GraphEdge) => {
-  const x1 = xForLane(edge.fromLane)
-  const y1 = yForRow(edge.fromRow)
-  const x2 = xForLane(edge.toLane)
-  const y2 = yForRow(edge.toRow)
+const linePath = (line: GraphLine) => {
+  const x1 = xForLane(line.fromLane)
+  const y1 = yForRow(line.fromRow)
+  const x2 = xForLane(line.toLane)
+  const y2 = yForRow(line.toRow)
 
-  if (edge.fromLane === edge.toLane) {
+  if (line.fromLane === line.toLane) {
     return `M ${x1} ${y1} L ${x2} ${y2}`
   }
 
@@ -138,7 +138,7 @@ function TooltipContent(props: {
 
 export function GitGraphList(props: {
   nodes: GraphNode[]
-  edges: GraphEdge[]
+  lines: GraphLine[]
   lanes: number
   currentBranch: string | null | undefined
   uncommitted?: { count: number; files: string[] }
@@ -184,12 +184,12 @@ export function GitGraphList(props: {
           viewBox={`0 0 ${railWidth()} ${height()}`}
           preserveAspectRatio="none"
         >
-          <For each={props.edges}>
-            {(edge) => (
+          <For each={props.lines}>
+            {(line) => (
               <path
-                d={edgePath(edge)}
+                d={linePath(line)}
                 fill="none"
-                stroke={color(edge.fromLane)}
+                stroke={line.committed ? color(line.colorIndex) : "#808080"}
                 stroke-width="1.5"
                 stroke-linecap="round"
                 opacity="0.6"

--- a/packages/app/src/pages/session/git-graph/render.tsx
+++ b/packages/app/src/pages/session/git-graph/render.tsx
@@ -1,4 +1,5 @@
 import { For, Show, createMemo, createSignal, onCleanup } from "solid-js"
+import { createStore } from "solid-js/store"
 import { Portal } from "solid-js/web"
 import type { Column, Columns } from "./columns"
 import { autoColumns, fitColumns, resizeColumns, template } from "./columns"
@@ -19,7 +20,7 @@ export function GitGraphList(props: {
   onCommitClick?: (hash: string) => void
   onContextMenu?: (hash: string, event: MouseEvent) => void
 }) {
-  const [hovered, setHovered] = createSignal<GraphNode | null>(null)
+  const [hover, setHover] = createStore<{ row: GraphNode | null; tip: GraphNode | null }>({ row: null, tip: null })
   const [tooltipX, setTooltipX] = createSignal(0)
   const [tooltipY, setTooltipY] = createSignal(0)
   const [tooltipSide, setTooltipSide] = createSignal<"left" | "right">("right")
@@ -43,13 +44,20 @@ export function GitGraphList(props: {
   onCleanup(() => observer?.disconnect())
 
   const handleCircleEnter = (node: GraphNode, e: MouseEvent) => {
-    setHovered(node)
+    setHover({ row: node, tip: node })
     updatePos(e)
   }
 
-  const handleRowEnter = (node: GraphNode, e: MouseEvent) => {
-    setHovered(node)
-    updatePos(e, cols().graph)
+  const handleCircleLeave = () => {
+    setHover({ row: null, tip: null })
+  }
+
+  const handleRowEnter = (node: GraphNode) => {
+    setHover("row", node)
+  }
+
+  const handleRowLeave = () => {
+    setHover({ row: null, tip: null })
   }
 
   const startResize = (left: Column, right: Column, event: MouseEvent) => {
@@ -115,7 +123,7 @@ export function GitGraphList(props: {
             height={bodyHeight()}
             onNodeEnter={handleCircleEnter}
             onNodeMove={updatePos}
-            onNodeLeave={() => setHovered(null)}
+            onNodeLeave={handleCircleLeave}
             onNodeClick={props.onCommitClick}
             onNodeContextMenu={props.onContextMenu}
           />
@@ -128,10 +136,10 @@ export function GitGraphList(props: {
                   columns={cols()}
                   currentBranch={props.currentBranch}
                   uncommitted={props.uncommitted}
-                  hovered={hovered()?.hash === node.hash}
+                  hovered={hover.row?.hash === node.hash}
                   selected={props.selectedHash === node.hash}
                   onEnter={handleRowEnter}
-                  onLeave={() => setHovered(null)}
+                  onLeave={handleRowLeave}
                   onClick={props.onCommitClick}
                   onContextMenu={props.onContextMenu}
                 />
@@ -142,7 +150,7 @@ export function GitGraphList(props: {
       </div>
 
       <Portal>
-        <Show when={hovered()}>
+        <Show when={hover.tip}>
           {(node) => (
             <div
               class="fixed z-[1000] pointer-events-none"

--- a/packages/app/src/pages/session/git-graph/render.tsx
+++ b/packages/app/src/pages/session/git-graph/render.tsx
@@ -1,145 +1,18 @@
-import { For, Show, createMemo, createSignal } from "solid-js"
+import { For, Show, createMemo, createSignal, onCleanup } from "solid-js"
 import { Portal } from "solid-js/web"
-import { PALETTE, ROW_HEIGHT, LANE_GAP, RAIL_PAD, type GraphLine, type GraphNode } from "./model"
-
-const DELTA = ROW_HEIGHT * 0.8
-
-const color = (idx: number) => PALETTE[idx % PALETTE.length]
-
-const xForLane = (lane: number) => RAIL_PAD + lane * LANE_GAP
-const yForRow = (row: number) => row * ROW_HEIGHT + ROW_HEIGHT / 2
-
-const abbrev = (hash: string) => hash.slice(0, 7)
-
-const ago = (date: number) => {
-  const now = Math.floor(Date.now() / 1000)
-  const diff = now - date
-  if (diff < 60) return "now"
-  if (diff < 3600) return `${Math.floor(diff / 60)}m`
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h`
-  if (diff < 604800) return `${Math.floor(diff / 86400)}d`
-  return `${Math.floor(diff / 604800)}w`
-}
-
-const formatDate = (date: number) => {
-  const d = new Date(date * 1000)
-  return d.toLocaleDateString() + " " + d.toLocaleTimeString()
-}
-
-const linePath = (line: GraphLine) => {
-  const x1 = xForLane(line.fromLane)
-  const y1 = yForRow(line.fromRow)
-  const x2 = xForLane(line.toLane)
-  const y2 = yForRow(line.toRow)
-
-  if (line.fromLane === line.toLane) {
-    return `M ${x1} ${y1} L ${x2} ${y2}`
-  }
-
-  const d = Math.min(DELTA, Math.abs(y2 - y1) * 0.5)
-  return `M ${x1} ${y1} C ${x1} ${y1 + d}, ${x2} ${y2 - d}, ${x2} ${y2}`
-}
-
-function TooltipContent(props: {
-  node: GraphNode
-  currentBranch: string | null
-  uncommitted?: { count: number; files: string[] }
-}) {
-  const c = color(props.node.colorIndex)
-
-  return (
-    <div
-      class="text-xs text-text-base"
-      style={{
-        "border-left": `3px solid ${c}`,
-        "max-width": "320px",
-      }}
-    >
-      <div class="font-mono text-11-regular text-text-weaker px-3 pt-2 pb-1">
-        {props.node.isUncommitted ? "Uncommitted Changes" : `Commit ${abbrev(props.node.hash)}`}
-      </div>
-
-      <Show when={props.currentBranch && !props.node.isUncommitted}>
-        <div class="px-3 pb-1 text-text-weaker">
-          {props.node.heads.includes(props.currentBranch!) ? (
-            <span>
-              Included in <span class="text-text-base font-medium">HEAD</span>
-            </span>
-          ) : (
-            <span>
-              <b>
-                <i>Not</i>
-              </b>{" "}
-              included in <span class="text-text-base font-medium">HEAD</span>
-            </span>
-          )}
-        </div>
-      </Show>
-
-      <Show when={props.node.isUncommitted && props.uncommitted}>
-        <div class="px-3 pb-1 text-text-weaker">
-          {props.uncommitted!.count} file{props.uncommitted!.count !== 1 ? "s" : ""} changed
-          <div class="mt-1 max-h-[120px] overflow-y-auto">
-            <For each={props.uncommitted!.files.slice(0, 20)}>
-              {(file) => <div class="truncate font-mono text-[10px]">{file}</div>}
-            </For>
-          </div>
-          <Show when={(props.uncommitted?.files.length ?? 0) > 20}>
-            <div class="text-text-weaker mt-0.5">...and {props.uncommitted!.files.length - 20} more</div>
-          </Show>
-        </div>
-      </Show>
-
-      <Show when={props.node.heads.length > 0}>
-        <div class="px-3 pb-1 text-text-weaker">
-          Branches:
-          <span class="text-text-base">
-            {props.node.heads.slice(0, 5).join(", ")}
-            {props.node.heads.length > 5 ? ` +${props.node.heads.length - 5} more` : ""}
-          </span>
-        </div>
-      </Show>
-
-      <Show when={props.node.tags.length > 0}>
-        <div class="px-3 pb-1 text-text-weaker">
-          Tags:
-          <span class="text-text-base">
-            {props.node.tags
-              .slice(0, 5)
-              .map((t) => t.name)
-              .join(", ")}
-            {props.node.tags.length > 5 ? ` +${props.node.tags.length - 5} more` : ""}
-          </span>
-        </div>
-      </Show>
-
-      <Show when={props.node.remotes.length > 0}>
-        <div class="px-3 pb-1 text-text-weaker">
-          Remotes:
-          <span class="text-text-base">
-            {props.node.remotes
-              .slice(0, 5)
-              .map((r) => r.name)
-              .join(", ")}
-            {props.node.remotes.length > 5 ? ` +${props.node.remotes.length - 5} more` : ""}
-          </span>
-        </div>
-      </Show>
-
-      <Show when={!props.node.isUncommitted}>
-        <div class="px-3 pb-1 text-text-weaker">
-          {props.node.author} · {formatDate(props.node.date)}
-        </div>
-        <div class="px-3 pb-2 text-text-base break-words whitespace-pre-wrap">{props.node.message}</div>
-      </Show>
-    </div>
-  )
-}
+import type { Column, Columns } from "./columns"
+import { autoColumns, fitColumns, resizeColumns, template } from "./columns"
+import { ROW_HEIGHT, type GraphLine, type GraphNode } from "./model"
+import { GitGraphSvg } from "./graph-svg"
+import { GitGraphRow } from "./row"
+import { GitGraphTooltip } from "./tooltip"
+import { HEADER_HEIGHT, TOOLTIP_WIDTH, color, railWidth } from "./style"
 
 export function GitGraphList(props: {
   nodes: GraphNode[]
   lines: GraphLine[]
   lanes: number
+  graphWidth?: number
   currentBranch: string | null | undefined
   uncommitted?: { count: number; files: string[] }
   selectedHash?: string | null
@@ -149,175 +22,122 @@ export function GitGraphList(props: {
   const [hovered, setHovered] = createSignal<GraphNode | null>(null)
   const [tooltipX, setTooltipX] = createSignal(0)
   const [tooltipY, setTooltipY] = createSignal(0)
+  const [tooltipSide, setTooltipSide] = createSignal<"left" | "right">("right")
+  const [width, setWidth] = createSignal(0)
+  const [fixed, setFixed] = createSignal<Columns | null>(null)
 
-  const railWidth = createMemo(() => props.lanes * LANE_GAP + RAIL_PAD * 2)
-  const height = createMemo(() => Math.max(ROW_HEIGHT, props.nodes.length * ROW_HEIGHT))
+  let observer: ResizeObserver | undefined
+
+  const graphWidth = createMemo(() => props.graphWidth ?? railWidth(props.lanes))
+  const cols = createMemo(() => (fixed() ? fitColumns(fixed()!, width()) : autoColumns(width(), graphWidth())))
+  const bodyHeight = createMemo(() => Math.max(ROW_HEIGHT, props.nodes.length * ROW_HEIGHT))
+  const height = createMemo(() => HEADER_HEIGHT + bodyHeight())
+
+  const bind = (el: HTMLDivElement) => {
+    const sync = () => setWidth(el.clientWidth)
+    sync()
+    observer = new ResizeObserver(sync)
+    observer.observe(el)
+  }
+
+  onCleanup(() => observer?.disconnect())
 
   const handleCircleEnter = (node: GraphNode, e: MouseEvent) => {
     setHovered(node)
     updatePos(e)
   }
 
-  const updatePos = (e: MouseEvent) => {
-    const rect = (e.currentTarget as SVGCircleElement).getBoundingClientRect()
+  const handleRowEnter = (node: GraphNode, e: MouseEvent) => {
+    setHovered(node)
+    updatePos(e, cols().graph)
+  }
+
+  const startResize = (left: Column, right: Column, event: MouseEvent) => {
+    event.preventDefault()
+    const base = cols()
+    const start = event.clientX
+    setFixed(base)
+
+    const move = (e: MouseEvent) => {
+      setFixed(resizeColumns(base, left, right, e.clientX - start, width()))
+    }
+    const up = () => {
+      document.removeEventListener("mousemove", move)
+      document.removeEventListener("mouseup", up)
+    }
+
+    document.addEventListener("mousemove", move)
+    document.addEventListener("mouseup", up)
+  }
+
+  const updatePos = (e: MouseEvent, offset = 0) => {
+    const rect = (e.currentTarget as Element).getBoundingClientRect()
     const gap = 6
-    const estimatedWidth = 330
     const margin = 12
 
-    let x = rect.right + gap
-    if (x + estimatedWidth > window.innerWidth - margin) {
-      x = rect.left - estimatedWidth - gap
-    }
-    if (x < margin) x = margin
+    const anchor = offset > 0 ? rect.left + offset : rect.right
+    const left = anchor - TOOLTIP_WIDTH - gap
+    const right = anchor + gap
+    const side = right + TOOLTIP_WIDTH > window.innerWidth - margin && left > margin ? "left" : "right"
+    const x = side === "right" ? Math.min(right, window.innerWidth - TOOLTIP_WIDTH - margin) : Math.max(left, margin)
 
+    setTooltipSide(side)
     setTooltipX(x)
     setTooltipY(rect.top + rect.height / 2)
   }
 
+  const header = () => (
+    <div
+      class="sticky top-0 z-30 grid overflow-hidden border-b border-border-weaker-base bg-background-base/95 text-[11px] font-medium text-text-weaker backdrop-blur"
+      style={{
+        height: `${HEADER_HEIGHT}px`,
+        "grid-template-columns": template(cols()),
+      }}
+    >
+      <Head label="Graph" onResize={(event) => startResize("graph", "description", event)} />
+      <Head label="Description" onResize={(event) => startResize("description", "author", event)} />
+      <Head label="Author" onResize={(event) => startResize("author", "date", event)} />
+      <Head label="Date" align="right" onResize={(event) => startResize("date", "commit", event)} />
+      <Head label="Commit" />
+    </div>
+  )
+
   return (
-    <div class="relative h-full min-h-0">
-      <div class="relative min-w-0" style={{ height: `${height()}px` }}>
-        <svg
-          class="pointer-events-none absolute left-0 top-0 z-20"
-          width={railWidth()}
-          height={height()}
-          viewBox={`0 0 ${railWidth()} ${height()}`}
-          preserveAspectRatio="none"
-        >
-          <For each={props.lines}>
-            {(line) => (
-              <path
-                d={linePath(line)}
-                fill="none"
-                stroke={line.committed ? color(line.colorIndex) : "#808080"}
-                stroke-width="1.5"
-                stroke-linecap="round"
-                opacity="0.6"
-              />
-            )}
-          </For>
+    <div ref={bind} class="relative h-full min-h-0 w-full overflow-x-hidden">
+      <div class="relative min-w-0 overflow-x-hidden" style={{ height: `${height()}px` }}>
+        {header()}
 
-          <For each={props.nodes}>
-            {(node) => {
-              const cx = createMemo(() => xForLane(node.lane))
-              const cy = createMemo(() => yForRow(node.row))
-              const c = createMemo(() => color(node.colorIndex))
-              const r = createMemo(() => (node.isHead ? 5 : 4))
+        <div class="relative overflow-x-hidden" style={{ height: `${bodyHeight()}px` }}>
+          <GitGraphSvg
+            nodes={props.nodes}
+            lines={props.lines}
+            visibleWidth={cols().graph}
+            height={bodyHeight()}
+            onNodeEnter={handleCircleEnter}
+            onNodeMove={updatePos}
+            onNodeLeave={() => setHovered(null)}
+            onNodeClick={props.onCommitClick}
+            onNodeContextMenu={props.onContextMenu}
+          />
 
-              return (
-                <>
-                  <Show when={node.isUncommitted}>
-                    <circle
-                      cx={cx()}
-                      cy={cy()}
-                      r={r()}
-                      fill="transparent"
-                      stroke="#808080"
-                      stroke-width="1.5"
-                      style="pointer-events:auto;cursor:pointer"
-                      onMouseEnter={(e) => handleCircleEnter(node, e)}
-                      onMouseMove={(e) => updatePos(e)}
-                      onMouseLeave={() => setHovered(null)}
-                      onClick={() => props.onCommitClick?.(node.hash)}
-                      onContextMenu={(e) => {
-                        e.preventDefault()
-                        props.onContextMenu?.(node.hash, e)
-                      }}
-                    />
-                  </Show>
-                  <Show when={!node.isUncommitted && node.isHead}>
-                    <circle
-                      cx={cx()}
-                      cy={cy()}
-                      r={r()}
-                      fill="transparent"
-                      stroke={c()}
-                      stroke-width="2"
-                      style="pointer-events:auto;cursor:pointer"
-                      onMouseEnter={(e) => handleCircleEnter(node, e)}
-                      onMouseMove={(e) => updatePos(e)}
-                      onMouseLeave={() => setHovered(null)}
-                      onClick={() => props.onCommitClick?.(node.hash)}
-                      onContextMenu={(e) => {
-                        e.preventDefault()
-                        props.onContextMenu?.(node.hash, e)
-                      }}
-                    />
-                  </Show>
-                  <Show when={!node.isUncommitted && !node.isHead}>
-                    <circle
-                      cx={cx()}
-                      cy={cy()}
-                      r={r()}
-                      fill={c()}
-                      style="pointer-events:auto;cursor:pointer"
-                      onMouseEnter={(e) => handleCircleEnter(node, e)}
-                      onMouseMove={(e) => updatePos(e)}
-                      onMouseLeave={() => setHovered(null)}
-                      onClick={() => props.onCommitClick?.(node.hash)}
-                      onContextMenu={(e) => {
-                        e.preventDefault()
-                        props.onContextMenu?.(node.hash, e)
-                      }}
-                    />
-                  </Show>
-                </>
-              )
-            }}
-          </For>
-        </svg>
-
-        <div class="relative z-10">
-          <For each={props.nodes}>
-            {(node) => (
-              <div
-                class="flex items-center gap-2 border-b border-border-weaker-base text-sm"
-                classList={{
-                  "bg-surface-base": hovered()?.hash === node.hash,
-                  "bg-accent-base/10": props.selectedHash === node.hash,
-                }}
-                style={{
-                  height: `${ROW_HEIGHT}px`,
-                  "padding-left": `${railWidth() + 8}px`,
-                  "padding-right": "8px",
-                  cursor: "pointer",
-                }}
-                onMouseEnter={() => setHovered(node)}
-                onMouseLeave={() => setHovered(null)}
-                onClick={() => props.onCommitClick?.(node.hash)}
-                onContextMenu={(e) => {
-                  e.preventDefault()
-                  props.onContextMenu?.(node.hash, e)
-                }}
-              >
-                <Show when={node.heads.length > 0 || node.isHead}>
-                  <span class="shrink-0 flex items-center gap-1">
-                    <For each={node.heads}>
-                      {(h) => (
-                        <span class="inline-flex items-center rounded bg-accent-base/10 px-1 text-[11px] text-accent-base">
-                          {h === "HEAD" ? "HEAD" : h}
-                        </span>
-                      )}
-                    </For>
-                  </span>
-                </Show>
-
-                <span class="min-w-0 flex-1 truncate text-text-base">
-                  {node.isUncommitted
-                    ? `Uncommitted Changes${props.uncommitted ? ` (${props.uncommitted.count})` : ""}`
-                    : node.message}
-                </span>
-
-                <Show when={!node.isUncommitted}>
-                  <span class="shrink-0 font-mono text-[11px] text-text-weaker">{abbrev(node.hash)}</span>
-                </Show>
-
-                <span class="shrink-0 text-[11px] text-text-weaker">{node.author}</span>
-
-                <span class="shrink-0 w-10 text-right text-[11px] text-text-weaker">{ago(node.date)}</span>
-              </div>
-            )}
-          </For>
+          <div class="relative z-10">
+            <For each={props.nodes}>
+              {(node) => (
+                <GitGraphRow
+                  node={node}
+                  columns={cols()}
+                  currentBranch={props.currentBranch}
+                  uncommitted={props.uncommitted}
+                  hovered={hovered()?.hash === node.hash}
+                  selected={props.selectedHash === node.hash}
+                  onEnter={handleRowEnter}
+                  onLeave={() => setHovered(null)}
+                  onClick={props.onCommitClick}
+                  onContextMenu={props.onContextMenu}
+                />
+              )}
+            </For>
+          </div>
         </div>
       </div>
 
@@ -332,17 +152,31 @@ export function GitGraphList(props: {
                 transform: "translateY(-50%)",
               }}
             >
-              <div class="rounded shadow-lg border border-border-weaker-base bg-surface-base overflow-hidden">
-                <TooltipContent
-                  node={node()}
-                  currentBranch={props.currentBranch ?? null}
-                  uncommitted={props.uncommitted}
-                />
-              </div>
+              <GitGraphTooltip
+                node={node()}
+                color={color(node().colorIndex)}
+                side={tooltipSide()}
+                currentBranch={props.currentBranch ?? null}
+                uncommitted={props.uncommitted}
+              />
             </div>
           )}
         </Show>
       </Portal>
+    </div>
+  )
+}
+
+function Head(props: { label: string; align?: "left" | "right"; onResize?: (event: MouseEvent) => void }) {
+  return (
+    <div class="relative min-w-0 overflow-hidden px-1" classList={{ "text-right": props.align === "right" }}>
+      <span class="truncate">{props.label}</span>
+      <Show when={props.onResize}>
+        <span
+          class="absolute right-0 top-0 h-full w-1 cursor-col-resize"
+          onMouseDown={(event) => props.onResize?.(event)}
+        />
+      </Show>
     </div>
   )
 }

--- a/packages/app/src/pages/session/git-graph/render.tsx
+++ b/packages/app/src/pages/session/git-graph/render.tsx
@@ -4,10 +4,15 @@ import { Portal } from "solid-js/web"
 import type { Column, Columns } from "./columns"
 import { autoColumns, fitColumns, resizeColumns, template } from "./columns"
 import { ROW_HEIGHT, type GraphLine, type GraphNode } from "./model"
+import { CommitDetail } from "./detail"
 import { GitGraphSvg } from "./graph-svg"
 import { GitGraphRow } from "./row"
 import { GitGraphTooltip } from "./tooltip"
 import { HEADER_HEIGHT, TOOLTIP_WIDTH, color, railWidth } from "./style"
+
+const DETAIL_HEIGHT = 280
+const DETAIL_MIN = 160
+const DETAIL_MAX = 640
 
 export function GitGraphList(props: {
   nodes: GraphNode[]
@@ -17,10 +22,13 @@ export function GitGraphList(props: {
   currentBranch: string | null | undefined
   uncommitted?: { count: number; files: string[] }
   selectedHash?: string | null
+  selectedParentHash?: string | null
   onCommitClick?: (hash: string) => void
+  onCloseDetail?: () => void
   onContextMenu?: (hash: string, event: MouseEvent) => void
 }) {
   const [hover, setHover] = createStore<{ row: GraphNode | null; tip: GraphNode | null }>({ row: null, tip: null })
+  const [panel, setPanel] = createStore({ height: DETAIL_HEIGHT })
   const [tooltipX, setTooltipX] = createSignal(0)
   const [tooltipY, setTooltipY] = createSignal(0)
   const [tooltipSide, setTooltipSide] = createSignal<"left" | "right">("right")
@@ -31,7 +39,11 @@ export function GitGraphList(props: {
 
   const graphWidth = createMemo(() => props.graphWidth ?? railWidth(props.lanes))
   const cols = createMemo(() => (fixed() ? fitColumns(fixed()!, width()) : autoColumns(width(), graphWidth())))
-  const bodyHeight = createMemo(() => Math.max(ROW_HEIGHT, props.nodes.length * ROW_HEIGHT))
+  const expandedRow = createMemo(() =>
+    props.selectedHash ? props.nodes.findIndex((node) => node.hash === props.selectedHash) : -1,
+  )
+  const expandedHeight = createMemo(() => (expandedRow() >= 0 ? panel.height : 0))
+  const bodyHeight = createMemo(() => Math.max(ROW_HEIGHT, props.nodes.length * ROW_HEIGHT + expandedHeight()))
   const height = createMemo(() => HEADER_HEIGHT + bodyHeight())
 
   const bind = (el: HTMLDivElement) => {
@@ -58,6 +70,26 @@ export function GitGraphList(props: {
 
   const handleRowLeave = () => {
     setHover({ row: null, tip: null })
+  }
+
+  const detailMax = () => Math.max(DETAIL_MIN, Math.min(DETAIL_MAX, window.innerHeight - 160))
+  const clamp = (value: number) => Math.max(DETAIL_MIN, Math.min(detailMax(), value))
+
+  const startDetailResize = (event: MouseEvent) => {
+    event.preventDefault()
+    const base = panel.height
+    const start = event.clientY
+
+    const move = (e: MouseEvent) => {
+      setPanel("height", clamp(base + e.clientY - start))
+    }
+    const up = () => {
+      document.removeEventListener("mousemove", move)
+      document.removeEventListener("mouseup", up)
+    }
+
+    document.addEventListener("mousemove", move)
+    document.addEventListener("mouseup", up)
   }
 
   const startResize = (left: Column, right: Column, event: MouseEvent) => {
@@ -121,6 +153,8 @@ export function GitGraphList(props: {
             lines={props.lines}
             visibleWidth={cols().graph}
             height={bodyHeight()}
+            expandedRow={expandedRow()}
+            expandedHeight={expandedHeight()}
             onNodeEnter={handleCircleEnter}
             onNodeMove={updatePos}
             onNodeLeave={handleCircleLeave}
@@ -131,18 +165,33 @@ export function GitGraphList(props: {
           <div class="relative z-10">
             <For each={props.nodes}>
               {(node) => (
-                <GitGraphRow
-                  node={node}
-                  columns={cols()}
-                  currentBranch={props.currentBranch}
-                  uncommitted={props.uncommitted}
-                  hovered={hover.row?.hash === node.hash}
-                  selected={props.selectedHash === node.hash}
-                  onEnter={handleRowEnter}
-                  onLeave={handleRowLeave}
-                  onClick={props.onCommitClick}
-                  onContextMenu={props.onContextMenu}
-                />
+                <>
+                  <GitGraphRow
+                    node={node}
+                    columns={cols()}
+                    currentBranch={props.currentBranch}
+                    uncommitted={props.uncommitted}
+                    hovered={hover.row?.hash === node.hash}
+                    selected={props.selectedHash === node.hash}
+                    onEnter={handleRowEnter}
+                    onLeave={handleRowLeave}
+                    onClick={props.onCommitClick}
+                    onContextMenu={props.onContextMenu}
+                  />
+                  <Show when={props.selectedHash === node.hash}>
+                    <div class="grid overflow-hidden" style={{ "grid-template-columns": template(cols()) }}>
+                      <div class="min-w-0 border-b border-border-weaker-base bg-surface-base" />
+                      <CommitDetail
+                        hash={node.hash}
+                        parentHash={props.selectedParentHash ?? null}
+                        height={panel.height}
+                        class="col-span-4 min-w-0 border-b border-border-weaker-base"
+                        onClose={() => props.onCloseDetail?.()}
+                        onResizeStart={startDetailResize}
+                      />
+                    </div>
+                  </Show>
+                </>
               )}
             </For>
           </div>

--- a/packages/app/src/pages/session/git-graph/row.tsx
+++ b/packages/app/src/pages/session/git-graph/row.tsx
@@ -1,0 +1,79 @@
+import { Show } from "solid-js"
+import type { Columns } from "./columns"
+import type { GraphNode } from "./model"
+import { RefLabels } from "./refs"
+import { ROW_HEIGHT } from "./model"
+import { template } from "./columns"
+import { abbrev, ago, color } from "./style"
+
+export function GitGraphRow(props: {
+  node: GraphNode
+  columns: Columns
+  currentBranch: string | null | undefined
+  uncommitted?: { count: number; files: string[] }
+  hovered: boolean
+  selected: boolean
+  onEnter: (node: GraphNode, event: MouseEvent) => void
+  onLeave: () => void
+  onClick?: (hash: string) => void
+  onContextMenu?: (hash: string, event: MouseEvent) => void
+}) {
+  const message = () =>
+    props.node.isUncommitted
+      ? `Uncommitted Changes${props.uncommitted ? ` (${props.uncommitted.count})` : ""}`
+      : props.node.message
+
+  return (
+    <div
+      class="grid cursor-pointer items-center overflow-hidden border-b border-border-weaker-base text-[13px] transition-colors"
+      classList={{
+        "bg-surface-base-hover": props.hovered,
+        "bg-surface-base-active": props.selected,
+      }}
+      style={{
+        height: `${ROW_HEIGHT}px`,
+        "grid-template-columns": template(props.columns),
+      }}
+      onMouseEnter={(event) => props.onEnter(props.node, event)}
+      onMouseLeave={props.onLeave}
+      onClick={() => props.onClick?.(props.node.hash)}
+      onContextMenu={(event) => {
+        event.preventDefault()
+        props.onContextMenu?.(props.node.hash, event)
+      }}
+    >
+      <div class="min-w-0 overflow-hidden" />
+      <div class="flex min-w-0 items-center gap-1 overflow-hidden px-1">
+        <Show when={props.node.isHead}>
+          <span
+            class="size-2 shrink-0 rounded-full border-2"
+            style={{
+              "border-color": color(props.node.colorIndex),
+            }}
+            title="This commit is currently checked out"
+          />
+        </Show>
+        <RefLabels node={props.node} currentBranch={props.currentBranch} />
+        <span
+          class="min-w-0 flex-1 truncate text-text-base"
+          classList={{
+            "font-semibold": props.node.isHead,
+            "text-text-weaker": props.node.isUncommitted,
+          }}
+          title={message()}
+        >
+          {message()}
+        </span>
+      </div>
+      <div class="min-w-0 truncate px-1 text-text-weaker" title={props.node.author}>
+        {props.node.author}
+      </div>
+      <div class="min-w-0 truncate px-1 text-right text-text-weaker" title={new Date(props.node.date * 1000).toString()}>
+        {props.node.isUncommitted ? "" : ago(props.node.date)}
+      </div>
+      <div class="min-w-0 truncate px-1 font-mono text-[11px] text-text-weaker" title={props.node.hash}>
+        {props.node.isUncommitted ? "" : abbrev(props.node.hash)}
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/pages/session/git-graph/style.ts
+++ b/packages/app/src/pages/session/git-graph/style.ts
@@ -1,0 +1,49 @@
+import { LANE_GAP, PALETTE, RAIL_PAD, ROW_HEIGHT, type GraphLine } from "./model"
+
+export const HEADER_HEIGHT = 30
+export const UNCOMMITTED_COLOR = "#808080"
+export const GRAPH_SHADOW = "var(--background-base)"
+export const GRAPH_LINE_WIDTH = 2
+export const GRAPH_SHADOW_WIDTH = 4
+export const GRAPH_DOT_RADIUS = 4
+export const GRAPH_HEAD_RADIUS = 5
+export const TOOLTIP_WIDTH = 340
+
+const DELTA = ROW_HEIGHT * 0.8
+
+export const color = (idx: number) => PALETTE[idx % PALETTE.length]
+
+export const railWidth = (lanes: number) => lanes * LANE_GAP + RAIL_PAD * 2
+
+export const xForLane = (lane: number) => RAIL_PAD + lane * LANE_GAP
+
+export const yForRow = (row: number) => row * ROW_HEIGHT + ROW_HEIGHT / 2
+
+export const abbrev = (hash: string) => hash.slice(0, 7)
+
+export const ago = (date: number) => {
+  const now = Math.floor(Date.now() / 1000)
+  const diff = now - date
+  if (diff < 60) return "now"
+  if (diff < 3600) return `${Math.floor(diff / 60)}m`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h`
+  if (diff < 604800) return `${Math.floor(diff / 86400)}d`
+  return `${Math.floor(diff / 604800)}w`
+}
+
+export const formatDate = (date: number) => {
+  const d = new Date(date * 1000)
+  return d.toLocaleDateString() + " " + d.toLocaleTimeString()
+}
+
+export const linePath = (line: GraphLine) => {
+  const x1 = xForLane(line.fromLane)
+  const y1 = yForRow(line.fromRow)
+  const x2 = xForLane(line.toLane)
+  const y2 = yForRow(line.toRow)
+
+  if (line.fromLane === line.toLane) return `M ${x1} ${y1} L ${x2} ${y2}`
+
+  const d = Math.min(DELTA, Math.abs(y2 - y1) * 0.5)
+  return `M ${x1} ${y1} C ${x1} ${y1 + d}, ${x2} ${y2 - d}, ${x2} ${y2}`
+}

--- a/packages/app/src/pages/session/git-graph/style.ts
+++ b/packages/app/src/pages/session/git-graph/style.ts
@@ -36,11 +36,11 @@ export const formatDate = (date: number) => {
   return d.toLocaleDateString() + " " + d.toLocaleTimeString()
 }
 
-export const linePath = (line: GraphLine) => {
+export const linePath = (line: GraphLine, yFor = yForRow) => {
   const x1 = xForLane(line.fromLane)
-  const y1 = yForRow(line.fromRow)
+  const y1 = yFor(line.fromRow)
   const x2 = xForLane(line.toLane)
-  const y2 = yForRow(line.toRow)
+  const y2 = yFor(line.toRow)
 
   if (line.fromLane === line.toLane) return `M ${x1} ${y1} L ${x2} ${y2}`
 

--- a/packages/app/src/pages/session/git-graph/tab.tsx
+++ b/packages/app/src/pages/session/git-graph/tab.tsx
@@ -303,6 +303,7 @@ export function GitGraphTab() {
                 nodes={g().nodes}
                 lines={g().lines}
                 lanes={g().lanes}
+                graphWidth={g().graphWidth}
                 currentBranch={data()?.data?.branch}
                 uncommitted={uncommitted()}
                 selectedHash={selectedHash()}

--- a/packages/app/src/pages/session/git-graph/tab.tsx
+++ b/packages/app/src/pages/session/git-graph/tab.tsx
@@ -301,7 +301,7 @@ export function GitGraphTab() {
             >
               <GitGraphList
                 nodes={g().nodes}
-                edges={g().edges}
+                lines={g().lines}
                 lanes={g().lanes}
                 currentBranch={data()?.data?.branch}
                 uncommitted={uncommitted()}

--- a/packages/app/src/pages/session/git-graph/tab.tsx
+++ b/packages/app/src/pages/session/git-graph/tab.tsx
@@ -125,7 +125,7 @@ export function GitGraphTab() {
       let commits = [...raw.data.commits]
       const files = uncommittedFiles()
       if (files.length > 0) {
-        const headCommit = raw.data.commits.find((c) => c.heads.includes(raw.data.head ?? ""))
+        const headCommit = raw.data.commits.find((c) => c.hash === raw.data.head)
         commits = [
           {
             hash: UNCOMMITTED,
@@ -214,10 +214,8 @@ export function GitGraphTab() {
       const raw = data()
       if (raw?.data?.moreAvailable && !loading()) {
         const nextSkip = raw.data.commits.length
-        void load(
-          filter() === "all" ? undefined : filter() === "current" ? (raw.data.head ?? undefined) : filter(),
-          nextSkip,
-        )
+        const current = raw.data.branch ?? raw.data.head ?? undefined
+        void load(filter() === "all" ? undefined : filter() === "current" ? current : filter(), nextSkip)
       }
     }
   }
@@ -225,8 +223,8 @@ export function GitGraphTab() {
   const scrollToHead = () => {
     const graphData = graph()
     if (!graphData || !scroll) return
-    const currentBranch = data()?.data?.head
-    const headNode = graphData.nodes.find((n) => currentBranch && n.heads.includes(currentBranch))
+    const head = data()?.data?.head
+    const headNode = graphData.nodes.find((n) => n.hash === head)
     if (!headNode) return
     const y = headNode.row * ROW_HEIGHT - scroll.clientHeight / 2
     scroll.scrollTo({ top: Math.max(0, y), behavior: "smooth" })
@@ -236,7 +234,8 @@ export function GitGraphTab() {
     if (b === "all") return language.t("session.tab.gitGraph.allBranches") ?? "All Branches"
     if (b === "current")
       return (
-        (language.t("session.tab.gitGraph.currentBranch") ?? "Current Branch") + ` (${data()?.data?.head ?? "HEAD"})`
+        (language.t("session.tab.gitGraph.currentBranch") ?? "Current Branch") +
+        ` (${data()?.data?.branch ?? data()?.data?.head ?? "HEAD"})`
       )
     return b
   }
@@ -244,7 +243,8 @@ export function GitGraphTab() {
   const handleBranchSelect = (b: string | undefined) => {
     if (!b) return
     if (b === filter()) return
-    const apiBranch = b === "all" ? undefined : b === "current" ? data()?.data?.head : b
+    const raw = data()
+    const apiBranch = b === "all" ? undefined : b === "current" ? (raw?.data?.branch ?? raw?.data?.head) : b
     setFilter(b)
     void load(apiBranch ?? undefined)
   }
@@ -303,7 +303,7 @@ export function GitGraphTab() {
                 nodes={g().nodes}
                 edges={g().edges}
                 lanes={g().lanes}
-                currentBranch={data()?.data?.head}
+                currentBranch={data()?.data?.branch}
                 uncommitted={uncommitted()}
                 selectedHash={selectedHash()}
                 onCommitClick={handleCommitClick}
@@ -396,7 +396,7 @@ export function GitGraphTab() {
             dialog.show(() => (
               <DialogMerge
                 hash={m().hash}
-                branch={data()?.data?.head ?? ""}
+                branch={data()?.data?.branch ?? ""}
                 onAction={(opts) => {
                   const args = ["merge", m().hash]
                   if (opts.squash) args.push("--squash")
@@ -412,7 +412,7 @@ export function GitGraphTab() {
             dialog.show(() => (
               <DialogRebase
                 hash={m().hash}
-                branch={data()?.data?.head ?? ""}
+                branch={data()?.data?.branch ?? ""}
                 onAction={(opts) => {
                   const args = ["rebase", m().hash]
                   if (opts.ignoreDate) args.push("--ignore-date")

--- a/packages/app/src/pages/session/git-graph/tab.tsx
+++ b/packages/app/src/pages/session/git-graph/tab.tsx
@@ -18,7 +18,6 @@ import { DialogAddTag } from "@/components/git-graph/dialog-add-tag"
 import { DialogCherryPick } from "@/components/git-graph/dialog-cherry-pick"
 import { computeGraphLayout, UNCOMMITTED, ROW_HEIGHT } from "./model"
 import { GitGraphList } from "./render"
-import { CommitDetail } from "./detail"
 
 export function GitGraphTab() {
   const sdk = useSDK()
@@ -307,16 +306,15 @@ export function GitGraphTab() {
                 currentBranch={data()?.data?.branch}
                 uncommitted={uncommitted()}
                 selectedHash={selectedHash()}
+                selectedParentHash={parentHash()}
                 onCommitClick={handleCommitClick}
+                onCloseDetail={() => setSelectedHash(null)}
                 onContextMenu={handleContextMenu}
               />
             </ScrollView>
           )}
         </Show>
       </div>
-      <Show when={selectedHash()}>
-        {(hash) => <CommitDetail hash={hash()} parentHash={parentHash()} onClose={() => setSelectedHash(null)} />}
-      </Show>
       <Show when={menu()}>
         {(m) => {
           const item = "px-2 py-1 text-xs cursor-pointer hover:bg-surface-hover text-text-base"

--- a/packages/app/src/pages/session/git-graph/tooltip.tsx
+++ b/packages/app/src/pages/session/git-graph/tooltip.tsx
@@ -1,0 +1,131 @@
+import { For, Show } from "solid-js"
+import type { JSX } from "solid-js"
+import type { GraphNode } from "./model"
+import { RefChip, refsFor } from "./refs"
+import { abbrev, formatDate } from "./style"
+
+const Section = (props: { children: JSX.Element }) => (
+  <div class="border-t border-border-weaker-base px-3 py-1">{props.children}</div>
+)
+
+function RefList(props: { refs: ReturnType<typeof refsFor> }) {
+  return (
+    <span class="ml-1 inline-flex max-w-[240px] flex-wrap items-center gap-1 align-middle">
+      <For each={props.refs.slice(0, 8)}>{(ref) => <RefChip item={ref} />}</For>
+      <Show when={props.refs.length > 8}>
+        <span class="text-[11px] text-text-weaker">+{props.refs.length - 8}</span>
+      </Show>
+    </span>
+  )
+}
+
+export function GitGraphTooltip(props: {
+  node: GraphNode
+  color: string
+  side: "left" | "right"
+  currentBranch: string | null
+  uncommitted?: { count: number; files: string[] }
+}) {
+  const refs = () => refsFor(props.node, props.currentBranch)
+  const heads = () => refs().filter((ref) => ref.kind === "head")
+  const remotes = () => refs().filter((ref) => ref.kind === "remote")
+  const tags = () => refs().filter((ref) => ref.kind === "tag")
+
+  return (
+    <div
+      class="relative text-xs text-text-base"
+      style={{
+        width: "340px",
+      }}
+    >
+      <div
+        class="absolute top-1/2 h-0.5 w-6 -translate-y-1/2"
+        classList={{
+          "left-0": props.side === "right",
+          "right-0": props.side === "left",
+        }}
+        style={{ "background-color": props.color }}
+      />
+      <div
+        class="absolute top-1/2 size-2 -translate-y-1/2 rotate-45 border-b border-l border-border-weaker-base bg-surface-base"
+        classList={{
+          "left-[21px]": props.side === "right",
+          "right-[21px]": props.side === "left",
+        }}
+      />
+      <div
+        class="relative overflow-hidden rounded-md border-2 bg-surface-base shadow-lg"
+        classList={{
+          "ml-6": props.side === "right",
+          "mr-6": props.side === "left",
+        }}
+        style={{ "border-color": props.color }}
+      >
+        <div class="px-3 py-1 text-center font-mono text-11-regular font-semibold text-text-base">
+          {props.node.isUncommitted ? "Uncommitted Changes" : `Commit ${abbrev(props.node.hash)}`}
+        </div>
+
+        <Show when={props.currentBranch && !props.node.isUncommitted}>
+          <Section>
+            {props.node.heads.includes(props.currentBranch!) ? (
+              <span>
+                Included in <span class="font-medium text-text-base">HEAD</span>
+              </span>
+            ) : (
+              <span>
+                <b>
+                  <i>Not</i>
+                </b>{" "}
+                included in <span class="font-medium text-text-base">HEAD</span>
+              </span>
+            )}
+          </Section>
+        </Show>
+
+        <Show when={props.node.isUncommitted && props.uncommitted}>
+          <Section>
+            {props.uncommitted!.count} file{props.uncommitted!.count !== 1 ? "s" : ""} changed
+            <div class="mt-1 max-h-[120px] overflow-y-auto">
+              <For each={props.uncommitted!.files.slice(0, 20)}>
+                {(file) => <div class="truncate font-mono text-[10px] text-text-weaker">{file}</div>}
+              </For>
+            </div>
+            <Show when={(props.uncommitted?.files.length ?? 0) > 20}>
+              <div class="mt-0.5 text-text-weaker">...and {props.uncommitted!.files.length - 20} more</div>
+            </Show>
+          </Section>
+        </Show>
+
+        <Show when={heads().length > 0}>
+          <Section>
+            Branches:
+            <RefList refs={heads()} />
+          </Section>
+        </Show>
+
+        <Show when={tags().length > 0}>
+          <Section>
+            Tags:
+            <RefList refs={tags()} />
+          </Section>
+        </Show>
+
+        <Show when={remotes().length > 0}>
+          <Section>
+            Remotes:
+            <RefList refs={remotes()} />
+          </Section>
+        </Show>
+
+        <Show when={!props.node.isUncommitted}>
+          <Section>
+            <div class="text-text-weaker">
+              {props.node.author} · {formatDate(props.node.date)}
+            </div>
+            <div class="mt-1 break-words whitespace-pre-wrap text-text-base">{props.node.message}</div>
+          </Section>
+        </Show>
+      </div>
+    </div>
+  )
+}

--- a/packages/opencode/src/git/git-graph.ts
+++ b/packages/opencode/src/git/git-graph.ts
@@ -1,0 +1,82 @@
+export type Ref = {
+  hash: string
+  name: string
+}
+
+export type Tag = Ref & {
+  annotated: boolean
+}
+
+export type Refs = {
+  head: string | undefined
+  heads: Ref[]
+  tags: Tag[]
+  remotes: Ref[]
+}
+
+const tag = "refs/tags/"
+const head = "refs/heads/"
+const remote = "refs/remotes/"
+const peel = "^{}"
+
+export function parseRefs(text: string): Refs {
+  const heads: Ref[] = []
+  const remotes: Ref[] = []
+  const direct = new Map<string, string>()
+  const peeled = new Map<string, string>()
+  const order: string[] = []
+  const seen = new Set<string>()
+  let current: string | undefined
+
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim()
+    if (!line) continue
+    const idx = line.indexOf(" ")
+    if (idx === -1) continue
+
+    const hash = line.slice(0, idx)
+    const ref = line.slice(idx + 1)
+    if (!hash || !ref) continue
+
+    if (ref === "HEAD") {
+      current = hash
+      continue
+    }
+
+    if (ref.startsWith(head)) {
+      heads.push({ hash, name: ref.slice(head.length) })
+      continue
+    }
+
+    if (ref.startsWith(remote)) {
+      const name = ref.slice(remote.length)
+      if (name.endsWith("/HEAD")) continue
+      remotes.push({ hash, name })
+      continue
+    }
+
+    if (!ref.startsWith(tag)) continue
+
+    const rawtag = ref.slice(tag.length)
+    const name = rawtag.endsWith(peel) ? rawtag.slice(0, -peel.length) : rawtag
+    if (!seen.has(name)) {
+      seen.add(name)
+      order.push(name)
+    }
+    if (rawtag.endsWith(peel)) peeled.set(name, hash)
+    else direct.set(name, hash)
+  }
+
+  const tags: Tag[] = []
+  for (const name of order) {
+    const hash = peeled.get(name)
+    if (hash) {
+      tags.push({ hash, name, annotated: true })
+      continue
+    }
+    const value = direct.get(name)
+    if (value) tags.push({ hash: value, name, annotated: false })
+  }
+
+  return { head: current, heads, tags, remotes }
+}

--- a/packages/opencode/src/git/index.ts
+++ b/packages/opencode/src/git/index.ts
@@ -301,7 +301,7 @@ export namespace Git {
         } else {
           args.push("--all")
         }
-        args.push("--topo-order")
+        args.push("--date-order")
         return (yield* lines(args, { cwd })).map((line) => {
           const [hash, parents, author, email, date, ...rest] = line.split(sep)
           return {
@@ -317,30 +317,37 @@ export namespace Git {
 
       const commitDetails = Effect.fn("Git.commitDetails")(function* (cwd: string, hash: string) {
         const sep = "\x1F"
-        const [meta, rawNameStatus, rawNumstat] = yield* Effect.all(
-          [
-            text(
-              ["log", "-1", `--format=%H${sep}%P${sep}%an${sep}%ae${sep}%at${sep}%cn${sep}%ce${sep}%ct${sep}%B`, hash],
-              { cwd },
-            ),
-            text(["diff-tree", "--name-status", "-r", "--root", "--find-renames", "--diff-filter=AMDR", "-z", hash], {
-              cwd,
-            }),
-            text(["diff-tree", "--numstat", "-r", "--root", "--find-renames", "--diff-filter=AMDR", "-z", hash], {
-              cwd,
-            }),
-          ],
-          { concurrency: 3 },
+        const meta = yield* text(
+          ["log", "-1", `--format=%H${sep}%P${sep}%an${sep}%ae${sep}%at${sep}%cn${sep}%ce${sep}%ct${sep}%B`, hash],
+          { cwd },
         )
 
         const parts = meta.split(sep)
+        const parents = parts[1] ? parts[1].split(" ").filter(Boolean) : []
         const body = parts.slice(9).join(sep).trim()
+        const from = parents.length > 0 ? `${hash}^` : hash
+        const [rawNameStatus, rawNumstat] = yield* Effect.all(
+          parents.length > 0
+            ? [
+                text(["diff", "--name-status", "--find-renames", "--diff-filter=AMDR", "-z", from, hash], { cwd }),
+                text(["diff", "--numstat", "--find-renames", "--diff-filter=AMDR", "-z", from, hash], { cwd }),
+              ]
+            : [
+                text(["diff-tree", "--name-status", "-r", "--root", "--find-renames", "--diff-filter=AMDR", "-z", hash], {
+                  cwd,
+                }),
+                text(["diff-tree", "--numstat", "-r", "--root", "--find-renames", "--diff-filter=AMDR", "-z", hash], {
+                  cwd,
+                }),
+              ],
+          { concurrency: 2 },
+        )
 
         const nameStatus = nuls(rawNameStatus)
-        nameStatus.shift()
+        if (parents.length === 0) nameStatus.shift()
 
         const numstat = nuls(rawNumstat)
-        numstat.shift()
+        if (parents.length === 0) numstat.shift()
 
         const statMap = new Map<string, { additions: number | null; deletions: number | null }>()
         const statOldMap = new Map<string, { additions: number | null; deletions: number | null }>()
@@ -405,7 +412,7 @@ export namespace Git {
 
         return {
           hash: parts[0],
-          parents: parts[1] ? parts[1].split(" ").filter(Boolean) : [],
+          parents,
           author: parts[2],
           authorEmail: parts[3],
           authorDate: parseInt(parts[4], 10),

--- a/packages/opencode/src/git/index.ts
+++ b/packages/opencode/src/git/index.ts
@@ -3,6 +3,7 @@ import * as CrossSpawnSpawner from "@/effect/cross-spawn-spawner"
 import { Effect, Layer, ServiceMap, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { makeRuntime } from "@/effect/run-service"
+import * as Graph from "./git-graph"
 
 export namespace Git {
   const cfg = [
@@ -112,6 +113,7 @@ export namespace Git {
       opts?: { max?: number; branch?: string; skip?: number },
     ) => Effect.Effect<readonly LogItem[]>
     readonly refs: (cwd: string, ...prefixes: string[]) => Effect.Effect<readonly Ref[]>
+    readonly graphRefs: (cwd: string) => Effect.Effect<Graph.Refs>
     readonly commitDetails: (cwd: string, hash: string) => Effect.Effect<CommitDetail>
     readonly fileContent: (cwd: string, hash: string, path: string) => Effect.Effect<string>
   }
@@ -438,6 +440,10 @@ export namespace Git {
         })
       })
 
+      const graphRefs = Effect.fn("Git.graphRefs")(function* (cwd: string) {
+        return Graph.parseRefs(yield* text(["show-ref", "-d", "--head"], { cwd }))
+      })
+
       return Service.of({
         run,
         branch,
@@ -451,6 +457,7 @@ export namespace Git {
         stats,
         log,
         refs,
+        graphRefs,
         commitDetails,
         fileContent,
       })
@@ -511,6 +518,10 @@ export namespace Git {
 
   export function refs(cwd: string, ...prefixes: string[]) {
     return runPromise((git) => git.refs(cwd, ...prefixes))
+  }
+
+  export function graphRefs(cwd: string) {
+    return runPromise((git) => git.graphRefs(cwd))
   }
 
   export function commitDetails(cwd: string, hash: string) {

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -170,6 +170,7 @@ export namespace Vcs {
     .object({
       commits: CommitLogItem.array(),
       head: z.string().nullable(),
+      branch: z.string().nullable(),
       tags: z.string().array(),
       moreAvailable: z.boolean(),
     })
@@ -280,19 +281,17 @@ export namespace Vcs {
         }),
         graph: Effect.fn("Vcs.graph")(function* (opts?: { max?: number; branch?: string; skip?: number }) {
           if (Instance.project.vcs !== "git") {
-            return { commits: [], head: null, tags: [], moreAvailable: false } satisfies GraphResult
+            return { commits: [], head: null, branch: null, tags: [], moreAvailable: false } satisfies GraphResult
           }
           const cwd = Instance.directory
           const max = opts?.max ?? 300
-          const [commits, heads, tags, remotes, head] = yield* Effect.all(
+          const [commits, refs, branch] = yield* Effect.all(
             [
               git.log(cwd, { max: max + 1, branch: opts?.branch, skip: opts?.skip }),
-              git.refs(cwd, "refs/heads/"),
-              git.refs(cwd, "refs/tags/"),
-              git.refs(cwd, "refs/remotes/"),
+              git.graphRefs(cwd),
               git.branch(cwd),
             ],
-            { concurrency: 5 },
+            { concurrency: 3 },
           )
 
           const moreAvailable = commits.length === max + 1
@@ -316,19 +315,19 @@ export namespace Vcs {
             return commit
           })
 
-          for (const ref of heads) {
+          for (const ref of refs.heads) {
             const idx = lookup.get(ref.hash)
             if (idx !== undefined) enriched[idx].heads.push(ref.name)
           }
 
-          for (const ref of tags) {
+          for (const ref of refs.tags) {
             const idx = lookup.get(ref.hash)
             if (idx !== undefined) {
-              enriched[idx].tags.push({ name: ref.name, annotated: ref.type === "tag" })
+              enriched[idx].tags.push({ name: ref.name, annotated: ref.annotated })
             }
           }
 
-          for (const ref of remotes) {
+          for (const ref of refs.remotes) {
             const idx = lookup.get(ref.hash)
             if (idx !== undefined) {
               const slash = ref.name.indexOf("/")
@@ -339,9 +338,15 @@ export namespace Vcs {
             }
           }
 
-          const tagsList = [...new Set(tags.map((t) => t.name))]
+          const tagsList = [...new Set(refs.tags.map((t) => t.name))]
 
-          return { commits: enriched, head: head ?? null, tags: tagsList, moreAvailable } satisfies GraphResult
+          return {
+            commits: enriched,
+            head: refs.head ?? null,
+            branch: branch ?? null,
+            tags: tagsList,
+            moreAvailable,
+          } satisfies GraphResult
         }),
         commitDetails: Effect.fn("Vcs.commitDetails")(function* (hash: string) {
           if (Instance.project.vcs !== "git") {

--- a/packages/opencode/test/git-graph.test.ts
+++ b/packages/opencode/test/git-graph.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test"
+import { parseRefs } from "../src/git/git-graph"
+
+describe("git graph refs", () => {
+  test("parses head, local branches, remotes, and tags", () => {
+    const refs = parseRefs(
+      [
+        "1111111111111111111111111111111111111111 HEAD",
+        "1111111111111111111111111111111111111111 refs/heads/dev",
+        "2222222222222222222222222222222222222222 refs/heads/feature/git-graph",
+        "1111111111111111111111111111111111111111 refs/remotes/origin/dev",
+        "1111111111111111111111111111111111111111 refs/remotes/origin/HEAD",
+        "3333333333333333333333333333333333333333 refs/tags/v1.0.0",
+      ].join("\n"),
+    )
+
+    expect(refs.head).toBe("1111111111111111111111111111111111111111")
+    expect(refs.heads).toEqual([
+      { hash: "1111111111111111111111111111111111111111", name: "dev" },
+      { hash: "2222222222222222222222222222222222222222", name: "feature/git-graph" },
+    ])
+    expect(refs.remotes).toEqual([{ hash: "1111111111111111111111111111111111111111", name: "origin/dev" }])
+    expect(refs.tags).toEqual([{ hash: "3333333333333333333333333333333333333333", name: "v1.0.0", annotated: false }])
+  })
+
+  test("uses peeled hashes for annotated tags", () => {
+    const refs = parseRefs(
+      [
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/tags/v2.0.0",
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb refs/tags/v2.0.0^{}",
+      ].join("\n"),
+    )
+
+    expect(refs.tags).toEqual([{ hash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", name: "v2.0.0", annotated: true }])
+  })
+
+  test("does not duplicate direct and peeled records for one tag", () => {
+    const refs = parseRefs(
+      [
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa refs/tags/v2.0.0",
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb refs/tags/v2.0.0^{}",
+        "cccccccccccccccccccccccccccccccccccccccc refs/tags/v3.0.0",
+      ].join("\n"),
+    )
+
+    expect(refs.tags).toEqual([
+      { hash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", name: "v2.0.0", annotated: true },
+      { hash: "cccccccccccccccccccccccccccccccccccccccc", name: "v3.0.0", annotated: false },
+    ])
+  })
+})

--- a/packages/opencode/test/git-graph.test.ts
+++ b/packages/opencode/test/git-graph.test.ts
@@ -1,5 +1,19 @@
+import { $ } from "bun"
 import { describe, expect, test } from "bun:test"
+import path from "path"
+import { ManagedRuntime } from "effect"
+import { Git } from "../src/git"
 import { parseRefs } from "../src/git/git-graph"
+import { tmpdir } from "./fixture/fixture"
+
+async function withGit<T>(fn: (rt: ManagedRuntime.ManagedRuntime<Git.Service, never>) => Promise<T>) {
+  const rt = ManagedRuntime.make(Git.defaultLayer)
+  try {
+    return await fn(rt)
+  } finally {
+    await rt.dispose()
+  }
+}
 
 describe("git graph refs", () => {
   test("parses head, local branches, remotes, and tags", () => {
@@ -47,5 +61,39 @@ describe("git graph refs", () => {
       { hash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", name: "v2.0.0", annotated: true },
       { hash: "cccccccccccccccccccccccccccccccccccccccc", name: "v3.0.0", annotated: false },
     ])
+  })
+})
+
+describe("git graph commit details", () => {
+  test("shows files changed by a merge commit against its first parent", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await $`git branch -M main`.cwd(tmp.path).quiet()
+    await Bun.write(path.join(tmp.path, "main.txt"), "main\n")
+    await $`git add .`.cwd(tmp.path).quiet()
+    await $`git commit --no-gpg-sign -m "main file"`.cwd(tmp.path).quiet()
+    await $`git checkout -b feature`.cwd(tmp.path).quiet()
+    await Bun.write(path.join(tmp.path, "feature.txt"), "feature\n")
+    await $`git add .`.cwd(tmp.path).quiet()
+    await $`git commit --no-gpg-sign -m "feature file"`.cwd(tmp.path).quiet()
+    await $`git checkout main`.cwd(tmp.path).quiet()
+    await Bun.write(path.join(tmp.path, "main.txt"), "main\nnext\n")
+    await $`git add .`.cwd(tmp.path).quiet()
+    await $`git commit --no-gpg-sign -m "main update"`.cwd(tmp.path).quiet()
+    await $`git merge --no-ff --no-gpg-sign -m "merge feature" feature`.cwd(tmp.path).quiet()
+    const hash = (await $`git rev-parse HEAD`.cwd(tmp.path).quiet().text()).trim()
+
+    await withGit(async (rt) => {
+      const detail = await rt.runPromise(Git.Service.use((git) => git.commitDetails(tmp.path, hash)))
+
+      expect(detail.parents).toHaveLength(2)
+      expect(detail.files).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            status: "A",
+            file: "feature.txt",
+          }),
+        ]),
+      )
+    })
   })
 })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2278,6 +2278,7 @@ export type CommitLogItem = {
 export type VcsGraphResult = {
   commits: Array<CommitLogItem>
   head: string | null
+  branch: string | null
   tags: Array<string>
   moreAvailable: boolean
 }


### PR DESCRIPTION
### Issue for this PR

No issue.

### Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Improves the web UI git graph view to better match vscode-git-graph.

This PR aligns graph layout and branch/ref label rendering, changes commit ordering to date order, fixes merge commit file changes by diffing against the first parent, removes row-hover commit popovers, and moves commit details into an inline expandable panel below the selected commit row with manual height resizing.

### How did you verify your code works?

- `packages/opencode`: `bun test test/git-graph.test.ts`
- `packages/opencode`: `bun typecheck`
- `packages/app`: `bun test --preload ./happydom.ts ./src/pages/session/git-graph/model.test.ts`
- `packages/app`: `bun typecheck`
- Pre-push hook ran `bun turbo typecheck` successfully.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
