### PR TITLE
fix: repair session stop and finish state

### DIFF
--- a/docs/rollback-2505/v0.6.0-to-origin-dev-commits.md
+++ b/docs/rollback-2505/v0.6.0-to-origin-dev-commits.md
@@ -1,7 +1,7 @@
 # v0.6.0 到 origin/dev 的主线提交梳理
 
 核查时间：2026-05-09
-更新时间：2026-05-10 00:00 CST
+更新时间：2026-05-11 00:00 CST
 
 核查口径：
 
@@ -50,7 +50,7 @@
 | 33 | `457abbb08` #630 | 2026-05-05 16:43 | yqmaphy | code-JDS | 修复 Electron 打包和显示身份，调整 publish workflow、builder config、desktop main 文件和 launcher。 | 否 | 否 | 是（`7db60c8bf`） |
 | 34 | `fb0749e59` #636 | 2026-05-05 16:44 | yqmaphy | code-JDS | Git Graph 第三阶段交互增强，更新前端图渲染、VCS API、SDK/OpenAPI。 | 否 | 否 | 是（`336a8fa1e`） |
 | 35 | `fa35b0700` #638 | 2026-05-05 16:49 | Dongshan Jian | yqmaphy | Git Graph layout 对 undefined commits/parents 加保护。 | 否 | 否 | 是（`c884b98af`） |
-| 36 | `ef3ed8f9d` #640 | 2026-05-05 20:30 | lixfrank | yqmaphy | stop 按钮按下时恢复卡住的 session DB artifacts，改 session index/prompt。 | 否 | 是 | 否 |
+| 36 | `ef3ed8f9d` #640 | 2026-05-05 20:30 | lixfrank | yqmaphy | stop 按钮按下时恢复卡住的 session DB artifacts，改 session index/prompt。 | 否 | 是 | 已整合 |
 | 37 | `b7daf01f3` #642 | 2026-05-05 20:31 | lixfrank | yqmaphy | 尝试修复 Web UI 会话结束后 busy 指示残留，改 working-state 和 processor。 | 否 | 是 | 否 |
 | 38 | `5f4bf90a0` revert | 2026-05-05 22:32 | dsjian | - | 回滚 #642 的 stale busy indicators 修复，恢复 LICENSE、working-state、processor。 | 否 | 是 | 否 |
 | 39 | `35f02c19c` #654 | 2026-05-06 12:59 | yqmaphy | code-JDS | standalone binary 构建补 Windows PE metadata。 | 否 | 否 | 是（`372a8a920`） |
@@ -63,13 +63,13 @@
 | 46 | `ac15c02d8` revert | 2026-05-06 21:52 | dsjian | - | 回滚 orphaned lease/SSE stuck 强制退出补丁，移除 web 命令相关逻辑。 | 否 | 是 | 否 |
 | 47 | `5a30c47aa` #668 | 2026-05-07 00:04 | Dongshan Jian | yqmaphy | 修复 skill-refresh 注入 synthetic user message 导致 sidebar 显示 `(no text)`。 | Skill | 部分 | 否 |
 | 48 | `47ee366c3` #669 | 2026-05-07 00:10 | Dongshan Jian | Spin-Particle | 知识库状态迁移到统一 JSON 持久化，解决跨端口丢失；改 app knowledge context、Electron persist/store、server route。 | 否 | 否 | 是（`3f96fd787`） |
-| 49 | `f0469403b` #671 | 2026-05-07 00:10 | Dongshan Jian | yqmaphy | 再次修复 session completion 后 busy indicator 卡住，改 processor 和 prompt。 | 否 | 是 | 否 |
+| 49 | `f0469403b` #671 | 2026-05-07 00:10 | Dongshan Jian | yqmaphy | 再次修复 session completion 后 busy indicator 卡住，改 processor 和 prompt。 | 否 | 是 | 已整合 |
 | 50 | `b787bdd4c` #675 | 2026-05-07 11:17 | Dongshan Jian | yqmaphy | basicAuth 放行 PWA manifest 和 favicon 路径。 | 否 | 否 | 是（`e45f7ebc0`） |
 | 51 | `b42343111` direct | 2026-05-07 12:35 | Spin-Particle | - | 修复 electron-vite renderer base override 造成白屏，调整 app Vite 配置。 | 否 | 否 | 是（`7049f1770`） |
 | 52 | `316faa994` direct | 2026-05-07 14:33 | dsjian | - | 支持 base path 下的 PTY websocket，精简 server 路由逻辑并补 web cache 测试。 | 否 | 是 | 是（`534a08b0d`） |
 | 53 | `b3478f4d4` #682 | 2026-05-07 20:09 | Dongshan Jian | bzzzzz040806 | memory 增加 backfill 和 scoped pending inbox，大改 memory index/inbox、session 集成、设置页、SDK 和测试。 | Memory | 部分 | 否 |
 | 54 | `128bb3e23` #673 | 2026-05-07 20:10 | Dongshan Jian | lixfrank | 引入 agent infrastructure：自定义模式、discipline、permissions、并发/background session、MCP per-agent、mode-switch/task tools 和文档测试。 | 轻度 Skill | 是 | 否 |
-| 55 | `3558f0a2a` #684 | 2026-05-07 20:18 | Dongshan Jian | yqmaphy | LLM 返回未知 `finish_reason` 且无 tool calls 时按 stop 处理，避免会话状态异常。 | 否 | 是 | 否 |
+| 55 | `3558f0a2a` #684 | 2026-05-07 20:18 | Dongshan Jian | yqmaphy | LLM 返回未知 `finish_reason` 且无 tool calls 时按 stop 处理，避免会话状态异常。 | 否 | 是 | 已整合 |
 | 56 | `9d4516e3d` #681 | 2026-05-07 20:18 | Dongshan Jian | code-JDS | 增加 macOS Intel 发布产物，调整 publish workflow、安装/上传文档和 web-update 测试。 | 否 | 否 | 是（`be5a2cfb5`） |
 | 57 | `8e5c5ad00` #686 | 2026-05-08 06:57 | yqmaphy | code-JDS | Git Graph Phase 4：提交详情面板和 git 操作上下文菜单，新增多种 dialog、VCS endpoints、SDK 和 i18n。 | 否 | 否 | 是（`b8304de50`） |
 | 58 | `8153fb454` #687 | 2026-05-08 14:03 | Dongshan Jian | Spade6-v | 增加语音输入和 Qwen-Omni 转写，包含前端按钮/录音/设置、后端 voice route、README 和 icon。 | 否 | 否 | 是（`489f636c3`） |
@@ -89,13 +89,13 @@
 
 `220f31eeb` #622：让 `summarize_dirs` 支持 AbortSignal。`ctx.abort` 被传进目录遍历和 LLM 摘要调用，stop 按钮能真正中断长时间目录摘要，而不只是把 session 状态改成 idle。
 
-`ef3ed8f9d` #640：stop 后恢复卡住的 DB artifacts。新增 `Session.recoverStuckParts`：把未完成 tool part 标 error，把未完成 assistant message 补 `time.completed`。`SessionPrompt.cancel` 无论是否找到 active controller 都会做恢复。解决 stop 后 UI 仍认为 session busy 的一类根因。
+`ef3ed8f9d` #640：stop 后恢复卡住的 DB artifacts。原提交新增 `Session.recoverStuckParts`：把未完成 tool part 标 error，把未完成 assistant message 补 `time.completed`。当前分支已按同等语义整合到 `SessionRecovery.repairSession`，并让 `SessionPrompt.cancel` 无论是否找到 active controller 都先做恢复、再置 idle。解决 stop 后 UI 仍认为 session busy 的一类根因。
 
-`f0469403b` #671：再次修复 completion 后 busy indicator 卡住。重点是 processor 不再在 error 分支里立刻 `SessionStatus.set(idle)`，而是等 assistant message 写入 `time.completed` 后再置 idle；cancel 也改成先 recover stuck parts，再统一 idle。它是 #642 被回滚后的替代修正。
+`f0469403b` #671：再次修复 completion 后 busy indicator 卡住。当前分支已整合其最终顺序：processor 不再在 error 分支里立刻 `SessionStatus.set(idle)`，而是等 tool cleanup、assistant message 写入 `time.completed` 并发布 `message.updated` 后再置 idle；cancel 也改成先 repair stuck artifacts，再统一 idle。它是 #642 被回滚后的替代修正。
 
 `316faa994` direct：base path 下 PTY websocket。当前分支已经以 `534a08b0d` cherry-pick 进来了。它把 server 改成 Hono `route(basePath, app).route("/", app)`，让 websocket upgrade 也走 base path，不再依赖手写 API path 白名单。
 
-`3558f0a2a` #684：处理 provider 返回 unknown `finish_reason`。LLM stream 中如果 raw 是 `unknown`：有 tool call 就归一为 `tool-calls`，没有 tool call 就归一为 `stop`；prompt loop 不再把 `unknown` 当成未完成状态。效果是减少 session 因结束原因异常而继续循环或状态异常。
+`3558f0a2a` #684：处理 provider 返回 unknown `finish_reason`。当前分支按 AI SDK v2 的字符串 finish reason 形态整合：LLM stream 中如果 finish reason 是 `unknown`，有 tool call 就归一为 `tool-calls`，没有 tool call 就归一为 `stop`；有 tool call 但 finish reason 是 `stop` 也归一为 `tool-calls`；prompt loop 不再把 `unknown` 当成未完成状态。效果是减少 session 因结束原因异常而继续循环或状态异常。
 
 ### 回滚对
 
@@ -115,11 +115,11 @@
 
 Web busy / revert guard 组合：`2921e43e0` + `1552b1d27` + `8db25ce08`。前两者统一 busy 判断与 UI 交互语义，#580 在此基础上阻止 busy revert，并补 server/TUI 兜底。
 
-stop / completion 收口组合：`220f31eeb` + `ef3ed8f9d` + `f0469403b`。#622 让长工具能响应 stop；#640 清理已卡住的 part/message；#671 修正新一轮处理结束时 idle 与 message completion 的写入顺序。
+stop / completion 收口组合：`220f31eeb` + `ef3ed8f9d` + `f0469403b`。#622 让长工具能响应 stop；#640 清理已卡住的 part/message；#671 修正新一轮处理结束时 idle 与 message completion 的写入顺序。当前分支已整合 #640/#671 的状态收口语义；#622 仍未恢复。
 
-LLM 结束原因补丁：`3558f0a2a` 不直接改 UI busy，但减少 processor 因 unknown finish reason 误判未完成而造成的状态异常。
+LLM 结束原因补丁：`3558f0a2a` 不直接改 UI busy，但减少 processor 因 unknown finish reason 误判未完成而造成的状态异常。当前分支已整合其核心语义；未机械恢复 origin/dev 上依赖 `providerExecuted` 的历史 tool-call guard。
 
-当前分支已包含 `316faa994` 的效果；#642 和 #656 两组已被主线回滚，不建议恢复。
+当前分支已包含 `316faa994` 的效果，并已手工整合 #640、#671、#684 的必要效果；#642 和 #656 两组已被主线回滚，不建议恢复。
 
 ### 风险备注
 

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -10,6 +10,7 @@ import {
   type ToolSet,
   tool,
   jsonSchema,
+  type LanguageModelMiddleware,
 } from "ai"
 import { mergeDeep, pipe } from "remeda"
 import { GitLabWorkflowLanguageModel } from "gitlab-ai-provider"
@@ -44,6 +45,38 @@ export namespace LLM {
   }
 
   export type StreamOutput = StreamTextResult<ToolSet, unknown>
+
+  const finish: LanguageModelMiddleware = {
+    async wrapStream(input) {
+      const result = await input.doStream()
+      let calls = false
+      return {
+        ...result,
+        stream: result.stream.pipeThrough(
+          new TransformStream({
+            transform(part, controller) {
+              if (part.type === "tool-call") calls = true
+              if (part.type === "finish" && (part.finishReason as string) === "unknown") {
+                controller.enqueue({
+                  ...part,
+                  finishReason: (calls ? "tool-calls" : "stop") as typeof part.finishReason,
+                })
+                return
+              }
+              if (part.type === "finish" && calls && part.finishReason === "stop") {
+                controller.enqueue({
+                  ...part,
+                  finishReason: "tool-calls" as typeof part.finishReason,
+                })
+                return
+              }
+              controller.enqueue(part)
+            },
+          }),
+        ),
+      }
+    },
+  }
 
   export async function stream(input: StreamInput) {
     const l = log
@@ -276,6 +309,7 @@ export namespace LLM {
       model: wrapLanguageModel({
         model: language,
         middleware: [
+          finish,
           {
             async transformParams(args) {
               if (args.type === "stream") {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -35,6 +35,7 @@ export namespace SessionProcessor {
     let blocked = false
     let attempt = 0
     let needsCompaction = false
+    let idle = false
 
     const result = {
       get message() {
@@ -46,6 +47,7 @@ export namespace SessionProcessor {
       async process(streamInput: LLM.StreamInput) {
         log.info("process")
         needsCompaction = false
+        idle = false
         const shouldBreak = (await Config.get()).experimental?.continue_loop_on_deny !== true
         while (true) {
           try {
@@ -382,7 +384,7 @@ export namespace SessionProcessor {
                 sessionID: input.assistantMessage.sessionID,
                 error: input.assistantMessage.error,
               })
-              await SessionStatus.set(input.sessionID, { type: "idle" })
+              idle = true
             }
           }
           if (snapshot) {
@@ -418,6 +420,7 @@ export namespace SessionProcessor {
           }
           input.assistantMessage.time.completed = Date.now()
           await Session.updateMessage(input.assistantMessage)
+          if (idle) await SessionStatus.set(input.sessionID, { type: "idle" })
           if (needsCompaction) return "compact"
           if (blocked) return "stop"
           if (input.assistantMessage.error) return "stop"

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -52,6 +52,7 @@ import { Truncate } from "@/tool/truncate"
 import { Knowledge } from "../knowledge"
 import { decodeDataUrl } from "@/util/data-url"
 import { Process } from "@/util/process"
+import { SessionRecovery } from "./recovery"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -264,14 +265,12 @@ export namespace SessionPrompt {
     log.info("cancel", { sessionID })
     const s = state()
     const match = s[sessionID]
-    if (!match) {
-      await SessionStatus.set(sessionID, { type: "idle" })
-      return
+    if (match) {
+      match.abort.abort()
+      delete s[sessionID]
     }
-    match.abort.abort()
-    delete s[sessionID]
+    await SessionRecovery.repairSession(sessionID)
     await SessionStatus.set(sessionID, { type: "idle" })
-    return
   }
 
   export const LoopInput = z.object({
@@ -321,7 +320,7 @@ export namespace SessionPrompt {
       if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
       if (
         lastAssistant?.finish &&
-        !["tool-calls", "unknown"].includes(lastAssistant.finish) &&
+        !["tool-calls"].includes(lastAssistant.finish) &&
         lastUser.id < lastAssistant.id
       ) {
         log.info("exiting loop", { sessionID })
@@ -699,8 +698,8 @@ export namespace SessionPrompt {
         break
       }
 
-      // Check if model finished (finish reason is not "tool-calls" or "unknown")
-      const modelFinished = processor.message.finish && !["tool-calls", "unknown"].includes(processor.message.finish)
+      // Check if model finished (finish reason is not "tool-calls")
+      const modelFinished = processor.message.finish && !["tool-calls"].includes(processor.message.finish)
 
       if (modelFinished && !processor.message.error) {
         if (format.type === "json_schema") {

--- a/packages/opencode/src/session/recovery.ts
+++ b/packages/opencode/src/session/recovery.ts
@@ -1,62 +1,92 @@
 import { Log } from "@/util/log"
 import { MessageV2 } from "./message-v2"
 import { Session } from "."
+import type { SessionID } from "./schema"
 
 export namespace SessionRecovery {
   const log = Log.create({ service: "session.recovery" })
   const limit = 100_000
+
+  async function repair(input: {
+    messages: MessageV2.WithParts[]
+    completed: number
+    message: string
+    tool: string
+    previous: boolean
+  }) {
+    const stale = input.messages.flatMap((msg) => {
+      if (msg.info.role !== "assistant") return []
+      if (typeof msg.info.time.completed === "number") return []
+      if (input.previous && msg.info.time.created >= input.completed) return []
+      return [{ info: msg.info, parts: msg.parts }]
+    })
+
+    await Promise.all(
+      stale.map((msg) =>
+        Promise.all([
+          ...msg.parts
+            .filter((part): part is MessageV2.ToolPart => part.type === "tool")
+            .filter((part) => part.state.status !== "completed" && part.state.status !== "error")
+            .map((part) =>
+              Session.updatePart({
+                ...part,
+                state: {
+                  ...("metadata" in part.state ? { metadata: part.state.metadata } : {}),
+                  status: "error",
+                  input: part.state.input,
+                  error: input.tool,
+                  time: {
+                    start: part.state.status === "running" ? part.state.time.start : input.completed,
+                    end: input.completed,
+                  },
+                },
+              }),
+            ),
+          Session.updateMessage({
+            ...msg.info,
+            error:
+              msg.info.error ??
+              MessageV2.fromError(new Error(input.message), {
+                providerID: msg.info.providerID,
+              }),
+            time: {
+              ...msg.info.time,
+              completed: input.completed,
+            },
+          }),
+        ]),
+      ),
+    )
+
+    return stale.length
+  }
 
   export async function repairInterrupted() {
     const boot = Date.now()
     let count = 0
 
     for (const session of Session.list({ limit })) {
-      const messages = await Session.messages({ sessionID: session.id }).catch(() => [])
-      const stale = messages.flatMap((msg) => {
-        if (msg.info.role !== "assistant") return []
-        if (typeof msg.info.time.completed === "number") return []
-        if (msg.info.time.created >= boot) return []
-        return [{ info: msg.info, parts: msg.parts }]
+      count += await repair({
+        messages: await Session.messages({ sessionID: session.id }).catch(() => []),
+        completed: boot,
+        message: "Assistant response was interrupted by a previous shutdown.",
+        tool: "Tool execution interrupted by a previous shutdown.",
+        previous: true,
       })
-
-      await Promise.all(
-        stale.map((msg) =>
-          Promise.all([
-            ...msg.parts
-              .filter((part): part is MessageV2.ToolPart => part.type === "tool")
-              .filter((part) => part.state.status !== "completed" && part.state.status !== "error")
-              .map((part) =>
-                Session.updatePart({
-                  ...part,
-                  state: {
-                    ...part.state,
-                    status: "error",
-                    error: "Tool execution interrupted by a previous shutdown.",
-                    time: {
-                      start: Date.now(),
-                      end: Date.now(),
-                    },
-                  },
-                }),
-              ),
-            Session.updateMessage({
-              ...msg.info,
-              error:
-                msg.info.error ??
-                MessageV2.fromError(new Error("Assistant response was interrupted by a previous shutdown."), {
-                  providerID: msg.info.providerID,
-                }),
-              time: {
-                ...msg.info.time,
-                completed: boot,
-              },
-            }),
-          ]),
-        ),
-      )
-      count += stale.length
     }
 
     if (count > 0) log.info("repaired interrupted assistant messages", { count })
+  }
+
+  export async function repairSession(sessionID: SessionID) {
+    const count = await repair({
+      messages: await Session.messages({ sessionID }).catch(() => []),
+      completed: Date.now(),
+      message: "Assistant response was interrupted.",
+      tool: "Tool execution interrupted.",
+      previous: false,
+    })
+
+    if (count > 0) log.info("repaired interrupted session", { sessionID, count })
   }
 }

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -160,7 +160,19 @@ afterAll(() => {
   state.server?.stop()
 })
 
-function createChatStream(text: string) {
+function createChatStream(text: string, finish: string | null | undefined = "stop") {
+  const done =
+    finish === undefined
+      ? {
+          id: "chatcmpl-1",
+          object: "chat.completion.chunk",
+          choices: [{ delta: {} }],
+        }
+      : {
+          id: "chatcmpl-1",
+          object: "chat.completion.chunk",
+          choices: [{ delta: {}, finish_reason: finish }],
+        }
   const payload =
     [
       `data: ${JSON.stringify({
@@ -173,11 +185,74 @@ function createChatStream(text: string) {
         object: "chat.completion.chunk",
         choices: [{ delta: { content: text } }],
       })}`,
+      `data: ${JSON.stringify(done)}`,
+      "data: [DONE]",
+    ].join("\n\n") + "\n\n"
+
+  const encoder = new TextEncoder()
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(payload))
+      controller.close()
+    },
+  })
+}
+
+function createToolStream(finish: string | null | undefined = "stop") {
+  const done =
+    finish === undefined
+      ? {
+          id: "chatcmpl-1",
+          object: "chat.completion.chunk",
+          choices: [{ delta: {} }],
+        }
+      : {
+          id: "chatcmpl-1",
+          object: "chat.completion.chunk",
+          choices: [{ delta: {}, finish_reason: finish }],
+        }
+  const payload =
+    [
       `data: ${JSON.stringify({
         id: "chatcmpl-1",
         object: "chat.completion.chunk",
-        choices: [{ delta: {}, finish_reason: "stop" }],
+        choices: [{ delta: { role: "assistant" } }],
       })}`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl-1",
+        object: "chat.completion.chunk",
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_1",
+                  type: "function",
+                  function: { name: "question", arguments: "" },
+                },
+              ],
+            },
+          },
+        ],
+      })}`,
+      `data: ${JSON.stringify({
+        id: "chatcmpl-1",
+        object: "chat.completion.chunk",
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  function: { arguments: "{}" },
+                },
+              ],
+            },
+          },
+        ],
+      })}`,
+      `data: ${JSON.stringify(done)}`,
       "data: [DONE]",
     ].join("\n\n") + "\n\n"
 
@@ -227,6 +302,172 @@ function createEventResponse(chunks: unknown[], includeDone = false) {
 }
 
 describe("session.llm.stream", () => {
+  test("normalizes unknown finish reason without tool calls to stop", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "alibaba"
+    const modelID = "qwen-plus"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+
+    waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello", undefined), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await Provider.getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-unknown-finish")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+        const user = {
+          id: MessageID.make("user-unknown-finish"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        const stream = await LLM.stream({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        let reason = ""
+        for await (const part of stream.fullStream) {
+          if (part.type === "finish") reason = part.finishReason
+        }
+
+        expect(reason).toBe("stop")
+      },
+    })
+  })
+
+  test("keeps tool call turns active when finish reason is unknown", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "alibaba"
+    const modelID = "qwen-plus"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+
+    waitRequest(
+      "/chat/completions",
+      new Response(createToolStream(undefined), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await Provider.getModel(ProviderID.make(providerID), ModelID.make(model.id))
+        const sessionID = SessionID.make("session-test-tool-finish")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+        const user = {
+          id: MessageID.make("user-tool-finish"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        const stream = await LLM.stream({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Use the tool" }],
+          tools: {
+            question: tool({
+              description: "Ask a question",
+              inputSchema: z.object({}),
+              execute: async () => ({ output: "" }),
+            }),
+          },
+        })
+
+        let reason = ""
+        for await (const part of stream.fullStream) {
+          if (part.type === "finish") reason = part.finishReason
+        }
+
+        expect(reason).toBe("tool-calls")
+      },
+    })
+  })
+
   test("sends temperature, tokens, and reasoning options for openai-compatible models", async () => {
     const server = state.server
     if (!server) {

--- a/packages/opencode/test/session/recovery.test.ts
+++ b/packages/opencode/test/session/recovery.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { MessageV2 } from "../../src/session/message-v2"
+import { SessionRecovery } from "../../src/session/recovery"
+import { MessageID, PartID } from "../../src/session/schema"
+import { tmpdir } from "../fixture/fixture"
+
+describe("session.recovery", () => {
+  test("repairs unfinished assistant messages and tools for a stopped session", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const user = MessageID.ascending()
+        const assistant = MessageID.ascending()
+
+        await Session.updateMessage({
+          id: user,
+          sessionID: session.id,
+          role: "user",
+          time: { created: Date.now() },
+          agent: "build",
+          model: { providerID: "test", modelID: "test" },
+          tools: {},
+        } as unknown as MessageV2.Info)
+        await Session.updateMessage({
+          id: assistant,
+          sessionID: session.id,
+          role: "assistant",
+          parentID: user,
+          time: { created: Date.now() },
+          providerID: "test",
+          modelID: "test",
+          mode: "build",
+          agent: "build",
+          path: { cwd: tmp.path, root: tmp.path },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        } as unknown as MessageV2.Info)
+        await Session.updatePart({
+          id: PartID.ascending(),
+          messageID: assistant,
+          sessionID: session.id,
+          type: "tool",
+          callID: "call-test",
+          tool: "bash",
+          state: {
+            status: "running",
+            input: {},
+            time: { start: Date.now() },
+          },
+        })
+
+        await SessionRecovery.repairSession(session.id)
+
+        const messages = await Session.messages({ sessionID: session.id })
+        const msg = messages.find((item) => item.info.id === assistant)
+        const part = msg?.parts.find((item): item is MessageV2.ToolPart => item.type === "tool")
+
+        expect(msg?.info.role).toBe("assistant")
+        if (msg?.info.role !== "assistant") throw new Error("expected repaired assistant")
+        expect(typeof msg.info.time.completed).toBe("number")
+        expect(msg.info.error?.data.message).toContain("interrupted")
+        expect(part?.state.status).toBe("error")
+        if (part?.state.status !== "error") throw new Error("expected repaired tool error")
+        expect(part.state.error).toBe("Tool execution interrupted.")
+      },
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #703

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Repairs session state cleanup around stop/cancel and provider finish reasons.

- Repairs unfinished assistant messages and pending/running tool parts when a session is cancelled.
- Ensures processor error paths publish `message.updated` with `time.completed` before sending idle status.
- Normalizes unknown finish reasons: no tool calls become `stop`, tool-call turns become `tool-calls`.
- Updates rollback tracking docs to mark #640, #671, and #684 as integrated.

### How did you verify your code works?

- `bun install --frozen-lockfile`
- `bun typecheck` from `packages/opencode`
- `bun test test/session/llm.test.ts test/session/recovery.test.ts` from `packages/opencode`
- push hook ran `bun turbo typecheck` successfully

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR