### PR TITLE
fix: deduplicate project_recent and use global_project_map to locate correct session DB

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -83,7 +83,7 @@ export namespace Project {
 
   type Row = typeof ProjectTable.$inferSelect
 
-  function norm(input: string) {
+  export function norm(input: string) {
     const next = input.replace(/\\/g, "/")
     const trim = /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
     return trim.toLowerCase()
@@ -122,14 +122,19 @@ export namespace Project {
     const recentRows = Database.use((db) =>
       db.select().from(ProjectRecentTable).where(eq(ProjectRecentTable.kind, "project")).all(),
     )
+    const seen = new Set<ProjectID>()
     const result: Info[] = []
     for (const row of recentRows) {
       if (!row.project_id) continue
+      if (seen.has(row.project_id)) continue
       if (!Database.hasProject(row.project_id)) continue
       const projectRow = Database.useProject(row.project_id, (d) =>
         d.select().from(ProjectTable).where(eq(ProjectTable.id, row.project_id!)).get(),
       )
-      if (projectRow) result.push(fromRow(projectRow))
+      if (projectRow) {
+        seen.add(row.project_id)
+        result.push(fromRow(projectRow))
+      }
     }
     return result.sort((a, b) => a.id.localeCompare(b.id))
   }
@@ -137,12 +142,29 @@ export namespace Project {
     const recentRows = Database.use((d) =>
       d.select().from(ProjectRecentTable).orderBy(desc(ProjectRecentTable.activity_at)).all(),
     )
-    return recentRows
+    const gpm = Database.use((d) => d.select().from(GlobalProjectMapTable).all())
+    const canonicalPID = new Map<string, string>()
+    for (const row of gpm) canonicalPID.set(norm(row.directory), row.project_id)
+    const seen = new Map<string, (typeof recentRows)[number]>()
+    for (const row of recentRows) {
+      const key = norm(row.directory)
+      const prev = seen.get(key)
+      if (!prev || row.activity_at > prev.activity_at) seen.set(key, row)
+    }
+    return [...seen.values()]
       .map((row) => {
-        if (row.kind === "project" && row.project_id) {
-          if (!Database.hasProject(row.project_id)) return undefined
-          const projectRow = Database.useProject(row.project_id, (d) =>
-            d.select().from(ProjectTable).where(eq(ProjectTable.id, row.project_id!)).get(),
+        const resolvedPID =
+          row.kind === "project" && row.project_id
+            ? (canonicalPID.get(norm(row.directory)) ?? row.project_id)
+            : undefined
+        if (row.kind === "project" && resolvedPID) {
+          if (!Database.hasProject(resolvedPID)) return undefined
+          const projectRow = Database.useProject(resolvedPID, (d) =>
+            d
+              .select()
+              .from(ProjectTable)
+              .where(eq(ProjectTable.id, resolvedPID as ProjectID))
+              .get(),
           )
           const known = projectRow ? fromRow(projectRow) : undefined
           const icon = (() => {
@@ -155,7 +177,7 @@ export namespace Project {
           return {
             id: row.key,
             kind: "project" as const,
-            projectID: row.project_id,
+            projectID: resolvedPID,
             directory: row.directory,
             worktree: known?.worktree,
             vcs: known?.vcs,

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -41,6 +41,8 @@ import { fn } from "@/util/fn"
 import { Command } from "../command"
 import { Snapshot } from "@/snapshot"
 import { ProjectID } from "../project/schema"
+import { Project } from "../project/project"
+import { GlobalProjectMapTable } from "../project/global-project-map.sql"
 import { WorkspaceID } from "../control-plane/schema"
 import { SessionID, TreeID, MessageID, PartID } from "./schema"
 
@@ -1121,8 +1123,16 @@ export namespace Session {
     search?: string
     limit?: number
   }) {
-    const project = Instance.project
-    const conditions = [eq(SessionTable.project_id, project.id)]
+    const limit = input?.limit ?? 100
+    let projectID: ProjectID = Instance.project.id
+    if (input?.directory) {
+      const dir = Project.norm(input.directory)
+      const row = Database.use((d) =>
+        d.select().from(GlobalProjectMapTable).where(eq(GlobalProjectMapTable.directory, dir)).get(),
+      )
+      if (row) projectID = row.project_id as ProjectID
+    }
+    const conditions = [eq(SessionTable.project_id, projectID)]
     if (input?.directory) {
       conditions.push(eq(SessionTable.directory, Filesystem.resolve(input.directory)))
     }
@@ -1135,10 +1145,7 @@ export namespace Session {
     if (input?.search) {
       conditions.push(like(SessionTable.title, `%${input.search}%`))
     }
-
-    const limit = input?.limit ?? 100
-
-    const rows = Database.useProject(Instance.project.id, (db) =>
+    const rows = Database.useProject(projectID, (db) =>
       db
         .select()
         .from(SessionTable)


### PR DESCRIPTION
### Issue for this PR

Closes #730

### Type of change

- [x] Bug fix

### What does this PR do?

After the split-project refactoring, `project_recent` retains stale pre-split entries where multiple directories all map to the same `project_id` (based on the old git-root logic). This caused:

1. **Duplicate projects in sidebar** — `canonical()` returned the same project multiple times because multiple `project_recent` rows share one `project_id`.
2. **Wrong projectID** — `recent()` used `project_recent.project_id` directly, which is the stale pre-split value. The correct `project_id` per directory now lives in `global_project_map`.
3. **Sessions invisible for other directories** — `Session.list()` always queried the Instance's project database, but the correct database (from `global_project_map`) may differ.

**Fixes (2 files, all in main DB layer):**

- `project.ts`: `canonical()` deduplicates by `project_id` with a `Set`; `recent()` deduplicates by normalized directory, cross-references `global_project_map` to resolve the correct `projectID` instead of trusting the stale `project_recent.project_id`.
- `session/index.ts`: `list()` when `directory` is specified, looks up `global_project_map` to find the correct `projectID`/database to query, instead of always using `Instance.project.id`.

### How did you verify your code works?

- `bun typecheck` passes for both `packages/opencode` and `packages/app`
- Started dev servers via `run.bat`, verified `/project/recent` API returns deduplicated entries with correct `projectID` per directory
- Verified `/session?directory=E:\work\AI\Aether\session-preference` returns sessions; other directories return `[]` (their databases are genuinely empty — old dirty data is not displayed, per agreed approach)
- Verified web UI sidebar shows each project separately (session-preference, find-projects, debug, session-preference-new)

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR