### PR TITLE
fix: use normalized path comparison to prevent duplicate workspace entries

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -2153,8 +2153,14 @@ export default function Layout(props: ParentProps) {
     const local = project.worktree
     const dirs = [local, ...(project.sandboxes ?? [])]
     const active = currentProject()
-    const directory = active?.worktree === project.worktree ? currentDir() : undefined
-    const extra = directory && directory !== local && !dirs.includes(directory) ? directory : undefined
+    const directory =
+      active?.worktree && workspaceKey(active.worktree) === workspaceKey(project.worktree) ? currentDir() : undefined
+    const extra =
+      directory &&
+      workspaceKey(directory) !== workspaceKey(local) &&
+      !dirs.some((d) => workspaceKey(d) === workspaceKey(directory))
+        ? directory
+        : undefined
     const pending = extra ? WorktreeState.get(extra)?.status === "pending" : false
 
     const ordered = effectiveWorkspaceOrder(local, dirs, store.workspaceOrder[project.worktree])

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -416,7 +416,10 @@ export namespace Project {
           vcs: data.vcs,
           time: { ...existing.time, updated: Date.now() },
         }
-        if (data.sandbox !== result.worktree && !result.sandboxes.includes(data.sandbox))
+        if (
+          norm(data.sandbox) !== norm(result.worktree) &&
+          !result.sandboxes.some((s) => norm(s) === norm(data.sandbox))
+        )
           result.sandboxes.push(data.sandbox)
         result.sandboxes = yield* Effect.forEach(
           result.sandboxes,
@@ -630,7 +633,7 @@ export namespace Project {
         const row = yield* dbProject(id, (d) => d.select().from(ProjectTable).where(eq(ProjectTable.id, id)).get())
         if (!row) throw new Error(`Project not found: ${id}`)
         const sboxes = [...row.sandboxes]
-        if (!sboxes.includes(directory)) sboxes.push(directory)
+        if (!sboxes.some((s) => norm(s) === norm(directory))) sboxes.push(directory)
         const result = yield* dbProject(id, (d) =>
           d
             .update(ProjectTable)
@@ -646,7 +649,7 @@ export namespace Project {
       const removeSandbox = Effect.fn("Project.removeSandbox")(function* (id: ProjectID, directory: string) {
         const row = yield* dbProject(id, (d) => d.select().from(ProjectTable).where(eq(ProjectTable.id, id)).get())
         if (!row) throw new Error(`Project not found: ${id}`)
-        const sboxes = row.sandboxes.filter((s) => s !== directory)
+        const sboxes = row.sandboxes.filter((s) => norm(s) !== norm(directory))
         const result = yield* dbProject(id, (d) =>
           d
             .update(ProjectTable)


### PR DESCRIPTION
## Summary

On Windows, when `currentDir()` (from URL base64 decode) and `project.worktree` (from API) have different string representations but point to the same physical directory (e.g. different slash direction or drive-letter casing), `workspaceIds()` uses strict string comparison (`===`, `!==`, `includes`) while `effectiveWorkspaceOrder()` uses `workspaceKey` (normalized) for dedup. This mismatch causes an `extra` entry to be appended even after `effectiveWorkspaceOrder` correctly filters it out, producing two workspace entries pointing to the same directory — both showing the same branch and identical session data.

## Changes

- **`packages/app/src/pages/layout.tsx`**: Replace strict string comparisons in `workspaceIds()` with `workspaceKey()`-based comparisons (lines 2156-2157).
- **`packages/opencode/src/project/project.ts`**: Replace strict string comparisons in `fromDirectory`, `addSandbox`, and `removeSandbox` with `Project.norm()`-based comparisons.

## Test plan

- Open a git project on Windows
- Enable workspaces toggle
- Verify sidebar shows only one "本地" workspace entry (no duplicate "沙盒" entry for the same directory)
- Create a real sandbox workspace and verify it appears as a distinct "沙盒" entry
- Delete the sandbox and verify it disappears correctly