### PR TITLE
fix: reduce default sync limit from 10 to 5

### DIFF
--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -183,7 +183,7 @@ export function createChildStoreManager(input: {
             mcp: {},
             lsp: [],
             vcs: vcsStore.value,
-            limit: 10,
+            limit: 5,
             message: {},
             part: {},
             preference: {},

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -78,7 +78,7 @@ const baseState = (input: Partial<State> = {}) =>
     mcp: {},
     lsp: [],
     vcs: undefined,
-    limit: 10,
+    limit: 5,
     message: {},
     part: {},
     preference: {} as State["preference"],


### PR DESCRIPTION
### Issue for this PR

Closes #744

### Type of change

- [x] Bug fix

### What does this PR do?

Reduce the default global-sync limit from 10 to 5 in `createChildStoreManager` and the corresponding test base state. A lower limit reduces unnecessary data transfer on initial sync.

### How did you verify your code works?

- typecheck passes
- test base state updated to match the new default

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR