### PR TITLE
恢复 Web busy 与 revert guard 行为

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,7 +13,7 @@
 *.py text eol=lf
 *.xml text eol=lf
 *.xsd text eol=lf
-*.tex text eol=lf
+*.tex text=auto
 *.lock text eol=lf
 *.command text eol=lf
 *.sh text eol=lf

--- a/.opencode/skills/response-to-referee/assets/Reply-and-changes.tex
+++ b/.opencode/skills/response-to-referee/assets/Reply-and-changes.tex
@@ -20,12 +20,12 @@
 \author{}
 \maketitle
 
-\noindent\textbf{Manuscript ID:} 
+\noindent\textbf{Manuscript ID:}
 
 
-\noindent\textbf{Title of Paper:} 
+\noindent\textbf{Title of Paper:}
 
-\noindent\textbf{Authors:} 
+\noindent\textbf{Authors:}
 
 We are grateful to referee's comments and suggestions. The following is our response:
 

--- a/docs/rollback-2505/v0.6.0-to-origin-dev-commits.md
+++ b/docs/rollback-2505/v0.6.0-to-origin-dev-commits.md
@@ -1,7 +1,7 @@
 # v0.6.0 到 origin/dev 的主线提交梳理
 
 核查时间：2026-05-09
-更新时间：2026-05-09 21:04 CST
+更新时间：2026-05-10 00:00 CST
 
 核查口径：
 
@@ -11,12 +11,12 @@
 - 终点：`origin/dev` (`28793c96faa28967d2bbbfde13cc92023bc59055`)
 - 提交序列：`git log --first-parent --reverse v0.6.0..origin/dev`
 - 合并进 `origin/dev` 的分支只记录最终合并提交；表中“PR 作者”来自 `gh pr view`，非 PR 提交标记为 `-`。
-- Cherry-pick 核对：对照当前分支 `webui-busy-state` 的 `git log --first-parent --reverse v0.6.0..HEAD`，按 PR 号或 direct 提交主题匹配；表中 `已 cherry-pick` 记录对应的新提交短哈希。
+- Cherry-pick 核对：对照当前分支 `webui-busy-state` 的 `git log --first-parent --reverse v0.6.0..HEAD`，按 PR 号或 direct 提交主题匹配；表中 `已 cherry-pick` 记录对应的新提交短哈希；对未直接 cherry-pick、但已在当前分支手工恢复整合的提交，标记为“已整合”。
 
 | # | Commit / PR | 时间 | 作者 | PR 作者 | 主要修改 | Memory/Skill | 进程/会话补丁 | 已 cherry-pick |
 |---:|---|---|---|---|---|---|---|---|
-| 1 | `2921e43e0` #578 | 2026-05-03 09:24 | Dongshan Jian | yqmaphy | 统一 Web 会话 busy 状态判断，递归检查子会话，busy 时阻止发送；改动 prompt input、sidebar、session timeline 和 working-state。 | 否 | 是 | 否 |
-| 2 | `8db25ce08` #580 | 2026-05-03 10:04 | Dongshan Jian | yqmaphy | busy 会话执行 revert 时改为阻止并提示 Cancel/Fork；同时覆盖 Web、TUI、server route 和 session revert。 | 否 | 是 | 否 |
+| 1 | `2921e43e0` #578 | 2026-05-03 09:24 | Dongshan Jian | yqmaphy | 统一 Web 会话 busy 状态判断，递归检查子会话，busy 时阻止发送；改动 prompt input、sidebar、session timeline 和 working-state。 | 否 | 是 | 已整合 |
+| 2 | `8db25ce08` #580 | 2026-05-03 10:04 | Dongshan Jian | yqmaphy | busy 会话执行 revert 时改为阻止并提示 Cancel/Fork；同时覆盖 Web、TUI、server route 和 session revert。 | 否 | 是 | 已整合 |
 | 3 | `7c815c099` #575 | 2026-05-03 13:49 | Dongshan Jian | dfshfghj | 调整 code editor 样式，使编辑器和 viewer 视觉一致。 | 否 | 否 | 是（`5cc53f75a`） |
 | 4 | `a642f00f7` #581 | 2026-05-03 14:10 | Dongshan Jian | yqmaphy | 注册 `aether://` URL scheme，补充三端更新脚本、launcher handler 和构建/发布脚本。 | 否 | 否 | 是（`c5913bd12`） |
 | 5 | `ca116a79f` #583 | 2026-05-03 14:14 | Dongshan Jian | catmeow123456 | provider 层对 chat completions 剥离 responses-only reasoning options，并补 provider/session LLM 测试。 | 否 | 否 | 是（`150ab8e9d`） |
@@ -26,7 +26,7 @@
 | 9 | `a8068cec6` #587 | 2026-05-03 23:53 | Dongshan Jian | shellmind112 | 修正 skill source 优先级和 `skills.urls` 恢复逻辑，新增优先级测试与文档。 | Skill | 否 | 否 |
 | 10 | `acaa026a4` #589 | 2026-05-03 23:55 | Dongshan Jian | shellmind112 | 增加单个 skill 禁用 evolution 的 UI、配置、server route 和 `skill_manage` 支持。 | Skill | 否 | 否 |
 | 11 | `f8142227f` #591 | 2026-05-03 23:57 | Dongshan Jian | shellmind112 | skill 创建/编辑时优先沿用已有 category 名称，调整 evolution/system prompt 和 skill_manage。 | Skill | 否 | 否 |
-| 12 | `1552b1d27` beta merge | 2026-05-04 14:08 | dsjian | - | 从 `origin/beta` 合入 steering、sidebar、working-state 等小修。 | 否 | 是 | 否 |
+| 12 | `1552b1d27` beta merge | 2026-05-04 14:08 | dsjian | - | 从 `origin/beta` 合入 steering、sidebar、working-state 等小修。 | 否 | 是 | 已整合 |
 | 13 | `e98d418ce` #596 | 2026-05-04 14:32 | Dongshan Jian | shellmind112 | 修复 skill interval/max versions 设置更新时实例被 dispose 的问题，并补配置路由和测试。 | Skill | 否 | 否 |
 | 14 | `0da2b56cb` #604 | 2026-05-04 15:50 | Dongshan Jian | ycx-git | 支持引用 AI 回复继续追问，新增 quote context、选区锚点、comment note 处理和测试。 | 否 | 否 | 否 |
 | 15 | `bbc135fae` #602 | 2026-05-04 15:51 | Dongshan Jian | yqmaphy | 修复微信连接震荡和消息处理失败，改 mobile context 与 wechat 后端。 | 否 | 否 | 是（`2245d0c52`） |
@@ -120,3 +120,9 @@ stop / completion 收口组合：`220f31eeb` + `ef3ed8f9d` + `f0469403b`。#622 
 LLM 结束原因补丁：`3558f0a2a` 不直接改 UI busy，但减少 processor 因 unknown finish reason 误判未完成而造成的状态异常。
 
 当前分支已包含 `316faa994` 的效果；#642 和 #656 两组已被主线回滚，不建议恢复。
+
+### 风险备注
+
+启动恢复 unfinished assistant message 的方案只能作为单后端进程模型下的恢复兜底：程序重启后，旧进程已经不可能继续完成先前的 assistant response，因此在 project instance bootstrap 时把启动前遗留的 unfinished assistant 标记为中断并补 `time.completed`，可以避免 Web/Electron 永久把会话视为 busy。
+
+该方案不能可靠区分“上次进程崩溃遗留”与“另一个后端进程正在同一项目目录中正常生成”。如果两个后端进程同时打开同一个项目目录，其中一个进程启动恢复扫描，可能把另一个进程正在响应的 assistant message 误标为 interrupted/completed。彻底规避需要项目级进程锁、租约或 server instance registry；这超出当前 busy/revert guard 的低侵入修复范围。

--- a/docs/rollback-2505/v0.6.0-to-origin-dev-commits.md
+++ b/docs/rollback-2505/v0.6.0-to-origin-dev-commits.md
@@ -1,6 +1,7 @@
 # v0.6.0 到 origin/dev 的主线提交梳理
 
 核查时间：2026-05-09
+更新时间：2026-05-09 21:04 CST
 
 核查口径：
 
@@ -10,65 +11,112 @@
 - 终点：`origin/dev` (`28793c96faa28967d2bbbfde13cc92023bc59055`)
 - 提交序列：`git log --first-parent --reverse v0.6.0..origin/dev`
 - 合并进 `origin/dev` 的分支只记录最终合并提交；表中“PR 作者”来自 `gh pr view`，非 PR 提交标记为 `-`。
+- Cherry-pick 核对：对照当前分支 `webui-busy-state` 的 `git log --first-parent --reverse v0.6.0..HEAD`，按 PR 号或 direct 提交主题匹配；表中 `已 cherry-pick` 记录对应的新提交短哈希。
 
-| # | Commit / PR | 时间 | 作者 | PR 作者 | 主要修改 | Memory/Skill | 进程/会话补丁 |
-|---:|---|---|---|---|---|---|---|
-| 1 | `2921e43e0` #578 | 2026-05-03 09:24 | Dongshan Jian | yqmaphy | 统一 Web 会话 busy 状态判断，递归检查子会话，busy 时阻止发送；改动 prompt input、sidebar、session timeline 和 working-state。 | 否 | 是 |
-| 2 | `8db25ce08` #580 | 2026-05-03 10:04 | Dongshan Jian | yqmaphy | busy 会话执行 revert 时改为阻止并提示 Cancel/Fork；同时覆盖 Web、TUI、server route 和 session revert。 | 否 | 是 |
-| 3 | `7c815c099` #575 | 2026-05-03 13:49 | Dongshan Jian | dfshfghj | 调整 code editor 样式，使编辑器和 viewer 视觉一致。 | 否 | 否 |
-| 4 | `a642f00f7` #581 | 2026-05-03 14:10 | Dongshan Jian | yqmaphy | 注册 `aether://` URL scheme，补充三端更新脚本、launcher handler 和构建/发布脚本。 | 否 | 否 |
-| 5 | `ca116a79f` #583 | 2026-05-03 14:14 | Dongshan Jian | catmeow123456 | provider 层对 chat completions 剥离 responses-only reasoning options，并补 provider/session LLM 测试。 | 否 | 否 |
-| 6 | `a2e052603` #565 | 2026-05-03 16:03 | Dongshan Jian | shellmind112 | 大规模引入 Skill Evolution：skill 管理/版本/guard/refresh/seed、设置页、文档、watcher 优化和 SDK 更新。 | Skill | 部分 |
-| 7 | `ad640ac01` #585 | 2026-05-03 21:26 | Dongshan Jian | code-JDS | 修复 Linux protocol registration 脚本变量定义顺序。 | 否 | 否 |
-| 8 | `d89f55753` #592 | 2026-05-03 23:49 | Dongshan Jian | Spin-Particle | 移动端连接弹窗补英文 i18n，并整理中英文文案。 | 否 | 否 |
-| 9 | `a8068cec6` #587 | 2026-05-03 23:53 | Dongshan Jian | shellmind112 | 修正 skill source 优先级和 `skills.urls` 恢复逻辑，新增优先级测试与文档。 | Skill | 否 |
-| 10 | `acaa026a4` #589 | 2026-05-03 23:55 | Dongshan Jian | shellmind112 | 增加单个 skill 禁用 evolution 的 UI、配置、server route 和 `skill_manage` 支持。 | Skill | 否 |
-| 11 | `f8142227f` #591 | 2026-05-03 23:57 | Dongshan Jian | shellmind112 | skill 创建/编辑时优先沿用已有 category 名称，调整 evolution/system prompt 和 skill_manage。 | Skill | 否 |
-| 12 | `1552b1d27` beta merge | 2026-05-04 14:08 | dsjian | - | 从 `origin/beta` 合入 steering、sidebar、working-state 等小修。 | 否 | 是 |
-| 13 | `e98d418ce` #596 | 2026-05-04 14:32 | Dongshan Jian | shellmind112 | 修复 skill interval/max versions 设置更新时实例被 dispose 的问题，并补配置路由和测试。 | Skill | 否 |
-| 14 | `0da2b56cb` #604 | 2026-05-04 15:50 | Dongshan Jian | ycx-git | 支持引用 AI 回复继续追问，新增 quote context、选区锚点、comment note 处理和测试。 | 否 | 否 |
-| 15 | `bbc135fae` #602 | 2026-05-04 15:51 | Dongshan Jian | yqmaphy | 修复微信连接震荡和消息处理失败，改 mobile context 与 wechat 后端。 | 否 | 否 |
-| 16 | `e64af134c` #605 | 2026-05-04 15:53 | Dongshan Jian | code-JDS | 增加 skill scan paths command，并让 session prompt/skill loader 支持扫描路径输出。 | Skill | 否 |
-| 17 | `d2ca52e6f` #607 | 2026-05-04 17:12 | Dongshan Jian | code-JDS | 稳定 child session navigation e2e，主要调整 Playwright 测试等待逻辑。 | 否 | 否 |
-| 18 | `d3becbbcd` #594 | 2026-05-04 17:55 | Dongshan Jian | shellmind112 | evolution 关闭时禁用 `skill_manage` 并放宽 edit/write guard，新增 no-skill-guard prompt 和测试。 | Skill | 否 |
-| 19 | `3911f091a` #617 | 2026-05-04 23:48 | yqmaphy | code-JDS | 为 Monaco font option 补齐多语言 i18n key。 | 否 | 否 |
-| 20 | `e1d650e90` #614 | 2026-05-04 23:49 | yqmaphy | code-JDS | 对齐 skill evolution 文档与实际实现。 | Skill | 否 |
-| 21 | `6772f6443` #612 | 2026-05-04 23:52 | yqmaphy | shellmind112 | 增加默认折叠消息设置，影响 general settings、settings context 和 message timeline。 | 否 | 否 |
-| 22 | `87cca3c30` #618 | 2026-05-04 23:55 | yqmaphy | code-JDS | 限制 `summarize_dirs` 只能在显式全仓探索场景使用，调整 agent/session prompts。 | 否 | 否 |
-| 23 | `24bda0d20` #609 | 2026-05-04 23:56 | Dongshan Jian | shellmind112 | 修复 Ctrl+F 搜索栏触发和可见性，改 session、chat-find、timeline。 | 否 | 否 |
-| 24 | `b5db076b5` branch | 2026-05-05 00:46 | dsjian | - | 增加 debugbar 开关设置，并让 layout 按设置显示。 | 否 | 否 |
-| 25 | `220f31eeb` #622 | 2026-05-05 00:49 | Dongshan Jian | yqmaphy | 为 `summarize_dirs` 贯穿 AbortSignal，让停止按钮能取消目录摘要。 | 否 | 是 |
-| 26 | `13ab4ecd5` #621 | 2026-05-05 00:50 | Dongshan Jian | yqmaphy | 移动端连接界面增加重新扫码/配置和启动自动连接，改 mobile route/wechat。 | 否 | 否 |
-| 27 | `fb6e50652` #600 | 2026-05-05 01:12 | Dongshan Jian | catmeow123456 | 升级 AI SDK v6，回迁 LLM 调用链，新增大量 provider/session/system smoke 测试和文档。 | 轻度 Skill | 部分 |
-| 28 | `2fb196bd1` #624 | 2026-05-05 06:30 | yqmaphy | code-JDS | 初版 Git Graph 侧栏视图，新增前端 model/render/tab、后端 git/VCS API、SDK/OpenAPI。 | 否 | 否 |
-| 29 | `b7d283802` #625 | 2026-05-05 11:07 | Dongshan Jian | yqmaphy | 修复 `@` mention 空查询时仍应搜索文件的问题。 | 否 | 否 |
-| 30 | `3975d07e0` #633 | 2026-05-05 16:21 | Dongshan Jian | yqmaphy | 移动端连接弹窗小幅补强，增加界面处理。 | 否 | 否 |
-| 31 | `61cb8bbf8` #635 | 2026-05-05 16:28 | dsjian | yqmaphy | 手动合入 PR 分支，修复浏览器 autofill 并实现 localStorage 凭据自动填充；涉及 login/register/mobile dialogs。 | 否 | 否 |
-| 32 | `dcacc1dee` #628 | 2026-05-05 16:42 | yqmaphy | code-JDS | skill 模块把 `console.log` 替换为 `log.debug`，减少冗余输出。 | Skill | 否 |
-| 33 | `457abbb08` #630 | 2026-05-05 16:43 | yqmaphy | code-JDS | 修复 Electron 打包和显示身份，调整 publish workflow、builder config、desktop main 文件和 launcher。 | 否 | 否 |
-| 34 | `fb0749e59` #636 | 2026-05-05 16:44 | yqmaphy | code-JDS | Git Graph 第三阶段交互增强，更新前端图渲染、VCS API、SDK/OpenAPI。 | 否 | 否 |
-| 35 | `fa35b0700` #638 | 2026-05-05 16:49 | Dongshan Jian | yqmaphy | Git Graph layout 对 undefined commits/parents 加保护。 | 否 | 否 |
-| 36 | `ef3ed8f9d` #640 | 2026-05-05 20:30 | lixfrank | yqmaphy | stop 按钮按下时恢复卡住的 session DB artifacts，改 session index/prompt。 | 否 | 是 |
-| 37 | `b7daf01f3` #642 | 2026-05-05 20:31 | lixfrank | yqmaphy | 尝试修复 Web UI 会话结束后 busy 指示残留，改 working-state 和 processor。 | 否 | 是 |
-| 38 | `5f4bf90a0` revert | 2026-05-05 22:32 | dsjian | - | 回滚 #642 的 stale busy indicators 修复，恢复 LICENSE、working-state、processor。 | 否 | 是 |
-| 39 | `35f02c19c` #654 | 2026-05-06 12:59 | yqmaphy | code-JDS | standalone binary 构建补 Windows PE metadata。 | 否 | 否 |
-| 40 | `88cccc8cc` #652 | 2026-05-06 13:00 | yqmaphy | code-JDS | 修复 Git Graph 无限循环和 VCS panel 闪烁，改 session 与 git-graph tab。 | 否 | 否 |
-| 41 | `97df8392e` #645 | 2026-05-06 13:06 | Dongshan Jian | shellmind112 | session activity log 改写入 cache 下专用文件，并清理 skill evolution/refresh 日志输出。 | Skill | 部分 |
-| 42 | `664968f19` #647 | 2026-05-06 13:11 | Dongshan Jian | Alice-Shimada | memory 增加 inbox-scoped recall 与 reflection catch-up，更新 cron、memory API/tool、设置页、SDK 和测试。 | Memory | 否 |
-| 43 | `031582400` #656 | 2026-05-06 13:27 | Dongshan Jian | yqmaphy | 为 orphaned lease 且 SSE 被 Chrome connection pooling 卡住的场景强制退出。 | 否 | 是 |
-| 44 | `cda85140e` direct | 2026-05-06 15:41 | ycx-git | - | 修复聊天数学公式渲染，兼容 `\\(...\\)` / `\\[...]` 并在渲染前解码 HTML entity，补 marked 测试。 | 否 | 否 |
-| 45 | `5b6904547` #661 | 2026-05-06 17:45 | yqmaphy | code-JDS | 用 `OPENCODE_DISABLE_AUTOUPDATE` 关闭 web-update 和 `/upgrade` endpoints。 | 否 | 否 |
-| 46 | `ac15c02d8` revert | 2026-05-06 21:52 | dsjian | - | 回滚 orphaned lease/SSE stuck 强制退出补丁，移除 web 命令相关逻辑。 | 否 | 是 |
-| 47 | `5a30c47aa` #668 | 2026-05-07 00:04 | Dongshan Jian | yqmaphy | 修复 skill-refresh 注入 synthetic user message 导致 sidebar 显示 `(no text)`。 | Skill | 部分 |
-| 48 | `47ee366c3` #669 | 2026-05-07 00:10 | Dongshan Jian | Spin-Particle | 知识库状态迁移到统一 JSON 持久化，解决跨端口丢失；改 app knowledge context、Electron persist/store、server route。 | 否 | 否 |
-| 49 | `f0469403b` #671 | 2026-05-07 00:10 | Dongshan Jian | yqmaphy | 再次修复 session completion 后 busy indicator 卡住，改 processor 和 prompt。 | 否 | 是 |
-| 50 | `b787bdd4c` #675 | 2026-05-07 11:17 | Dongshan Jian | yqmaphy | basicAuth 放行 PWA manifest 和 favicon 路径。 | 否 | 否 |
-| 51 | `b42343111` direct | 2026-05-07 12:35 | Spin-Particle | - | 修复 electron-vite renderer base override 造成白屏，调整 app Vite 配置。 | 否 | 否 |
-| 52 | `316faa994` direct | 2026-05-07 14:33 | dsjian | - | 支持 base path 下的 PTY websocket，精简 server 路由逻辑并补 web cache 测试。 | 否 | 是 |
-| 53 | `b3478f4d4` #682 | 2026-05-07 20:09 | Dongshan Jian | bzzzzz040806 | memory 增加 backfill 和 scoped pending inbox，大改 memory index/inbox、session 集成、设置页、SDK 和测试。 | Memory | 部分 |
-| 54 | `128bb3e23` #673 | 2026-05-07 20:10 | Dongshan Jian | lixfrank | 引入 agent infrastructure：自定义模式、discipline、permissions、并发/background session、MCP per-agent、mode-switch/task tools 和文档测试。 | 轻度 Skill | 是 |
-| 55 | `3558f0a2a` #684 | 2026-05-07 20:18 | Dongshan Jian | yqmaphy | LLM 返回未知 `finish_reason` 且无 tool calls 时按 stop 处理，避免会话状态异常。 | 否 | 是 |
-| 56 | `9d4516e3d` #681 | 2026-05-07 20:18 | Dongshan Jian | code-JDS | 增加 macOS Intel 发布产物，调整 publish workflow、安装/上传文档和 web-update 测试。 | 否 | 否 |
-| 57 | `8e5c5ad00` #686 | 2026-05-08 06:57 | yqmaphy | code-JDS | Git Graph Phase 4：提交详情面板和 git 操作上下文菜单，新增多种 dialog、VCS endpoints、SDK 和 i18n。 | 否 | 否 |
-| 58 | `8153fb454` #687 | 2026-05-08 14:03 | Dongshan Jian | Spade6-v | 增加语音输入和 Qwen-Omni 转写，包含前端按钮/录音/设置、后端 voice route、README 和 icon。 | 否 | 否 |
-| 59 | `28793c96f` #690 | 2026-05-09 09:53 | yqmaphy | code-JDS | 优化 Git Graph 对齐与 inline details，拆分 columns/layout/row/refs/tooltip/svg，新增后端 git-graph 和测试。 | 否 | 否 |
+| # | Commit / PR | 时间 | 作者 | PR 作者 | 主要修改 | Memory/Skill | 进程/会话补丁 | 已 cherry-pick |
+|---:|---|---|---|---|---|---|---|---|
+| 1 | `2921e43e0` #578 | 2026-05-03 09:24 | Dongshan Jian | yqmaphy | 统一 Web 会话 busy 状态判断，递归检查子会话，busy 时阻止发送；改动 prompt input、sidebar、session timeline 和 working-state。 | 否 | 是 | 否 |
+| 2 | `8db25ce08` #580 | 2026-05-03 10:04 | Dongshan Jian | yqmaphy | busy 会话执行 revert 时改为阻止并提示 Cancel/Fork；同时覆盖 Web、TUI、server route 和 session revert。 | 否 | 是 | 否 |
+| 3 | `7c815c099` #575 | 2026-05-03 13:49 | Dongshan Jian | dfshfghj | 调整 code editor 样式，使编辑器和 viewer 视觉一致。 | 否 | 否 | 是（`5cc53f75a`） |
+| 4 | `a642f00f7` #581 | 2026-05-03 14:10 | Dongshan Jian | yqmaphy | 注册 `aether://` URL scheme，补充三端更新脚本、launcher handler 和构建/发布脚本。 | 否 | 否 | 是（`c5913bd12`） |
+| 5 | `ca116a79f` #583 | 2026-05-03 14:14 | Dongshan Jian | catmeow123456 | provider 层对 chat completions 剥离 responses-only reasoning options，并补 provider/session LLM 测试。 | 否 | 否 | 是（`150ab8e9d`） |
+| 6 | `a2e052603` #565 | 2026-05-03 16:03 | Dongshan Jian | shellmind112 | 大规模引入 Skill Evolution：skill 管理/版本/guard/refresh/seed、设置页、文档、watcher 优化和 SDK 更新。 | Skill | 部分 | 否 |
+| 7 | `ad640ac01` #585 | 2026-05-03 21:26 | Dongshan Jian | code-JDS | 修复 Linux protocol registration 脚本变量定义顺序。 | 否 | 否 | 是（`7d9cafe93`） |
+| 8 | `d89f55753` #592 | 2026-05-03 23:49 | Dongshan Jian | Spin-Particle | 移动端连接弹窗补英文 i18n，并整理中英文文案。 | 否 | 否 | 否 |
+| 9 | `a8068cec6` #587 | 2026-05-03 23:53 | Dongshan Jian | shellmind112 | 修正 skill source 优先级和 `skills.urls` 恢复逻辑，新增优先级测试与文档。 | Skill | 否 | 否 |
+| 10 | `acaa026a4` #589 | 2026-05-03 23:55 | Dongshan Jian | shellmind112 | 增加单个 skill 禁用 evolution 的 UI、配置、server route 和 `skill_manage` 支持。 | Skill | 否 | 否 |
+| 11 | `f8142227f` #591 | 2026-05-03 23:57 | Dongshan Jian | shellmind112 | skill 创建/编辑时优先沿用已有 category 名称，调整 evolution/system prompt 和 skill_manage。 | Skill | 否 | 否 |
+| 12 | `1552b1d27` beta merge | 2026-05-04 14:08 | dsjian | - | 从 `origin/beta` 合入 steering、sidebar、working-state 等小修。 | 否 | 是 | 否 |
+| 13 | `e98d418ce` #596 | 2026-05-04 14:32 | Dongshan Jian | shellmind112 | 修复 skill interval/max versions 设置更新时实例被 dispose 的问题，并补配置路由和测试。 | Skill | 否 | 否 |
+| 14 | `0da2b56cb` #604 | 2026-05-04 15:50 | Dongshan Jian | ycx-git | 支持引用 AI 回复继续追问，新增 quote context、选区锚点、comment note 处理和测试。 | 否 | 否 | 否 |
+| 15 | `bbc135fae` #602 | 2026-05-04 15:51 | Dongshan Jian | yqmaphy | 修复微信连接震荡和消息处理失败，改 mobile context 与 wechat 后端。 | 否 | 否 | 是（`2245d0c52`） |
+| 16 | `e64af134c` #605 | 2026-05-04 15:53 | Dongshan Jian | code-JDS | 增加 skill scan paths command，并让 session prompt/skill loader 支持扫描路径输出。 | Skill | 否 | 否 |
+| 17 | `d2ca52e6f` #607 | 2026-05-04 17:12 | Dongshan Jian | code-JDS | 稳定 child session navigation e2e，主要调整 Playwright 测试等待逻辑。 | 否 | 否 | 是（`b7de9c87d`） |
+| 18 | `d3becbbcd` #594 | 2026-05-04 17:55 | Dongshan Jian | shellmind112 | evolution 关闭时禁用 `skill_manage` 并放宽 edit/write guard，新增 no-skill-guard prompt 和测试。 | Skill | 否 | 否 |
+| 19 | `3911f091a` #617 | 2026-05-04 23:48 | yqmaphy | code-JDS | 为 Monaco font option 补齐多语言 i18n key。 | 否 | 否 | 是（`dcfa5057e`） |
+| 20 | `e1d650e90` #614 | 2026-05-04 23:49 | yqmaphy | code-JDS | 对齐 skill evolution 文档与实际实现。 | Skill | 否 | 否 |
+| 21 | `6772f6443` #612 | 2026-05-04 23:52 | yqmaphy | shellmind112 | 增加默认折叠消息设置，影响 general settings、settings context 和 message timeline。 | 否 | 否 | 否 |
+| 22 | `87cca3c30` #618 | 2026-05-04 23:55 | yqmaphy | code-JDS | 限制 `summarize_dirs` 只能在显式全仓探索场景使用，调整 agent/session prompts。 | 否 | 否 | 否 |
+| 23 | `24bda0d20` #609 | 2026-05-04 23:56 | Dongshan Jian | shellmind112 | 修复 Ctrl+F 搜索栏触发和可见性，改 session、chat-find、timeline。 | 否 | 否 | 否 |
+| 24 | `b5db076b5` branch | 2026-05-05 00:46 | dsjian | - | 增加 debugbar 开关设置，并让 layout 按设置显示。 | 否 | 否 | 否 |
+| 25 | `220f31eeb` #622 | 2026-05-05 00:49 | Dongshan Jian | yqmaphy | 为 `summarize_dirs` 贯穿 AbortSignal，让停止按钮能取消目录摘要。 | 否 | 是 | 否 |
+| 26 | `13ab4ecd5` #621 | 2026-05-05 00:50 | Dongshan Jian | yqmaphy | 移动端连接界面增加重新扫码/配置和启动自动连接，改 mobile route/wechat。 | 否 | 否 | 否 |
+| 27 | `fb6e50652` #600 | 2026-05-05 01:12 | Dongshan Jian | catmeow123456 | 升级 AI SDK v6，回迁 LLM 调用链，新增大量 provider/session/system smoke 测试和文档。 | 轻度 Skill | 部分 | 否 |
+| 28 | `2fb196bd1` #624 | 2026-05-05 06:30 | yqmaphy | code-JDS | 初版 Git Graph 侧栏视图，新增前端 model/render/tab、后端 git/VCS API、SDK/OpenAPI。 | 否 | 否 | 是（`b79b3b9f9`） |
+| 29 | `b7d283802` #625 | 2026-05-05 11:07 | Dongshan Jian | yqmaphy | 修复 `@` mention 空查询时仍应搜索文件的问题。 | 否 | 否 | 是（`4cdfaea89`） |
+| 30 | `3975d07e0` #633 | 2026-05-05 16:21 | Dongshan Jian | yqmaphy | 移动端连接弹窗小幅补强，增加界面处理。 | 否 | 否 | 是（`b5b28921e`） |
+| 31 | `61cb8bbf8` #635 | 2026-05-05 16:28 | dsjian | yqmaphy | 手动合入 PR 分支，修复浏览器 autofill 并实现 localStorage 凭据自动填充；涉及 login/register/mobile dialogs。 | 否 | 否 | 否 |
+| 32 | `dcacc1dee` #628 | 2026-05-05 16:42 | yqmaphy | code-JDS | skill 模块把 `console.log` 替换为 `log.debug`，减少冗余输出。 | Skill | 否 | 否 |
+| 33 | `457abbb08` #630 | 2026-05-05 16:43 | yqmaphy | code-JDS | 修复 Electron 打包和显示身份，调整 publish workflow、builder config、desktop main 文件和 launcher。 | 否 | 否 | 是（`7db60c8bf`） |
+| 34 | `fb0749e59` #636 | 2026-05-05 16:44 | yqmaphy | code-JDS | Git Graph 第三阶段交互增强，更新前端图渲染、VCS API、SDK/OpenAPI。 | 否 | 否 | 是（`336a8fa1e`） |
+| 35 | `fa35b0700` #638 | 2026-05-05 16:49 | Dongshan Jian | yqmaphy | Git Graph layout 对 undefined commits/parents 加保护。 | 否 | 否 | 是（`c884b98af`） |
+| 36 | `ef3ed8f9d` #640 | 2026-05-05 20:30 | lixfrank | yqmaphy | stop 按钮按下时恢复卡住的 session DB artifacts，改 session index/prompt。 | 否 | 是 | 否 |
+| 37 | `b7daf01f3` #642 | 2026-05-05 20:31 | lixfrank | yqmaphy | 尝试修复 Web UI 会话结束后 busy 指示残留，改 working-state 和 processor。 | 否 | 是 | 否 |
+| 38 | `5f4bf90a0` revert | 2026-05-05 22:32 | dsjian | - | 回滚 #642 的 stale busy indicators 修复，恢复 LICENSE、working-state、processor。 | 否 | 是 | 否 |
+| 39 | `35f02c19c` #654 | 2026-05-06 12:59 | yqmaphy | code-JDS | standalone binary 构建补 Windows PE metadata。 | 否 | 否 | 是（`372a8a920`） |
+| 40 | `88cccc8cc` #652 | 2026-05-06 13:00 | yqmaphy | code-JDS | 修复 Git Graph 无限循环和 VCS panel 闪烁，改 session 与 git-graph tab。 | 否 | 否 | 是（`047b0941b`） |
+| 41 | `97df8392e` #645 | 2026-05-06 13:06 | Dongshan Jian | shellmind112 | session activity log 改写入 cache 下专用文件，并清理 skill evolution/refresh 日志输出。 | Skill | 部分 | 否 |
+| 42 | `664968f19` #647 | 2026-05-06 13:11 | Dongshan Jian | Alice-Shimada | memory 增加 inbox-scoped recall 与 reflection catch-up，更新 cron、memory API/tool、设置页、SDK 和测试。 | Memory | 否 | 否 |
+| 43 | `031582400` #656 | 2026-05-06 13:27 | Dongshan Jian | yqmaphy | 为 orphaned lease 且 SSE 被 Chrome connection pooling 卡住的场景强制退出。 | 否 | 是 | 否 |
+| 44 | `cda85140e` direct | 2026-05-06 15:41 | ycx-git | - | 修复聊天数学公式渲染，兼容 `\\(...\\)` / `\\[...]` 并在渲染前解码 HTML entity，补 marked 测试。 | 否 | 否 | 是（`4d07fdad1`） |
+| 45 | `5b6904547` #661 | 2026-05-06 17:45 | yqmaphy | code-JDS | 用 `OPENCODE_DISABLE_AUTOUPDATE` 关闭 web-update 和 `/upgrade` endpoints。 | 否 | 否 | 是（`6ce9d362f`） |
+| 46 | `ac15c02d8` revert | 2026-05-06 21:52 | dsjian | - | 回滚 orphaned lease/SSE stuck 强制退出补丁，移除 web 命令相关逻辑。 | 否 | 是 | 否 |
+| 47 | `5a30c47aa` #668 | 2026-05-07 00:04 | Dongshan Jian | yqmaphy | 修复 skill-refresh 注入 synthetic user message 导致 sidebar 显示 `(no text)`。 | Skill | 部分 | 否 |
+| 48 | `47ee366c3` #669 | 2026-05-07 00:10 | Dongshan Jian | Spin-Particle | 知识库状态迁移到统一 JSON 持久化，解决跨端口丢失；改 app knowledge context、Electron persist/store、server route。 | 否 | 否 | 是（`3f96fd787`） |
+| 49 | `f0469403b` #671 | 2026-05-07 00:10 | Dongshan Jian | yqmaphy | 再次修复 session completion 后 busy indicator 卡住，改 processor 和 prompt。 | 否 | 是 | 否 |
+| 50 | `b787bdd4c` #675 | 2026-05-07 11:17 | Dongshan Jian | yqmaphy | basicAuth 放行 PWA manifest 和 favicon 路径。 | 否 | 否 | 是（`e45f7ebc0`） |
+| 51 | `b42343111` direct | 2026-05-07 12:35 | Spin-Particle | - | 修复 electron-vite renderer base override 造成白屏，调整 app Vite 配置。 | 否 | 否 | 是（`7049f1770`） |
+| 52 | `316faa994` direct | 2026-05-07 14:33 | dsjian | - | 支持 base path 下的 PTY websocket，精简 server 路由逻辑并补 web cache 测试。 | 否 | 是 | 是（`534a08b0d`） |
+| 53 | `b3478f4d4` #682 | 2026-05-07 20:09 | Dongshan Jian | bzzzzz040806 | memory 增加 backfill 和 scoped pending inbox，大改 memory index/inbox、session 集成、设置页、SDK 和测试。 | Memory | 部分 | 否 |
+| 54 | `128bb3e23` #673 | 2026-05-07 20:10 | Dongshan Jian | lixfrank | 引入 agent infrastructure：自定义模式、discipline、permissions、并发/background session、MCP per-agent、mode-switch/task tools 和文档测试。 | 轻度 Skill | 是 | 否 |
+| 55 | `3558f0a2a` #684 | 2026-05-07 20:18 | Dongshan Jian | yqmaphy | LLM 返回未知 `finish_reason` 且无 tool calls 时按 stop 处理，避免会话状态异常。 | 否 | 是 | 否 |
+| 56 | `9d4516e3d` #681 | 2026-05-07 20:18 | Dongshan Jian | code-JDS | 增加 macOS Intel 发布产物，调整 publish workflow、安装/上传文档和 web-update 测试。 | 否 | 否 | 是（`be5a2cfb5`） |
+| 57 | `8e5c5ad00` #686 | 2026-05-08 06:57 | yqmaphy | code-JDS | Git Graph Phase 4：提交详情面板和 git 操作上下文菜单，新增多种 dialog、VCS endpoints、SDK 和 i18n。 | 否 | 否 | 是（`b8304de50`） |
+| 58 | `8153fb454` #687 | 2026-05-08 14:03 | Dongshan Jian | Spade6-v | 增加语音输入和 Qwen-Omni 转写，包含前端按钮/录音/设置、后端 voice route、README 和 icon。 | 否 | 否 | 是（`489f636c3`） |
+| 59 | `28793c96f` #690 | 2026-05-09 09:53 | yqmaphy | code-JDS | 优化 Git Graph 对齐与 inline details，拆分 columns/layout/row/refs/tooltip/svg，新增后端 git-graph 和测试。 | 否 | 否 | 是（`8b9ca8517`） |
+
+## 进程/会话补丁详析
+
+本节只整理与 session 状态、会话恢复、停止/取消、revert/fork、Web server 连接生命周期、LLM 结束原因相关的提交。凡主效应属于 skill evolution 或 memory 机制的提交，即使触碰 `session` 代码，也不纳入候选。
+
+### 纳入候选
+
+`2921e43e0` #578：统一 Web busy 状态判断。核心是扩展 `createWorkingState`，把父会话的 busy 判断递归到子会话；sidebar、timeline、composer、prompt submit 都开始依赖统一 busy 状态。效果是子会话忙时，父会话也显示或表现为忙，并阻止继续发送。
+
+`8db25ce08` #580：busy 时阻止 revert。Web 侧弹 `session-busy` 保护弹窗，只给 Cancel/Fork；server route 捕获 `Session.BusyError` 返回 409；`SessionRevert.revert` 前置 `SessionPrompt.assertNotBusy`；TUI 也把 busy revert 改成 Cancel/Fork。效果是避免运行中的会话被 revert 破坏状态。
+
+`1552b1d27` beta merge：#578 后续语义修正。把多个 UI 使用点从 `visual` 改为 `interactive`，并让 interactive 也考虑 pending assistant message。它和 #578 修改同一套 busy 逻辑，不能孤立看；如果恢复 #578，通常也要吸收这部分后续修正。
+
+`220f31eeb` #622：让 `summarize_dirs` 支持 AbortSignal。`ctx.abort` 被传进目录遍历和 LLM 摘要调用，stop 按钮能真正中断长时间目录摘要，而不只是把 session 状态改成 idle。
+
+`ef3ed8f9d` #640：stop 后恢复卡住的 DB artifacts。新增 `Session.recoverStuckParts`：把未完成 tool part 标 error，把未完成 assistant message 补 `time.completed`。`SessionPrompt.cancel` 无论是否找到 active controller 都会做恢复。解决 stop 后 UI 仍认为 session busy 的一类根因。
+
+`f0469403b` #671：再次修复 completion 后 busy indicator 卡住。重点是 processor 不再在 error 分支里立刻 `SessionStatus.set(idle)`，而是等 assistant message 写入 `time.completed` 后再置 idle；cancel 也改成先 recover stuck parts，再统一 idle。它是 #642 被回滚后的替代修正。
+
+`316faa994` direct：base path 下 PTY websocket。当前分支已经以 `534a08b0d` cherry-pick 进来了。它把 server 改成 Hono `route(basePath, app).route("/", app)`，让 websocket upgrade 也走 base path，不再依赖手写 API path 白名单。
+
+`3558f0a2a` #684：处理 provider 返回 unknown `finish_reason`。LLM stream 中如果 raw 是 `unknown`：有 tool call 就归一为 `tool-calls`，没有 tool call 就归一为 `stop`；prompt loop 不再把 `unknown` 当成未完成状态。效果是减少 session 因结束原因异常而继续循环或状态异常。
+
+### 回滚对
+
+`b7daf01f3` #642 与 `5f4bf90a0` revert 是一组完整回滚。#642 曾尝试解决 Web UI busy indicator 残留：一边改 `working-state.interactive`，一边延后 processor 的 idle 写入。但它随后被完整回滚，所以主线净效果为 0。后续真正保留下来的同类修正是 `f0469403b` #671，不应单独恢复 #642。
+
+`031582400` #656 与 `ac15c02d8` revert 是另一组完整回滚。#656 处理 orphaned lease + Chrome connection pooling 导致 SSE/pending 卡住的问题：lease 归零但 active/sse 仍存在时，30 秒后强制 shutdown。随后 `ac15c02d8` 完整回滚，主线净效果为 0，不应作为要恢复的补丁。
+
+### 边界项
+
+`128bb3e23` #673 不属于 skill evolution 或 memory，但它是大型 agent infrastructure：background session、并发槽位、task mode、discipline、permission intersection、session schema、fallback model 链等。它确实涉及 session/process，但不是 busy/stop/revert 小补丁。建议独立专题评估，不和这批补丁混合 cherry-pick。
+
+`fb6e50652` #600 是 AI SDK v6 迁移，触碰 LLM/session/processor/revert/summary，但主效应是 provider/SDK 迁移和系统测试，不是进程/会话稳定性小补丁。风险和改动面都很大，不建议纳入这批。
+
+`97df8392e` #645、`5a30c47aa` #668 与 skill refresh/evolution 直接相关，按本轮规则排除。`664968f19` #647、`b3478f4d4` #682 与 memory 机制直接相关，按本轮规则排除。
+
+### 组合效果
+
+Web busy / revert guard 组合：`2921e43e0` + `1552b1d27` + `8db25ce08`。前两者统一 busy 判断与 UI 交互语义，#580 在此基础上阻止 busy revert，并补 server/TUI 兜底。
+
+stop / completion 收口组合：`220f31eeb` + `ef3ed8f9d` + `f0469403b`。#622 让长工具能响应 stop；#640 清理已卡住的 part/message；#671 修正新一轮处理结束时 idle 与 message completion 的写入顺序。
+
+LLM 结束原因补丁：`3558f0a2a` 不直接改 UI busy，但减少 processor 因 unknown finish reason 误判未完成而造成的状态异常。
+
+当前分支已包含 `316faa994` 的效果；#642 和 #656 两组已被主线回滚，不建议恢复。

--- a/docs/session-busy/implementation-plan.md
+++ b/docs/session-busy/implementation-plan.md
@@ -1,0 +1,210 @@
+# Session Busy and Revert Guard Plan
+
+## Goal
+
+Restore the final behavior intended by `2921e43e0`, `1552b1d27`, and `8db25ce08` without replaying their intermediate implementation states. The desired result is a single, consistent busy model used by Web UI state indicators, message submission, revert/restore guards, backend safety checks, and TUI revert flows.
+
+The user-facing rule is:
+
+- If the current session or any descendant session is still working, do not let users accidentally send another prompt or mutate session history through revert/restore.
+- Give users a clear explanation and safe alternatives: stop the task first, cancel the operation, or fork from the selected point.
+
+The system-facing rule is:
+
+- Busy state must not be duplicated with slightly different logic across components.
+- Dangerous history mutation must have both UI-level prevention and backend-level enforcement.
+
+## Why Not Cherry-Pick
+
+The three historical commits form an evolution chain rather than independent patches:
+
+- `2921e43e0` introduced recursive Web busy checks and blocked send while busy.
+- `8db25ce08` added busy revert protection on top of that behavior.
+- `1552b1d27` corrected the `visual` versus `interactive` busy semantics afterward.
+
+Cherry-picking them one by one would reintroduce intermediate states, merge-commit noise, and behavior that has since been partially absorbed or changed. A fresh implementation should restore the final intended behavior and close known gaps such as descendant pending messages, restore feedback, API `unrevert` consistency, and undo/redo bypasses.
+
+## Implementation Plan
+
+### 1. Unified Web Busy State
+
+Extend `packages/app/src/utils/working-state.ts` so one helper can answer both display and interaction questions.
+
+Busy sources:
+
+- Current session status is `busy` or `retry`.
+- Current session has an assistant message without `time.completed`.
+- Any descendant session is busy by the same rules.
+
+Safety:
+
+- Descendant traversal must use a `seen` set so corrupt or cyclic session data cannot recurse forever.
+- `visual` remains appropriate for display and grace animation.
+- `interactive` is strict and is used to block sending, revert, restore, and command actions.
+
+User effect:
+
+- Parent sessions show and behave as busy while child work is still running.
+- The UI does not prematurely become interactive when an assistant message is still unfinished.
+
+System necessity:
+
+- This removes duplicated partial busy checks from individual components.
+- It establishes one consistent source of truth for later guards.
+
+### 2. Prompt Input and Submit Guard
+
+Wire the unified busy state into:
+
+- `packages/app/src/components/prompt-input.tsx`
+- `packages/app/src/components/prompt-input/submit.ts`
+
+Behavior:
+
+- Pressing Enter while busy does not send a new prompt.
+- The submit handler performs the same busy check before it builds and sends a request.
+- The stop action remains available when the session is working.
+
+User effect:
+
+- Users cannot accidentally start a second prompt while current or descendant work is still in progress.
+- Keyboard and button behavior match the session state.
+
+System necessity:
+
+- The prompt input is the visible entry point.
+- The submit handler is the final safety gate before creating a new user message.
+
+### 3. Sidebar, Timeline, and Composer State
+
+Wire the unified busy state into:
+
+- `packages/app/src/pages/layout/sidebar-items.tsx`
+- `packages/app/src/pages/session/message-timeline.tsx`
+- `packages/app/src/pages/session/composer/session-composer-state.ts`
+
+Behavior:
+
+- Sidebar session items reflect descendant work.
+- Timeline working indicators follow strict interactive busy state.
+- Composer stays live while current or descendant work is active.
+
+User effect:
+
+- Users see why actions are blocked.
+- Session list, message timeline, and input area do not disagree about whether the session is working.
+
+System necessity:
+
+- Blocking actions without matching state indicators creates confusing behavior.
+- These components are the state surface for the guard behavior.
+
+### 4. Web Revert and Restore Guard
+
+Wire the same busy state into:
+
+- `packages/app/src/pages/session.tsx`
+- `packages/app/src/components/dialog-revert-confirm.tsx`
+- `packages/app/src/pages/session/helpers.ts`
+- `packages/app/src/i18n/en.ts`
+- `packages/app/src/i18n/zh.ts`
+
+Behavior:
+
+- Revert is blocked while current or descendant work is busy.
+- Restore/unrevert is also blocked while busy.
+- Busy revert/restore shows a clear dialog instead of silently doing nothing.
+- The dialog offers cancel and, where applicable, fork.
+
+User effect:
+
+- Users cannot roll back session history or files while work is in progress.
+- Users understand the reason and have a safe branch-based alternative.
+
+System necessity:
+
+- Revert and restore mutate message history and file snapshots.
+- This is the highest-risk user action while a task is running.
+
+### 5. Backend Revert Safeguards
+
+Update:
+
+- `packages/opencode/src/session/revert.ts`
+- `packages/opencode/src/server/routes/session.ts`
+
+Behavior:
+
+- `SessionRevert.revert` asserts the session is not busy.
+- `SessionRevert.unrevert` keeps the existing busy assertion.
+- API routes for both revert and unrevert return HTTP 409 for `Session.BusyError`.
+
+User/API effect:
+
+- Direct API calls and races cannot bypass the same-session busy guard.
+- Clients receive a clear busy response instead of a generic failure.
+
+System necessity:
+
+- UI checks are not security or consistency boundaries.
+- Backend enforcement is required for TUI, SDK, scripts, and request races.
+
+### 6. TUI Revert Guard
+
+Update:
+
+- `packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx`
+
+Behavior:
+
+- Revert from the TUI message dialog is blocked while the current session is busy or has an unfinished assistant message.
+- The dialog offers Cancel/Fork.
+
+User effect:
+
+- Terminal users get the same safe revert behavior as Web users.
+
+System necessity:
+
+- TUI is a real client, not a test path.
+- Backend 409 protects data, but TUI should still present a useful user-facing choice.
+
+### 7. Undo and Redo Consistency
+
+Update:
+
+- `packages/app/src/pages/session/use-session-commands.tsx`
+- TUI command paths only if needed for consistency with existing behavior.
+
+Behavior:
+
+- Undo/redo must not automatically abort and continue with history mutation.
+- Busy undo/redo is blocked and reported to the user.
+
+User effect:
+
+- Command palette actions cannot bypass the message menu protection.
+- Users must explicitly stop work before history mutation.
+
+System necessity:
+
+- Undo/redo are revert/unrevert paths.
+- Allowing them to auto-abort and proceed would break the system-wide guard model.
+
+## Validation
+
+Required focused checks:
+
+- Current session status busy blocks Enter and Web revert.
+- Current session pending assistant with idle status is still treated as busy.
+- Descendant busy and descendant pending assistant make the parent busy.
+- Busy Web revert shows the busy dialog and does not call revert.
+- Busy restore shows feedback and does not call unrevert.
+- Busy API revert/unrevert returns 409.
+- Idle revert still allows existing inherited-prefix and descendant-branch protection.
+- TUI busy message revert shows Cancel/Fork.
+- Busy undo/redo does not mutate history.
+
+## Scope Control
+
+This change must not modify unrelated UI, formatting, SDK generation, provider behavior, memory, skill evolution, or general session processor behavior. Any change outside the files named above needs separate approval.

--- a/packages/app/src/components/dialog-revert-confirm.tsx
+++ b/packages/app/src/components/dialog-revert-confirm.tsx
@@ -24,6 +24,10 @@ const reasonDescriptions: Record<RevertProtectionReason, { titleKey: string; des
     titleKey: "dialog.revert.protected.incompleteTurnInheritedPrefix.title",
     descKey: "dialog.revert.protected.incompleteTurnInheritedPrefix.description",
   },
+  "session-busy": {
+    titleKey: "dialog.revert.protected.sessionBusy.title",
+    descKey: "dialog.revert.protected.sessionBusy.description",
+  },
 }
 
 export const DialogRevertConfirm: Component<DialogRevertConfirmProps> = (props) => {
@@ -60,9 +64,11 @@ export const DialogRevertConfirm: Component<DialogRevertConfirmProps> = (props) 
             <Button variant="ghost" onClick={close}>
               {language.t("common.cancel")}
             </Button>
-            <Button variant="secondary" onClick={fork}>
-              {language.t("dialog.revert.forkAction")}
-            </Button>
+            {props.onFork ? (
+              <Button variant="secondary" onClick={fork}>
+                {language.t("dialog.revert.forkAction")}
+              </Button>
+            ) : null}
           </div>
         ) : (
           <div class="flex justify-end gap-2">

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -61,7 +61,8 @@ import { promptPlaceholder } from "./prompt-input/placeholder"
 import { ImagePreview } from "@opencode-ai/ui/image-preview"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { KnowledgeButton } from "@/components/knowledge-button"
-import { createWorkingState } from "@/utils/working-state"
+import { createWorkingState, type ChildrenSource } from "@/utils/working-state"
+import { childMapByParent } from "@/pages/layout/helpers"
 import { SteerButton } from "@/components/steer-button"
 import { DialogDefaultSkills } from "@/components/dialog-default-skills"
 import { VoiceInputButton } from "@/components/voice-input-button"
@@ -279,7 +280,20 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       (msg) => msg.role === "assistant" && typeof msg.time.completed !== "number",
     ),
   )
-  const { interactive: working } = createWorkingState({ status: () => status(), pending: () => pending() })
+  const children = createMemo<ChildrenSource>(() => ({
+    childMap: () => childMapByParent(sync.data.session),
+    status: (id) => sync.data.session_status[id],
+    pending: (id) =>
+      (sync.data.message[id] ?? []).findLast(
+        (msg) => msg.role === "assistant" && typeof msg.time.completed !== "number",
+      ),
+  }))
+  const { interactive: working } = createWorkingState({
+    status: () => status(),
+    pending: () => pending(),
+    sessionID: () => params.id,
+    children: () => children(),
+  })
   const tip = () => {
     if (working()) {
       return (
@@ -1281,18 +1295,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault()
       if (event.repeat) return
-      if (
-        working() &&
-        prompt
-          .current()
-          .map((part) => ("content" in part ? part.content : ""))
-          .join("")
-          .trim().length === 0 &&
-        imageAttachments().length === 0 &&
-        commentCount() === 0
-      ) {
-        return
-      }
+      if (working()) return
       handleSubmit(event)
     }
   }

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -435,13 +435,17 @@ export function createPromptSubmit(input: PromptSubmitInput) {
   const handleSubmit = async (event: Event) => {
     event.preventDefault()
 
+    if (input.working()) {
+      abort()
+      return
+    }
+
     const currentPrompt = prompt.current()
     const text = currentPrompt.map((part) => ("content" in part ? part.content : "")).join("")
     const images = input.imageAttachments().slice()
     const mode = input.mode()
 
     if (text.trim().length === 0 && images.length === 0 && input.commentCount() === 0) {
-      if (input.working()) abort()
       return
     }
 

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -350,6 +350,8 @@ export const dict = {
   "dialog.revert.protected.descendantBranch.description": "A branch session already depends on messages at or after this point. Reverting would break that branch's connection. You can fork from this point to create a new branch instead.",
   "dialog.revert.protected.incompleteTurnInheritedPrefix.title": "Cannot revert here",
   "dialog.revert.protected.incompleteTurnInheritedPrefix.description": "The assistant has not finished responding to this message yet, so the system cannot determine whether this turn is within the inherited conversation history. To avoid modifying shared history, a fork is recommended. You can fork from this point to create a new branch instead.",
+  "dialog.revert.protected.sessionBusy.title": "Cannot revert while task is running",
+  "dialog.revert.protected.sessionBusy.description": "A task is still running in this session or one of its child sessions. Stop the task before changing session history.",
 
   "dialog.directory.search.placeholder": "Search folders",
   "dialog.directory.empty": "No subfolders in this directory",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -349,9 +349,10 @@ export const dict = {
   "dialog.revert.protected.descendantBranch.title": "Cannot revert here",
   "dialog.revert.protected.descendantBranch.description": "A branch session already depends on messages at or after this point. Reverting would break that branch's connection. You can fork from this point to create a new branch instead.",
   "dialog.revert.protected.incompleteTurnInheritedPrefix.title": "Cannot revert here",
-  "dialog.revert.protected.incompleteTurnInheritedPrefix.description": "The assistant has not finished responding to this message yet, so the system cannot determine whether this turn is within the inherited conversation history. To avoid modifying shared history, a fork is recommended. You can fork from this point to create a new branch instead.",
   "dialog.revert.protected.sessionBusy.title": "Cannot revert while task is running",
   "dialog.revert.protected.sessionBusy.description": "A task is still running in this session or one of its child sessions. Stop the task before changing session history.",
+  "dialog.revert.protected.incompleteTurnInheritedPrefix.description":
+    "The assistant has not finished responding to this message yet, so the system cannot determine whether this turn is within the inherited conversation history. To avoid modifying shared history, a fork is recommended. You can fork from this point to create a new branch instead.",
 
   "dialog.directory.search.placeholder": "Search folders",
   "dialog.directory.empty": "No subfolders in this directory",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -341,16 +341,17 @@ export const dict = {
   "dialog.fork.empty": "No messages to fork from",
 
   "dialog.revert.confirm.title": "Revert to this point?",
-  "dialog.revert.confirm.description": "This will discard all messages after the selected point and restore files to their earlier state. This action cannot be undone.",
+  "dialog.revert.confirm.description":
+    "This will discard all messages after the selected point and restore files to their earlier state. This action cannot be undone.",
   "dialog.revert.confirmAction": "Revert",
   "dialog.revert.forkAction": "Fork instead",
   "dialog.revert.protected.inheritedPrefix.title": "Cannot revert here",
-  "dialog.revert.protected.inheritedPrefix.description": "This message belongs to the parent session's conversation history. Reverting it would modify shared history that other branches depend on. You can fork from this point to create a new branch instead.",
+  "dialog.revert.protected.inheritedPrefix.description":
+    "This message belongs to the parent session's conversation history. Reverting it would modify shared history that other branches depend on. You can fork from this point to create a new branch instead.",
   "dialog.revert.protected.descendantBranch.title": "Cannot revert here",
-  "dialog.revert.protected.descendantBranch.description": "A branch session already depends on messages at or after this point. Reverting would break that branch's connection. You can fork from this point to create a new branch instead.",
+  "dialog.revert.protected.descendantBranch.description":
+    "A branch session already depends on messages at or after this point. Reverting would break that branch's connection. You can fork from this point to create a new branch instead.",
   "dialog.revert.protected.incompleteTurnInheritedPrefix.title": "Cannot revert here",
-  "dialog.revert.protected.sessionBusy.title": "Cannot revert while task is running",
-  "dialog.revert.protected.sessionBusy.description": "A task is still running in this session or one of its child sessions. Stop the task before changing session history.",
   "dialog.revert.protected.incompleteTurnInheritedPrefix.description":
     "The assistant has not finished responding to this message yet, so the system cannot determine whether this turn is within the inherited conversation history. To avoid modifying shared history, a fork is recommended. You can fork from this point to create a new branch instead.",
 
@@ -363,6 +364,9 @@ export const dict = {
   "dialog.directory.create.title": "Create folder",
   "dialog.directory.create.message": "This directory does not exist. Create this folder?",
   "dialog.directory.create.action": "Create",
+  "dialog.revert.protected.sessionBusy.title": "Cannot revert while task is running",
+  "dialog.revert.protected.sessionBusy.description":
+    "A task is still running in this session or one of its child sessions. Stop the task before changing session history.",
 
   "app.server.unreachable": "Could not reach {{server}}",
   "app.server.retrying": "Retrying automatically...",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -366,6 +366,8 @@ export const dict = {
   "dialog.revert.protected.descendantBranch.description": "已有分支会话依赖此位置或之后的消息。重置会破坏该分支的连接。可以从这里分叉，创建一个新分支。",
   "dialog.revert.protected.incompleteTurnInheritedPrefix.title": "无法重置到此位置",
   "dialog.revert.protected.incompleteTurnInheritedPrefix.description": "助手尚未完成对此消息的回复，系统无法判断此轮次是否位于继承的对话历史内。为避免修改共享历史，建议分叉。可以从这里分叉，创建一个新分支。",
+  "dialog.revert.protected.sessionBusy.title": "任务正在执行，无法重置",
+  "dialog.revert.protected.sessionBusy.description": "此会话或其子会话中仍有任务正在执行。请先停止任务，再修改会话历史。",
 
   "dialog.directory.search.placeholder": "搜索文件夹",
   "dialog.directory.empty": "该目录下无子文件夹",

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -22,7 +22,7 @@ import { usePermission } from "@/context/permission"
 import { messageAgentColor } from "@/utils/agent"
 import { sessionPermissionRequest } from "../session/composer/session-request-tree"
 import { createWorkingState } from "@/utils/working-state"
-import { hasProjectPermissions } from "./helpers"
+import { childMapByParent, hasProjectPermissions } from "./helpers"
 
 const OPENCODE_PROJECT_ID = "4b0ea68d7af9a6031a7ffda7ad66e0cb83315750"
 
@@ -330,7 +330,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
       return !permission.autoResponds(item, props.session.directory)
     })
   })
-  const selfWorking = createWorkingState({
+  const isWorking = createWorkingState({
     status: () => sessionStore.session_status[props.session.id],
     pending: () =>
       (sessionStore.message[props.session.id] ?? []).findLast(
@@ -338,24 +338,18 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
           message.role === "assistant" &&
           typeof (message as { time?: { completed?: unknown } }).time?.completed !== "number",
       ),
-    blocked: hasPermissions,
-  }).visual
-  const childWorking = createMemo(() => {
-    const ids = props.children.get(props.session.id)
-    if (!ids?.length) return false
-    for (const id of ids) {
-      const status = sessionStore.session_status[id]
-      if (status?.type === "busy" || status?.type === "retry") return true
-      const pending = (sessionStore.message[id] ?? []).findLast(
-        (message) =>
-          message.role === "assistant" &&
-          typeof (message as { time?: { completed?: unknown } }).time?.completed !== "number",
-      )
-      if (pending) return true
-    }
-    return false
-  })
-  const isWorking = createMemo(() => selfWorking() || childWorking())
+    sessionID: () => props.session.id,
+    children: () => ({
+      childMap: () => childMapByParent(sessionStore.session),
+      status: (id) => sessionStore.session_status[id],
+      pending: (id) =>
+        (sessionStore.message[id] ?? []).findLast(
+          (message) =>
+            message.role === "assistant" &&
+            typeof (message as { time?: { completed?: unknown } }).time?.completed !== "number",
+        ),
+    }),
+  }).interactive
 
   const tint = createMemo(() => {
     return messageAgentColor(sessionStore.message[props.session.id], sessionStore.agent)

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -57,6 +57,7 @@ import {
   focusTerminalById,
   shouldFocusTerminalOnKeyDown,
 } from "@/pages/session/helpers"
+import { childMapByParent } from "@/pages/layout/helpers"
 import { MessageTimeline } from "@/pages/session/message-timeline"
 import { type DiffStyle, SessionReviewTab, type SessionReviewTabProps } from "@/pages/session/review-tab"
 import { useSessionLayout } from "@/pages/session/session-layout"
@@ -1856,9 +1857,32 @@ function SessionPageContent(props: SessionPageProps = {}) {
 
   const busy = (sessionID: string) => {
     if ((sync.data.session_status[sessionID] ?? { type: "idle" as const }).type !== "idle") return true
-    return (sync.data.message[sessionID] ?? []).some(
-      (item) => item.role === "assistant" && typeof item.time.completed !== "number",
+    if (
+      (sync.data.message[sessionID] ?? []).some(
+        (item) => item.role === "assistant" && typeof item.time.completed !== "number",
+      )
     )
+      return true
+    const map = childMapByParent(sync.data.session)
+    const seen = new Set<string>()
+    const walk = (id: string): boolean => {
+      if (seen.has(id)) return false
+      seen.add(id)
+      const children = map.get(id)
+      if (!children?.length) return false
+      for (const child of children) {
+        if ((sync.data.session_status[child] ?? { type: "idle" as const }).type !== "idle") return true
+        if (
+          (sync.data.message[child] ?? []).some(
+            (item) => item.role === "assistant" && typeof item.time.completed !== "number",
+          )
+        )
+          return true
+        if (walk(child)) return true
+      }
+      return false
+    }
+    return walk(sessionID)
   }
 
   const queuedFollowups = createMemo(() => {
@@ -2067,8 +2091,16 @@ function SessionPageContent(props: SessionPageProps = {}) {
       .catch(fail)
   }
 
+  const showBusy = (input?: { sessionID: string; messageID: string }) => {
+    dialog.show(() => <DialogRevertConfirm reason="session-busy" onFork={input ? () => fork(input) : undefined} />)
+  }
+
   const revert = (input: { sessionID: string; messageID: string }) => {
     if (reverting()) return
+    if (busy(input.sessionID)) {
+      showBusy(input)
+      return
+    }
     const session = info()
     if (!session || session.id !== input.sessionID) {
       return revertMutation.mutateAsync(input)
@@ -2098,6 +2130,10 @@ function SessionPageContent(props: SessionPageProps = {}) {
 
   const restore = (id: string) => {
     if (!params.id || reverting()) return
+    if (busy(params.id)) {
+      showBusy()
+      return
+    }
     return restoreMutation.mutateAsync(id)
   }
 

--- a/packages/app/src/pages/session/composer/session-composer-state.ts
+++ b/packages/app/src/pages/session/composer/session-composer-state.ts
@@ -9,6 +9,7 @@ import { usePermission } from "@/context/permission"
 import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
 import { createWorkingState } from "@/utils/working-state"
+import { childMapByParent } from "@/pages/layout/helpers"
 import { composerDriver, composerEnabled, composerEvent } from "@/testing/session-composer"
 import { sessionPermissionRequest, sessionQuestionRequest } from "./session-request-tree"
 
@@ -114,7 +115,19 @@ export function createSessionComposerState(options?: { closeMs?: number | (() =>
     ),
   )
 
-  const { visual: busy } = createWorkingState({ status: () => status(), pending: () => pending() })
+  const { interactive: busy } = createWorkingState({
+    status: () => status(),
+    pending: () => pending(),
+    sessionID: () => params.id,
+    children: () => ({
+      childMap: () => childMapByParent(sync.data.session),
+      status: (id) => sync.data.session_status[id],
+      pending: (id) =>
+        (sync.data.message[id] ?? []).findLast(
+          (msg) => msg.role === "assistant" && typeof msg.time.completed !== "number",
+        ),
+    }),
+  })
   const live = createMemo(() => {
     if (test.on && test.live !== undefined) return test.live
     return busy() || blocked()

--- a/packages/app/src/pages/session/helpers.ts
+++ b/packages/app/src/pages/session/helpers.ts
@@ -277,7 +277,11 @@ export const hasProtectedDescendantBranch = (input: {
   return false
 }
 
-export type RevertProtectionReason = "inherited-prefix" | "descendant-branch" | "incomplete-turn-inherited-prefix"
+export type RevertProtectionReason =
+  | "inherited-prefix"
+  | "descendant-branch"
+  | "incomplete-turn-inherited-prefix"
+  | "session-busy"
 
 export type RevertProtectionResult = { protected: false } | { protected: true; reason: RevertProtectionReason }
 

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -1,5 +1,6 @@
 import { For, createEffect, createMemo, on, onCleanup, Show, Index, type JSX, createSignal } from "solid-js"
-import { createWorkingState } from "@/utils/working-state"
+import { createWorkingState, type ChildrenSource } from "@/utils/working-state"
+import { childMapByParent } from "@/pages/layout/helpers"
 import { createStore, produce, reconcile } from "solid-js/store"
 import { useNavigate } from "@solidjs/router"
 import { useMutation } from "@tanstack/solid-query"
@@ -304,9 +305,19 @@ export function MessageTimeline(props: {
     if (!id) return idle
     return sync.data.session_status[id] ?? idle
   })
-  const { visual: working } = createWorkingState({
+  const children = createMemo<ChildrenSource>(() => ({
+    childMap: () => childMapByParent(sync.data.session),
+    status: (id) => sync.data.session_status[id],
+    pending: (id) =>
+      (sync.data.message[id] ?? []).findLast(
+        (msg) => msg.role === "assistant" && typeof msg.time.completed !== "number",
+      ),
+  }))
+  const { interactive: working } = createWorkingState({
     status: () => sessionStatus(),
     pending: () => pending(),
+    sessionID: () => sessionID(),
+    children: () => children(),
   })
   const tint = createMemo(() => messageAgentColor(sessionMessages(), sync.data.agent))
 

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -18,6 +18,7 @@ import { DialogFork } from "@/components/dialog-fork"
 import { DialogReadingMode } from "@/components/dialog-reading-mode"
 import { showToast } from "@opencode-ai/ui/toast"
 import { findLast } from "@opencode-ai/util/array"
+import { childMapByParent } from "@/pages/layout/helpers"
 import { createSessionTabs } from "@/pages/session/helpers"
 import { extractPromptFromParts } from "@/utils/prompt"
 import { UserMessage } from "@opencode-ai/sdk/v2"
@@ -73,12 +74,32 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
   const closableTab = tabState.closableTab
 
   const idle = { type: "idle" as const }
-  const status = () => sync.data.session_status[params.id ?? ""] ?? idle
   const messages = () => {
     const id = params.id
     if (!id) return []
     return sync.data.message[id] ?? []
   }
+  const pending = (id: string) =>
+    (sync.data.message[id] ?? []).findLast((msg) => msg.role === "assistant" && typeof msg.time.completed !== "number")
+  const busy = (id: string, seen = new Set<string>()): boolean => {
+    if (seen.has(id)) return false
+    seen.add(id)
+    if ((sync.data.session_status[id] ?? idle).type !== "idle") return true
+    if (pending(id)) return true
+    const children = childMapByParent(sync.data.session).get(id)
+    if (!children?.length) return false
+    return children.some((child) => {
+      if ((sync.data.session_status[child] ?? idle).type !== "idle") return true
+      if (pending(child)) return true
+      return busy(child, seen)
+    })
+  }
+  const showBusy = () =>
+    showToast({
+      variant: "error",
+      title: language.t("dialog.revert.protected.sessionBusy.title"),
+      description: language.t("dialog.revert.protected.sessionBusy.description"),
+    })
   const userMessages = () => messages().filter((m) => m.role === "user") as UserMessage[]
   const visibleUserMessages = () => {
     const revert = info()?.revert?.messageID
@@ -428,8 +449,9 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
         onSelect: async () => {
           const sessionID = params.id
           if (!sessionID) return
-          if (status().type !== "idle") {
-            await sdk.client.session.abort({ sessionID }).catch(() => {})
+          if (busy(sessionID)) {
+            showBusy()
+            return
           }
           const revert = info()?.revert?.messageID
           const message = findLast(userMessages(), (x) => !revert || x.id < revert)
@@ -453,6 +475,10 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
         onSelect: async () => {
           const sessionID = params.id
           if (!sessionID) return
+          if (busy(sessionID)) {
+            showBusy()
+            return
+          }
           const revertMessageID = info()?.revert?.messageID
           if (!revertMessageID) return
           const nextMessage = userMessages().find((x) => x.id > revertMessageID)

--- a/packages/app/src/utils/working-state.ts
+++ b/packages/app/src/utils/working-state.ts
@@ -9,16 +9,39 @@ export type SessionStatus =
   | { type: "retry"; attempt: number; message: string; next: number }
   | undefined
 
+export type ChildrenSource = {
+  childMap: () => Map<string, string[]>
+  status: (id: string) => SessionStatus
+  pending: (id: string) => unknown
+}
+
+const busy = (status: SessionStatus) => status?.type === "busy" || status?.type === "retry"
+
+function descendant(id: string, source: ChildrenSource, seen = new Set<string>()) {
+  if (seen.has(id)) return false
+  seen.add(id)
+  const children = source.childMap().get(id)
+  if (!children?.length) return false
+  for (const child of children) {
+    if (busy(source.status(child))) return true
+    if (source.pending(child)) return true
+    if (descendant(child, source, seen)) return true
+  }
+  return false
+}
+
 export function createWorkingState(input: {
   status: () => SessionStatus
   pending: () => unknown
   blocked?: () => boolean
+  sessionID?: () => string | undefined
+  children?: () => ChildrenSource
 }) {
   const [grace, setGrace] = createSignal(false)
 
   createEffect(() => {
     const s = input.status()
-    if (s?.type === "busy" || s?.type === "retry") {
+    if (busy(s)) {
       setGrace(true)
       return
     }
@@ -27,18 +50,29 @@ export function createWorkingState(input: {
     }
   })
 
-  const visual = createMemo(() => {
+  const self = createMemo(() => {
     if (input.blocked?.()) return false
     const s = input.status()
-    if (s?.type === "busy" || s?.type === "retry") return true
+    if (busy(s)) return true
     if (grace()) return !!input.pending()
     return false
   })
 
-  const interactive = createMemo(() => {
+  const active = createMemo(() => {
     const s = input.status()
-    return s?.type === "busy" || s?.type === "retry"
+    if (busy(s)) return true
+    return !!input.pending()
   })
+
+  const child = createMemo(() => {
+    const id = input.sessionID?.()
+    const source = input.children?.()
+    if (!id || !source) return false
+    return descendant(id, source)
+  })
+
+  const visual = createMemo(() => self() || child())
+  const interactive = createMemo(() => active() || child())
 
   return { visual, interactive, grace }
 }

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
@@ -6,6 +6,32 @@ import { useRoute } from "@tui/context/route"
 import { Clipboard } from "@tui/util/clipboard"
 import type { PromptInfo } from "@tui/component/prompt/history"
 import { strip } from "@tui/component/prompt/part"
+import { useDialog } from "../../ui/dialog"
+
+function DialogBusyWarning(props: { onFork: () => void }) {
+  const dialog = useDialog()
+
+  return (
+    <DialogSelect
+      title="Task is running"
+      options={[
+        {
+          title: "Cancel",
+          value: "cancel",
+          description: "close this dialog",
+          onSelect: () => dialog.clear(),
+        },
+        {
+          title: "Fork",
+          value: "session.fork",
+          description: "create a new session from this point",
+          onSelect: props.onFork,
+        },
+      ]}
+      skipFilter
+    />
+  )
+}
 
 export function DialogMessage(props: {
   messageID: string
@@ -14,8 +40,42 @@ export function DialogMessage(props: {
 }) {
   const sync = useSync()
   const sdk = useSDK()
+  const dialog = useDialog()
   const message = createMemo(() => sync.data.message[props.sessionID]?.find((x) => x.id === props.messageID))
   const route = useRoute()
+  const status = createMemo(() => sync.data.session_status?.[props.sessionID] ?? ({ type: "idle" } as const))
+  const pending = createMemo(() =>
+    (sync.data.message[props.sessionID] ?? []).findLast(
+      (msg) => msg.role === "assistant" && typeof msg.time?.completed !== "number",
+    ),
+  )
+  const working = createMemo(() => status().type !== "idle" || !!pending())
+
+  async function fork() {
+    const result = await sdk.client.session.fork({
+      sessionID: props.sessionID,
+      messageID: props.messageID,
+    })
+    const msg = message()
+    const initialPrompt = msg
+      ? (sync.data.part[msg.id] ?? []).reduce(
+          (agg, part) => {
+            if (part.type === "text") {
+              if (!part.synthetic) agg.input += part.text
+            }
+            if (part.type === "file") agg.parts.push(part)
+            return agg
+          },
+          { input: "", parts: [] as PromptInfo["parts"] },
+        )
+      : undefined
+    route.navigate({
+      sessionID: result.data!.id,
+      type: "session",
+      initialPrompt,
+    })
+    dialog.clear()
+  }
 
   return (
     <DialogSelect
@@ -24,8 +84,12 @@ export function DialogMessage(props: {
         {
           title: "Revert",
           value: "session.revert",
-          description: "undo messages and file changes",
-          onSelect: (dialog) => {
+          description: working() ? "task is running - stop first or fork instead" : "undo messages and file changes",
+          onSelect: () => {
+            if (working()) {
+              dialog.replace(() => <DialogBusyWarning onFork={fork} />)
+              return
+            }
             const msg = message()
             if (!msg) return
 
@@ -76,33 +140,7 @@ export function DialogMessage(props: {
           title: "Fork",
           value: "session.fork",
           description: "create a new session",
-          onSelect: async (dialog) => {
-            const result = await sdk.client.session.fork({
-              sessionID: props.sessionID,
-              messageID: props.messageID,
-            })
-            const initialPrompt = (() => {
-              const msg = message()
-              if (!msg) return undefined
-              const parts = sync.data.part[msg.id]
-              return parts.reduce(
-                (agg, part) => {
-                  if (part.type === "text") {
-                    if (!part.synthetic) agg.input += part.text
-                  }
-                  if (part.type === "file") agg.parts.push(part)
-                  return agg
-                },
-                { input: "", parts: [] as PromptInfo["parts"] },
-              )
-            })()
-            route.navigate({
-              sessionID: result.data!.id,
-              type: "session",
-              initialPrompt,
-            })
-            dialog.clear()
-          },
+          onSelect: fork,
         },
       ]}
     />

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -129,6 +129,11 @@ export function Session() {
       .toSorted((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
   })
   const messages = createMemo(() => sync.data.message[route.sessionID] ?? [])
+  const working = createMemo(() => {
+    const status = sync.data.session_status?.[route.sessionID]
+    if (status?.type && status.type !== "idle") return true
+    return messages().some((msg) => msg.role === "assistant" && typeof msg.time.completed !== "number")
+  })
   const permissions = createMemo(() => {
     if (session()?.parentID) return []
     return children().flatMap((x) => sync.data.permission[x.id] ?? [])
@@ -509,8 +514,11 @@ export function Session() {
         name: "undo",
       },
       onSelect: async (dialog) => {
-        const status = sync.data.session_status?.[route.sessionID]
-        if (status?.type !== "idle") await sdk.client.session.abort({ sessionID: route.sessionID }).catch(() => {})
+        if (working()) {
+          toast.show({ message: "Task is running. Stop it before undoing messages.", variant: "error" })
+          dialog.clear()
+          return
+        }
         const revert = session()?.revert?.messageID
         const message = messages().findLast((x) => (!revert || x.id < revert) && x.role === "user")
         if (!message) return
@@ -549,6 +557,10 @@ export function Session() {
       },
       onSelect: (dialog) => {
         dialog.clear()
+        if (working()) {
+          toast.show({ message: "Task is running. Stop it before redoing messages.", variant: "error" })
+          return
+        }
         const messageID = session()?.revert?.messageID
         if (!messageID) return
         const message = messages().find((x) => x.role === "user" && x.id > messageID)

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -15,6 +15,7 @@ import { Instance } from "./instance"
 import { Log } from "@/util/log"
 import { ShareNext } from "@/share/share-next"
 import { PROJECT } from "@/persist/naming"
+import { SessionRecovery } from "@/session/recovery"
 
 export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
@@ -29,6 +30,9 @@ export async function InstanceBootstrap() {
   FileWatcher.init()
   Vcs.init()
   Snapshot.init()
+  await SessionRecovery.repairInterrupted().catch((error) => {
+    Log.Default.warn("failed to repair interrupted assistant messages", { error })
+  })
 
   Bus.subscribe(Command.Event.Executed, async (payload) => {
     if (payload.properties.name === Command.Default.INIT) {

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -1085,11 +1085,16 @@ export const SessionRoutes = lazy(() =>
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
         log.info("revert", c.req.valid("json"))
-        const session = await SessionRevert.revert({
-          sessionID,
-          ...c.req.valid("json"),
-        })
-        return c.json(session)
+        try {
+          const session = await SessionRevert.revert({
+            sessionID,
+            ...c.req.valid("json"),
+          })
+          return c.json(session)
+        } catch (err) {
+          if (err instanceof Session.BusyError) return c.json({ error: "Session is busy", sessionID }, 409)
+          throw err
+        }
       },
     )
     .post(
@@ -1118,8 +1123,13 @@ export const SessionRoutes = lazy(() =>
       ),
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
-        const session = await SessionRevert.unrevert({ sessionID })
-        return c.json(session)
+        try {
+          const session = await SessionRevert.unrevert({ sessionID })
+          return c.json(session)
+        } catch (err) {
+          if (err instanceof Session.BusyError) return c.json({ error: "Session is busy", sessionID }, 409)
+          throw err
+        }
       },
     )
     .post(

--- a/packages/opencode/src/session/recovery.ts
+++ b/packages/opencode/src/session/recovery.ts
@@ -1,0 +1,62 @@
+import { Log } from "@/util/log"
+import { MessageV2 } from "./message-v2"
+import { Session } from "."
+
+export namespace SessionRecovery {
+  const log = Log.create({ service: "session.recovery" })
+  const limit = 100_000
+
+  export async function repairInterrupted() {
+    const boot = Date.now()
+    let count = 0
+
+    for (const session of Session.list({ limit })) {
+      const messages = await Session.messages({ sessionID: session.id }).catch(() => [])
+      const stale = messages.flatMap((msg) => {
+        if (msg.info.role !== "assistant") return []
+        if (typeof msg.info.time.completed === "number") return []
+        if (msg.info.time.created >= boot) return []
+        return [{ info: msg.info, parts: msg.parts }]
+      })
+
+      await Promise.all(
+        stale.map((msg) =>
+          Promise.all([
+            ...msg.parts
+              .filter((part): part is MessageV2.ToolPart => part.type === "tool")
+              .filter((part) => part.state.status !== "completed" && part.state.status !== "error")
+              .map((part) =>
+                Session.updatePart({
+                  ...part,
+                  state: {
+                    ...part.state,
+                    status: "error",
+                    error: "Tool execution interrupted by a previous shutdown.",
+                    time: {
+                      start: Date.now(),
+                      end: Date.now(),
+                    },
+                  },
+                }),
+              ),
+            Session.updateMessage({
+              ...msg.info,
+              error:
+                msg.info.error ??
+                MessageV2.fromError(new Error("Assistant response was interrupted by a previous shutdown."), {
+                  providerID: msg.info.providerID,
+                }),
+              time: {
+                ...msg.info.time,
+                completed: boot,
+              },
+            }),
+          ]),
+        ),
+      )
+      count += stale.length
+    }
+
+    if (count > 0) log.info("repaired interrupted assistant messages", { count })
+  }
+}

--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -27,6 +27,7 @@ export namespace SessionRevert {
   export type RevertInput = z.infer<typeof RevertInput>
 
   export async function revert(input: RevertInput) {
+    SessionPrompt.assertNotBusy(input.sessionID)
     const done = Promise.withResolvers<void>()
     pending[input.sessionID] = done.promise
     try {


### PR DESCRIPTION
### Issue for this PR

无关联 issue。用户已确认本 PR 不对应现有 issue。

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

本 PR 手工恢复并整合 Web busy / revert guard 行为，而不是直接 cherry-pick 历史提交。

主要逻辑如下：

- 统一 Web 侧 working state：当前会话处于 `busy` / `retry`、存在未完成 assistant message，或任意子孙会话满足这些条件时，都视为正在工作。
- 将该 busy 判断接入 prompt 输入、提交入口、侧边栏、timeline 和 composer，避免父会话在子会话仍运行时提前变成可交互状态。
- 在 Web revert / restore / undo / redo 前增加 busy guard。任务仍在运行时不再修改 session history，而是展示清晰提示；从具体消息 revert 时仍提供 fork 作为安全替代。
- 在后端 `SessionRevert.revert` 增加 busy 断言，并让 revert / unrevert route 对 `Session.BusyError` 返回 HTTP 409，避免直接 API 调用绕过当前会话 busy guard。
- 在 TUI message revert、undo、redo 路径增加 busy guard，避免终端入口和 Web 行为明显分裂。
- 在 project instance bootstrap 时修复上一次进程异常遗留的 unfinished assistant message：启动恢复只处理启动前已经存在、缺少 `time.completed` 的 assistant message，并把未完成 tool part 标记为 error，避免 Web/Electron 重启后永久把会话视为 busy。
- 更新 rollback 分析文档，标记 #578、#580、beta merge 的相关行为已手工整合。

### How did you verify your code works?

- 在 `packages/opencode` 运行 `bun typecheck`，通过。
- 推送分支时触发 `bun turbo typecheck`，12 个 typecheck 任务全部通过。

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
