### PR TITLE
fix: remove addSteerMethods to let auto-generated SDK handle directory routing

### DIFF
--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -3,13 +3,7 @@ import { createSimpleContext } from "@opencode-ai/ui/context"
 import { createGlobalEmitter } from "@solid-primitives/event-bus"
 import { batch, onCleanup } from "solid-js"
 import z from "zod"
-import {
-  type AppClient,
-  addCronMethods,
-  addProjectDeleteMethod,
-  addSteerMethods,
-  createSdkForServer,
-} from "@/utils/server"
+import { type AppClient, addCronMethods, addProjectDeleteMethod, createSdkForServer } from "@/utils/server"
 import { useLanguage } from "./language"
 import { usePlatform } from "./platform"
 import { useServer } from "./server"
@@ -233,7 +227,6 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       throwOnError: true,
     })
     addCronMethods(sdk, server.current.http.url, authHeader(server.current.http), { throwOnError: true })
-    addSteerMethods(sdk, server.current.http.url, authHeader(server.current.http), { throwOnError: true })
     addProjectDeleteMethod(sdk, server.current.http.url, authHeader(server.current.http), { throwOnError: true })
 
     return {
@@ -249,7 +242,6 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
           ...opts,
         })
         addCronMethods(c, s.http.url, authHeader(s.http), { throwOnError: opts.throwOnError })
-        addSteerMethods(c, s.http.url, authHeader(s.http), { throwOnError: opts.throwOnError })
         addProjectDeleteMethod(c, s.http.url, authHeader(s.http), { throwOnError: opts.throwOnError })
         return c
       },

--- a/packages/app/src/utils/server.ts
+++ b/packages/app/src/utils/server.ts
@@ -171,7 +171,6 @@ export type AppClient = Base & {
       knowledgeBase?: Kb
       parts: unknown[]
     }): Promise<{ data?: unknown }>
-    steer(input: { sessionID: string; text: string }): Req<unknown>
   }
 }
 
@@ -260,31 +259,6 @@ function safeAssign(target: object, key: string, value: unknown) {
     if (existing && typeof existing === "object" && value && typeof value === "object")
       deepMerge(existing as object, value as object)
   }
-}
-
-export function addSteerMethods(
-  client: AppClient,
-  baseUrl: string,
-  auth?: Record<string, string>,
-  options?: RequestHelperOptions,
-): AppClient {
-  const headers: Record<string, string> = { "Content-Type": "application/json", ...auth }
-  const steerMethods = {
-    async steer(input: { sessionID: string; text: string }) {
-      return requestJSON(
-        `${baseUrl}/session/${input.sessionID}/steer`,
-        {
-          method: "POST",
-          headers,
-          body: JSON.stringify({ text: input.text }),
-        },
-        options,
-      )
-    },
-  }
-  safeAssign(client.session, "steer", steerMethods.steer)
-
-  return client
 }
 
 export function addCronMethods(


### PR DESCRIPTION
### Issue for this PR

Closes #750

### Type of change

- [x] Bug fix

### What does this PR do?

The custom `addSteerMethods` in `packages/app/src/utils/server.ts` manually constructed HTTP requests with only `Content-Type` and auth headers — no `directory` query param or `x-opencode-directory` header. After the per-project DB split, the server middleware resolves the project database from `directory`/`x-opencode-directory`. Without it, the middleware falls back to `process.cwd()`, which may not match the session's project directory → wrong project DB → steer fails.

This PR removes `addSteerMethods` entirely and lets the auto-generated SDK `steer` method (sdk.gen.ts:3182) handle it. The auto-generated method already passes `directory`/`workspace` as query params, and `createOpencodeClient` (client.ts:21-27) sets the `x-opencode-directory` header based on the `directory` config passed during client creation. The call in steer-button.tsx:57 (`sdk.client.session.steer({ sessionID, text })`) is fully compatible since `directory` and `workspace` are optional.

### How did you verify your code works?

- `bun typecheck` passes with zero errors in packages/app
- Pre-push hook ran full turbo typecheck across all packages (12/12 passed)

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR