### PR TITLE
fix: split-migration stale entries, infinite re-split, and sandbox misinheritance

### DIFF
--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -588,6 +588,11 @@ export namespace Database {
       .get()
     if (!hasTable) return
 
+    const projectRow = pSqlite.prepare("SELECT worktree FROM project WHERE id = ?").get(pid) as
+      | { worktree: string }
+      | undefined
+    const canonicalWorktree = projectRow?.worktree ?? "/"
+
     const metaRows = pSqlite.prepare("SELECT * FROM directory_meta").all() as {
       directory: string
       worktree: string
@@ -615,11 +620,13 @@ export namespace Database {
       const dirNorm = norm(row.directory)
       insertMap.run(dirNorm, pid, row.time_created, row.time_updated)
 
-      const isProject = row.worktree !== "/"
+      const isWorktree = row.worktree !== "/" && norm(row.directory) === norm(canonicalWorktree)
+      if (!isWorktree) continue
+
       insertRecent.run(
         `dir:${dirNorm}`,
-        isProject ? "project" : "directory",
-        isProject ? pid : null,
+        "project",
+        pid,
         row.directory,
         row.name,
         row.icon_url ?? null,
@@ -646,6 +653,7 @@ export namespace Database {
 
     const chDir = channelDir()
     const existingDbIds = new Set<string>()
+    const validWorktreeKeys = new Set<string>()
     if (existsSync(chDir)) {
       const pattern = /^aether-(.+)\.db$/
       for (const entry of readdirSync(chDir)) {
@@ -666,6 +674,10 @@ export namespace Database {
       try {
         ensureDirectoryMeta(pSqlite, pid, recentLookup)
         syncDirectoryMetaToGlobal(sqlite, pSqlite, pid)
+        const wt = pSqlite.prepare("SELECT worktree FROM project WHERE id = ?").get(pid) as
+          | { worktree: string }
+          | undefined
+        if (wt?.worktree && wt.worktree !== "/") validWorktreeKeys.add(`dir:${norm(wt.worktree)}`)
         synced++
       } finally {
         pSqlite.close()
@@ -674,12 +686,13 @@ export namespace Database {
     if (synced > 0) log.info("directory_meta sync complete", { synced })
 
     // Phase 2: Delete project_recent entries whose project_id has no corresponding DB
+    //          or whose directory is not the project's canonical worktree (e.g. sandbox dirs)
     const staleRows = sqlite
       .prepare("SELECT key, project_id FROM project_recent WHERE kind = 'project' AND project_id IS NOT NULL")
       .all() as { key: string; project_id: string }[]
     let removed = 0
     for (const row of staleRows) {
-      if (!existingDbIds.has(row.project_id)) {
+      if (!existingDbIds.has(row.project_id) || !validWorktreeKeys.has(row.key)) {
         sqlite.prepare("DELETE FROM project_recent WHERE key = ?").run(row.key)
         removed++
       }

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -697,7 +697,21 @@ export namespace Database {
         removed++
       }
     }
-    if (removed > 0) log.info("removed project_recent entries without project db", { removed })
+    if (removed > 0) log.info("removed stale project_recent entries", { removed })
+
+    // Phase 3: Delete global_project_map entries whose project_id has no corresponding DB
+    const staleMap = sqlite.prepare("SELECT directory, project_id FROM global_project_map").all() as {
+      directory: string
+      project_id: string
+    }[]
+    let mapRemoved = 0
+    for (const row of staleMap) {
+      if (!existingDbIds.has(row.project_id)) {
+        sqlite.prepare("DELETE FROM global_project_map WHERE directory = ?").run(row.directory)
+        mapRemoved++
+      }
+    }
+    if (mapRemoved > 0) log.info("removed stale global_project_map entries", { mapRemoved })
   }
 
   export function transaction<T>(

--- a/packages/opencode/src/storage/split-migration.ts
+++ b/packages/opencode/src/storage/split-migration.ts
@@ -524,7 +524,6 @@ export namespace SplitMigration {
       const mergeProject = (pid: string, info: ProjectIdentity.Info, row?: any) => {
         const prev = projectById.get(pid)
         const sandboxes = new Set<string>(json(prev?.sandboxes))
-        for (const item of json(row?.sandboxes)) sandboxes.add(item)
         if (info.sandbox !== info.root) sandboxes.add(info.sandbox)
         projectById.set(pid, {
           id: pid,

--- a/packages/opencode/src/storage/split-migration.ts
+++ b/packages/opencode/src/storage/split-migration.ts
@@ -545,14 +545,7 @@ export namespace SplitMigration {
 
       const resolveProject = (s: any) => {
         const row = projectByOld.get(s.project_id)
-        // For sessions with a real project_id, use the project's worktree to
-        // find the git root — all sessions under the same project should share
-        // one DB regardless of which worktree/subdirectory they were created in.
-        // For "global" sessions, use the session's own directory.
-        const dir =
-          s.project_id !== "global" && row?.worktree && row.worktree !== "/"
-            ? row.worktree
-            : s.directory || row?.worktree || "/"
+        const dir = s.directory || row?.worktree || "/"
         const info = ProjectIdentity.resolve(dir)
         const pid = info.id
         if (s.project_id !== "global") oldProjectIdMap.set(s.project_id, pid)
@@ -669,7 +662,9 @@ export namespace SplitMigration {
       }
 
       for (const w of workspaces) {
-        const pid = oldProjectIdMap.get(w.project_id) ?? directoryProjectMap.get(norm(w.project_id)) ?? w.project_id
+        const dir = w.directory || w.project_id
+        const info = ProjectIdentity.resolve(dir)
+        const pid = info.id
         const bucket = workspaceByProject.get(pid) ?? []
         bucket.push({ ...w, project_id: pid })
         workspaceByProject.set(pid, bucket)
@@ -913,8 +908,8 @@ export namespace SplitMigration {
       }[]
       for (const row of recentRows) {
         const pid =
-          (row.project_id ? oldProjectIdMap.get(row.project_id) : undefined) ??
-          directoryProjectMap.get(norm(row.directory ?? ""))
+          directoryProjectMap.get(norm(row.directory ?? "")) ??
+          (row.project_id ? oldProjectIdMap.get(row.project_id) : undefined)
         if (pid && uniqueProjectIds.has(pid)) {
           destSqlite
             .prepare("UPDATE project_recent SET kind = 'project', project_id = ? WHERE key = ?")

--- a/packages/opencode/src/storage/split-migration.ts
+++ b/packages/opencode/src/storage/split-migration.ts
@@ -139,37 +139,29 @@ export namespace SplitMigration {
 
     if (!existsSync(main)) return "none"
 
-    if (readAttempts() > 0 && existsSync(backupDbPath(main))) {
-      const backup = new BunDatabase(backupDbPath(main), { readonly: true })
-      try {
-        const has = backup.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='session'").get()
-        if (has) {
-          const sessions = backup.prepare("SELECT count(*) as cnt FROM session").get() as { cnt: number } | null
-          if (sessions && sessions.cnt > 0) return "initial-split"
-        }
-      } finally {
-        backup.close()
-      }
-    }
     const sqlite = new BunDatabase(main, { readonly: true })
     try {
       const hasSessionTable = sqlite
         .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='session'")
         .get()
-      if (hasSessionTable) {
-        const hasSessions = sqlite.prepare("SELECT count(*) as cnt FROM session").get() as { cnt: number } | null
-        if (hasSessions && hasSessions.cnt > 0) {
-          sqlite.close()
-          return "initial-split"
-        }
+      if (!hasSessionTable) {
+        sqlite.close()
+        deleteWithCompanions(destCopyPath(main))
+        return "none"
       }
-      sqlite.close()
-      deleteWithCompanions(destCopyPath(main))
-      return "none"
+      const hasSessions = sqlite.prepare("SELECT count(*) as cnt FROM session").get() as { cnt: number } | null
+      if (!hasSessions || hasSessions.cnt === 0) {
+        sqlite.close()
+        deleteWithCompanions(destCopyPath(main))
+        return "none"
+      }
     } catch {
       sqlite.close()
       return "none"
     }
+    sqlite.close()
+
+    return "initial-split"
   }
 
   function norm(input: string) {

--- a/packages/opencode/src/storage/split-migration.ts
+++ b/packages/opencode/src/storage/split-migration.ts
@@ -897,25 +897,28 @@ export namespace SplitMigration {
           )
           .run(dir, pid, Date.now(), Date.now())
       }
-      log.info("step: stripping project_recent FK")
+      log.info("step: rebuilding project_recent from project worktrees")
       destSqlite.exec(stripProjectRecentFK)
-      const recentRows = destSqlite.prepare("SELECT key, kind, project_id, directory FROM project_recent").all() as {
-        key: string
-        kind: string
-        project_id: string | null
-        directory: string
-      }[]
-      for (const row of recentRows) {
-        const pid =
-          directoryProjectMap.get(norm(row.directory ?? "")) ??
-          (row.project_id ? oldProjectIdMap.get(row.project_id) : undefined)
-        if (pid && uniqueProjectIds.has(pid)) {
-          destSqlite
-            .prepare("UPDATE project_recent SET kind = 'project', project_id = ? WHERE key = ?")
-            .run(pid, row.key)
-          continue
-        }
-        destSqlite.prepare("DELETE FROM project_recent WHERE key = ?").run(row.key)
+      destSqlite.exec("DELETE FROM project_recent")
+      const insertRecent = destSqlite.prepare(
+        "INSERT INTO project_recent (key, kind, project_id, directory, name, activity_at, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+      )
+      for (const pid of uniqueProjectIds) {
+        const proj = projectById.get(pid)
+        if (!proj) continue
+        const dir = proj.worktree
+        if (!dir || dir === "/") continue
+        const key = `dir:${norm(dir)}`
+        insertRecent.run(
+          key,
+          "project",
+          pid,
+          dir,
+          proj.name ?? null,
+          proj.time_updated,
+          proj.time_created,
+          proj.time_updated,
+        )
       }
       const hasSessionPref = destSqlite
         .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='session_preference'")


### PR DESCRIPTION
### Issue for this PR

Closes #734

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes six defects in the DB split-migration path:

1. Prune stale `global_project_map` entries whose `project_id` has no corresponding DB on startup.
2. Only sync project worktree to `project_recent`, not sandbox dirs; prune stale non-worktree entries on startup.
3. Check main DB instead of backup to decide whether split-migration is needed, preventing infinite re-split on every restart.
4. Rebuild `project_recent` from project worktrees instead of migrating old entries with duplicates and sandboxes.
5. Don't inherit old project row sandboxes into unrelated projects in split-migration.
6. Use `session.directory` to resolve `project_id` in split-migration so each git root gets its own DB.

### How did you verify your code works?

Local testing with multi-project setups; verified split-migration runs only once, `project_recent` contains only worktree entries, and stale `global_project_map` entries are cleaned.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR