### PR TITLE
fix: branch session busy state should not affect parent send/stop button

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -288,7 +288,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         (msg) => msg.role === "assistant" && typeof msg.time.completed !== "number",
       ),
   }))
-  const { interactive: working } = createWorkingState({
+  const { selfInteractive: working } = createWorkingState({
     status: () => status(),
     pending: () => pending(),
     sessionID: () => params.id,

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -313,7 +313,7 @@ export function MessageTimeline(props: {
         (msg) => msg.role === "assistant" && typeof msg.time.completed !== "number",
       ),
   }))
-  const { interactive: working } = createWorkingState({
+  const { selfInteractive: working } = createWorkingState({
     status: () => sessionStatus(),
     pending: () => pending(),
     sessionID: () => sessionID(),

--- a/packages/app/src/utils/working-state.ts
+++ b/packages/app/src/utils/working-state.ts
@@ -71,8 +71,9 @@ export function createWorkingState(input: {
     return descendant(id, source)
   })
 
+  const selfInteractive = createMemo(() => active())
   const visual = createMemo(() => self() || child())
   const interactive = createMemo(() => active() || child())
 
-  return { visual, interactive, grace }
+  return { visual, interactive, selfInteractive, grace }
 }


### PR DESCRIPTION
## Summary

- When a branch (child) session is busy, the parent session's send/stop button incorrectly shows "stop" state, because `interactive` in `createWorkingState` includes `child` (descendant sessions).
- Add `selfInteractive` signal that only reflects the current session's own active state (without child propagation), and use it for the prompt-input send/stop button and message-timeline working indicator.
- `interactive` (with child) is preserved for sidebar spinner and other consumers that legitimately need to show branch activity.