### PR TITLE
fix: revert isSubagentSession to structural check to prevent subagent sessions leaking into conversation tree

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -62,10 +62,7 @@ export namespace Session {
   const forkTitlePattern = /^(.*) \(fork #(\d+)\)$/
 
   function isSubagentSession(session: Info) {
-    if (!session.parentID) return false
-    if (session.forkParentSessionID) return false
-    if (forkTitlePattern.test(session.title)) return false
-    return session.title.startsWith(childTitlePrefix)
+    return !!session.parentID && !session.forkParentSessionID
   }
 
   function createDefaultTitle(isChild = false) {


### PR DESCRIPTION
### Issue for this PR

Closes #719

### Type of change

- [x] Bug fix

### What does this PR do?

Reverts the `isSubagentSession` filter to the original structural check `!!parentID && !session.forkParentSessionID`, removing the title-based conditions that were silently added in `c8146ea80` ("Fix split DB migration invariants"). The title-based filter caused subagent sessions with LLM-generated titles (not starting with "Child session - ") to leak into the conversation tree.

The simple structural check is safe because:
- Fork sessions always have `forkParentSessionID` set, so they won't be misidentified.
- `repairTreeForkParents` is called before `tree()` and `graph()` queries, ensuring fork sessions within a tree have the field populated.

### How did you verify your code works?

- Reviewed the three call sites (`Session.children`, `Session.tree`, `Session.graph`) to confirm no non-subagent sessions satisfy `!!parentID && !forkParentSessionID` after `repairTreeForkParents` runs.
- Verified the diff is limited to the single function (4 lines removed, 1 line added).
- Typecheck passes.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR