### PR TITLE
fix(knowledge): 重启后恢复 knowledge_search 工具的后端配置

### DIFF
--- a/packages/app/src/context/knowledge.tsx
+++ b/packages/app/src/context/knowledge.tsx
@@ -334,6 +334,19 @@ export const KnowledgeProvider: Component<{ children: JSX.Element }> = (props) =
     if (state.knowledgeBases.length > 0) {
       refreshAllStats()
     }
+
+    // 恢复后端 knowledge_search 工具的进程内存配置（重启后丢失）
+    for (const kb of state.knowledgeBases) {
+      if (!state.activeIds.includes(kb.id)) continue
+      fetchApi("/knowledge/config", {
+        method: "POST",
+        body: JSON.stringify({
+          path: kb.path,
+          apiKey: kb.apiKey,
+          baseURL: kb.baseURL,
+        }),
+      }).catch(() => {})
+    }
   })
 
   // 状态变更时自动持久化


### PR DESCRIPTION
### Issue for this PR

Closes #736

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Aether 重启后 knowledge_search 工具会失效。根因是后端的 globalKnowledgeConfig 为进程内存变量，重启后丢失。前端虽有恢复知识库列表，但未重新通知后端的知识库搜索工具层。

在 onMount 中恢复知识库列表后，遍历每个 active 知识库，逐一调用 POST /knowledge/config 将路径、apiKey、baseURL 写入后端进程内存，恢复 knowledge_search 工具的正常工作状态。

### How did you verify your code works?

添加知识库 → 关闭 Aether → 重新打开 Aether → 验证 knowledge_search 工具能正常搜索知识库内容

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR