### PR TITLE
fix: remove process.cwd() fallback that creates empty project DBs

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -354,12 +354,13 @@ export namespace Server {
       .use(async (c, next) => {
         if (c.req.path === "/log") return next()
         const rawWorkspaceID = c.req.query("workspace") || c.req.header("x-opencode-workspace")
-        const raw = c.req.query("directory") || c.req.header("x-opencode-directory") || process.cwd()
+        const raw = c.req.query("directory") || c.req.header("x-opencode-directory")
+        const noDirectory = !raw
         const decoded = (() => {
           try {
-            return decodeURIComponent(raw)
+            return decodeURIComponent(raw ?? "")
           } catch {
-            return raw
+            return raw ?? ""
           }
         })()
         const directory = Filesystem.resolve(decoded)
@@ -368,7 +369,7 @@ export namespace Server {
         const isBrowse = browsePaths.some(
           (p) => c.req.path === p || c.req.path.startsWith(p + "/") || c.req.path.startsWith(p + "?"),
         )
-        const create = isBrowse ? Instance.has(directory) : true
+        const create = noDirectory ? false : isBrowse ? Instance.has(directory) : true
 
         return WorkspaceContext.provide({
           workspaceID: rawWorkspaceID ? WorkspaceID.make(rawWorkspaceID) : undefined,


### PR DESCRIPTION
### Issue for this PR

Closes #752

### Type of change

- [x] Bug fix

### What does this PR do?

When no `directory` query/header is provided in HTTP requests, the server middleware falls back to `process.cwd()` (the aether installation directory). This triggers `Instance.provide({ create: true })` → `Project.fromDirectory()` → `Database.attach()`, creating an empty per-project DB for the installation directory.

This happens on **every frontend startup** — the global SDK's `project.list()` and `project.recent()` requests go through the directory middleware without `x-opencode-directory`, so `|| process.cwd()` is hit each time. Each aether version installs to a new directory path, producing a new SHA1 project ID and a new empty ~221KB DB file with 0 sessions.

Fix: remove `|| process.cwd()` fallback. When no directory is provided, set `create=false` so `Instance.provide()` creates a lightweight browse-only context that does not create project DBs. Routes like `/project/list` and `/project/recent` only read the main DB and don't depend on `Instance.project`, so browse-only context works correctly.

### How did you verify your code works?

- `bun typecheck` passes in `packages/opencode`
- Verified that `/global/*` routes (event stream, config, health) are mounted before the directory middleware and are unaffected
- Verified that `Project.list()` and `Project.recentList()` only read the main DB, not `Instance.project`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR