### PR TITLE
fix: skip missing project db in verifySplit instead of hard-failing

### DIFF
--- a/packages/opencode/src/storage/split-migration.ts
+++ b/packages/opencode/src/storage/split-migration.ts
@@ -352,10 +352,7 @@ export namespace SplitMigration {
     let totalParts = 0
     for (const pid of projectIds) {
       const pPath = projectDbPath(pid)
-      if (!existsSync(pPath)) {
-        log.error("verification failed: project db missing", { pid, path: pPath })
-        return false
-      }
+      if (!existsSync(pPath)) continue
       const pDb = new BunDatabase(pPath)
       totalSessions += (pDb.prepare("SELECT count(*) as cnt FROM session").get() as { cnt: number }).cnt
       totalMessages += (pDb.prepare("SELECT count(*) as cnt FROM message").get() as { cnt: number }).cnt


### PR DESCRIPTION
### Issue for this PR

Closes #732

### Type of change

- [x] Bug fix

### What does this PR do?

`verifySplit()` 对 `uniqueProjectIds` 中每个项目 ID 都检查其 db 文件是否存在，遇到缺失即返回 `false` 中断整个迁移。但 `uniqueProjectIds` 包含来自 `project` 表的空项目（无 session/workspace/permission），而创建 db 的循环会跳过这些空项目，导致验证永远失败、主数据库的 session 表始终未被清除。

将缺失项目 db 的检查从硬失败改为 `continue`，仅保留 session/message/part 总数一致性验证。空项目无数据贡献，跳过不影响计数校验。

### How did you verify your code works?

- 检查本地 `aether-prod.db` 中有 6 个空项目（仅存在于 `project` 表，无 session），验证它们不会导致迁移失败
- 日志确认迁移失败原因正是 `verification failed: project db missing`
- typecheck 通过

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR