### PR TITLE
fix(mobile): respect explicit session switch via /s n instead of overriding with most recent

### DIFF
--- a/packages/opencode/src/mobile/base.ts
+++ b/packages/opencode/src/mobile/base.ts
@@ -483,10 +483,8 @@ export abstract class MobileManagerBase {
     const pinned = this.sessionMap[scope]
     if (pinned) {
       const stillValid = recent.some((s) => s.id === pinned)
-      if (stillValid && recent[0]?.id === pinned) return pinned
-      if (!stillValid) {
-        delete this.sessionMap[scope]
-      }
+      if (stillValid) return pinned
+      delete this.sessionMap[scope]
     }
     if (recent[0]) {
       this.sessionMap[scope] = recent[0].id


### PR DESCRIPTION
### Issue for this PR

Closes #697

### Type of change

- [x] Bug fix

### What does this PR do?

`currentSession()` 只在 pinned session 同时是最新会话时才返回它，否则 fallthrough 将 `sessionMap` 重写为 `recent[0]`，导致 `/s n` 切换到非最新会话后下一条消息就被覆盖回最新。修复：只要 pinned session 有效就返回，不要求它是最新。

### How did you verify your code works?

- `bun typecheck` 在 `packages/opencode` 通过
- pre-push hook 执行 `turbo typecheck` 全量通过
- 代码审查确认逻辑正确：移除 `recent[0]?.id === pinned` 条件后，用户显式切换的会话不会被 fallthrough 覆盖

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR