### PR TITLE
feat(mobile): 添加启动时自动连接和微信重新扫码功能

### DIFF
--- a/packages/app/src/components/dialog-mobile.tsx
+++ b/packages/app/src/components/dialog-mobile.tsx
@@ -2,6 +2,7 @@ import { Button } from "@opencode-ai/ui/button"
 import { Icon } from "@opencode-ai/ui/icon"
 import { Dialog } from "@opencode-ai/ui/dialog"
 import { Collapsible } from "@opencode-ai/ui/collapsible"
+import { Switch as SwitchToggle } from "@opencode-ai/ui/switch"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { Component, Show, Switch, Match, createSignal, onMount } from "solid-js"
 import { createStore } from "solid-js/store"
@@ -22,7 +23,10 @@ import {
   fetchStatus,
   forceTakeover,
   retryBridge,
+  rescanBridge,
   setStatus,
+  autoConnect,
+  setAutoConnect,
   type MobilePlatform,
   type MobileStatus,
 } from "@/context/mobile"
@@ -146,7 +150,7 @@ export const DialogMobile: Component<Props> = (props) => {
                 连接{platformName(props.platform)}后，可在{platformName(props.platform)}中使用 Aether AI
               </p>
               <Show
-                when={(p() === "feishu" || p() === "qq") && hasConfig(p())}
+                when={hasConfig(p())}
                 fallback={
                   p() === "feishu" || p() === "qq" ? (
                     <Button variant="primary" onClick={config}>
@@ -163,8 +167,15 @@ export const DialogMobile: Component<Props> = (props) => {
                   <Button variant="primary" onClick={doStart}>
                     {label().connect}
                   </Button>
-                  <Button variant="ghost" onClick={config}>
-                    重新配置
+                  <Button
+                    variant="ghost"
+                    onClick={() => {
+                      setPrevStatus("idle")
+                      if (p() === "wechat") rescanBridge("wechat")
+                      else setStatus(p(), "config")
+                    }}
+                  >
+                    {p() === "wechat" ? "重新扫码" : "重新配置"}
                   </Button>
                 </div>
               </Show>
@@ -348,7 +359,16 @@ export const DialogMobile: Component<Props> = (props) => {
                   />
                 </Show>
                 <p class="text-14-regular text-text-base">请用微信扫描二维码登录</p>
-                <Button variant="ghost" onClick={() => stopBridge("wechat")}>
+                <Button
+                  variant="ghost"
+                  onClick={() => {
+                    if (prevStatus() === "connected") {
+                      stopBridge("wechat").then(() => startBridge("wechat", true))
+                    } else {
+                      stopBridge("wechat")
+                    }
+                  }}
+                >
                   取消
                 </Button>
               </div>
@@ -397,10 +417,20 @@ export const DialogMobile: Component<Props> = (props) => {
                 <Button variant="secondary" onClick={() => stopBridge(p())}>
                   断开连接
                 </Button>
-                <Button variant="ghost" onClick={() => logout(p())}>
-                  {p() === "wechat" ? "切换账号" : "切换应用"}
+                <Button
+                  variant="ghost"
+                  onClick={() => {
+                    setPrevStatus(status(p()))
+                    if (p() === "wechat") rescanBridge("wechat")
+                    else setStatus(p(), "config")
+                  }}
+                >
+                  {p() === "wechat" ? "重新扫码" : "重新配置"}
                 </Button>
               </div>
+              <SwitchToggle checked={autoConnect(p())} onChange={(v) => setAutoConnect(p(), v)}>
+                启动时自动连接
+              </SwitchToggle>
             </div>
           </Match>
 

--- a/packages/app/src/context/mobile.ts
+++ b/packages/app/src/context/mobile.ts
@@ -162,6 +162,7 @@ function connectSSE(p: MobilePlatform) {
               if (props.appId) u.appId = props.appId
               if (props.user) u.user = props.user
               patch(p, u)
+              setAutoConnect(p, true)
               clearSseRetry(p)
             } else if (type.endsWith(".reconnecting")) {
               updateStatus(p, "reconnecting")
@@ -277,6 +278,24 @@ function stopPing() {
   }
 }
 
+const STORAGE_KEY = (p: MobilePlatform) => `opencode:mobile:autoConnect:${p}`
+
+const [autoConnectState, setAutoConnectState] = createSignal<Record<MobilePlatform, boolean>>({
+  feishu: localStorage.getItem(STORAGE_KEY("feishu")) === "true",
+  qq: localStorage.getItem(STORAGE_KEY("qq")) === "true",
+  wechat: localStorage.getItem(STORAGE_KEY("wechat")) === "true",
+})
+
+export function autoConnect(p: MobilePlatform) {
+  return autoConnectState()[p]
+}
+
+export function setAutoConnect(p: MobilePlatform, v: boolean) {
+  if (v) localStorage.setItem(STORAGE_KEY(p), "true")
+  else localStorage.removeItem(STORAGE_KEY(p))
+  setAutoConnectState((prev) => ({ ...prev, [p]: v }))
+}
+
 export async function fetchStatus(p: MobilePlatform) {
   const { url, headers } = api()
   try {
@@ -287,7 +306,7 @@ export async function fetchStatus(p: MobilePlatform) {
       patch("wechat", { locked: true, user: data.user || prev("wechat").user })
       return
     }
-    if (p === "wechat") patch("wechat", { locked: false })
+    if (p === "wechat") patch("wechat", { locked: false, hasConfig: data.hasConfig })
     if (p === "feishu") patch("feishu", { hasConfig: data.hasConfig })
     if (p === "qq") patch("qq", { hasConfig: data.hasConfig })
     if (data.status === "connected") {
@@ -295,6 +314,7 @@ export async function fetchStatus(p: MobilePlatform) {
       if (data.appId) u.appId = data.appId
       if (data.user) u.user = data.user
       patch(p, u)
+      setAutoConnect(p, true)
       startPing(p)
       connectSSE(p)
     } else if (data.status === "qrcode" && data.qrcode) {
@@ -310,6 +330,8 @@ export async function fetchStatus(p: MobilePlatform) {
       patch("feishu", { status: "idle" })
     } else if (p === "qq" && data.hasConfig) {
       patch("qq", { status: "idle" })
+    } else if (p === "wechat" && data.hasConfig && data.status === "idle") {
+      patch("wechat", { status: "idle", user: data.user })
     }
   } catch {}
 }
@@ -321,6 +343,7 @@ export async function startBridge(
   force = false,
   appIdVal?: string,
   appSecretVal?: string,
+  rescan = false,
 ) {
   patch(p, {
     status: "loading",
@@ -347,6 +370,7 @@ export async function startBridge(
       body.clientId = clientId
       body.autoInstall = auto
       body.force = force
+      body.rescan = rescan
       if (modelStr) body.model = modelStr
     }
 
@@ -377,6 +401,7 @@ export async function startBridge(
 
     if (data.status === "connected" && data.user) {
       patch(p, { user: data.user, status: "connected" })
+      setAutoConnect(p, true)
       startPing(p)
       return
     }
@@ -388,6 +413,7 @@ export async function startBridge(
 }
 
 export async function stopBridge(p: MobilePlatform) {
+  setAutoConnect(p, false)
   const abort = sseControllers[p]
   if (abort) {
     abort.abort()
@@ -453,6 +479,12 @@ export async function retryBridge(p: MobilePlatform) {
   }
 }
 
+export async function rescanBridge(p: MobilePlatform) {
+  if (p !== "wechat") return
+  await stopBridge("wechat")
+  return startBridge("wechat", true, undefined, false, undefined, undefined, true)
+}
+
 export async function forceTakeover(p: MobilePlatform, modelStr?: string) {
   return startBridge(p, true, modelStr, true)
 }
@@ -470,5 +502,9 @@ export function initMobile(p: MobilePlatform) {
       } catch {}
     })
   }
-  fetchStatus(p)
+  fetchStatus(p).then(() => {
+    if (autoConnect(p) && hasConfig(p) && status(p) === "idle") {
+      startBridge(p)
+    }
+  })
 }

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -134,6 +134,7 @@ export default function Layout(props: ParentProps) {
   })
   initMobile("wechat")
   initMobile("feishu")
+  initMobile("qq")
   const notification = useNotification()
   const permission = usePermission()
   const navigate = useNavigate()
@@ -1494,10 +1495,12 @@ export default function Layout(props: ParentProps) {
 
   function projectRoot(directory: string) {
     const dirKey = workspaceKey(directory)
-    const project = layout.projects
-      .list()
-      .find((item) => workspaceKey(item.worktree) === dirKey || item.sandboxes?.some((s) => workspaceKey(s) === dirKey))
-    if (project) return project.worktree
+    const projects = layout.projects.list()
+    const direct = projects.find((item) => workspaceKey(item.worktree) === dirKey)
+    if (direct) return direct.worktree
+
+    const sandbox = projects.find((item) => item.sandboxes?.some((s) => workspaceKey(s) === dirKey))
+    if (sandbox) return sandbox.worktree
 
     const known = Object.entries(store.workspaceOrder).find(
       ([root, dirs]) => workspaceKey(root) === dirKey || dirs.some((d) => workspaceKey(d) === dirKey),
@@ -1552,14 +1555,19 @@ export default function Layout(props: ParentProps) {
   async function navigateToProject(directory: string | undefined) {
     if (!directory) return
     const root = projectRoot(directory)
-    server.projects.touch(root)
+    server.projects.touch(directory)
     const project = layout.projects.list().find((item) => item.worktree === root)
     let dirs = project
       ? effectiveWorkspaceOrder(root, [root, ...(project.sandboxes ?? [])], store.workspaceOrder[root])
       : [root]
+    const siblingDirs = globalSync.project
+      .recent()
+      .filter((r) => r.kind === "project" && r.projectID === project?.id)
+      .map((r) => r.directory)
+    const allDirs = [...dirs, ...siblingDirs.filter((d) => !dirs.some((x) => workspaceKey(x) === workspaceKey(d)))]
     const canOpen = (value: string | undefined) => {
       if (!value) return false
-      return dirs.some((item) => workspaceKey(item) === workspaceKey(value))
+      return allDirs.some((item) => workspaceKey(item) === workspaceKey(value))
     }
     const refreshDirs = async (target?: string) => {
       if (!target || target === root || canOpen(target)) return canOpen(target)
@@ -1574,7 +1582,7 @@ export default function Layout(props: ParentProps) {
       if (!canOpen(target.directory)) return false
       const [data] = globalSync.child(target.directory, { bootstrap: false })
       if (data.session.some((item) => item.id === target.id)) {
-        setStore("lastProjectSession", root, { directory: target.directory, id: target.id, at: Date.now() })
+        setStore("lastProjectSession", directory, { directory: target.directory, id: target.id, at: Date.now() })
         navigateWithSidebarReset(`/${base64Encode(target.directory)}/session/${target.id}`)
         return true
       }
@@ -1584,21 +1592,21 @@ export default function Layout(props: ParentProps) {
         .catch(() => undefined)
       if (!resolved?.directory) return false
       if (!canOpen(resolved.directory)) return false
-      setStore("lastProjectSession", root, { directory: resolved.directory, id: resolved.id, at: Date.now() })
+      setStore("lastProjectSession", directory, { directory: resolved.directory, id: resolved.id, at: Date.now() })
       navigateWithSidebarReset(`/${base64Encode(resolved.directory)}/session/${resolved.id}`)
       return true
     }
 
-    const projectSession = store.lastProjectSession[root]
+    const projectSession = store.lastProjectSession[directory]
     if (projectSession?.id) {
       await refreshDirs(projectSession.directory)
       const opened = await openSession(projectSession)
       if (opened) return
-      clearLastProjectSession(root)
+      clearLastProjectSession(directory)
     }
 
     const latest = latestRootSession(
-      dirs.map((item) => globalSync.child(item, { bootstrap: false })[0]),
+      allDirs.map((item) => globalSync.child(item, { bootstrap: false })[0]),
       Date.now(),
     )
     if (latest && (await openSession(latest))) {
@@ -1607,7 +1615,7 @@ export default function Layout(props: ParentProps) {
 
     const fetched = latestRootSession(
       await Promise.all(
-        dirs.map(async (item) => ({
+        allDirs.map(async (item) => ({
           path: { directory: item },
           session: await globalSDK.client.session
             .list({ directory: item })
@@ -1621,7 +1629,7 @@ export default function Layout(props: ParentProps) {
       return
     }
 
-    navigateWithSidebarReset(`/${base64Encode(root)}/session`)
+    navigateWithSidebarReset(`/${base64Encode(directory)}/session`)
   }
 
   function navigateToSession(session: Session | undefined) {

--- a/packages/opencode/src/mobile/route.ts
+++ b/packages/opencode/src/mobile/route.ts
@@ -27,12 +27,15 @@ export function createMobileRoutes(platform: "feishu" | "qq" | "wechat") {
     status: z.enum(statusValues),
     ...(platform === "feishu" || platform === "qq"
       ? { appId: z.string().nullable(), hasConfig: z.boolean() }
-      : {
-          qrcode: z.string().nullable(),
-          user: z.object({ id: z.string(), name: z.string() }).nullable(),
-          locked: z.boolean().nullable(),
-          lockHolder: z.string().nullable(),
-        }),
+      : platform === "wechat"
+        ? {
+            qrcode: z.string().nullable(),
+            user: z.object({ id: z.string(), name: z.string() }).nullable(),
+            locked: z.boolean().nullable(),
+            lockHolder: z.string().nullable(),
+            hasConfig: z.boolean(),
+          }
+        : {}),
     error: z.object({ code: z.string(), message: z.string() }).nullable(),
   })
 
@@ -80,7 +83,7 @@ export function createMobileRoutes(platform: "feishu" | "qq" | "wechat") {
           } else if (!(await WeChatManager.tryLock(clientId))) {
             return c.json({ success: false, code: "locked", message: "微信已被其他客户端连接" })
           }
-          const result = await WeChatManager.start(body?.model, body?.autoInstall === true)
+          const result = await WeChatManager.start(body?.model, body?.autoInstall === true, body?.rescan === true)
           if (!result.success) {
             await WeChatManager.unlock(clientId)
           }
@@ -168,6 +171,7 @@ export function createMobileRoutes(platform: "feishu" | "qq" | "wechat") {
             error: WeChatManager.error,
             locked: WeChatManager.lockHolder !== null,
             lockHolder: WeChatManager.lockHolder,
+            hasConfig: !!session?.connected && !!session?.user,
           })
         }
       },

--- a/packages/opencode/src/mobile/wechat.ts
+++ b/packages/opencode/src/mobile/wechat.ts
@@ -204,6 +204,7 @@ class WeChatManagerImpl extends MobileManagerBase {
   async start(
     model?: string,
     auto = false,
+    rescan = false,
   ): Promise<{
     success: boolean
     message?: string
@@ -225,7 +226,7 @@ class WeChatManagerImpl extends MobileManagerBase {
     this._hiddenDirs = await this.loadHiddenDirs()
 
     const savedSession = await this.adapter.loadSession()
-    if (savedSession?.connected && savedSession.user) {
+    if (!rescan && savedSession?.connected && savedSession.user) {
       const state = await this.loadILinkState()
       if (state?.token) {
         this._ilinkToken = state.token


### PR DESCRIPTION
### Issue for this PR

Closes #728

### Type of change

- [x] New feature

### What does this PR do?

恢复 PR #621 中被回滚的移动端 auto-connect 功能，并修复 QQ 缺少 `initMobile` 调用的 bug：

1. **autoConnect/setAutoConnect** — 基于 localStorage 持久化，连接成功时默认开启，手动断开时自动关闭
2. **initMobile 自动连接** — 启动时检查 localStorage + hasConfig + idle 状态，自动连接之前已连接的平台
3. **QQ initMobile 缺失修复** — `layout.tsx` 中补充 `initMobile("qq")`，此前只有微信和飞书
4. **微信 rescan 参数** — `startBridge` 新增 `rescan` 参数，重新扫码时跳过恢复旧 session 但不删除凭证
5. **微信 hasConfig** — 后端 status API 为微信新增 `hasConfig` 字段，前端 idle 界面微信也显示"重新扫码"按钮
6. **connected 界面改进** — "切换账号/切换应用"改为"重新扫码/重新配置"，新增 Switch 开关"启动时自动连接"

### How did you verify your code works?

- `bun typecheck` 通过（packages/app 和 packages/opencode）
- 微信和飞书重启后自动连接正常
- QQ 重启后自动连接正常（修复 `initMobile("qq")` 缺失后）

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR