### PR TITLE
fix: split migration in CD builds + Windows InvalidVersionFormat

### DIFF
--- a/packages/opencode/src/storage/split-migration.ts
+++ b/packages/opencode/src/storage/split-migration.ts
@@ -139,6 +139,19 @@ export namespace SplitMigration {
     return sqlite
   }
 
+  const SPLIT_MIGRATION_NAME = "20260507071748_per_project_db_split"
+
+  function splitMigrationMeta(): { hash: string; name: string; millis: number } | undefined {
+    const entries = getMigrationEntries()
+    const entry = entries.find((e) => e.name === SPLIT_MIGRATION_NAME)
+    if (!entry) return undefined
+    return {
+      hash: createHash("sha256").update(entry.sql).digest("hex"),
+      name: entry.name,
+      millis: entry.timestamp,
+    }
+  }
+
   function getMigrationEntries(): { sql: string; timestamp: number; name: string }[] {
     if (typeof OPENCODE_MIGRATIONS !== "undefined") return OPENCODE_MIGRATIONS
     const dir = path.join(import.meta.dirname, "../../migration")
@@ -203,23 +216,14 @@ export namespace SplitMigration {
     const existingNames = new Set(
       (sqlite.prepare("SELECT name FROM __drizzle_migrations").all() as { name: string }[]).map((r) => r.name),
     )
-    const migrationDir = path.join(import.meta.dirname, "../../migration")
-    if (!existsSync(migrationDir)) return
-    const dirs = readdirSync(migrationDir, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => entry.name)
+    const entries = getMigrationEntries()
     const insert = sqlite.prepare(
       "INSERT INTO __drizzle_migrations (hash, created_at, name, applied_at) VALUES (?, ?, ?, ?)",
     )
-    for (const dirName of dirs) {
-      if (existingNames.has(dirName)) continue
-      const sqlFile = path.join(migrationDir, dirName, "migration.sql")
-      if (!existsSync(sqlFile)) continue
-      const sql = readFileSync(sqlFile, "utf-8")
-      const hash = createHash("sha256").update(sql).digest("hex")
-      const match = /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/.exec(dirName)
-      const millis = match ? Date.UTC(+match[1], +match[2] - 1, +match[3], +match[4], +match[5], +match[6]) : 0
-      insert.run(hash, millis, dirName, new Date().toISOString())
+    for (const entry of entries) {
+      if (existingNames.has(entry.name)) continue
+      const hash = createHash("sha256").update(entry.sql).digest("hex")
+      insert.run(hash, entry.timestamp, entry.name, new Date().toISOString())
     }
   }
 
@@ -545,16 +549,7 @@ export namespace SplitMigration {
       const allProjectIds = [...sessionByProject.keys(), ...projectById.keys()]
       const uniqueProjectIds = new Set(allProjectIds)
 
-      const migrationMeta = (() => {
-        const migrationDir = path.join(import.meta.dirname, "../../migration/20260507071748_per_project_db_split")
-        const sqlFile = path.join(migrationDir, "migration.sql")
-        if (!existsSync(sqlFile)) return undefined
-        const sql = readFileSync(sqlFile, "utf-8")
-        const hash = createHash("sha256").update(sql).digest("hex")
-        const name = "20260507071748_per_project_db_split"
-        const millis = Date.UTC(2026, 4, 7, 7, 17, 48)
-        return { hash, name, millis }
-      })()
+      const migrationMeta = splitMigrationMeta()
 
       let projectCount = 0
       let sessionCount = 0
@@ -835,16 +830,7 @@ export namespace SplitMigration {
 
     log.info("starting project ID rehash", { count: rows.length })
 
-    const migrationMeta = (() => {
-      const migrationDir = path.join(import.meta.dirname, "../../migration/20260507071748_per_project_db_split")
-      const sqlFile = path.join(migrationDir, "migration.sql")
-      if (!existsSync(sqlFile)) return undefined
-      const sql = readFileSync(sqlFile, "utf-8")
-      const hash = createHash("sha256").update(sql).digest("hex")
-      const name = "20260507071748_per_project_db_split"
-      const millis = Date.UTC(2026, 4, 7, 7, 17, 48)
-      return { hash, name, millis }
-    })()
+    const migrationMeta = splitMigrationMeta()
 
     const chDir = channelDir()
     let projectCount = 0


### PR DESCRIPTION
## Summary

Two fixes for CD/bundled build issues:

### 1. Split migration crash in CD builds (`undefined is not an object (evaluating 'extra.hash')`)

In bundled (CD) builds, migration SQL is inlined via `OPENCODE_MIGRATIONS` define and no migration directory exists on disk. The `migrationMeta` IIFE and `seedMigrationsFromDir` both read from `import.meta.dirname` which resolves to a nonexistent directory in bundled builds, causing `migrationMeta` to be `undefined`. This crashes `seedSplitMigrationOnly(pSqlite, migrationMeta!)` with `undefined is not an object (evaluating 'extra.hash')`, making split migration fail. After failure, `global_project_map` table is never created, causing `no such table: global_project_map` on startup.

**Fix**: Added `splitMigrationMeta()` that uses `getMigrationEntries()` (returns `OPENCODE_MIGRATIONS` in bundled builds) to derive metadata. Refactored `seedMigrationsFromDir()` similarly.

### 2. Windows build `InvalidVersionFormat` error

Preview versions like `0.0.0-system-20260511T1510` are invalid for Windows PE metadata, which requires `major.minor.patch.build` (all numeric, dot-separated). This causes Bun compile to fail with `InvalidVersionFormat`.

**Fix**: Convert version to numeric format for the `compile.windows.version` field: `major.minor.patch.1` for preview, `major.minor.patch.0` for release. `OPENCODE_VERSION` define keeps the original string.

## Test plan

- Build a CD (bundled) binary and verify per-project DB split completes without `extra.hash` error
- Build Windows target and verify no `InvalidVersionFormat` error
- Run dev mode via `run.bat` and verify split migration still works (regression check)