### PR TITLE
docs: major rewrite of README (en/zh/zht) to reflect current Aether features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,51 @@
 <h1 align="center">Aether</h1>
 <p align="center"><em>Autonomous Engine for Theoretical & Hands-on Exploration in Research</em></p>
-<p align="center">An AI researching assistant for researchers, built on <a href="https://github.com/anomalyco/opencode">OpenCode</a>.</p>
+<p align="center">An AI research assistant for researchers, built on <a href="https://github.com/anomalyco/opencode">OpenCode</a>.</p>
+<p align="center"><a href="https://aether.aiphys.cn/">🌐 aether.aiphys.cn</a></p>
 
 <p align="center">
   <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a>
+  <a href="README.zh.md">简体中文</a> |
+  <a href="README.zht.md">繁體中文</a>
 </p>
 
 ---
 
 ## Overview
 
-Aether extends OpenCode with research-focused improvements, supporting terminal, browser, and desktop interfaces. Key improvements over upstream:
+Aether is a feature-rich AI research assistant platform. It runs with a client/server architecture — the CLI starts a local HTTP server, providing a full interactive interface through the browser. Mobile access (WeChat / Feishu / QQ) is also supported. Desktop client (Electron) support is planned for the future.
 
-- **Ready to use**: Download and double-click to launch — no dev environment setup required; built-in default model settings so you can start immediately
-- **Built-in research Skills**: Pre-configured prompts for literature review, experiment logging, paper writing, and more — no manual prompt engineering needed
-- **PDF viewing**: Open PDF files directly in the Web UI for easy side-by-side reading while coding
-- **Provider-agnostic**: Works with Gemini, Claude, OpenAI, local models, or any private API
-- **Full coding capabilities**: Code execution, LSP code intelligence, and file/terminal operations — on par with a VS Code daily workflow
-- **Client/server architecture**: CLI runs a built-in HTTP server accessible from a browser or mobile device
-- **Voice input**: Click-to-record microphone button powered by Qwen-Omni, with conversation-context-aware transcription that auto-corrects technical terms and removes filler words. Reuses provider credentials via backend proxy — just connect a provider and select a voice model in Settings
+### Key Features
+
+- **Ready to use**: Download and double-click to launch; built-in default model settings
+- **Full coding capabilities**: Code execution, LSP code intelligence, file and terminal operations — covering the entire daily development workflow
+- **25+ AI providers**: Supports Anthropic, OpenAI, Google Gemini, AIhubmix, DeepSeek, Z.AI, Kimi, Qwen, and other mainstream platforms, plus any OpenAI-compatible API
+- **10+ built-in research Skills**: Literature review, paper writing, deep research, arXiv search, peer review, research grant writing, and more — ready to use out of the box
+- **Skill self-evolution**: After completing a task, the Agent automatically reviews the conversation history and solidifies successful experiences into reusable Skills (copy-on-write writes, security scanning, version snapshots), forming a continuous learning loop
+- **MCP protocol support**: Integrates Model Context Protocol — connect local or remote MCP servers to extend the toolset
+- **Knowledge base (RAG)**: Vector-index PDF and text documents, with semantic search that injects only relevant context, significantly reducing token usage
+- **PDF reading mode**: Read PDFs directly in the Web UI with highlights, bookmarks, notes, and AI-assisted translation and Q&A
+- **PDF to Markdown**: AI-driven multi-stage pipeline that converts PDF papers into high-quality editable Markdown (with formula and image extraction)
+- **Markdown translation**: AI-powered Markdown document translation that automatically preserves LaTeX formulas
+- **Voice input**: Speech-to-text powered by multimodal models, automatically removing filler words and correcting technical terms
+- **Git integration**: View branches, commit history, diffs, and file changes in the UI
+- **Scheduled tasks**: Supports cron expressions, fixed intervals, and one-time scheduled tasks for automating research workflows
+- **Memory mechanism**: AI automatically persists user preferences and interaction experiences to `memory.instruction.md`, reused across sessions without repetition
+- **Session sharing**: Generate shareable links with real-time conversation sync
 
 ---
 
-## Running from a Release Package
+## Installation & Launch
 
-Download the archive for your platform from the [Releases page](https://github.com/Science-Discovery/Aether/releases) and extract it.
+### Installer Script (Recommended)
 
-### Web Browser Version (Recommended)
+Download the installer script for your platform from the [official website](https://aether.aiphys.cn/) for one-click installation with automatic updates. After installation, simply launch from your system applications.
+
+### Manual Installation
+
+Download the archive for your platform from the [Releases page](https://github.com/Science-Discovery/Aether/releases).
+
+#### Web Browser Version
 
 Extracted directory layout:
 
@@ -38,27 +56,36 @@ Aether.vbs      ← Windows launcher
 Aether.command  ← macOS launcher
 ```
 
-**Windows:** Double-click `Aether.vbs` (if it errors, run `Aether.exe` first) — browser opens automatically, no console window.
+**Windows**: Double-click `Aether.vbs` (if it errors, run `Aether.exe` first) — the browser opens automatically.
 
-**macOS:** Double-click `Aether.command`, or run in terminal:
+**macOS**: Grant execute permission on first use, then double-click `Aether.command` to launch:
+
+```bash
+chmod +x Aether.command aether   # first time only
+```
+
+**Linux**:
 
 ```bash
 chmod +x aether   # first time only
 ./aether web
 ```
 
-**Linux:**
+After `aether web` starts, it displays local and network access URLs, and the browser opens automatically.
+
+<!-- Supported options:
 
 ```bash
-chmod +x aether   # first time only
-./aether web
-```
-
-If the browser doesn't open automatically, visit the URL shown in the terminal. Press `Ctrl+C` to stop.
+./aether web --port 8080              # specify port
+./aether web --hostname 0.0.0.0       # allow network access
+./aether web --idle-timeout 120       # idle timeout in seconds, 0 for always-on
+``` -->
 
 ### Electron Desktop Version
 
-Extract (or install) and double-click to run:
+Coming soon
+
+<!-- Extract (or install) and double-click to run:
 
 | Platform | File |
 |---|---|
@@ -66,93 +93,129 @@ Extract (or install) and double-click to run:
 | macOS | `aether-mac-arm64.dmg` (Apple Silicon) / `aether-mac-x64.dmg` |
 | Windows | `aether-win-x64.exe` installer / `win-unpacked/` portable |
 
----
+--- -->
 
 ## Running from Source
 
-**Requires:** [Bun](https://bun.sh/) 1.3+
+For development and debugging. **Requires:** [Bun](https://bun.sh/) 1.3+
 
 ```bash
 bun install
 ```
 
-### TUI Mode
+### Web UI Development Mode
 
-```bash
-# Run from the packages/opencode directory
-bun dev
-
-# Run from the repo root
-bun dev .
-
-# Run against a specific project directory
-# (recommended: open the target folder in a new window first, then run this command)
-bun dev <path>
-```
-
-Two built-in agents, switch with `Tab`:
-- **build**: Default mode with full permissions, for active development
-- **plan**: Read-only mode for code analysis and planning
-
-### Web Browser Mode
-
-Requires two terminals:
+Requires two terminals to start the backend and frontend separately:
 
 ```bash
 # Terminal 1: start the API server
 bun dev serve
 
-# Terminal 2: start the frontend
+# Terminal 2: start the frontend (then open the displayed http://localhost:xxxx)
 bun run --cwd packages/app dev
 ```
+If resources fail to load after the page opens, manually add the `http://localhost:xxxx` URL shown in Terminal 1 to the server list.
 
-Then open the `http://localhost:xxxx` URL shown in terminal 2.
+---
 
-### Custom API Configuration
+## Configuring AI Providers
 
-Create `~/.opencode.json` (example using a private Claude-compatible endpoint):
+You can use the built-in free providers, or add AI providers through the settings UI (recommended).
 
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "provider": {
-    "my-claude": {
-      "npm": "@ai-sdk/openai-compatible",
-      "options": {
-        "baseURL": "http://your-ip/v1",
-        "apiKey": "sk-your-key"
-      },
-      "models": {
-        "claude-opus-4-5-20251101": {},
-        "claude-haiku-4-5-20251001": {}
-      }
-    }
-  },
-  "model": "my-claude/claude-opus-4-5-20251101"
-}
-```
+## Feature Details
 
-> **Note:** `baseURL` must end with `/v1`.
+### Built-in Skills
 
-On WSL, explicitly set the config path:
+Aether includes 16 research-oriented Skills that auto-trigger based on their descriptions — no manual invocation needed:
+
+| Category | Skill | Function |
+|---|---|---|
+| Dev Tools | `skill-creator` | Create and optimize Agent Skills |
+| | `skill-manager` | Scan, classify, and manage Skills collections |
+| | `code-reviewer` | Code review (security, performance, best practices) |
+| | `project-signpost` | Generate project directory navigation files |
+| Academic Research | `academic-researcher` | Literature review, paper analysis, equation derivation |
+| | `literature-review` | Multi-database systematic literature review |
+| | `peer-review` | Peer review toolkit |
+| | `write-paper` | Generate LaTeX papers from research project files |
+| | `deep-research` | Multi-source synthesis and deep research |
+| | `arxiv-search` | Search arXiv for preprints |
+| | `read-arxiv-paper` | Read and analyze arXiv papers |
+| | `research-grants` | Write research grant proposals |
+| | `scientific-critical-thinking` | Scientific evidence quality assessment |
+| | `scientific-brainstorming` | Research hypothesis generation and interdisciplinary exploration |
+| | `response-to-referee` | Point-by-point responses to reviewer comments |
+| General | `brainstorming` | Turn ideas into designs before implementation |
+
+Academic Skills can be chained: `arxiv-search` → `read-arxiv-paper` → `literature-review` → `write-paper`
+
+### Knowledge Base
+
+Vector-index PDF papers or text documents (`.md`, `.txt`, `.json`, `.yaml`, `.csv`, `.tex`) in bulk:
+
+- **Three embedding options**: OpenAI API, local model `all-MiniLM-L6-v2` (no API key needed), or custom endpoints
+- **Semantic search**: Cosine similarity-based retrieval of the most relevant passages, injecting only necessary context rather than entire documents
+- **Auto-sync**: Detects file additions, modifications, and deletions, automatically updating the index
+
+### PDF Reading Mode
+
+Read PDFs directly in the Web UI:
+
+- **Annotation system**: Highlights (four colors), bookmarks, notes
+- **AI-assisted translation**: English-to-Chinese translation that preserves technical terms
+- **AI Q&A**: Answer questions based on the current page and surrounding context pages
+- **First-read summary**: Automatically generates a full-document summary when opening a document
+
+### PDF to Markdown
+
+AI-driven multi-stage pipeline:
+
+1. Page rendering → text extraction → figure localization → formula recognition
+2. LaTeX syntax validation and content integrity checks
+3. Automated fixes and cross-page quality verification
+
+### MCP Tool Integration
+
+Connect external MCP (Model Context Protocol) servers to extend AI capabilities:
 
 ```bash
-echo 'export OPENCODE_CONFIG="$HOME/.opencode.json"' >> ~/.bashrc
-source ~/.bashrc
+aether mcp add <name> <command>    # Add a local MCP server
+aether mcp list                     # List configured servers
+aether mcp auth <name>              # OAuth authentication
+aether mcp debug                    # Debug MCP connections
 ```
 
-Verify: `aether models` should list your custom models.
+### Mobile Access
 
-See [DEBUG.md](DEBUG.md) for the full development guide.
+Chat with Aether from your phone via WeChat, Feishu, or QQ bots. Configure credentials for the respective platforms in the Web UI settings.
+
+---
+
+## Other Commands
+
+```bash
+aether web            # Start web server and open browser
+aether serve          # Start headless API server
+aether run <message>  # Non-interactive command execution
+aether models         # List available models
+aether providers      # View providers
+aether mcp            # Manage MCP servers
+aether session        # Session management
+aether stats          # View usage statistics
+aether upgrade        # Self-update
+aether debug config   # View current configuration
+```
 
 ---
 
 ## Troubleshooting
 
-**API returns 404:** Check that `baseURL` ends with `/v1`.
+**API returns 404**: Check that `baseURL` ends with `/v1`.
 
-**API returns 429:** Wrong key, or overridden by a stale `auth.json` — delete `~/.local/share/opencode/auth.json` and retry.
+**API returns 429**: Wrong key, or overridden by a stale `auth.json` — delete `~/.local/share/opencode/auth.json` and retry.
 
-**Browser doesn't open automatically:** Visit the URL shown in the terminal manually (requires `xdg-open`).
+**Browser doesn't open automatically**: Visit the URL shown in the terminal manually (requires `xdg-open`).
 
-**Frontend assets not found:** Ensure the `aether` binary and `web/` directory are in the same folder.
+**Frontend assets not found**: Ensure the `aether` binary and `web/` directory are in the same folder.
+
+**Model list is empty**: Check that the `OPENCODE_CONFIG` environment variable path is correct.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,33 +1,51 @@
 <h1 align="center">Aether（以太）</h1>
 <p align="center"><em>Autonomous Engine for Theoretical & Hands-on Exploration in Research</em></p>
 <p align="center">面向科研人员的 AI 研究助手，基于 <a href="https://github.com/anomalyco/opencode">OpenCode</a> 深度定制。</p>
+<p align="center"><a href="https://aether.aiphys.cn/">🌐 aether.aiphys.cn</a></p>
 
 <p align="center">
   <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a>
+  <a href="README.zh.md">简体中文</a> |
+  <a href="README.zht.md">繁體中文</a>
 </p>
 
 ---
 
 ## 项目简介
 
-Aether 在 OpenCode 基础上针对研究场景做了大量改进，支持终端、浏览器和桌面三种使用方式。相比上游的主要改进：
+Aether 是一个功能丰富的 AI 研究助手平台。它以客户端/服务器架构运行——CLI 在本地启动 HTTP 服务，通过浏览器提供完整的交互界面。支持移动端（微信 / 飞书 / QQ）接入。未来预计支持桌面客户端（Electron）。
 
-- **开箱即用**：下载安装包双击即可启动，无需配置开发环境；内置默认模型设置，首次打开可直接使用
-- **内置科研 Skills**：预置文献阅读、实验记录、论文写作等科研场景提示词，无需手动编写 Prompt
-- **PDF 阅读**：可在 Web 界面中直接打开 PDF 文件，方便对照论文编写代码
-- **不绑定特定提供商**：支持 Gemini、Claude、OpenAI、本地模型或任何协议的私有 API
-- **完整编程能力**：支持代码运行、LSP 代码感知、文件终端操作，对齐 VS Code 的日常开发体验
-- **客户端/服务器架构**：CLI 内置 HTTP 服务，可在本机运行，同时用浏览器或移动设备远程访问
-- **语音输入**：基于 Qwen-Omni 的麦克风录音按钮，结合对话上下文智能转录，自动纠正专业术语并去除语气词。通过后端代理复用提供商凭证，只需连接提供商并在设置中选择语音模型即可使用
+### 核心特性
+
+- **开箱即用**：下载安装包双击即可启动，内置默认模型配置
+- **完整编程能力**：代码运行、LSP 代码感知、文件和终端操作，覆盖日常开发全流程
+- **25+ AI 提供商**：支持 Anthropic、OpenAI、Google Gemini、AIhubmix、DeepSeek、Z\.AI、Kimi、Qwen 等主流平台，以及任何 OpenAI 兼容接口
+- **10+ 个内置科研 Skills**：文献综述、论文写作、深度研究、arXiv 搜索、同行评审、研究基金撰写等，开箱即用
+- **Skill 自进化**：Agent 在完成任务后自动评审对话历史，将成功经验固化为可复用的 Skill（copy-on-write 写入、安全扫描、版本快照），形成持续学习闭环
+- **MCP 协议支持**：集成 Model Context Protocol，可连接本地或远程 MCP 服务器扩展工具集
+- **知识库（RAG）**：将 PDF 和文本文档向量化索引，支持语义搜索，按相关性注入上下文，大幅节省 Token
+- **PDF 阅读模式**：在 Web 界面中直接阅读 PDF，支持高亮标注、书签、笔记，以及 AI 辅助翻译和问答
+- **PDF 转 Markdown**：AI 驱动的多阶段处理流水线，将 PDF 论文高质量转换为可编辑的 Markdown（含公式和图片提取）
+- **Markdown 翻译**：AI 翻译 Markdown 文档，自动保护 LaTeX 公式不被破坏
+- **语音输入**：基于多模态模型的语音转文字，自动去除语气词并纠正专业术语
+- **Git 集成**：在界面中查看分支、提交历史、Diff 和文件变更等
+- **定时任务**：支持 Cron 表达式、固定间隔和一次性定时任务，可自动执行研究流程
+- **Memory 机制**：AI 自动将用户偏好和交互经验持久化到 `memory.instruction.md`，跨会话复用，无需重复说明
+- **会话分享**：生成分享链接，实时同步对话内容
 
 ---
 
-## 从安装包启动
+## 安装与启动
 
-从 [Releases 页面](https://github.com/Science-Discovery/Aether/releases)下载对应平台的压缩包，解压后按以下方式启动。
+### Installer 脚本安装（推荐）
 
-### Web 浏览器版（推荐）
+从 [官网](https://aether.aiphys.cn/) 下载对应平台的 Installer 脚本，一键安装并享受自动更新。安装完成后直接从系统应用程序中点击运行即可。
+
+### 手动安装
+
+从 [Releases 页面](https://github.com/Science-Discovery/Aether/releases)下载对应平台的压缩包。
+
+#### Web 浏览器版
 
 解压后目录结构：
 
@@ -38,13 +56,12 @@ Aether.vbs      ← Windows 启动器
 Aether.command  ← macOS 启动器
 ```
 
-**Windows**：双击 `Aether.vbs`（如果报错，则先点击Aether.exe），浏览器自动打开界面，无黑色命令窗口。
+**Windows**：双击 `Aether.vbs`（如果报错，先运行 `Aether.exe`），浏览器自动打开界面。
 
-**macOS**：双击 `Aether.command`，或在终端运行：
+**macOS**：首次使用赋予执行权限后，双击 `Aether.command` 即可启动：
 
 ```bash
-chmod +x aether   # 首次需要
-./aether web
+chmod +x Aether.command aether   # 首次需要
 ```
 
 **Linux**：
@@ -54,11 +71,21 @@ chmod +x aether   # 首次需要
 ./aether web
 ```
 
-浏览器未自动打开时，手动访问终端中显示的 URL。按 `Ctrl+C` 停止服务。
+`aether web` 启动后会显示本地和局域网访问地址，浏览器自动打开。
+
+<!-- 支持以下选项：
+
+```bash
+./aether web --port 8080              # 指定端口
+./aether web --hostname 0.0.0.0       # 允许局域网访问
+./aether web --idle-timeout 120       # 空闲超时（秒），0 表示常驻运行
+``` -->
 
 ### Electron 桌面版
 
-解压（或安装）后直接双击运行：
+敬请期待
+
+<!-- 解压（或安装）后双击运行：
 
 | 平台 | 文件 |
 |---|---|
@@ -66,81 +93,118 @@ chmod +x aether   # 首次需要
 | macOS | `aether-mac-arm64.dmg`（Apple Silicon）/ `aether-mac-x64.dmg` |
 | Windows | `aether-win-x64.exe` 安装程序 / `win-unpacked/` 便携版 |
 
----
+--- -->
 
-## 从源码启动
+## 从源码运行
 
-**依赖：** [Bun](https://bun.sh/) 1.3+
+适用于开发调试。**依赖：** [Bun](https://bun.sh/) 1.3+
 
 ```bash
 bun install
 ```
 
-### TUI 终端模式
+### Web UI 开发模式
 
-```bash
-# 在 packages/opencode 目录下运行
-bun dev
-
-# 在仓库根目录运行
-bun dev .
-
-# 在指定目录运行（推荐：新开一个窗口并打开目标项目文件夹，再运行此命令）
-bun dev <path>
-```
-
-内置两种 Agent，`Tab` 键切换：
-- **build**：默认模式，具备完整权限，适合开发
-- **plan**：只读模式，适合代码分析与规划
-
-### Web 浏览器模式
-
-需要两个终端：
+需要两个终端分别启动后端和前端：
 
 ```bash
 # 终端 1：启动 API Server
 bun dev serve
 
-# 终端 2：启动前端
+# 终端 2：启动前端（然后打开显示的 http://localhost:xxxx）
 bun run --cwd packages/app dev
 ```
+网页打开后如果发现资源加载失败，可以手动添加终端1中显示的 `http://localhost:xxxx` 到服务器列表中。
 
-然后打开终端 2 中显示的 `http://localhost:xxxx`。
+---
 
-### 接入自定义 API
+## 配置 AI 提供商
 
-在 `~/.opencode.json` 中配置（以私有 Claude 兼容接口为例）：
+可使用预置免费提供商，也可通过设置界面添加AI提供商（推荐）。
 
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "provider": {
-    "my-claude": {
-      "npm": "@ai-sdk/openai-compatible",
-      "options": {
-        "baseURL": "http://你的IP地址/v1",
-        "apiKey": "sk-你的KEY"
-      },
-      "models": {
-        "claude-opus-4-5-20251101": {},
-        "claude-haiku-4-5-20251001": {}
-      }
-    }
-  },
-  "model": "my-claude/claude-opus-4-5-20251101"
-}
-```
+## 功能详解
 
-WSL 环境需要额外指定配置文件路径：
+### 内置 Skills
+
+Aether 预置了 16 个面向科研场景的 Skills，通过描述自动触发，无需手动调用：
+
+| 类别 | Skill | 功能 |
+|---|---|---|
+| 开发工具 | `skill-creator` | 创建和优化 Agent Skills |
+| | `skill-manager` | 扫描、分类和管理 Skills 集合 |
+| | `code-reviewer` | 代码审查（安全、性能、最佳实践） |
+| | `project-signpost` | 生成项目目录导航文件 |
+| 学术研究 | `academic-researcher` | 文献综述、论文分析、公式推导 |
+| | `literature-review` | 多数据库系统文献综述 |
+| | `peer-review` | 同行评审工具包 |
+| | `write-paper` | 从研究项目文件生成 LaTeX 论文 |
+| | `deep-research` | 多源综合深度研究 |
+| | `arxiv-search` | 搜索 arXiv 预印本 |
+| | `read-arxiv-paper` | 阅读和分析 arXiv 论文 |
+| | `research-grants` | 撰写研究基金申请书 |
+| | `scientific-critical-thinking` | 科学证据质量评估 |
+| | `scientific-brainstorming` | 科研假设生成与跨学科探索 |
+| | `response-to-referee` | 逐条回复审稿人意见 |
+| 通用 | `brainstorming` | 在实现之前将想法转化为设计方案 |
+
+学术 Skills 可串联使用：`arxiv-search` → `read-arxiv-paper` → `literature-review` → `write-paper`
+
+### 知识库
+
+将 PDF 论文或文本文档（`.md`、`.txt`、`.json`、`.yaml`、`.csv`、`.tex`）批量向量化索引：
+
+- **三种嵌入方式**：OpenAI API、本地模型 `all-MiniLM-L6-v2`（无需 API Key）、自定义接口
+- **语义搜索**：基于余弦相似度检索最相关段落，只注入必要的上下文，而非整篇文献
+- **自动同步**：检测文件增删改，自动更新索引
+
+### PDF 阅读模式
+
+在 Web 界面中直接阅读 PDF：
+
+- **标注系统**：高亮（四种颜色）、书签、笔记
+- **AI 辅助翻译**：保留专业术语的英中翻译
+- **AI 问答**：基于当前页及上下文页面的内容回答问题
+- **首次阅读摘要**：打开文档时自动生成全文摘要
+
+### PDF 转 Markdown
+
+AI 驱动的多阶段处理流水线：
+
+1. 页面渲染 → 文本提取 → 图片定位 → 公式识别
+2. LaTeX 语法校验和内容完整性检查
+3. 自动修复和跨页面质量校验
+
+### MCP 工具集成
+
+支持连接外部 MCP（Model Context Protocol）服务器扩展 AI 能力：
 
 ```bash
-echo 'export OPENCODE_CONFIG="$HOME/.opencode.json"' >> ~/.bashrc
-source ~/.bashrc
+aether mcp add <name> <command>    # 添加本地 MCP 服务器
+aether mcp list                     # 列出已配置的服务器
+aether mcp auth <name>              # OAuth 认证
+aether mcp debug                    # 调试 MCP 连接
 ```
 
-验证：`aether models` 能看到自定义模型即配置生效。
+### 移动端
 
-详细调试指南见 [DEBUG.md](DEBUG.md)。
+通过微信、飞书、QQ 机器人从手机端与 Aether 对话。在 Web 界面的设置中配置对应平台的凭证即可启用。
+
+---
+
+## 其他命令
+
+```bash
+aether web            # 启动 Web 服务并打开浏览器
+aether serve          # 启动无头 API 服务器
+aether run <message>  # 非交互式执行指令
+aether models         # 列出可用模型
+aether providers      # 查看提供商
+aether mcp            # 管理 MCP 服务器
+aether session        # 会话管理
+aether stats          # 查看使用统计
+aether upgrade        # 自更新
+aether debug config   # 查看当前配置
+```
 
 ---
 
@@ -148,9 +212,12 @@ source ~/.bashrc
 
 **API 返回 404**：检查 `baseURL` 是否遗漏了 `/v1`。
 
-**API 返回 429**：Key 填错，或被旧的 `auth.json` 覆盖，删除 `~/.local/share/opencode/auth.json` 后重试。
+**API 返回 429**：Key 填错，或被旧的 `auth.json` 覆盖。删除 `~/.local/share/opencode/auth.json` 后重试。
 
 **浏览器未自动打开**：手动访问终端中显示的 URL（依赖 `xdg-open`）。
 
 **提示找不到前端资源**：确认 `aether` 二进制和 `web/` 目录在同一目录下。
-**加入我们的社区** [飞书](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=738j8655-cd59-4633-a30a-1124e0096789&qr_code=true) | [X.com](https://x.com/opencode)
+
+**模型列表为空**：检查环境变量 `OPENCODE_CONFIG` 路径是否正确。
+
+---

--- a/README.zht.md
+++ b/README.zht.md
@@ -1,140 +1,221 @@
-<p align="center">
-  <a href="https://opencode.ai">
-    <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
-    </picture>
-  </a>
-</p>
-<p align="center">開源的 AI Coding Agent。</p>
-<p align="center">
-  <a href="https://opencode.ai/discord"><img alt="Discord" src="https://img.shields.io/discord/1391832426048651334?style=flat-square&label=discord" /></a>
-  <a href="https://www.npmjs.com/package/opencode-ai"><img alt="npm" src="https://img.shields.io/npm/v/opencode-ai?style=flat-square" /></a>
-  <a href="https://github.com/anomalyco/opencode/actions/workflows/publish.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/anomalyco/opencode/publish.yml?style=flat-square&branch=dev" /></a>
-</p>
+<h1 align="center">Aether（以太）</h1>
+<p align="center"><em>Autonomous Engine for Theoretical & Hands-on Exploration in Research</em></p>
+<p align="center">面向科研人員的 AI 研究助手，基於 <a href="https://github.com/anomalyco/opencode">OpenCode</a> 深度定制。</p>
+<p align="center"><a href="https://aether.aiphys.cn/">🌐 aether.aiphys.cn</a></p>
 
 <p align="center">
   <a href="README.md">English</a> |
   <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.bs.md">Bosanski</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
+  <a href="README.zht.md">繁體中文</a>
 </p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+---
+
+## 專案簡介
+
+Aether 是一個功能豐富的 AI 研究助手平台。它以客戶端/伺服器架構運行——CLI 在本機啟動 HTTP 服務，透過瀏覽器提供完整的互動介面。支援行動端（微信 / 飛書 / QQ）接入。未來預計支援桌面客戶端（Electron）。
+
+### 核心特性
+
+- **開箱即用**：下載安裝包雙擊即可啟動，內建預設模型配置
+- **完整程式設計能力**：程式碼執行、LSP 程式碼感知、檔案和終端機操作，覆蓋日常開發全流程
+- **25+ AI 提供商**：支援 Anthropic、OpenAI、Google Gemini、AIhubmix、DeepSeek、Z\.AI、Kimi、Qwen 等主流平台，以及任何 OpenAI 相容介面
+- **10+ 個內建科研 Skills**：文獻綜述、論文寫作、深度研究、arXiv 搜尋、同行評審、研究基金撰寫等，開箱即用
+- **Skill 自進化**：Agent 在完成任務後自動評審對話歷史，將成功經驗固化為可複用的 Skill（copy-on-write 寫入、安全掃描、版本快照），形成持續學習閉環
+- **MCP 協定支援**：整合 Model Context Protocol，可連接本機或遠端 MCP 伺服器擴充工具集
+- **知識庫（RAG）**：將 PDF 和文字文件向量化索引，支援語義搜尋，按相關性注入上下文，大幅節省 Token
+- **PDF 閱讀模式**：在 Web 介面中直接閱讀 PDF，支援高亮標注、書籤、筆記，以及 AI 輔助翻譯和問答
+- **PDF 轉 Markdown**：AI 驅動的多階段處理流水線，將 PDF 論文高品質轉換為可編輯的 Markdown（含公式和圖片提取）
+- **Markdown 翻譯**：AI 翻譯 Markdown 文件，自動保護 LaTeX 公式不被破壞
+- **語音輸入**：基於多模態模型的語音轉文字，自動去除語氣詞並糾正專業術語
+- **Git 整合**：在介面中檢視分支、提交歷史、Diff 和檔案變更等
+- **定時任務**：支援 Cron 表示式、固定間隔和一次性定時任務，可自動執行研究流程
+- **Memory 機制**：AI 自動將使用者偏好和互動經驗持久化到 `memory.instruction.md`，跨會話複用，無需重複說明
+- **會話分享**：產生分享連結，即時同步對話內容
 
 ---
 
-### 安裝
+## 安裝與啟動
 
-```bash
-# 直接安裝 (YOLO)
-curl -fsSL https://opencode.ai/install | bash
+### Installer 腳本安裝（推薦）
 
-# 套件管理員
-npm i -g opencode-ai@latest        # 也可使用 bun/pnpm/yarn
-scoop install opencode             # Windows
-choco install opencode             # Windows
-brew install anomalyco/tap/opencode # macOS 與 Linux（推薦，始終保持最新）
-brew install opencode              # macOS 與 Linux（官方 brew formula，更新頻率較低）
-sudo pacman -S opencode            # Arch Linux (Stable)
-paru -S opencode-bin               # Arch Linux (Latest from AUR)
-mise use -g opencode               # 任何作業系統
-nix run nixpkgs#opencode           # 或使用 github:anomalyco/opencode 以取得最新開發分支
+從[官網](https://aether.aiphys.cn/)下載對應平台的 Installer 腳本，一鍵安裝並享受自動更新。安裝完成後直接從系統應用程式中點擊執行即可。
+
+### 手動安裝
+
+從 [Releases 頁面](https://github.com/Science-Discovery/Aether/releases)下載對應平台的壓縮包。
+
+#### Web 瀏覽器版
+
+解壓後目錄結構：
+
+```
+aether          ← CLI 二進位（Windows 為 aether.exe）
+web/            ← 前端靜態資源（必須與二進位同目錄）
+Aether.vbs      ← Windows 啟動器
+Aether.command  ← macOS 啟動器
 ```
 
-> [!TIP]
-> 安裝前請先移除 0.1.x 以前的舊版本。
+**Windows**：雙擊 `Aether.vbs`（如果報錯，先執行 `Aether.exe`），瀏覽器自動開啟介面。
 
-### 桌面應用程式 (BETA)
-
-OpenCode 也提供桌面版應用程式。您可以直接從 [發佈頁面 (releases page)](https://github.com/anomalyco/opencode/releases) 或 [opencode.ai/download](https://opencode.ai/download) 下載。
-
-| 平台                  | 下載連結                              |
-| --------------------- | ------------------------------------- |
-| macOS (Apple Silicon) | `opencode-desktop-darwin-aarch64.dmg` |
-| macOS (Intel)         | `opencode-desktop-darwin-x64.dmg`     |
-| Windows               | `opencode-desktop-windows-x64.exe`    |
-| Linux                 | `.deb`, `.rpm`, 或 AppImage           |
+**macOS**：首次使用賦予執行權限後，雙擊 `Aether.command` 即可啟動：
 
 ```bash
-# macOS (Homebrew Cask)
-brew install --cask opencode-desktop
-# Windows (Scoop)
-scoop bucket add extras; scoop install extras/opencode-desktop
+chmod +x Aether.command aether   # 首次需要
 ```
 
-#### 安裝目錄
-
-安裝腳本會依據以下優先順序決定安裝路徑：
-
-1. `$OPENCODE_INSTALL_DIR` - 自定義安裝目錄
-2. `$XDG_BIN_DIR` - 符合 XDG 基礎目錄規範的路徑
-3. `$HOME/bin` - 標準使用者執行檔目錄 (若存在或可建立)
-4. `$HOME/.opencode/bin` - 預設備用路徑
+**Linux**：
 
 ```bash
-# 範例
-OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
-XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
+chmod +x aether   # 首次需要
+./aether web
 ```
 
-### Agents
+`aether web` 啟動後會顯示本機和區域網路存取位址，瀏覽器自動開啟。
 
-OpenCode 內建了兩種 Agent，您可以使用 `Tab` 鍵快速切換。
+<!-- 支援以下選項：
 
-- **build** - 預設模式，具備完整權限的 Agent，適用於開發工作。
-- **plan** - 唯讀模式，適用於程式碼分析與探索。
-  - 預設禁止修改檔案。
-  - 執行 bash 指令前會詢問權限。
-  - 非常適合用來探索陌生的程式碼庫或規劃變更。
+```bash
+./aether web --port 8080              # 指定連接埠
+./aether web --hostname 0.0.0.0       # 允許區域網路存取
+./aether web --idle-timeout 120       # 空閒逾時（秒），0 表示常駐執行
+``` -->
 
-此外，OpenCode 還包含一個 **general** 子 Agent，用於處理複雜搜尋與多步驟任務。此 Agent 供系統內部使用，亦可透過在訊息中輸入 `@general` 來呼叫。
+### Electron 桌面版
 
-了解更多關於 [Agents](https://opencode.ai/docs/agents) 的資訊。
+敬請期待
 
-### 線上文件
+<!-- 解壓（或安裝）後雙擊執行：
 
-關於如何設定 OpenCode 的詳細資訊，請參閱我們的 [**官方文件**](https://opencode.ai/docs)。
+| 平台 | 檔案 |
+|---|---|
+| Linux | `aether-linux-x64.AppImage` / `.deb` / `.rpm` |
+| macOS | `aether-mac-arm64.dmg`（Apple Silicon）/ `aether-mac-x64.dmg` |
+| Windows | `aether-win-x64.exe` 安裝程式 / `win-unpacked/` 便攜版 |
 
-### 參與貢獻
+--- -->
 
-如果您有興趣參與 OpenCode 的開發，請在提交 Pull Request 前先閱讀我們的 [貢獻指南 (Contributing Docs)](./CONTRIBUTING.md)。
+## 從原始碼執行
 
-### 基於 OpenCode 進行開發
+適用於開發除錯。**依賴：** [Bun](https://bun.sh/) 1.3+
 
-如果您正在開發與 OpenCode 相關的專案，並在名稱中使用了 "opencode"（例如 "opencode-dashboard" 或 "opencode-mobile"），請在您的 README 中加入聲明，說明該專案並非由 OpenCode 團隊開發，且與我們沒有任何隸屬關係。
+```bash
+bun install
+```
 
-### 常見問題 (FAQ)
+### Web UI 開發模式
 
-#### 這跟 Claude Code 有什麼不同？
+需要兩個終端機分別啟動後端和前端：
 
-在功能面上與 Claude Code 非常相似。以下是關鍵差異：
+```bash
+# 終端機 1：啟動 API Server
+bun dev serve
 
-- 100% 開源。
-- 不綁定特定的服務提供商。雖然我們推薦使用透過 [OpenCode Zen](https://opencode.ai/zen) 提供的模型，但 OpenCode 也可搭配 Claude, OpenAI, Google 甚至本地模型使用。隨著模型不斷演進，彼此間的差距會縮小且價格會下降，因此具備「不限廠商 (provider-agnostic)」的特性至關重要。
-- 內建 LSP (語言伺服器協定) 支援。
-- 專注於終端機介面 (TUI)。OpenCode 由 Neovim 愛好者與 [terminal.shop](https://terminal.shop) 的創作者打造。我們將不斷挑戰終端機介面的極限。
-- 客戶端/伺服器架構 (Client/Server Architecture)。這讓 OpenCode 能夠在您的電腦上運行的同時，由行動裝置進行遠端操控。這意味著 TUI 前端只是眾多可能的客戶端之一。
+# 終端機 2：啟動前端（然後開啟顯示的 http://localhost:xxxx）
+bun run --cwd packages/app dev
+```
+網頁開啟後如果發現資源載入失敗，可以手動新增終端機 1 中顯示的 `http://localhost:xxxx` 到伺服器列表中。
 
 ---
 
-**加入我們的社群** [飞书](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=738j8655-cd59-4633-a30a-1124e0096789&qr_code=true) | [X.com](https://x.com/opencode)
+## 設定 AI 提供商
+
+可使用預建免費提供商，也可透過設定介面新增 AI 提供商（推薦）。
+
+## 功能詳解
+
+### 內建 Skills
+
+Aether 預建了 16 個面向科研場景的 Skills，透過描述自動觸發，無需手動呼叫：
+
+| 類別 | Skill | 功能 |
+|---|---|---|
+| 開發工具 | `skill-creator` | 建立和最佳化 Agent Skills |
+| | `skill-manager` | 掃描、分類和管理 Skills 集合 |
+| | `code-reviewer` | 程式碼審查（安全、效能、最佳實踐） |
+| | `project-signpost` | 產生專案目錄導航檔案 |
+| 學術研究 | `academic-researcher` | 文獻綜述、論文分析、公式推導 |
+| | `literature-review` | 多資料庫系統文獻綜述 |
+| | `peer-review` | 同行評審工具包 |
+| | `write-paper` | 從研究專案檔案產生 LaTeX 論文 |
+| | `deep-research` | 多源綜合深度研究 |
+| | `arxiv-search` | 搜尋 arXiv 預印本 |
+| | `read-arxiv-paper` | 閱讀和分析 arXiv 論文 |
+| | `research-grants` | 撰寫研究基金申請書 |
+| | `scientific-critical-thinking` | 科學證據品質評估 |
+| | `scientific-brainstorming` | 科研假設產生與跨學科探索 |
+| | `response-to-referee` | 逐條回覆審稿人意見 |
+| 通用 | `brainstorming` | 在實作之前將想法轉化為設計方案 |
+
+學術 Skills 可串聯使用：`arxiv-search` → `read-arxiv-paper` → `literature-review` → `write-paper`
+
+### 知識庫
+
+將 PDF 論文或文字文件（`.md`、`.txt`、`.json`、`.yaml`、`.csv`、`.tex`）批次向量化索引：
+
+- **三種嵌入方式**：OpenAI API、本機模型 `all-MiniLM-L6-v2`（無需 API Key）、自訂介面
+- **語義搜尋**：基於餘弦相似度檢索最相關段落，只注入必要的上下文，而非整篇文獻
+- **自動同步**：偵測檔案增刪改，自動更新索引
+
+### PDF 閱讀模式
+
+在 Web 介面中直接閱讀 PDF：
+
+- **標注系統**：高亮（四種顏色）、書籤、筆記
+- **AI 輔助翻譯**：保留專業術語的英中翻譯
+- **AI 問答**：基於目前頁及上下文頁面的內容回答問題
+- **首次閱讀摘要**：開啟文件時自動產生全文摘要
+
+### PDF 轉 Markdown
+
+AI 驅動的多階段處理流水線：
+
+1. 頁面渲染 → 文字提取 → 圖片定位 → 公式辨識
+2. LaTeX 語法驗證和內容完整性檢查
+3. 自動修復和跨頁面品質校驗
+
+### MCP 工具整合
+
+支援連接外部 MCP（Model Context Protocol）伺服器擴充 AI 能力：
+
+```bash
+aether mcp add <name> <command>    # 新增本機 MCP 伺服器
+aether mcp list                     # 列出已設定的伺服器
+aether mcp auth <name>              # OAuth 認證
+aether mcp debug                    # 除錯 MCP 連線
+```
+
+### 行動端
+
+透過微信、飛書、QQ 機器人從手機端與 Aether 對話。在 Web 介面的設定中配置對應平台的憑證即可啟用。
+
+---
+
+## 其他指令
+
+```bash
+aether web            # 啟動 Web 服務並開啟瀏覽器
+aether serve          # 啟動無頭 API 伺服器
+aether run <message>  # 非互動式執行指令
+aether models         # 列出可用模型
+aether providers      # 檢視提供商
+aether mcp            # 管理 MCP 伺服器
+aether session        # 會話管理
+aether stats          # 檢視使用統計
+aether upgrade        # 自更新
+aether debug config   # 檢視目前設定
+```
+
+---
+
+## 常見問題
+
+**API 回傳 404**：檢查 `baseURL` 是否遺漏了 `/v1`。
+
+**API 回傳 429**：Key 填錯，或被舊的 `auth.json` 覆蓋。刪除 `~/.local/share/opencode/auth.json` 後重試。
+
+**瀏覽器未自動開啟**：手動存取終端機中顯示的 URL（依賴 `xdg-open`）。
+
+**提示找不到前端資源**：確認 `aether` 二進位和 `web/` 目錄在同一目錄下。
+
+**模型列表為空**：檢查環境變數 `OPENCODE_CONFIG` 路徑是否正確。


### PR DESCRIPTION
### Issue for this PR

No associated issue.

### Type of change

- [x] Documentation

### What does this PR do?

Major rewrite of all three README variants (English, Simplified Chinese, Traditional Chinese) to accurately reflect the current state of Aether:

- Remove TUI mode references — only Web UI is supported now
- Add installer script from official website (https://aether.aiphys.cn/) as the recommended installation method
- Add previously undocumented features: Skill self-evolution, Memory mechanism, Knowledge base (RAG), PDF reading mode, PDF-to-Markdown converter, Markdown translator, MCP integration, scheduled tasks, session sharing, mobile access (WeChat/Feishu/QQ), voice input
- Add full built-in Skills table (16 research-oriented Skills)
- Update AI providers list (25+ providers including DeepSeek, AIhubmix, Z.AI, Kimi, Qwen)
- Clarify macOS launch instructions (double-click `Aether.command`)
- Keep all three language versions fully aligned

### How did you verify your code works?

Manually reviewed all three README files for consistency and accuracy against the current codebase.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have not included unrelated changes in this PR