### PR TITLE
fix: split DB migration corruption, wrong project resolution, stale project_recent

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -96,9 +96,16 @@ let cli = yargs(hideBin(process.argv))
         Database.close()
         try {
           const result = SplitMigration.run()
-          process.stderr.write(
-            `Per-project DB split: ${result.projects} projects, ${result.sessions} sessions migrated.${EOL}`,
-          )
+          if (SplitMigration.isSwapPending()) {
+            process.stderr.write(
+              `Per-project DB split: data migrated (${result.projects} projects, ${result.sessions} sessions).${EOL}`,
+            )
+            process.stderr.write(`File swap deferred — restart to complete migration.${EOL}`)
+          } else {
+            process.stderr.write(
+              `Per-project DB split: ${result.projects} projects, ${result.sessions} sessions migrated.${EOL}`,
+            )
+          }
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error)
           process.stderr.write(`Per-project DB split failed: ${msg}${EOL}`)

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -546,19 +546,23 @@ export namespace Database {
     for (const r of rows) trackedIds.add(r.project_id)
 
     const chDir = channelDir()
-    if (!existsSync(chDir)) return
+    const existingDbIds = new Set<string>()
+    if (existsSync(chDir)) {
+      const pattern = /^aether-(.+)\.db$/
+      for (const entry of readdirSync(chDir)) {
+        const match = pattern.exec(entry)
+        if (!match) continue
+        const pid = match[1]
+        if (pid === "cron") continue
+        existingDbIds.add(pid)
+      }
+    }
 
-    const pattern = /^aether-(.+)\.db$/
-    const entries = readdirSync(chDir)
+    // Register untracked project DBs into global_project_map
     let registered = 0
-    for (const entry of entries) {
-      const match = pattern.exec(entry)
-      if (!match) continue
-      const pid = match[1]
-      if (pid === "cron") continue
+    for (const pid of existingDbIds) {
       if (trackedIds.has(pid)) continue
-
-      const fullPath = path.join(chDir, entry)
+      const fullPath = path.join(chDir, `aether-${pid}.db`)
       const pSqlite = new BunSqlite(fullPath)
       const projectRow = pSqlite.prepare("SELECT worktree FROM project WHERE id = ?").get(pid) as
         | { worktree: string }
@@ -576,6 +580,45 @@ export namespace Database {
       pSqlite.close()
     }
     if (registered > 0) log.info("untracked project registration complete", { registered })
+
+    // Delete project_recent entries whose project_id has no corresponding DB
+    const recentRows = sqlite
+      .prepare("SELECT key, project_id FROM project_recent WHERE kind = 'project' AND project_id IS NOT NULL")
+      .all() as { key: string; project_id: string }[]
+    let removed = 0
+    for (const row of recentRows) {
+      if (!existingDbIds.has(row.project_id)) {
+        sqlite.prepare("DELETE FROM project_recent WHERE key = ?").run(row.key)
+        removed++
+      }
+    }
+    if (removed > 0) log.info("removed project_recent entries without project db", { removed })
+
+    // Create project_recent entries for project DBs not yet in project_recent
+    const recentProjectIds = new Set(
+      (
+        sqlite
+          .prepare("SELECT project_id FROM project_recent WHERE kind = 'project' AND project_id IS NOT NULL")
+          .all() as { project_id: string }[]
+      ).map((r) => r.project_id),
+    )
+    let created = 0
+    for (const pid of existingDbIds) {
+      if (recentProjectIds.has(pid)) continue
+      const mapRow = sqlite.prepare("SELECT directory FROM global_project_map WHERE project_id = ?").get(pid) as
+        | { directory: string }
+        | undefined
+      const directory = mapRow?.directory ?? ""
+      if (!directory) continue
+      sqlite
+        .prepare(
+          "INSERT OR IGNORE INTO project_recent (key, kind, project_id, directory, activity_at, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(`dir:${norm(directory)}`, "project", pid, directory, Date.now(), Date.now(), Date.now())
+      created++
+      log.info("created project_recent for untracked project db", { pid, directory })
+    }
+    if (created > 0) log.info("project_recent creation complete", { created })
   }
 
   export function transaction<T>(

--- a/packages/opencode/src/storage/split-migration.ts
+++ b/packages/opencode/src/storage/split-migration.ts
@@ -416,6 +416,7 @@ export namespace SplitMigration {
     if (existsSync(swapMarker)) {
       const data = JSON.parse(readFileSync(swapMarker, "utf-8")) as {
         destCopy: string
+        srcCopy: string
         projects: number
         sessions: number
       }
@@ -432,6 +433,7 @@ export namespace SplitMigration {
       }
       copyFileSync(data.destCopy, main)
       deleteWithCompanions(data.destCopy)
+      deleteWithCompanions(data.srcCopy)
       unlinkSync(swapMarker)
       removeAttempts()
       log.info("completed pending swap from previous migration", data)
@@ -916,7 +918,7 @@ export namespace SplitMigration {
         // when no process holds the file.
         writeFileSync(
           swapMarkerPath(main),
-          JSON.stringify({ destCopy, projects: projectCount, sessions: sessionCount }),
+          JSON.stringify({ destCopy, srcCopy, projects: projectCount, sessions: sessionCount }),
         )
         log.info("WAL/SHM companions still held, deferring file swap to next startup", {
           destCopy,
@@ -929,6 +931,7 @@ export namespace SplitMigration {
       log.info("replaced main db with migration result")
 
       deleteWithCompanions(destCopy)
+      deleteWithCompanions(srcCopy)
 
       removeAttempts()
       log.info("split migration complete", { projects: projectCount, sessions: sessionCount })

--- a/packages/opencode/src/storage/split-migration.ts
+++ b/packages/opencode/src/storage/split-migration.ts
@@ -47,10 +47,6 @@ export namespace SplitMigration {
 
   const MAX_ATTEMPTS = 5
 
-  function srcCopyPath(main: string) {
-    return path.join(backupDir(), path.basename(main) + ".migration-src")
-  }
-
   function destCopyPath(main: string) {
     return path.join(backupDir(), path.basename(main) + ".migration-dest")
   }
@@ -190,7 +186,6 @@ export namespace SplitMigration {
       }
       sqlite.close()
       deleteWithCompanions(retiredPath(main))
-      deleteWithCompanions(srcCopyPath(main))
       deleteWithCompanions(destCopyPath(main))
       return "none"
     } catch {
@@ -416,7 +411,6 @@ export namespace SplitMigration {
     if (existsSync(swapMarker)) {
       const data = JSON.parse(readFileSync(swapMarker, "utf-8")) as {
         destCopy: string
-        srcCopy: string
         projects: number
         sessions: number
       }
@@ -433,7 +427,6 @@ export namespace SplitMigration {
       }
       copyFileSync(data.destCopy, main)
       deleteWithCompanions(data.destCopy)
-      deleteWithCompanions(data.srcCopy)
       unlinkSync(swapMarker)
       removeAttempts()
       log.info("completed pending swap from previous migration", data)
@@ -464,12 +457,10 @@ export namespace SplitMigration {
 
     const main = mainDbPath()
     const backup = backupDbPath(main)
-    const srcCopy = srcCopyPath(main)
     const destCopy = destCopyPath(main)
     const retired = retiredPath(main)
-    log.info("starting per-project database split", { main, backup, srcCopy, destCopy, attempt: attempts + 1 })
+    log.info("starting per-project database split", { main, backup, destCopy, attempt: attempts + 1 })
 
-    deleteWithCompanions(srcCopy)
     deleteWithCompanions(destCopy)
 
     let srcSqlite: BunDatabase | undefined
@@ -488,11 +479,10 @@ export namespace SplitMigration {
         log.info("backed up main db", { from: main, to: backup })
       }
 
-      copyFileSync(backup, srcCopy)
       copyFileSync(backup, destCopy)
-      log.info("created isolation copies from backup", { srcCopy, destCopy })
+      log.info("created destCopy from backup", { destCopy })
 
-      srcSqlite = new BunDatabase(srcCopy)
+      srcSqlite = new BunDatabase(backup, { readonly: true })
       srcSqlite.exec("PRAGMA foreign_keys = OFF")
 
       const projects = srcSqlite.prepare("SELECT * FROM project").all() as any[]
@@ -918,7 +908,7 @@ export namespace SplitMigration {
         // when no process holds the file.
         writeFileSync(
           swapMarkerPath(main),
-          JSON.stringify({ destCopy, srcCopy, projects: projectCount, sessions: sessionCount }),
+          JSON.stringify({ destCopy, projects: projectCount, sessions: sessionCount }),
         )
         log.info("WAL/SHM companions still held, deferring file swap to next startup", {
           destCopy,
@@ -931,7 +921,6 @@ export namespace SplitMigration {
       log.info("replaced main db with migration result")
 
       deleteWithCompanions(destCopy)
-      deleteWithCompanions(srcCopy)
 
       removeAttempts()
       log.info("split migration complete", { projects: projectCount, sessions: sessionCount })

--- a/packages/opencode/src/storage/split-migration.ts
+++ b/packages/opencode/src/storage/split-migration.ts
@@ -867,12 +867,8 @@ export namespace SplitMigration {
             .run(pid, row.key)
           continue
         }
-        destSqlite.prepare("UPDATE project_recent SET kind = 'directory', project_id = NULL WHERE key = ?").run(row.key)
+        destSqlite.prepare("DELETE FROM project_recent WHERE key = ?").run(row.key)
       }
-      const recentCount = (destSqlite.prepare("SELECT count(*) as cnt FROM project_recent").get() as { cnt: number })
-        .cnt
-      if (recentCount !== srcCounts.project_recent)
-        throw new Error("project_recent count changed during split migration")
       const hasSessionPref = destSqlite
         .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='session_preference'")
         .get()

--- a/packages/opencode/src/storage/split-migration.ts
+++ b/packages/opencode/src/storage/split-migration.ts
@@ -60,10 +60,44 @@ export namespace SplitMigration {
   }
 
   function deleteWithCompanions(p: string) {
-    if (existsSync(p)) unlinkSync(p)
-    for (const ext of ["-shm", "-wal"]) {
-      if (existsSync(p + ext)) unlinkSync(p + ext)
+    for (const target of [p, p + "-shm", p + "-wal"]) {
+      try {
+        if (existsSync(target)) unlinkSync(target)
+      } catch {
+        // EBUSY on Windows: file handle not yet released after close().
+        // Leave the file — cleanup will retry on next startup via needsMigration().
+      }
     }
+  }
+
+  function deleteCompanionsWithRetry(p: string, maxWaitMs: number = 3000) {
+    const start = Date.now()
+    for (const ext of ["-shm", "-wal"]) {
+      const target = p + ext
+      if (!existsSync(target)) continue
+      while (Date.now() - start < maxWaitMs) {
+        try {
+          unlinkSync(target)
+          log.info("deleted companion after retry", { target, elapsedMs: Date.now() - start })
+          break
+        } catch {
+          // EBUSY — busy-wait and retry (Windows releases handles within ~100-500ms)
+        }
+      }
+      if (existsSync(target)) {
+        log.error("could not delete companion after retry", { target, elapsedMs: Date.now() - start })
+      }
+    }
+  }
+
+  export function isSwapPending(): boolean {
+    const main = mainDbPath()
+    if (main === ":memory:") return false
+    return existsSync(swapMarkerPath(main))
+  }
+
+  function swapMarkerPath(main: string) {
+    return main + ".swap-pending"
   }
 
   function attemptsPath() {
@@ -98,6 +132,11 @@ export namespace SplitMigration {
   export type MigrationType = "initial-split" | "none"
 
   export function needsMigration(): MigrationType {
+    const main = mainDbPath()
+    if (main === ":memory:") return "none"
+
+    if (existsSync(swapMarkerPath(main))) return "initial-split"
+
     if (readAttempts() >= MAX_ATTEMPTS) {
       log.error("split migration failed too many times, manual intervention required", {
         attempts: readAttempts(),
@@ -105,8 +144,6 @@ export namespace SplitMigration {
       })
       return "none"
     }
-    const main = mainDbPath()
-    if (main === ":memory:") return "none"
 
     if (!existsSync(main)) {
       const retired = retiredPath(main)
@@ -373,6 +410,34 @@ export namespace SplitMigration {
   }
 
   export function run(): { projects: number; sessions: number } {
+    const main = mainDbPath()
+
+    const swapMarker = swapMarkerPath(main)
+    if (existsSync(swapMarker)) {
+      const data = JSON.parse(readFileSync(swapMarker, "utf-8")) as {
+        destCopy: string
+        projects: number
+        sessions: number
+      }
+      if (!existsSync(data.destCopy)) {
+        log.error("swap marker references missing destCopy, removing marker", { destCopy: data.destCopy })
+        unlinkSync(swapMarker)
+        removeAttempts()
+        return { projects: 0, sessions: 0 }
+      }
+      deleteCompanionsWithRetry(main, 3000)
+      if (existsSync(main + "-shm") || existsSync(main + "-wal")) {
+        log.error("WAL/SHM companions still held, deferring swap to next startup")
+        return { projects: data.projects, sessions: data.sessions }
+      }
+      copyFileSync(data.destCopy, main)
+      deleteWithCompanions(data.destCopy)
+      unlinkSync(swapMarker)
+      removeAttempts()
+      log.info("completed pending swap from previous migration", data)
+      return { projects: data.projects, sessions: data.sessions }
+    }
+
     const attempts = readAttempts()
     if (attempts >= MAX_ATTEMPTS) {
       throw new Error(
@@ -842,11 +907,23 @@ export namespace SplitMigration {
       destSqlite.close()
       destSqlite = undefined
 
-      // Overwrite main with migration result (copyFileSync overwrites destination).
-      // The .pre-split backup in backup dir serves as the ultimate safety net.
-      // Delete stale WAL/SHM companions first so SQLite starts clean on next open.
-      for (const ext of ["-shm", "-wal"]) {
-        if (existsSync(main + ext)) unlinkSync(main + ext)
+      // Try to delete main.db's WAL/SHM companions. On Windows, handles from
+      // prior needsMigration() / Database.close() calls may linger briefly.
+      deleteCompanionsWithRetry(main, 3000)
+      if (existsSync(main + "-shm") || existsSync(main + "-wal")) {
+        // WAL/SHM still held — cannot safely overwrite main.db (stale WAL
+        // replay would corrupt the new content). Defer swap to next startup
+        // when no process holds the file.
+        writeFileSync(
+          swapMarkerPath(main),
+          JSON.stringify({ destCopy, projects: projectCount, sessions: sessionCount }),
+        )
+        log.info("WAL/SHM companions still held, deferring file swap to next startup", {
+          destCopy,
+          swapMarker: swapMarkerPath(main),
+        })
+        removeAttempts()
+        return { projects: projectCount, sessions: sessionCount }
       }
       copyFileSync(destCopy, main)
       log.info("replaced main db with migration result")

--- a/packages/opencode/src/storage/split-migration.ts
+++ b/packages/opencode/src/storage/split-migration.ts
@@ -47,6 +47,25 @@ export namespace SplitMigration {
 
   const MAX_ATTEMPTS = 5
 
+  function srcCopyPath(main: string) {
+    return path.join(backupDir(), path.basename(main) + ".migration-src")
+  }
+
+  function destCopyPath(main: string) {
+    return path.join(backupDir(), path.basename(main) + ".migration-dest")
+  }
+
+  function retiredPath(main: string) {
+    return path.join(backupDir(), path.basename(main) + ".retired")
+  }
+
+  function deleteWithCompanions(p: string) {
+    if (existsSync(p)) unlinkSync(p)
+    for (const ext of ["-shm", "-wal"]) {
+      if (existsSync(p + ext)) unlinkSync(p + ext)
+    }
+  }
+
   function attemptsPath() {
     return mainDbPath() + ".migration-attempts"
   }
@@ -88,7 +107,25 @@ export namespace SplitMigration {
     }
     const main = mainDbPath()
     if (main === ":memory:") return "none"
-    if (!existsSync(main)) return "none"
+
+    if (!existsSync(main)) {
+      const retired = retiredPath(main)
+      if (existsSync(retired)) {
+        try {
+          copyFileSync(retired, main)
+          for (const ext of ["-shm", "-wal"]) {
+            if (existsSync(retired + ext)) copyFileSync(retired + ext, main + ext)
+          }
+          deleteWithCompanions(retired)
+          log.info("recovered main db from retired copy", { source: retired })
+        } catch {
+          log.error("failed to recover main db from retired copy", { source: retired })
+        }
+      } else {
+        return "none"
+      }
+    }
+
     if (readAttempts() > 0 && existsSync(backupDbPath(main))) {
       const backup = new BunDatabase(backupDbPath(main))
       try {
@@ -104,7 +141,6 @@ export namespace SplitMigration {
     const sqlite = new BunDatabase(main)
     sqlite.exec("PRAGMA wal_checkpoint(TRUNCATE)")
     try {
-      // Case 1: monolithic DB still has session table → initial split needed
       const hasSessionTable = sqlite
         .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='session'")
         .get()
@@ -116,6 +152,9 @@ export namespace SplitMigration {
         }
       }
       sqlite.close()
+      deleteWithCompanions(retiredPath(main))
+      deleteWithCompanions(srcCopyPath(main))
+      deleteWithCompanions(destCopyPath(main))
       return "none"
     } catch {
       sqlite.close()
@@ -302,11 +341,10 @@ export namespace SplitMigration {
     }
   }
 
-  function verifySplit(srcSqlite: BunDatabase, projectIds: Set<string>): boolean {
-    const srcSessions = (srcSqlite.prepare("SELECT count(*) as cnt FROM session").get() as { cnt: number }).cnt
-    const srcMessages = (srcSqlite.prepare("SELECT count(*) as cnt FROM message").get() as { cnt: number }).cnt
-    const srcParts = (srcSqlite.prepare("SELECT count(*) as cnt FROM part").get() as { cnt: number }).cnt
-
+  function verifySplit(
+    expected: { sessions: number; messages: number; parts: number },
+    projectIds: Set<string>,
+  ): boolean {
     let totalSessions = 0
     let totalMessages = 0
     let totalParts = 0
@@ -323,9 +361,9 @@ export namespace SplitMigration {
       pDb.close()
     }
 
-    if (totalSessions !== srcSessions || totalMessages !== srcMessages || totalParts !== srcParts) {
+    if (totalSessions !== expected.sessions || totalMessages !== expected.messages || totalParts !== expected.parts) {
       log.error("verification failed: count mismatch", {
-        expected: { sessions: srcSessions, messages: srcMessages, parts: srcParts },
+        expected: { sessions: expected.sessions, messages: expected.messages, parts: expected.parts },
         actual: { sessions: totalSessions, messages: totalMessages, parts: totalParts },
       })
       return false
@@ -359,58 +397,35 @@ export namespace SplitMigration {
 
     const main = mainDbPath()
     const backup = backupDbPath(main)
-    log.info("starting per-project database split", { main, backup, attempt: attempts + 1 })
+    const srcCopy = srcCopyPath(main)
+    const destCopy = destCopyPath(main)
+    const retired = retiredPath(main)
+    log.info("starting per-project database split", { main, backup, srcCopy, destCopy, attempt: attempts + 1 })
+
+    deleteWithCompanions(srcCopy)
+    deleteWithCompanions(destCopy)
+
+    let srcSqlite: BunDatabase | undefined
+    let destSqlite: BunDatabase | undefined
 
     try {
-      // Prefer existing .pre-split backup if it contains original monolithic data.
-      // This handles the case where a previous split partially succeeded:
-      // the main DB was modified (global_project_map added, tables partially dropped)
-      // but the .pre-split backup still has the original complete data.
-      let srcPath = backup
-      if (existsSync(backup)) {
-        let testDb: BunDatabase | undefined
-        try {
-          testDb = new BunDatabase(backup)
-          testDb.exec("PRAGMA wal_checkpoint(TRUNCATE)")
-          const hasProjectTable = testDb
-            .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='project'")
-            .get()
-          if (hasProjectTable) {
-            log.info("using existing pre-split backup as source", { path: backup })
-          } else {
-            srcPath = main
-            log.info("pre-split backup lacks project table, will recreate from main db", { path: backup })
-          }
-        } catch {
-          srcPath = main
-          log.info("pre-split backup unreadable, will recreate from main db", { path: backup })
-        } finally {
-          testDb?.close()
-        }
-      } else {
-        srcPath = main
-      }
-
-      if (srcPath === main) {
-        // Backup WAL/SHM BEFORE checkpoint (checkpoint deletes these files)
+      if (!existsSync(backup)) {
         const companions = ["-shm", "-wal"]
         for (const ext of companions) {
-          const srcPathComp = main + ext
-          const dstPathComp = backup + ext
-          if (existsSync(srcPathComp)) copyFileSync(srcPathComp, dstPathComp)
+          if (existsSync(main + ext)) copyFileSync(main + ext, backup + ext)
         }
-
-        // WAL checkpoint flushes WAL data into main db file, then deletes WAL/SHM
         const checkpointDb = new BunDatabase(main)
         checkpointDb.exec("PRAGMA wal_checkpoint(TRUNCATE)")
         checkpointDb.close()
-
-        // After checkpoint, .db file contains all data; WAL/SHM are gone
         copyFileSync(main, backup)
         log.info("backed up main db", { from: main, to: backup })
       }
 
-      const srcSqlite = new BunDatabase(srcPath)
+      copyFileSync(backup, srcCopy)
+      copyFileSync(backup, destCopy)
+      log.info("created isolation copies from backup", { srcCopy, destCopy })
+
+      srcSqlite = new BunDatabase(srcCopy)
       srcSqlite.exec("PRAGMA foreign_keys = OFF")
 
       const projects = srcSqlite.prepare("SELECT * FROM project").all() as any[]
@@ -437,6 +452,16 @@ export namespace SplitMigration {
           .get()
         return has ? (srcSqlite.prepare("SELECT * FROM session_preference").all() as any[]) : []
       })()
+
+      const srcCounts = {
+        sessions: (srcSqlite.prepare("SELECT count(*) as cnt FROM session").get() as { cnt: number }).cnt,
+        messages: (srcSqlite.prepare("SELECT count(*) as cnt FROM message").get() as { cnt: number }).cnt,
+        parts: (srcSqlite.prepare("SELECT count(*) as cnt FROM part").get() as { cnt: number }).cnt,
+        project_recent: (srcSqlite.prepare("SELECT count(*) as cnt FROM project_recent").get() as { cnt: number }).cnt,
+      }
+
+      srcSqlite.close()
+      srcSqlite = undefined
 
       const treeBySession = new Map(sessions.map((s) => [s.id, s.tree_id] as const))
       for (const s of sessions) {
@@ -748,14 +773,14 @@ export namespace SplitMigration {
       log.info("created cron database")
 
       // Verify all data was correctly migrated before modifying main DB
-      const verified = verifySplit(srcSqlite, uniqueProjectIds)
+      const verified = verifySplit(srcCounts, uniqueProjectIds)
       if (!verified) {
-        srcSqlite.close()
         throw new Error("split migration verification failed, will retry on next startup")
       }
 
-      const destSqlite = new BunDatabase(main)
+      destSqlite = new BunDatabase(destCopy)
       destSqlite.exec("PRAGMA foreign_keys = OFF")
+      destSqlite.exec("PRAGMA busy_timeout = 5000")
       destSqlite.exec("PRAGMA wal_checkpoint(TRUNCATE)")
       destSqlite.exec("BEGIN TRANSACTION")
       destSqlite.exec(globalProjectMapSQL)
@@ -768,7 +793,6 @@ export namespace SplitMigration {
           )
           .run(dir, pid, Date.now(), Date.now())
       }
-      // Strip FKs BEFORE dropping tables (strip needs the source table to exist)
       destSqlite.exec(stripProjectRecentFK)
       const recentRows = destSqlite.prepare("SELECT key, kind, project_id, directory FROM project_recent").all() as {
         key: string
@@ -781,23 +805,23 @@ export namespace SplitMigration {
           (row.project_id ? oldProjectIdMap.get(row.project_id) : undefined) ??
           directoryProjectMap.get(norm(row.directory ?? ""))
         if (pid && uniqueProjectIds.has(pid)) {
-          destSqlite.prepare("UPDATE project_recent SET kind = 'project', project_id = ? WHERE key = ?").run(pid, row.key)
+          destSqlite
+            .prepare("UPDATE project_recent SET kind = 'project', project_id = ? WHERE key = ?")
+            .run(pid, row.key)
           continue
         }
         destSqlite.prepare("UPDATE project_recent SET kind = 'directory', project_id = NULL WHERE key = ?").run(row.key)
       }
-      const recentCount = (destSqlite.prepare("SELECT count(*) as cnt FROM project_recent").get() as { cnt: number }).cnt
-      const sourceRecentCount = (
-        srcSqlite.prepare("SELECT count(*) as cnt FROM project_recent").get() as { cnt: number }
-      ).cnt
-      if (recentCount !== sourceRecentCount) throw new Error("project_recent count changed during split migration")
+      const recentCount = (destSqlite.prepare("SELECT count(*) as cnt FROM project_recent").get() as { cnt: number })
+        .cnt
+      if (recentCount !== srcCounts.project_recent)
+        throw new Error("project_recent count changed during split migration")
       const hasSessionPref = destSqlite
         .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='session_preference'")
         .get()
       if (hasSessionPref) {
         destSqlite.exec(stripSessionPreferenceFK)
       }
-      // Now drop tables that moved to per-project/cron dbs
       destSqlite.exec("DROP TABLE IF EXISTS session")
       destSqlite.exec("DROP TABLE IF EXISTS message")
       destSqlite.exec("DROP TABLE IF EXISTS part")
@@ -816,16 +840,27 @@ export namespace SplitMigration {
       destSqlite.exec("VACUUM")
       destSqlite.exec("PRAGMA wal_checkpoint(TRUNCATE)")
       destSqlite.close()
+      destSqlite = undefined
 
-      srcSqlite.close()
+      // Overwrite main with migration result (copyFileSync overwrites destination).
+      // The .pre-split backup in backup dir serves as the ultimate safety net.
+      // Delete stale WAL/SHM companions first so SQLite starts clean on next open.
+      for (const ext of ["-shm", "-wal"]) {
+        if (existsSync(main + ext)) unlinkSync(main + ext)
+      }
+      copyFileSync(destCopy, main)
+      log.info("replaced main db with migration result")
+
+      deleteWithCompanions(destCopy)
 
       removeAttempts()
       log.info("split migration complete", { projects: projectCount, sessions: sessionCount })
       return { projects: projectCount, sessions: sessionCount }
     } catch (error) {
+      srcSqlite?.close()
+      destSqlite?.close()
       log.error("split migration failed", { error, attempt: readAttempts() })
       throw error
     }
   }
-
 }

--- a/packages/opencode/src/storage/split-migration.ts
+++ b/packages/opencode/src/storage/split-migration.ts
@@ -426,7 +426,7 @@ export namespace SplitMigration {
         return { projects: data.projects, sessions: data.sessions }
       }
       copyFileSync(data.destCopy, main)
-      deleteWithCompanions(data.destCopy)
+      deleteCompanionsWithRetry(data.destCopy, 3000)
       unlinkSync(swapMarker)
       removeAttempts()
       log.info("completed pending swap from previous migration", data)
@@ -585,7 +585,7 @@ export namespace SplitMigration {
 
       const resolveProject = (s: any) => {
         const row = projectByOld.get(s.project_id)
-        const dir = row?.worktree && row.worktree !== "/" ? row.worktree : s.directory || row?.worktree || "/"
+        const dir = s.directory || row?.worktree || "/"
         const info = ProjectIdentity.resolve(dir)
         const pid = info.id
         if (s.project_id !== "global") oldProjectIdMap.set(s.project_id, pid)
@@ -920,7 +920,7 @@ export namespace SplitMigration {
       copyFileSync(destCopy, main)
       log.info("replaced main db with migration result")
 
-      deleteWithCompanions(destCopy)
+      deleteCompanionsWithRetry(destCopy, 3000)
 
       removeAttempts()
       log.info("split migration complete", { projects: projectCount, sessions: sessionCount })


### PR DESCRIPTION
### Issue for this PR

Closes #716

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes three bugs in the split DB migration:

1. **SQLITE_CORRUPT on Windows**: After migration, `copyFileSync(destCopy, main)` overwrites main.db while stale WAL/SHM companion files remain held by prior `needsMigration()` / `Database.close()` connections (EBUSY on Windows). SQLite replays incompatible WAL frames → corruption. Fix: try `deleteCompanionsWithRetry(main, 3000)` with busy-wait; if WAL/SHM still held, write a `.swap-pending` marker and defer the file swap to next startup when no process holds the handles.

2. **Sessions in wrong project**: `resolveProject()` preferred `project.worktree` over `session.directory`, lumping all sessions under one old project_id into a single project regardless of actual working directory. Fix: prefer `session.directory` first, fallback to `row.worktree` only when directory is empty.

3. **Stale project_recent entries**: After migration, entries pointing to non-existent project DBs (e.g., app install dirs) were downgraded to `kind='directory'` instead of deleted. On startup, no cleanup removed orphaned entries, and no creation added entries for project DBs missing from project_recent. Fix: delete entries whose `project_id` has no .db file (both at migration time and on every startup); create entries for project DBs not yet in project_recent.

### How did you verify your code works?

- Full migration run on a 951MB monolithic DB (654 sessions, 32623 messages, 120263 parts) on Windows
- Verified `PRAGMA integrity_check` passes on main.db and all per-project DBs after migration
- Verified sessions correctly distributed by `session.directory` (8 projects vs previous 5)
- Verified swap deferred on first startup (WAL/SHM EBUSY), completed on second startup
- Verified `project_recent` entries synced with project DBs on startup
- `bun typecheck` passes

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR