### PR TITLE
fix: remove duplicate SSE handler that prevented browser connection tracking

### DIFF
--- a/packages/opencode/src/server/routes/event.ts
+++ b/packages/opencode/src/server/routes/event.ts
@@ -4,13 +4,13 @@ import { streamSSE } from "hono/streaming"
 import { Log } from "@/util/log"
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
-import { lazy } from "../../util/lazy"
 import { AsyncQueue } from "../../util/queue"
 
 const log = Log.create({ service: "server" })
 
-export const EventRoutes = lazy(() =>
-  new Hono().get(
+export function EventRoutes(onBrowserConnectionChange?: (count: number) => void) {
+  let sseConnectionCount = 0
+  return new Hono().get(
     "/event",
     describeRoute({
       summary: "Subscribe to events",
@@ -31,6 +31,8 @@ export const EventRoutes = lazy(() =>
       log.info("event connected")
       c.header("X-Accel-Buffering", "no")
       c.header("X-Content-Type-Options", "nosniff")
+      sseConnectionCount++
+      onBrowserConnectionChange?.(sseConnectionCount)
       return streamSSE(c, async (stream) => {
         const q = new AsyncQueue<string | null>()
         let done = false
@@ -58,6 +60,8 @@ export const EventRoutes = lazy(() =>
           clearInterval(heartbeat)
           unsub()
           q.push(null)
+          sseConnectionCount--
+          onBrowserConnectionChange?.(sseConnectionCount)
           log.info("event disconnected")
         }
 
@@ -80,5 +84,5 @@ export const EventRoutes = lazy(() =>
         }
       })
     },
-  ),
-)
+  )
+}

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -197,7 +197,6 @@ export namespace Server {
       log.error("cron start failed", { error })
     })
     const app = new Hono<ServerEnv>()
-    let sseConnectionCount = 0
     const corsware = cors({
       credentials: true,
       origin(input) {
@@ -465,7 +464,7 @@ export namespace Server {
       .route("/provider", ProviderRoutes())
       .route("/database", DatabaseRoutes())
       .route("/", FileRoutes())
-      .route("/", EventRoutes())
+      .route("/", EventRoutes(opts.onBrowserConnectionChange))
       .route("/mcp", McpRoutes())
       .route("/tui", TuiRoutes())
       .route("/knowledge", KnowledgeRoutes())
@@ -841,84 +840,6 @@ export namespace Server {
         }),
         async (c) => {
           return c.json(await Format.status())
-        },
-      )
-      .get(
-        "/event",
-        describeRoute({
-          summary: "Subscribe to events",
-          description: "Get events",
-          operationId: "event.subscribe",
-          responses: {
-            200: {
-              description: "Event stream",
-              content: {
-                "text/event-stream": {
-                  schema: resolver(BusEvent.payloads()),
-                },
-              },
-            },
-          },
-        }),
-        async (c) => {
-          log.info("event connected")
-          c.header("X-Accel-Buffering", "no")
-          c.header("X-Content-Type-Options", "nosniff")
-          sseConnectionCount++
-          opts.onBrowserConnectionChange?.(sseConnectionCount)
-          return streamSSE(c, async (stream) => {
-            stream.writeSSE({
-              data: JSON.stringify({
-                type: "server.connected",
-                properties: {},
-              }),
-            })
-            const unsub = Bus.subscribeAll(async (event) => {
-              await stream.writeSSE({
-                data: JSON.stringify(event),
-              })
-              if (event.type === Bus.InstanceDisposed.type) {
-                stream.close()
-              }
-            })
-
-            // Track disconnection via either onAbort (immediate) or heartbeat
-            // write failure (Bun only detects TCP close on next write attempt).
-            let disconnected = false
-            const onDisconnect = () => {
-              if (disconnected) return
-              disconnected = true
-              sseConnectionCount--
-              opts.onBrowserConnectionChange?.(sseConnectionCount)
-            }
-
-            let resolve!: () => void
-            let resolved = false
-            const finish = () => {
-              if (resolved) return
-              resolved = true
-              clearInterval(heartbeat)
-              unsub()
-              onDisconnect()
-              resolve()
-              log.info("event disconnected")
-            }
-            const heartbeat = setInterval(() => {
-              stream
-                .writeSSE({
-                  data: JSON.stringify({
-                    type: "server.heartbeat",
-                    properties: {},
-                  }),
-                })
-                .catch(finish)
-            }, 3_000)
-
-            await new Promise<void>((r) => {
-              resolve = r
-              stream.onAbort(finish)
-            })
-          })
         },
       )
       .all("/*", async (c) => {


### PR DESCRIPTION
### Issue for this PR

Closes #748

### Type of change

- [x] Bug fix

### What does this PR do?

Two SSE handlers were registered for `GET /event` in `server.ts`:
1. `EventRoutes()` (routes/event.ts) — registered via `.route("/", EventRoutes())`, uses AsyncQueue pattern
2. Inline handler — registered via `.get("/event", ...)`, contains `sseConnectionCount++/--` and `opts.onBrowserConnectionChange` callback

Hono matches the first registered handler, so the inline handler was never reached. This caused:
- `sseConnectionCount` always 0
- `onBrowserConnectionChange` never fires
- `web.ts` idle timeout can't detect browser SSE connections (`sse` always 0)
- Packaged (CD-compiled) version: second browser tab freezes because server may auto-exit after idle timeout

The inline handler was properly removed in commit `054075189` when SSE was extracted to `EventRoutes()`, but was later re-added via an incorrect merge resolution.

Fix: move `sseConnectionCount` tracking and `onBrowserConnectionChange` callback into `EventRoutes()`, remove the duplicate inline handler from server.ts.

### How did you verify your code works?

- `bun typecheck` passes in `packages/opencode`
- The `EventRoutes` handler now correctly tracks connection count and fires the callback on connect/disconnect
- The duplicate inline handler (77 lines) is fully removed

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR