### PR TITLE
feat: Skill 文件热更新 —— 基于 mtime 快照的缓存失效机制

### DIFF
--- a/docs/skill-loading-mechanism.md
+++ b/docs/skill-loading-mechanism.md
@@ -1,0 +1,437 @@
+# Aether Skill 加载机制
+
+Aether 的 skill 加载机制负责在每次项目实例初始化时，将来自多个来源的 `SKILL.md` 文件合并成一张统一的 skill 注册表，供 AI 在对话中按需调用。加载结果按项目实例缓存在内存中，远程 skill 则额外缓存在本地磁盘。
+
+---
+
+## 目录
+
+- [整体流程](#整体流程)
+- [扫描来源与优先级](#扫描来源与优先级)
+- [内存缓存机制（InstanceState）](#内存缓存机制instancestate)
+- [执行时重读机制（SkillTool）](#执行时重读机制skilltool)
+- [远程 Skill 的磁盘缓存（Discovery）](#远程-skill-的磁盘缓存discovery)
+- [Default Skills（内置 Skill）](#default-skills内置-skill)
+- [可用性过滤与权限](#可用性过滤与权限)
+- [关键文件速查](#关键文件速查)
+
+---
+
+## 整体流程
+
+Skill 加载由 Effect Layer 机制驱动，依附于项目实例的生命周期。整个流程分两个阶段：**按需初始化**（首次访问时扫描磁盘）和**执行时重读**（tool 调用时从磁盘取最新内容）。
+
+```
+项目实例创建（Instance.provide）
+        │
+        │  Skill.layer 作为 Effect Layer 挂载，
+        │  其内部状态由 InstanceState（ScopedCache）管理
+        │
+        ▼
+┌──────────────────────────────────────────────────────────────┐
+│  首次调用 Skill.all() / Skill.get() / Skill.available() 时   │
+│  ScopedCache 检查当前 Instance.directory 是否已有缓存          │
+│  （同一项目实例生命周期内只初始化一次）                          │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+               ┌─────────────────────────────────────────────┐
+               │  Instance.directory 已有缓存？             │
+               │  （即当前打开的项目目录，如 /home/foo/proj） │
+               └───────────┬─────────────────────────────────┘
+                     是 /    \ 否
+                    /          \
+                   ▼            ▼
+              直接返回       执行 loadSkills()
+              内存中的       按优先级扫描所有来源
+              State          填充 state.skills
+                   \               │
+                    \              ▼
+                     \   禁用列表过滤：
+                      \  删除 cfg.skills.disabled 中的条目
+                       \       │
+                        └──────┘
+                               │
+                               ▼
+                  skill 注册表就绪，
+                  供对话中的 skill tool 调用
+```
+
+---
+
+## 扫描来源与优先级
+
+`loadSkills()` 按**低优先级→高优先级**的顺序依次扫描，后扫描的同名 skill 覆盖先扫描的。
+
+```
+──────────────────────────────────────────────────────────────────────
+优先级 1（最低）：全局外部目录
+──────────────────────────────────────────────────────────────────────
+
+扫描 ~/.agents/、~/.claude/、~/.opencode/、~/.aether/ 中的
+skills/**/SKILL.md
+（EXTERNAL_DIRS 的顺序即优先级：.agents 最低，.aether 最高）
+
+作用：用户在 home 目录放置的个人全局 skill，对所有项目生效
+
+──────────────────────────────────────────────────────────────────────
+优先级 2：AI 后台生成的 skill（项目级，优先级最低的项目来源）
+──────────────────────────────────────────────────────────────────────
+
+扫描 ~/.aether/skill-sessions/<projectId>/skills/ 中的 **/SKILL.md
+
+作用：skill 自进化系统后台评审后自动写入的 skill，
+      仅对当前项目可见，优先级刻意低于用户手动放置的内容，
+      防止 AI 自动生成结果意外覆盖用户预期
+
+──────────────────────────────────────────────────────────────────────
+优先级 3：项目外部目录（项目目录 → worktree 路径向上遍历）
+──────────────────────────────────────────────────────────────────────
+
+从 directory 向上遍历到 worktree，
+收集沿途的 .agents/、.claude/、.opencode/、.aether/ 目录，
+反转后依序扫描，使内层（靠近 directory）的同名 skill 优先级更高
+
+示例：
+  /project/.aether/skills/foo/SKILL.md     ← 最高（内层 .aether）
+  /project/.opencode/skills/foo/SKILL.md
+  /project/.claude/skills/foo/SKILL.md
+  /project/.agents/skills/foo/SKILL.md     ← 最低（内层 .agents）
+  /worktree/.aether/skills/foo/SKILL.md    ← 比所有 directory 内来源优先级低
+
+作用：项目团队共享的 skill（提交到代码仓库中）
+
+──────────────────────────────────────────────────────────────────────
+优先级 4：Config.directories() 中的配置目录
+──────────────────────────────────────────────────────────────────────
+
+遍历 Config.directories() 返回的目录列表，
+扫描 {skill,skills}/**/SKILL.md
+
+特别处理：已在优先级 1 扫描过的全局家目录（~/.*）被排除，
+          防止这些目录再次参与扫描而错误覆盖项目级 skill
+
+──────────────────────────────────────────────────────────────────────
+优先级 5：cfg.skills.paths 自定义路径
+──────────────────────────────────────────────────────────────────────
+
+读取 opencode.json 中 skills.paths 字段，
+支持 ~/ 展开和相对路径解析（相对于 directory），
+扫描 **/SKILL.md
+
+作用：允许用户将 skill 目录放在任意位置并在配置中显式声明
+
+──────────────────────────────────────────────────────────────────────
+优先级 6（最高）：cfg.skills.urls 远程注册表
+──────────────────────────────────────────────────────────────────────
+
+调用 Discovery.pull(url) 从远程拉取 skill 文件，
+下载缓存到本地磁盘后，扫描缓存目录
+
+（详见「远程 Skill 的磁盘缓存」章节）
+```
+
+所有来源扫描完成后，统一执行禁用列表过滤：
+
+```
+所有来源扫描完毕，state.skills 已填充
+        │
+        ▼
+┌──────────────────────────────────────────────────────────────┐
+│  读取 cfg.skills.disabled 列表                                │
+│  对列表中的每个 name，若 state.skills[name] 存在则删除         │
+│  并写入日志 "skill disabled by config"                        │
+└──────────────────────────────────────────────────────────────┘
+        │
+        ▼
+skill 注册表最终版本，等待内存缓存
+```
+
+---
+
+## 内存缓存机制（InstanceState）
+
+这是加载机制中最核心的内存管理部分。Skill 状态通过 `InstanceState`（底层为 Effect 的 `ScopedCache`）缓存在内存中，实现按项目隔离、懒加载、实例销毁时自动失效。
+
+### 缓存结构
+
+```
+InstanceState<State>
+        │
+        └── ScopedCache<string, State>
+                    │
+                    key = Instance.directory（项目绝对路径）
+                    │
+                    每个项目实例维护一份独立的 State：
+                    ┌────────────────────────────────────┐
+                    │  State {                           │
+                    │    skills: Record<name, Info>      │
+                    │    dirs:   Set<string>             │
+                    │  }                                 │
+                    │                                    │
+                    │  Info {                            │
+                    │    name:     string                │
+                    │    description: string             │
+                    │    location: string  ← 磁盘绝对路径 │
+                    │    content:  string  ← 扫描时读取  │
+                    │  }                                 │
+                    └────────────────────────────────────┘
+```
+
+### 缓存生命周期
+
+```
+首次调用 Skill.available() 或其他方法
+        │
+        │  此时 ScopedCache 中尚无当前目录的记录
+        │
+        ▼
+┌──────────────────────────────────────────────────────────────┐
+│  执行 loadSkills()：遍历所有来源，读取 SKILL.md，填充 State    │
+│  （I/O 密集操作，可能耗时数百毫秒，取决于 skill 数量）          │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+                           ▼
+┌──────────────────────────────────────────────────────────────┐
+│  State 写入 ScopedCache，key = 当前 Instance.directory        │
+│  后续同一实例的所有调用直接从内存读取，不再访问磁盘             │
+└──────────────────────────────────────────────────────────────┘
+
+        ─ ─ ─ ─ ─ ─ ─（对话正常进行中）─ ─ ─ ─ ─ ─ ─
+
+项目实例销毁（Instance.dispose 被调用）
+        │
+        │  Skill.layer 在 Effect Scope 结束时
+        │  通过 registerDisposer 回调自动触发
+        │
+        ▼
+┌──────────────────────────────────────────────────────────────┐
+│  ScopedCache.invalidate(directory)                           │
+│  内存中当前目录的 State 被清除                                 │
+│  下次访问将重新扫描磁盘（捕获期间发生的文件变化）               │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**重要限制**：缓存不监听文件系统事件。在同一实例生命周期内（通常对应一次 Aether 启动），新增或删除 `SKILL.md` 文件不会被自动感知。Skill 自进化系统通过 `shadow-writer.ts` 写入后主动调用 `InstanceState.invalidate` 来使缓存失效，从而绕过这一限制。
+
+---
+
+## 执行时重读机制（SkillTool）
+
+`InstanceState` 中缓存的 `Info.content` 是扫描时读取的快照。但 `skill` tool 在每次被调用时，会**绕过缓存，从磁盘重新读取 `SKILL.md`**，以确保 AI 拿到的是最新内容。
+
+```
+AI 调用 skill tool（params.name = "check-pr"）
+        │
+        ▼
+┌──────────────────────────────────────────────────────────────┐
+│  Skill.get(name)：从 InstanceState 中取出 Info               │
+│  主要目的是获取 Info.location（磁盘绝对路径）                  │
+│  以及判断 skill 是否存在                                      │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+               ┌───────────▼──────────────┐
+               │  skill 存在且文件可访问？  │
+               └───────────┬──────────────┘
+                     是 /    \ 否
+                    /          \
+                   ▼            ▼
+┌──────────────────────────┐  向 AI 返回错误：
+│  权限检查                 │  "Skill not found.
+│  ctx.ask(permission:     │   Available skills: ..."
+│    "skill", [name])      │
+└──────────────┬───────────┘
+               │
+               ▼
+┌──────────────────────────────────────────────────────────────┐
+│  ConfigMarkdown.parse(skill.location)                        │
+│  从磁盘重新读取 SKILL.md                                      │
+│  ← 不使用 Info.content（扫描时的缓存），直接读磁盘             │
+│  ← 这意味着修改 SKILL.md 内容后无需重启，下次 tool 调用即生效  │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+                           ▼
+┌──────────────────────────────────────────────────────────────┐
+│  用 ripgrep 扫描 skill 目录，最多列出 10 个附属文件            │
+│  （脚本、模板、参考资料等，SKILL.md 本身排除）                  │
+│  提供给 AI 以便它能读取 skill 携带的辅助资源                   │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+                           ▼
+封装成 <skill_content name="..."> 块返回给 AI，
+其中包含完整的 skill 指令、基础目录路径、附属文件列表
+```
+
+两级内存的分工：
+
+```
+InstanceState（内存缓存）        SkillTool（执行时）
+─────────────────────────       ─────────────────────────
+存储：name, description,         使用：location（路径）
+      location, content          重读：SKILL.md 最新内容
+作用：快速列出可用 skill，         作用：保证 AI 拿到最新版本，
+      供 fmt() 生成摘要注入        支持热修改（不重启生效）
+      system prompt
+```
+
+---
+
+## 远程 Skill 的磁盘缓存（Discovery）
+
+通过 `cfg.skills.urls` 配置的远程 skill 注册表，由 `Discovery` 模块负责拉取，并将文件缓存到本地磁盘。本地磁盘缓存在进程重启后依然有效，相同文件不重复下载。
+
+```
+loadSkills() 处理 cfg.skills.urls 中的每个 URL
+        │
+        ▼
+┌──────────────────────────────────────────────────────────────┐
+│  GET {url}/index.json                                        │
+│  期望格式：                                                   │
+│  { skills: [{ name: string, files: string[] }, ...] }        │
+│  files 列表必须包含 "SKILL.md"，否则该条目被跳过              │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+                           ▼
+对 index 中每个有效 skill，并发（最多 4 个）处理：
+
+┌──────────────────────────────────────────────────────────────┐
+│  对 skill 的每个文件（并发最多 8 个）：                         │
+│  dest = ~/.cache/aether/skills/<name>/<file>                 │
+│                                                              │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │  dest 文件已存在？                                    │    │
+│  └──────────┬──────────────────────────────────────────┘    │
+│       是 /    \ 否                                           │
+│      /          \                                           │
+│     ▼            ▼                                          │
+│  跳过下载     从远端 GET 下载，写入 dest                       │
+│  （幂等，     失败时记录 error 日志，跳过该文件               │
+│   保证缓存     不抛异常，其他 skill 继续处理）                  │
+│   稳定性）                                                   │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+                           ▼
+┌──────────────────────────────────────────────────────────────┐
+│  检查 dest/SKILL.md 是否存在                                   │
+│  存在 → 将该缓存目录加入返回列表，后续由 scan() 扫描            │
+│  不存在 → 下载失败，跳过该 skill                               │
+└──────────────────────────────────────────────────────────────┘
+```
+
+磁盘缓存的特点：
+
+```
+~/.cache/aether/skills/
+  └── <skill-name>/
+        ├── SKILL.md              ← 永久保留直到手动删除
+        └── （其他 skill 附属文件）
+
+缓存策略：只新增，不更新，不过期
+  ─ 远端 skill 内容更新时，本地旧版本不会自动覆盖
+  ─ 需手动删除缓存目录后重启，才会重新下载最新版本
+  ─ 网络不可用时，只要缓存目录存在，skill 仍可正常加载
+```
+
+---
+
+## Default Skills（内置 Skill）
+
+服务器启动时，通过 `findServerSkillsDirSync()` **同步、一次性**地确定内置 skill 目录，结果存为进程级常量，整个进程生命周期内不再变化。
+
+```
+Node.js 进程启动（模块加载时同步执行）
+        │
+        ▼
+┌──────────────────────────────────────────────────────────────┐
+│  检查可执行文件同级目录（打包发布场景）：                         │
+│  path.dirname(process.execPath) + /{.opencode,.aether}/skills/│
+│  ← 适用于 macOS/Windows 打包后的单一可执行文件发布              │
+│     skill 文件随二进制一起打包在相邻目录                        │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+               ┌───────────▼──────────────┐
+               │  找到有效目录？            │
+               └───────────┬──────────────┘
+                     是 /    \ 否
+                    /          \
+                   ▼            ▼
+          返回该目录       从 process.cwd() 向上遍历，
+          赋值给           逐级检查 {.opencode,.aether}/skills/
+          _serverSkillsDir  直到文件系统根目录
+          （进程级常量）    ← 适用于 CLI / 开发环境，
+                              从当前工作目录找到项目根
+                               │
+                    ┌──────────▼──────────┐
+                    │  找到有效目录？       │
+                    └──────────┬──────────┘
+                         是 /    \ 否
+                        /          \
+                       ▼            ▼
+              返回该目录         _serverSkillsDir = undefined
+              赋值给             listDefaultSkills() 返回 []
+              _serverSkillsDir
+```
+
+`listDefaultSkills()` / `saveDefaultSkill()` / `deleteDefaultSkill()` 均基于这个常量路径操作，供 UI 的「内置 skill 管理」功能使用。
+
+---
+
+## 可用性过滤与权限
+
+`Skill.available(agent?)` 在返回 skill 列表前，会根据 agent 的权限配置进行过滤：
+
+```
+Skill.available(agent?) 被调用
+        │
+        ▼
+从 InstanceState 取出全部 skills，
+按 name 字母序排序（保证列表顺序稳定）
+        │
+        ▼
+┌───────────────────────────────────┐
+│  传入了 agent 参数？               │
+└──────────────┬────────────────────┘
+         是 /    \ 否
+        /          \
+       ▼            ▼
+对每个 skill：      返回全部
+Permission.evaluate(
+  "skill",
+  skill.name,
+  agent.permission
+)
+       │
+  ┌────┴──────────────┐
+  │  evaluate 结果？   │
+  └────┬──────────────┘
+deny /   \ 其他（allow / ask / ...）
+    /      \
+   ▼        ▼
+ 过滤掉    保留，
+ 不可用    返回给调用方
+```
+
+权限配置示例（opencode.json）：
+
+```
+{
+  "permission": {
+    "skill": {
+      "check-pr": "allow",
+      "huashu-design": "deny"   ← 该 agent 看不到此 skill
+    }
+  }
+}
+```
+
+---
+
+## 关键文件速查
+
+| 文件 | 职责 |
+|------|------|
+| [packages/opencode/src/skill/index.ts](packages/opencode/src/skill/index.ts) | 主加载逻辑、InstanceState 缓存、优先级扫描、available() 过滤 |
+| [packages/opencode/src/skill/discovery.ts](packages/opencode/src/skill/discovery.ts) | 远程 URL 拉取与磁盘缓存 |
+| [packages/opencode/src/tool/skill.ts](packages/opencode/src/tool/skill.ts) | skill tool：执行时重读磁盘、权限检查、附属文件列举 |
+| [packages/opencode/src/config/config.ts:1464](packages/opencode/src/config/config.ts#L1464) | Default skills 目录查找（`findServerSkillsDirSync`，进程级常量） |
+| [packages/opencode/src/effect/instance-state.ts](packages/opencode/src/effect/instance-state.ts) | InstanceState / ScopedCache 实现 |
+| [packages/opencode/src/config/paths.ts](packages/opencode/src/config/paths.ts) | `Config.directories()` 配置目录枚举 |

--- a/docs/skill-mtime-cache-design.md
+++ b/docs/skill-mtime-cache-design.md
@@ -17,6 +17,7 @@
 - [改动位置](#改动位置)
 - [能检测到的变化 vs 检测盲区](#能检测到的变化-vs-检测盲区)
 - [与 skill-watcher 的关系](#与-skill-watcher-的关系)
+- [性能问题与优化方向](#性能问题与优化方向)
 
 ---
 
@@ -337,6 +338,92 @@ writeSnapshot(projectId, snapshot):
 ✓ 替换 SKILL.md               覆盖写入 → mtime 更新 → 不 fresh
 ✓ 进程重启后文件有变化          快照在磁盘上持久化，重启后仍可比对
 ```
+
+---
+
+## 性能问题与优化方向
+
+### 实测耗时
+
+日志（`~/.local/share/aether/log/dev.log`）显示，`isFresh` 每次调用耗时 19～87ms：
+
+```
+INFO  service=skill fresh=false ms=87 isFresh check
+INFO  service=skill fresh=false ms=19 isFresh check
+```
+
+且几乎全部返回 `false`，缓存从未命中（原因另见下节）。
+
+### 为什么这么慢
+
+`isFresh` 每次调用做两件事：
+
+1. **stat 已知文件**：对快照里每个 skill 文件各做一次 `fs.stat`，检测修改和删除。每次 stat 是一次系统调用，在 WSL2 上需要跨 Linux→Windows 文件系统桥，单次就有几毫秒开销。
+
+2. **glob 全量扫描**（`scanAllSkillPaths`）：对 4 个全局目录 + 项目路径沿途每一级目录各做一次递归目录遍历，检测是否有新增 skill。glob 内部要对每一级目录执行 `readdir`，读出所有目录项名称，再逐层递归，系统调用次数远多于 stat。
+
+这两步的开销接近 `loadSkills()` 本身，相当于"为了判断要不要加载，先做了一半加载的工作"。
+
+### 优化方向：用 readdir 计数替代 glob
+
+stat 已经覆盖了"已有文件是否被改/删"这两种情况。glob 唯一多做的事是发现新增 skill。
+
+新增一个 skill 必然在 `skills/` 顶层多出一个子目录。因此不需要递归遍历整棵树，只需 `readdir` 一下 `skills/` 的第一层，数一下子目录数量，与快照里存的数量对比——数量变了说明有新增，没变则不用继续扫。
+
+`readdir` 只读一层、一次系统调用，比递归 glob 便宜得多。
+
+快照格式相应调整，新增一个 `dirCounts` 字段：
+
+```json
+{
+  "dirCounts": {
+    "/home/zheng/.aether/skills": 5,
+    "/home/zheng/.claude/skills": 2
+  },
+  "files": {
+    "/home/zheng/.aether/skills/check-pr/SKILL.md": 1748000000000
+  }
+}
+```
+
+`isFresh` 的新逻辑：
+
+```
+① 对 snapshot.files 里每个路径做 stat，检测修改/删除
+② 对 snapshot.dirCounts 里每个目录做 readdir，数子目录数量，检测新增
+③ 两项都一致 → fresh
+```
+
+去掉 `scanAllSkillPaths` 调用后，`isFresh` 的系统调用次数从"几十次"降为"文件数 + 目录数"，预计耗时可降到 5ms 以内。
+
+### 对旧文件的改动分类
+
+#### 直接替换方案（侵入性大）
+
+最直接的做法是修改现有的 `readSnapshot`、`writeSnapshot`、`isFresh` 函数，同时删除 `scanAllSkillPaths`：
+
+| 类型 | 位置 |
+|------|------|
+| 删除 | `scanAllSkillPaths` 整个函数 |
+| 新增 | `Snapshot` 类型定义 |
+| 侵入性 | `readSnapshot` 返回类型 |
+| 侵入性 | `writeSnapshot` 参数类型 |
+| 侵入性 | `isFresh` 函数签名（去掉 `directory`、`worktree` 参数） |
+| 侵入性 | `isFresh` 函数体（移除 glob，改为 readdir 计数） |
+| 侵入性 | `loadSkills` 末尾快照写入块（写新格式） |
+| 侵入性 | `getState` 中 `isFresh` 的调用（去掉两个参数） |
+
+侵入性改动共 6 处，改动面较大。
+
+#### 最小侵入方案（推荐）
+
+不改任何现有函数，而是平行新增一套快照机制，只在 `getState` 的调用处做一行切换：
+
+- **新增**：`Snapshot2` 类型、`readSnapshot2`、`writeSnapshot2`、`isFreshFast` 函数
+- **插入性**：`loadSkills` 末尾追加 `writeSnapshot2(...)` 调用（紧跟现有 `writeSnapshot` 之后）
+- **侵入性**：`getState` 里 1 行，把 `isFresh(...)` 换成 `isFreshFast(...)`
+
+原有的 `readSnapshot`、`writeSnapshot`、`isFresh`、`scanAllSkillPaths` 全部保持不动，变为死代码，后续可单独清理。侵入性改动从 6 处降到 1 处。
 
 ---
 

--- a/docs/skill-mtime-cache-design.md
+++ b/docs/skill-mtime-cache-design.md
@@ -67,9 +67,10 @@ InstanceState.get(state)
 ┌──────────────────────────────────────────────────────────────┐
 │  isFresh()                                                   │
 │                                                              │
-│  ① 用 fs.stat 读取磁盘上所有已知 SKILL.md 的当前 mtime        │
+│  ① 扫描 skills 相关目录，用 fs.stat 读取当前所有 SKILL.md 的   │
+│     mtime，得到当前磁盘状态 { path → mtime }                  │
 │  ② 读取磁盘上的 mtime 快照文件（上次加载时保存的旧 mtime）      │
-│  ③ 逐一比对                                                   │
+│  ③ 比对两份数据（数量、路径、mtime 三项全部一致才算 fresh）      │
 │                                                              │
 │  快照文件不存在（首次运行）→ 视为「不 fresh」                   │
 └──────────────────────────┬───────────────────────────────────┘
@@ -105,6 +106,13 @@ isFresh() 被调用
         │
         ▼
 ┌──────────────────────────────────────────────────────────────┐
+│  扫描 skills 相关目录（与 loadSkills() 扫描的目录相同）          │
+│  对找到的每个 SKILL.md 执行 fs.stat，得到其当前 mtime           │
+│  结果：当前磁盘状态 { path → mtime }                           │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+                           ▼
+┌──────────────────────────────────────────────────────────────┐
 │  读取磁盘上的 mtime 快照文件                                   │
 │  路径：~/.aether/skill-snapshots/<project-id>.json           │
 └──────────────────────────┬───────────────────────────────────┘
@@ -116,31 +124,17 @@ isFresh() 被调用
                     /          \
                    ▼            ▼
            读取快照内容         返回 false
-           { path → mtime }    （视为不 fresh，需要重新加载）
+           { path → mtime }    （首次运行，视为不 fresh）
                    │
                    ▼
-遍历快照中每一条记录（path, 快照里的 mtime）
-        │
-        ▼
 ┌──────────────────────────────────────────────────────────────┐
-│  fs.stat(path) 读取该文件当前的 mtime                         │
+│  比对当前磁盘状态与快照                                        │
 │                                                              │
-│  stat 失败（文件已被删除）→ 立即返回 false                     │
-└──────────────────────────┬───────────────────────────────────┘
-                           │
-               ┌───────────▼────────────────────────┐
-               │  当前 mtime === 快照里的 mtime？     │
-               └───────────┬────────────────────────┘
-                     是 /    \ 否
-                    /          \
-                   ▼            ▼
-           继续检查下一个     立即返回 false
-           文件              （文件内容已被修改）
-
-所有文件检查完毕，全部一致
-        │
-        ▼
-返回 true
+│  · 当前有、快照没有 → 新增了 skill    → 返回 false             │
+│  · 快照有、当前没有 → 删除了 skill    → 返回 false             │
+│  · 同一路径 mtime 不同 → 文件被修改   → 返回 false             │
+│  · 完全一致                          → 返回 true              │
+└──────────────────────────────────────────────────────────────┘
 ```
 
 ---
@@ -193,12 +187,24 @@ State = {
   await writeSnapshot(projectId, snapshot)
 
 改动 2：新增 isFresh() 函数
-  async function isFresh(projectId: string): Promise<boolean> {
+  async function isFresh(projectId: string, directory: string, worktree: string): Promise<boolean> {
+    // 第一步：扫描当前磁盘上所有 SKILL.md，得到 { path → mtime }
+    const current: Record<string, number> = {}
+    for (const match of await scanAllSkillPaths(directory, worktree)) {
+      const s = await fs.stat(match).catch(() => null)
+      if (s) current[match] = s.mtimeMs
+    }
+
+    // 第二步：读快照
     const snapshot = await readSnapshot(projectId)
     if (!snapshot) return false
-    for (const [skillPath, cachedMtime] of Object.entries(snapshot)) {
-      const s = await fs.stat(skillPath).catch(() => null)
-      if (!s || s.mtimeMs !== cachedMtime) return false
+
+    // 第三步：比对
+    const currentPaths = new Set(Object.keys(current))
+    const snapshotPaths = new Set(Object.keys(snapshot))
+    if (currentPaths.size !== snapshotPaths.size) return false
+    for (const [path, mtime] of Object.entries(current)) {
+      if (snapshot[path] !== mtime) return false
     }
     return true
   }
@@ -230,23 +236,15 @@ writeSnapshot(projectId, snapshot):
 
 ---
 
-## 能检测到的变化 vs 检测盲区
+## 能检测到的变化
 
 ```
-能检测（mtime 会变化）：
-  ✓ 编辑已有 SKILL.md 的内容
-  ✓ 删除已有 SKILL.md（stat 失败 → 返回 false）
-  ✓ 替换 SKILL.md（覆盖写入 → mtime 更新）
-  ✓ 进程重启后文件发生了变化（快照持久化在磁盘上）
-
-检测盲区：
-  ✗ 在已监控目录下新增 SKILL.md
-    → 新路径不在快照中，不会被检查到
-    → isFresh 仍返回 true，新技能不可见
-    → 依赖 Instance.dispose() 或 skill-watcher 兜底
+✓ 编辑已有 SKILL.md 的内容     mtime 变化 → 比对不一致 → 不 fresh
+✓ 新增 SKILL.md               扫描时发现新路径，快照里没有 → 不 fresh
+✓ 删除 SKILL.md               扫描结果比快照少一条 → 不 fresh
+✓ 替换 SKILL.md               覆盖写入 → mtime 更新 → 不 fresh
+✓ 进程重启后文件有变化          快照在磁盘上持久化，重启后仍可比对
 ```
-
-新增技能的检测盲区是此方案的已知局限。如需覆盖，可在快照中额外记录各 `skills/` 目录本身的 mtime（目录 mtime 在子文件增删时会更新），但这是独立需求，本文档不展开。
 
 ---
 
@@ -259,7 +257,7 @@ writeSnapshot(projectId, snapshot):
                              （拉取式，有一次访问延迟）
 shadow-writer.ts 写入       ✓ 兜底                      ✓ 主动失效优先
 进程重启后文件有变化         ✓ 快照在磁盘上，跨进程有效   ✓ 重启后重新监听
-新增 SKILL.md               ✗ 快照中无此路径，感知不到   ✓ 目录监听可感知
+新增 SKILL.md               ✓ 扫描时发现新路径，不 fresh  ✓ 目录监听可感知
 删除 SKILL.md               ✓ stat 失败 → 不 fresh       ✓ 文件事件驱动
 ```
 

--- a/docs/skill-mtime-cache-design.md
+++ b/docs/skill-mtime-cache-design.md
@@ -441,3 +441,212 @@ shadow-writer.ts 写入       ✓ 兜底                      ✓ 主动失效�
 ```
 
 mtime 快照校验是**拉取式**保险：无需额外进程，每次访问时顺带检查，在 skill-watcher 不可用时独立生效。两者互补，不冲突。
+
+---
+
+## feat/skill-evolution 的 manifest 机制
+
+`feat/skill-evolution` 分支实现了一套更彻底的缓存方案，从根本上解决了当前 `scanAllSkillPaths` 与 `loadSkills` 不对称的问题。
+
+### 核心思路
+
+当前方案的问题在于两边语义不一致：
+
+- **snapshot** 记录的是"解析成功且未被禁用的 skill 文件路径 → mtime"
+- **scanAllSkillPaths** 返回的是"glob 扫到的所有 SKILL.md 路径"（包含解析失败、被覆盖的文件）
+
+`feat/skill-evolution` 的解法：**两边都用同一份原始 manifest**。snapshot 里不仅存加载结果（skills 列表），还同时存一份原始 manifest（所有 SKILL.md 的路径 + mtime + size）。判断新鲜度时，重新扫一遍磁盘构建新 manifest，与 snapshot 里的旧 manifest 逐条对比——因为两边都是 raw，所以天然对称，不存在孤儿路径的问题。
+
+### 类型定义
+
+```typescript
+// filepath → [mtimeMs, size]
+type SnapshotManifest = Record<string, [number, number]>
+
+// snapshot 文件格式
+{
+  version: 3,
+  manifest: SnapshotManifest,   // 原始文件清单（用于新鲜度判断）
+  skills: SnapshotSkill[],      // 加载结果（命中时直接用）
+}
+```
+
+mtime + size 双重校验：只改内容不改扩展名的场景（如覆盖写同大小内容）下，单靠 mtime 可能漏检，size 作为补充保险。
+
+### 关键函数
+
+**`buildSkillsManifest(dirs)`**
+
+对给定目录列表进行 glob 扫描（`**/SKILL.md`，`dot: true`），对每个结果文件执行 `fs.stat`，将路径和 `[mtimeMs, size]` 写入 manifest 对象并返回。解析失败的文件、`.archive/` 下的归档文件、无 frontmatter 的文件，全部一律收录——manifest 只关心文件存在与否和元数据，不做语义过滤。
+
+**`manifestsMatch(a, b)`**
+
+对两份 manifest 做完全对比：先比较 key 数量，再对排序后的 key 列表逐一比对路径、mtime、size 三元组，任一不同则返回 false。
+
+**`loadSkillsSnapshot(snapshotPath, manifest)`**
+
+读取 snapshot 文件，校验 version 字段后，用 `manifestsMatch` 比较文件里存的旧 manifest 与入参的新 manifest：
+
+- 一致 → 返回缓存的 skills 列表（cache hit）
+- 不一致 → 返回 null（cache miss，需要重新扫描）
+
+**`writeSkillsSnapshot(snapshotPath, manifest, skills)`**
+
+原子写入：先写临时文件（`snapshotPath + ".tmp." + Date.now()`），写完后 `rename` 替换目标文件，避免写到一半时进程崩溃导致快照损坏。
+
+### Global / Project 分离
+
+`feat/skill-evolution` 把扫描目录分为 global（`~/.aether/`、`~/.claude/` 等）和 project（当前项目路径沿途的 `.aether/` 等）两个 scope，分别维护独立的 snapshot 文件：
+
+```
+~/.cache/aether/.skills_prompt_snapshot.global.json   ← 全局 snapshot
+~/.cache/aether/skills-prompt/<slug>.<hash>.json      ← 项目 snapshot
+```
+
+全局 snapshot 在不同项目之间可以复用——只要 `~/.aether/skills/` 没有变化，切换项目时全局 skill 列表直接命中缓存，不需要重新扫描。
+
+### 完整加载流程
+
+```
+loadSkillsData(directory, worktree)
+        │
+        ├── buildSources()    构建扫描源列表（含 scope、dir、pattern、order）
+        │
+        ├── manifestDirs()    从 sources 提取 global / project 目录列表
+        │
+        ├── buildSkillsManifest(globalDirs)   → globalManifest
+        ├── buildSkillsManifest(projectDirs)  → projectManifest
+        │   （只做 stat，不解析文件内容，比 glob+parse 便宜）
+        │
+        ├── loadSkillsSnapshot(globalPath, globalManifest)
+        │       ├── hit  → 直接用缓存的 globalSkills
+        │       └── miss → scanSources("global") → 解析文件 → writeSkillsSnapshot(...)
+        │
+        ├── loadSkillsSnapshot(projectPath, projectManifest)
+        │       ├── hit  → 直接用缓存的 projectSkills
+        │       └── miss → scanSources("project") → 解析文件 → writeSkillsSnapshot(...)
+        │
+        └── mergeSkills(globalSkills, projectSkills, disabled)
+                按 order 排序后合并，project 覆盖 global，过滤 disabled
+```
+
+### 如何解决 .archive/ 的问题
+
+当前方案的 `.archive/` bug 根因是：`loadSkills` 只把解析成功的文件写进 snapshot，而 `scanAllSkillPaths` 把解析失败的文件（如无 frontmatter 的归档测试 skill）也返回出来，导致 Phase 2 永远发现"当前路径不在 snapshot 里"，缓存永远 miss。
+
+manifest 机制不存在这个问题：`buildSkillsManifest` 的结果包含所有 SKILL.md（含 `.archive/` 下的），snapshot 里存的旧 manifest 也是同样逻辑产生的，两边用完全相同的函数构建，天然对称。无论 `.archive/` 下有多少文件、是否能解析、是否有同名覆盖，都不会产生孤儿路径。
+
+### 与当前方案的对比
+
+| 维度 | 当前方案（feat/manifest） | feat/skill-evolution |
+|---|---|---|
+| 新鲜度判断 | scanAllSkillPaths（raw）vs snapshot（仅加载成功的） | manifest（raw）vs snapshot.manifest（raw） |
+| 两边是否对称 | 不对称，.archive/ 解析失败的文件造成孤儿路径 | 完全对称，两边用同一函数构建 |
+| .archive/ 问题 | 需要手动过滤补丁 | 不存在 |
+| snapshot 格式 | `{ path: mtime }` | `{ version, manifest: { path: [mtime, size] }, skills: [...] }` |
+| 文件变化检测 | mtime | mtime + size（更严格） |
+| 写入安全性 | 直接写 | tmp + rename（原子写入） |
+| Global/Project 分离 | 无（单文件，按 projectId 区分） | 有（全局 snapshot 跨项目复用） |
+| 扫描函数重复 | loadSkills + scanAllSkillPaths 两套逻辑 | buildSources 统一描述，无重复 |
+
+---
+
+## 改进方案：manifest 写入对齐
+
+### 旧方案 vs 新方案
+
+当前方案的根本缺陷在于快照的**写入端**和**校验端**使用了不同的数据源：
+
+| | 写入快照（loadSkills 末尾） | 读取校验（isFresh Phase 2） |
+|---|---|---|
+| 数据来源 | `state.skills`（仅解析成功且未被禁用的 skill） | `scanAllSkillPaths`（glob 原始结果，含解析失败文件） |
+| `.archive/` 处理 | 解析失败的归档文件不进 `state.skills`，不写入快照 | glob 返回所有 `.archive/` 路径，包括无 frontmatter 的文件 |
+| 结果 | 快照中缺少 `.archive/` 孤儿路径 | Phase 2 发现孤儿路径不在快照 → 永远 miss |
+
+新方案只改一件事：**让写入端和校验端使用同一份数据**。具体做法是，写快照时不再遍历 `state.skills`，而是调用与 `scanAllSkillPaths` 同源的函数扫出所有 SKILL.md 文件并记录其 mtime，写入快照。这样快照与 `isFresh` Phase 2 的数据集天然对齐，不存在孤儿路径。
+
+快照格式、`isFresh` 逻辑、`scanAllSkillPaths` 本身均**无需改动**。
+
+### 新增函数：`buildManifest`
+
+在 `scanAllSkillPaths` 下方新增一个函数，对其返回的路径逐一执行 `fs.stat`，得到 `{ 路径 → mtime }` 的完整 manifest：
+
+```typescript
+async function buildManifest(directory: string, worktree: string, projectId: string): Promise<Record<string, number>> {
+  const paths = await scanAllSkillPaths(directory, worktree, projectId)
+  const manifest: Record<string, number> = {}
+  for (const p of paths) {
+    const stat = await fs.stat(p).catch(() => null)
+    if (stat) manifest[p] = stat.mtimeMs
+  }
+  return manifest
+}
+```
+
+`buildManifest` 内部复用 `scanAllSkillPaths`，不重复扫描逻辑。`scanAllSkillPaths` 保持不动。
+
+### 改动位置
+
+#### 新增（不触碰任何现有代码）
+
+| 位置 | 内容 |
+|---|---|
+| `scanAllSkillPaths` 函数体之后 | 新增 `buildManifest` 函数 |
+
+#### 侵入性改动（修改现有代码行）
+
+仅一处：`loadSkills` 末尾的快照写入块，将遍历 `state.skills` 的逻辑替换为调用 `buildManifest`：
+
+```typescript
+// 改动前：只记录加载成功的 skill
+const snapshot: Record<string, number> = {}
+for (const info of Object.values(state.skills)) {
+  const stat = await fs.stat(info.location).catch(() => null)
+  if (stat) snapshot[info.location] = stat.mtimeMs
+}
+await writeSnapshot(projectId, snapshot)
+
+// 改动后：记录所有扫描到的 SKILL.md（与 isFresh Phase 2 数据源一致）
+const snapshot = await buildManifest(directory, worktree, projectId)
+await writeSnapshot(projectId, snapshot)
+```
+
+其余所有函数（`isFresh`、`scanAllSkillPaths`、`readSnapshot`、`writeSnapshot`、`getState`）**均不改动**。
+
+### 改动后的数据流
+
+```
+loadSkills() 结束时
+        │
+        ▼
+buildManifest(directory, worktree, projectId)
+  └── scanAllSkillPaths(...)   ← 与 isFresh Phase 2 完全相同的扫描逻辑
+        └── fs.stat 每个路径   ← 得到 { path → mtime }
+        │
+        ▼
+writeSnapshot(projectId, snapshot)
+  快照现在包含所有扫描到的 SKILL.md（含 .archive/、无 frontmatter 的文件）
+
+──────────────────────────────────────────────
+
+isFresh() 校验时（逻辑不变）
+        │
+Phase 1: 遍历 snapshot 每条记录 → fs.stat 检测修改和删除  ✓
+        │
+Phase 2: scanAllSkillPaths(...) → 检查每条路径是否在 snapshot 中
+         因为 snapshot 由同一扫描逻辑写入 → 路径集合完全一致 → Phase 2 始终通过  ✓
+        │
+        ▼
+        返回 true（fresh）
+```
+
+### 与 feat/skill-evolution 的关系
+
+| 维度 | feat/skill-evolution | 本方案 |
+|---|---|---|
+| 对称性保证 | `buildSources` 统一描述扫描逻辑，两端共用 | `buildManifest` 内部调用 `scanAllSkillPaths`，两端共用 |
+| Global/Project 分离 | 有，两个独立 snapshot | 无，单一 snapshot（按 projectId 区分） |
+| Snapshot 格式 | `{ version, manifest: { path: [mtime, size] }, skills: [...] }` | `{ path: mtime }`（保持现有格式不变） |
+| 原子写入 | tmp + rename | 现有 writeSnapshot 行为（不改） |
+| 侵入性 | 较大（重写整个缓存机制） | 极小（新增 1 函数 + 修改 1 处写入逻辑） |
+| .archive/ 问题 | 根本不存在 | 修复 |

--- a/docs/skill-mtime-cache-design.md
+++ b/docs/skill-mtime-cache-design.md
@@ -8,6 +8,7 @@
 
 ## 目录
 
+- [对旧文件的改动](#对旧文件的改动)
 - [现有缓存流程（改动前）](#现有缓存流程改动前)
 - [改动后流程](#改动后流程)
 - [isFresh 内部逻辑](#isfresh-内部逻辑)
@@ -16,6 +17,97 @@
 - [改动位置](#改动位置)
 - [能检测到的变化 vs 检测盲区](#能检测到的变化-vs-检测盲区)
 - [与 skill-watcher 的关系](#与-skill-watcher-的关系)
+
+---
+
+## 对旧文件的改动
+
+改动文件：`packages/opencode/src/skill/index.ts`
+
+按对原有代码的侵入程度，分为三类：
+
+---
+
+### 侵入性改动
+
+直接修改了现有函数中已有的代码行，改变了原有行为。
+
+| 位置 | 原代码 | 修改后 |
+|------|--------|--------|
+| `get()` 方法体 | `yield* InstanceState.get(state)` | `yield* getState()` |
+| `all()` 方法体 | `yield* InstanceState.get(state)` | `yield* getState()` |
+| `dirs()` 方法体 | `yield* InstanceState.get(state)` | `yield* getState()` |
+| `available()` 方法体 | `yield* InstanceState.get(state)` | `yield* getState()` |
+
+**必要性**
+
+mtime 校验必须在"读缓存"这一动作的入口处执行，否则校验无法生效。
+
+`InstanceState.get(state)` 是 Skill 模块里唯一触发缓存读取的调用点——内存中有数据时直接返回，没有数据时才调用 `loadSkills()`。如果不在这里拦截，`isFresh()` 的检查就无处插入：
+
+- 不能放在 `loadSkills()` 里：`loadSkills()` 只在缓存为空时执行，文件被外部修改后缓存仍然命中，`loadSkills()` 根本不会被调用到。
+- 不能放在调用方（`get`/`all` 等）之外：这四个方法是对外的全部读接口，在更上层拦截意味着要跨越模块边界修改调用者，侵入范围反而更大。
+
+因此，将这四处替换为 `getState()`（内部先调 `isFresh()`，不 fresh 则 `invalidate` 后再 `get`）是最小侵入方案：改动点最少，覆盖最完整，且逻辑收拢在一个地方便于后续维护。
+
+---
+
+### 新增
+
+全新添加的函数/常量，在改动前完全不存在。
+
+**模块级辅助函数**（添加在 `Skill` namespace 内，`loadSkills` 之前）：
+
+| 函数 | 签名 | 作用 |
+|------|------|------|
+| `snapshotPath` | `(projectId: string) => string` | 返回快照文件的磁盘路径 |
+| `readSnapshot` | `(projectId: string) => Promise<Record<string, number> \| null>` | 从磁盘读取 mtime 快照，文件不存在返回 `null` |
+| `writeSnapshot` | `(projectId: string, snapshot: Record<string, number>) => Promise<void>` | 将 mtime 快照写入磁盘，目录不存在时自动创建 |
+| `scanAllSkillPaths` | `(directory, worktree, projectId) => Promise<string[]>` | 镜像 `loadSkills` 的扫描逻辑，仅收集路径，不加载内容，供 `isFresh` 比对用 |
+| `isFresh` | `(projectId, directory, worktree) => Promise<boolean>` | 对比磁盘快照与当前文件系统状态，判断缓存是否仍然有效 |
+
+> `scanAllSkillPaths` 并非从 `loadSkills` 提取重构而来——`loadSkills` 原有代码完整保留，`scanAllSkillPaths` 是并行新增的镜像，只做路径收集（`Glob.scan` 返回路径列表）而不做 skill 加载（`scan(state, ...)` 写入 State）。
+
+**`Skill.layer` 内新增的局部常量**：
+
+```typescript
+const getState = Effect.fn("Skill.getState")(function* () {
+  const instance = Instance.current
+  const projectId = String(instance.project.id)
+  const fresh = yield* Effect.promise(() => isFresh(projectId, instance.directory, instance.worktree))
+  if (!fresh) yield* InstanceState.invalidate(state)
+  return yield* InstanceState.get(state)
+})
+```
+
+作为四个读方法共用的前置包装，封装"检查 mtime → 按需失效 → 取 State"三步逻辑。
+
+---
+
+### 插入性改动
+
+嵌入到现有文件的固定位置，但不修改任何已有代码行；去掉这部分代码，原有逻辑可完整复原。
+
+**文件顶部 import 块新增两行**：
+
+```typescript
+import fs from "fs/promises"          // 第 1 行（首行插入）
+import { Instance } from "@/project/instance"   // 插入在现有 import 块中
+```
+
+**`loadSkills()` 末尾追加快照写入块**（追加在 "Remove disabled skills" 逻辑之后）：
+
+```typescript
+// Write mtime snapshot so isFresh() can detect external edits on the next access.
+const snapshot: Record<string, number> = {}
+for (const info of Object.values(state.skills)) {
+  const stat = await fs.stat(info.location).catch(() => null)
+  if (stat) snapshot[info.location] = stat.mtimeMs
+}
+await writeSnapshot(projectId, snapshot)
+```
+
+`loadSkills` 原有的初始化、扫描、禁用逻辑均未被触碰；这段代码只是在函数返回前多做一件事——把本次加载结果的 mtime 固化到磁盘，供下次 `isFresh` 调用时比对。
 
 ---
 

--- a/docs/skill-mtime-cache-design.md
+++ b/docs/skill-mtime-cache-design.md
@@ -1,0 +1,266 @@
+# Skill 缓存 mtime 校验设计
+
+当前 `InstanceState` 缓存在同一项目实例生命周期内只初始化一次，只有 `Instance.dispose()` 或 `shadow-writer.ts` 主动调用时才会失效。用户在外部手动编辑 `SKILL.md` 后，若没有重启实例，变化无法被感知。
+
+本文档提出一种 **mtime 快照校验机制**：在每次读内存缓存之前，先把磁盘上所有 `SKILL.md` 的当前修改时间，与上次加载时保存在磁盘上的快照做比对。一致则直接用内存缓存，不一致则清空内存缓存并重新从磁盘加载，加载完后更新快照。
+
+---
+
+## 目录
+
+- [现有缓存流程（改动前）](#现有缓存流程改动前)
+- [改动后流程](#改动后流程)
+- [isFresh 内部逻辑](#isfresh-内部逻辑)
+- [快照文件](#快照文件)
+- [State 结构不变](#state-结构不变)
+- [改动位置](#改动位置)
+- [能检测到的变化 vs 检测盲区](#能检测到的变化-vs-检测盲区)
+- [与 skill-watcher 的关系](#与-skill-watcher-的关系)
+
+---
+
+## 现有缓存流程（改动前）
+
+内存缓存（InstanceState）的结构：
+
+```
+内存中的缓存对象
+  │
+  ├── "/home/zheng/code/Aether"   → State { skills, dirs }
+  ├── "/home/zheng/code/Binance"  → State { skills, dirs }
+  └── ...
+
+State = {
+  skills: { "check-pr": {...}, "review": {...} },  // 所有技能
+  dirs:   Set { "/path/to/skills" },               // 扫描过的目录
+}
+```
+
+调用流程：
+
+```
+调用 Skill.available() / Skill.get() / Skill.all()
+        │
+        ▼
+InstanceState.get(state)
+用 Instance.directory（当前项目路径）做 key 查内存缓存
+        │
+        ├── 内存中有这个项目的数据 → 直接返回
+        │   ← 不检查磁盘，无法感知外部对 SKILL.md 的修改
+        │
+        └── 内存中没有 → loadSkills() 从磁盘读
+                         存入内存缓存，返回
+```
+
+**问题所在**：内存命中后直接返回，不与磁盘做任何比对。外部手动修改 `SKILL.md` 后，只要实例没有重启，改动对运行中的程序完全不可见。
+
+---
+
+## 改动后流程
+
+在读内存缓存之前，先做一次磁盘层面的 mtime 比对。比对所需的"旧数据"不存在内存中，而是以快照文件的形式保存在磁盘上，所以这一步完全独立于内存缓存，可以放在 `InstanceState.get` 之前执行。
+
+```
+调用 Skill.available() / Skill.get() / Skill.all()
+        │
+        ▼
+┌──────────────────────────────────────────────────────────────┐
+│  isFresh()                                                   │
+│                                                              │
+│  ① 用 fs.stat 读取磁盘上所有已知 SKILL.md 的当前 mtime        │
+│  ② 读取磁盘上的 mtime 快照文件（上次加载时保存的旧 mtime）      │
+│  ③ 逐一比对                                                   │
+│                                                              │
+│  快照文件不存在（首次运行）→ 视为「不 fresh」                   │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+               ┌───────────▼──────────┐
+               │  isFresh 返回 true？  │
+               └───────────┬──────────┘
+                     是 /    \ 否
+                    /          \
+                   ▼            ▼
+                   │     清空内存中当前项目的缓存
+                   │            │
+                   └─────┬──────┘
+                         │
+                         ▼
+        InstanceState.get(state)
+        用 Instance.directory 做 key 查内存缓存
+                         │
+                         ├── 内存中有这个项目的数据 → 直接返回
+                         │
+                         └── 内存中没有 → loadSkills() 从磁盘读
+                                          存入内存缓存
+                                          写磁盘快照（覆盖旧快照）
+                                          返回
+```
+
+---
+
+## isFresh 内部逻辑
+
+```
+isFresh() 被调用
+        │
+        ▼
+┌──────────────────────────────────────────────────────────────┐
+│  读取磁盘上的 mtime 快照文件                                   │
+│  路径：~/.aether/skill-snapshots/<project-id>.json           │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+               ┌───────────▼──────────┐
+               │  快照文件存在？        │
+               └───────────┬──────────┘
+                     是 /    \ 否
+                    /          \
+                   ▼            ▼
+           读取快照内容         返回 false
+           { path → mtime }    （视为不 fresh，需要重新加载）
+                   │
+                   ▼
+遍历快照中每一条记录（path, 快照里的 mtime）
+        │
+        ▼
+┌──────────────────────────────────────────────────────────────┐
+│  fs.stat(path) 读取该文件当前的 mtime                         │
+│                                                              │
+│  stat 失败（文件已被删除）→ 立即返回 false                     │
+└──────────────────────────┬───────────────────────────────────┘
+                           │
+               ┌───────────▼────────────────────────┐
+               │  当前 mtime === 快照里的 mtime？     │
+               └───────────┬────────────────────────┘
+                     是 /    \ 否
+                    /          \
+                   ▼            ▼
+           继续检查下一个     立即返回 false
+           文件              （文件内容已被修改）
+
+所有文件检查完毕，全部一致
+        │
+        ▼
+返回 true
+```
+
+---
+
+## 快照文件
+
+快照是一个 JSON 文件，存在磁盘上，内容是上次 `loadSkills()` 扫描到的所有 `SKILL.md` 的路径和修改时间：
+
+```
+~/.aether/skill-snapshots/<project-id>.json
+
+内容示例：
+{
+  "/home/zheng/code/Aether/.aether/skills/check-pr/SKILL.md": 1748000000000,
+  "/home/zheng/code/Aether/.claude/skills/review/SKILL.md":   1747000000000
+}
+```
+
+写入时机：每次 `loadSkills()` 完成后，把这次读到的所有 `SKILL.md` 的 mtime 写入快照，覆盖旧文件。
+
+因为快照存在磁盘上，进程重启后依然有效。进程重启时内存缓存是空的，但 `isFresh` 仍可正常比对——若快照和磁盘一致，`InstanceState.get` 会触发 `loadSkills()` 重新加载（内存为空所以必须加载），流程正确。
+
+---
+
+## State 结构不变
+
+与我此前提出的方案不同，此方案的快照单独存在磁盘上，State 不需要增加任何字段：
+
+```
+State = {
+  skills: Record<string, Info>,   // 技能名 → 技能信息（不变）
+  dirs:   Set<string>,            // 扫描过的目录（不变）
+}
+```
+
+---
+
+## 改动位置
+
+改动集中在 `packages/opencode/src/skill/index.ts`，共三处：
+
+```
+改动 1：loadSkills() 完成后写快照
+  在 loadSkills() 最后追加：
+  const snapshot: Record<string, number> = {}
+  for (const info of Object.values(state.skills)) {
+    const s = await fs.stat(info.location).catch(() => null)
+    if (s) snapshot[info.location] = s.mtimeMs
+  }
+  await writeSnapshot(projectId, snapshot)
+
+改动 2：新增 isFresh() 函数
+  async function isFresh(projectId: string): Promise<boolean> {
+    const snapshot = await readSnapshot(projectId)
+    if (!snapshot) return false
+    for (const [skillPath, cachedMtime] of Object.entries(snapshot)) {
+      const s = await fs.stat(skillPath).catch(() => null)
+      if (!s || s.mtimeMs !== cachedMtime) return false
+    }
+    return true
+  }
+
+改动 3：Skill.layer 内新增 getState() 辅助函数
+  替换所有 InstanceState.get(state) 的调用：
+  const getState = Effect.fn("Skill.getState")(function* () {
+    const fresh = yield* Effect.promise(() => isFresh(projectId))
+    if (!fresh) {
+      yield* InstanceState.invalidate(state)  // 清空内存缓存
+    }
+    return yield* InstanceState.get(state)    // 内存有则直接取，没有则 loadSkills()
+  })
+
+  get / all / dirs / available 四个方法
+  将原来的 InstanceState.get(state) 替换为 getState()
+```
+
+快照的读写封装为两个辅助函数：
+
+```
+readSnapshot(projectId):
+  读 ~/.aether/skill-snapshots/<projectId>.json
+  文件不存在返回 null，否则返回解析后的对象
+
+writeSnapshot(projectId, snapshot):
+  将 snapshot 写入 ~/.aether/skill-snapshots/<projectId>.json
+```
+
+---
+
+## 能检测到的变化 vs 检测盲区
+
+```
+能检测（mtime 会变化）：
+  ✓ 编辑已有 SKILL.md 的内容
+  ✓ 删除已有 SKILL.md（stat 失败 → 返回 false）
+  ✓ 替换 SKILL.md（覆盖写入 → mtime 更新）
+  ✓ 进程重启后文件发生了变化（快照持久化在磁盘上）
+
+检测盲区：
+  ✗ 在已监控目录下新增 SKILL.md
+    → 新路径不在快照中，不会被检查到
+    → isFresh 仍返回 true，新技能不可见
+    → 依赖 Instance.dispose() 或 skill-watcher 兜底
+```
+
+新增技能的检测盲区是此方案的已知局限。如需覆盖，可在快照中额外记录各 `skills/` 目录本身的 mtime（目录 mtime 在子文件增删时会更新），但这是独立需求，本文档不展开。
+
+---
+
+## 与 skill-watcher 的关系
+
+```
+变更类型                   mtime 快照校验              skill-watcher
+─────────────────────────  ─────────────────────────   ─────────────────────
+手动编辑现有 SKILL.md       ✓ 下次访问时感知             ✓ 文件事件驱动，实时感知
+                             （拉取式，有一次访问延迟）
+shadow-writer.ts 写入       ✓ 兜底                      ✓ 主动失效优先
+进程重启后文件有变化         ✓ 快照在磁盘上，跨进程有效   ✓ 重启后重新监听
+新增 SKILL.md               ✗ 快照中无此路径，感知不到   ✓ 目录监听可感知
+删除 SKILL.md               ✓ stat 失败 → 不 fresh       ✓ 文件事件驱动
+```
+
+mtime 快照校验是**拉取式**保险：无需额外进程，每次访问时顺带检查，在 skill-watcher 不可用时独立生效。两者互补，不冲突。

--- a/docs/skill-mtime-cache-design.md
+++ b/docs/skill-mtime-cache-design.md
@@ -587,31 +587,32 @@ async function buildManifest(directory: string, worktree: string, projectId: str
 
 ### 改动位置
 
-#### 新增（不触碰任何现有代码）
+以下改动均相对于 **dev 分支**（`loadSkills` 在 dev 上没有任何快照写入逻辑，`isFresh`、`scanAllSkillPaths` 等函数均为 feat/manifest 新增）。
+
+#### 新增（全新代码，不触碰 dev 任何现有代码行）
 
 | 位置 | 内容 |
 |---|---|
 | `scanAllSkillPaths` 函数体之后 | 新增 `buildManifest` 函数 |
+| `snapshotPath` / `readSnapshot` / `writeSnapshot` | 沿用 feat/manifest 已新增的三个辅助函数，无需额外改动 |
+| `isFresh` | 沿用 feat/manifest 已新增的函数，无需额外改动 |
+| `getState` | 沿用 feat/manifest 已新增的局部常量，无需额外改动 |
 
-#### 侵入性改动（修改现有代码行）
+#### 插入性改动（在 dev 原有代码的固定位置嵌入，不修改任何 dev 已有代码行）
 
-仅一处：`loadSkills` 末尾的快照写入块，将遍历 `state.skills` 的逻辑替换为调用 `buildManifest`：
+| 位置 | 内容 |
+|---|---|
+| `loadSkills` 末尾（Remove disabled skills 逻辑之后） | 追加快照写入块，调用 `buildManifest` 后写入快照 |
 
 ```typescript
-// 改动前：只记录加载成功的 skill
-const snapshot: Record<string, number> = {}
-for (const info of Object.values(state.skills)) {
-  const stat = await fs.stat(info.location).catch(() => null)
-  if (stat) snapshot[info.location] = stat.mtimeMs
-}
-await writeSnapshot(projectId, snapshot)
-
-// 改动后：记录所有扫描到的 SKILL.md（与 isFresh Phase 2 数据源一致）
+// Write manifest snapshot so isFresh() can detect external edits on the next access.
 const snapshot = await buildManifest(directory, worktree, projectId)
 await writeSnapshot(projectId, snapshot)
 ```
 
-其余所有函数（`isFresh`、`scanAllSkillPaths`、`readSnapshot`、`writeSnapshot`、`getState`）**均不改动**。
+dev 上 `loadSkills` 末尾没有任何快照相关代码，这段是纯插入，移除后原有逻辑可完整复原。
+
+其余所有 dev 原有函数（`scan`、`add`、`loadSkills` 主体、`get`/`all`/`dirs`/`available` 等）**均不改动**。
 
 ### 改动后的数据流
 

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto"
 import fs from "fs/promises"
 import os from "os"
 import path from "path"
@@ -67,21 +68,22 @@ export namespace Skill {
     readonly available: (agent?: Agent.Info) => Effect.Effect<Info[]>
   }
 
-  function snapshotPath(projectId: string) {
-    return path.join(Global.Path.home, ".aether", "skill-snapshots", `${projectId}.json`)
+  function snapshotPath(projectId: string, directory: string) {
+    const dirHash = createHash("md5").update(directory).digest("hex").slice(0, 8)
+    return path.join(Global.Path.home, ".aether", "skill-snapshots", `${projectId}-${dirHash}.json`)
   }
 
-  async function readSnapshot(projectId: string): Promise<Record<string, number> | null> {
+  async function readSnapshot(projectId: string, directory: string): Promise<Record<string, number> | null> {
     try {
-      const content = await fs.readFile(snapshotPath(projectId), "utf-8")
+      const content = await fs.readFile(snapshotPath(projectId, directory), "utf-8")
       return JSON.parse(content) as Record<string, number>
     } catch {
       return null
     }
   }
 
-  async function writeSnapshot(projectId: string, snapshot: Record<string, number>): Promise<void> {
-    const p = snapshotPath(projectId)
+  async function writeSnapshot(projectId: string, directory: string, snapshot: Record<string, number>): Promise<void> {
+    const p = snapshotPath(projectId, directory)
     await fs.mkdir(path.dirname(p), { recursive: true })
     await fs.writeFile(p, JSON.stringify(snapshot, null, 2), "utf-8")
   }
@@ -174,7 +176,7 @@ export namespace Skill {
   // URL-pulled skills (stored in Global.Path.cache) are not rescanned from source;
   // their local copies are still checked via the snapshot mtime entries.
   async function isFresh(projectId: string, directory: string, worktree: string): Promise<boolean> {
-    const snapshot = await readSnapshot(projectId)
+    const snapshot = await readSnapshot(projectId, directory)
     if (!snapshot) return false
 
     for (const [p, snapshotMtime] of Object.entries(snapshot)) {
@@ -311,7 +313,7 @@ export namespace Skill {
 
     // Write mtime snapshot so isFresh() can detect external edits on the next access.
     const snapshot = await buildManifest(directory, worktree, projectId)
-    await writeSnapshot(projectId, snapshot)
+    await writeSnapshot(projectId, directory, snapshot)
   }
 
   export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/Skill") {}

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -1,3 +1,4 @@
+import fs from "fs/promises"
 import os from "os"
 import path from "path"
 import { pathToFileURL } from "url"
@@ -7,6 +8,7 @@ import { NamedError } from "@opencode-ai/util/error"
 import type { Agent } from "@/agent/agent"
 import { Bus } from "@/bus"
 import { InstanceState } from "@/effect/instance-state"
+import { Instance } from "@/project/instance"
 import { makeRuntime } from "@/effect/run-service"
 import { Flag } from "@/flag/flag"
 import { Global } from "@/global"
@@ -63,6 +65,119 @@ export namespace Skill {
     readonly all: () => Effect.Effect<Info[]>
     readonly dirs: () => Effect.Effect<string[]>
     readonly available: (agent?: Agent.Info) => Effect.Effect<Info[]>
+  }
+
+  function snapshotPath(projectId: string) {
+    return path.join(Global.Path.home, ".aether", "skill-snapshots", `${projectId}.json`)
+  }
+
+  async function readSnapshot(projectId: string): Promise<Record<string, number> | null> {
+    try {
+      const content = await fs.readFile(snapshotPath(projectId), "utf-8")
+      return JSON.parse(content) as Record<string, number>
+    } catch {
+      return null
+    }
+  }
+
+  async function writeSnapshot(projectId: string, snapshot: Record<string, number>): Promise<void> {
+    const p = snapshotPath(projectId)
+    await fs.mkdir(path.dirname(p), { recursive: true })
+    await fs.writeFile(p, JSON.stringify(snapshot, null, 2), "utf-8")
+  }
+
+  async function scanAllSkillPaths(directory: string, worktree: string, projectId: string): Promise<string[]> {
+    const paths: string[] = []
+
+    if (!Flag.OPENCODE_DISABLE_EXTERNAL_SKILLS) {
+      for (const dir of EXTERNAL_DIRS) {
+        const root = path.join(Global.Path.home, dir)
+        if (!(await Filesystem.isDir(root))) continue
+        const matches = await Glob.scan(EXTERNAL_SKILL_PATTERN, {
+          cwd: root,
+          absolute: true,
+          include: "file",
+          symlink: true,
+          dot: true,
+        }).catch(() => [])
+        paths.push(...matches)
+      }
+
+      const skillSessionsDir = path.join(Global.Path.home, ".aether", "skill-sessions", projectId, "skills")
+      if (await Filesystem.isDir(skillSessionsDir)) {
+        const matches = await Glob.scan(SKILL_PATTERN, {
+          cwd: skillSessionsDir,
+          absolute: true,
+          include: "file",
+          symlink: true,
+          dot: true,
+        }).catch(() => [])
+        paths.push(...matches)
+      }
+
+      const projectDirs: string[] = []
+      for await (const root of Filesystem.up({ targets: [...EXTERNAL_DIRS].reverse(), start: directory, stop: worktree })) {
+        projectDirs.push(root)
+      }
+      for (const root of projectDirs.toReversed()) {
+        const matches = await Glob.scan(EXTERNAL_SKILL_PATTERN, {
+          cwd: root,
+          absolute: true,
+          include: "file",
+          symlink: true,
+          dot: true,
+        }).catch(() => [])
+        paths.push(...matches)
+      }
+    }
+
+    const globalExternalDirs = new Set(EXTERNAL_DIRS.map((dir) => path.join(Global.Path.home, dir)))
+    for (const dir of await Config.directories()) {
+      if (globalExternalDirs.has(dir)) continue
+      const matches = await Glob.scan(OPENCODE_SKILL_PATTERN, {
+        cwd: dir,
+        absolute: true,
+        include: "file",
+        symlink: true,
+      }).catch(() => [])
+      paths.push(...matches)
+    }
+
+    const cfg = await Config.get()
+    for (const item of cfg.skills?.paths ?? []) {
+      const expanded = item.startsWith("~/") ? path.join(os.homedir(), item.slice(2)) : item
+      const dir = path.isAbsolute(expanded) ? expanded : path.join(directory, expanded)
+      if (!(await Filesystem.isDir(dir))) continue
+      const matches = await Glob.scan(SKILL_PATTERN, {
+        cwd: dir,
+        absolute: true,
+        include: "file",
+        symlink: true,
+      }).catch(() => [])
+      paths.push(...matches)
+    }
+
+    return paths
+  }
+
+  // Returns false when snapshot is absent or stale (file added/modified/deleted).
+  // URL-pulled skills (stored in Global.Path.cache) are not rescanned from source;
+  // their local copies are still checked via the snapshot mtime entries.
+  async function isFresh(projectId: string, directory: string, worktree: string): Promise<boolean> {
+    const snapshot = await readSnapshot(projectId)
+    if (!snapshot) return false
+
+    for (const [p, snapshotMtime] of Object.entries(snapshot)) {
+      const stat = await fs.stat(p).catch(() => null)
+      if (!stat || stat.mtimeMs !== snapshotMtime) return false
+    }
+
+    const currentPaths = await scanAllSkillPaths(directory, worktree, projectId)
+    for (const p of currentPaths) {
+      if (!(p in snapshot)) return false
+    }
+
+    return true
   }
 
   const add = async (state: State, match: string) => {
@@ -183,6 +298,14 @@ export namespace Skill {
         log.info("skill disabled by config", { name })
       }
     }
+
+    // Write mtime snapshot so isFresh() can detect external edits on the next access.
+    const snapshot: Record<string, number> = {}
+    for (const info of Object.values(state.skills)) {
+      const stat = await fs.stat(info.location).catch(() => null)
+      if (stat) snapshot[info.location] = stat.mtimeMs
+    }
+    await writeSnapshot(projectId, snapshot)
   }
 
   export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/Skill") {}
@@ -201,23 +324,33 @@ export namespace Skill {
         ),
       )
 
+      // Checks mtime snapshot before serving from cache so external edits to SKILL.md
+      // are picked up without restarting the instance.
+      const getState = Effect.fn("Skill.getState")(function* () {
+        const instance = Instance.current
+        const projectId = String(instance.project.id)
+        const fresh = yield* Effect.promise(() => isFresh(projectId, instance.directory, instance.worktree))
+        if (!fresh) yield* InstanceState.invalidate(state)
+        return yield* InstanceState.get(state)
+      })
+
       const get = Effect.fn("Skill.get")(function* (name: string) {
-        const s = yield* InstanceState.get(state)
+        const s = yield* getState()
         return s.skills[name]
       })
 
       const all = Effect.fn("Skill.all")(function* () {
-        const s = yield* InstanceState.get(state)
+        const s = yield* getState()
         return Object.values(s.skills)
       })
 
       const dirs = Effect.fn("Skill.dirs")(function* () {
-        const s = yield* InstanceState.get(state)
+        const s = yield* getState()
         return Array.from(s.dirs)
       })
 
       const available = Effect.fn("Skill.available")(function* (agent?: Agent.Info) {
-        const s = yield* InstanceState.get(state)
+        const s = yield* getState()
         const list = Object.values(s.skills).toSorted((a, b) => a.name.localeCompare(b.name))
         if (!agent) return list
         return list.filter((skill) => Permission.evaluate("skill", skill.name, agent.permission).action !== "deny")

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -1,4 +1,3 @@
-import { createHash } from "crypto"
 import fs from "fs/promises"
 import os from "os"
 import path from "path"
@@ -68,22 +67,22 @@ export namespace Skill {
     readonly available: (agent?: Agent.Info) => Effect.Effect<Info[]>
   }
 
-  function snapshotPath(projectId: string, directory: string) {
-    const dirHash = createHash("md5").update(directory).digest("hex").slice(0, 8)
-    return path.join(Global.Path.home, ".aether", "skill-snapshots", `${projectId}-${dirHash}.json`)
+  function snapshotPath(directory: string) {
+    const dirSlug = directory.replace(/\//g, "_").replace(/^_/, "")
+    return path.join(Global.Path.home, ".aether", "skill-snapshots", `${dirSlug}.json`)
   }
 
-  async function readSnapshot(projectId: string, directory: string): Promise<Record<string, number> | null> {
+  async function readSnapshot(directory: string): Promise<Record<string, number> | null> {
     try {
-      const content = await fs.readFile(snapshotPath(projectId, directory), "utf-8")
+      const content = await fs.readFile(snapshotPath(directory), "utf-8")
       return JSON.parse(content) as Record<string, number>
     } catch {
       return null
     }
   }
 
-  async function writeSnapshot(projectId: string, directory: string, snapshot: Record<string, number>): Promise<void> {
-    const p = snapshotPath(projectId, directory)
+  async function writeSnapshot(directory: string, snapshot: Record<string, number>): Promise<void> {
+    const p = snapshotPath(directory)
     await fs.mkdir(path.dirname(p), { recursive: true })
     await fs.writeFile(p, JSON.stringify(snapshot, null, 2), "utf-8")
   }
@@ -176,7 +175,7 @@ export namespace Skill {
   // URL-pulled skills (stored in Global.Path.cache) are not rescanned from source;
   // their local copies are still checked via the snapshot mtime entries.
   async function isFresh(projectId: string, directory: string, worktree: string): Promise<boolean> {
-    const snapshot = await readSnapshot(projectId, directory)
+    const snapshot = await readSnapshot(directory)
     if (!snapshot) return false
 
     for (const [p, snapshotMtime] of Object.entries(snapshot)) {
@@ -313,7 +312,7 @@ export namespace Skill {
 
     // Write mtime snapshot so isFresh() can detect external edits on the next access.
     const snapshot = await buildManifest(directory, worktree, projectId)
-    await writeSnapshot(projectId, directory, snapshot)
+    await writeSnapshot(directory, snapshot)
   }
 
   export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/Skill") {}

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -68,7 +68,10 @@ export namespace Skill {
   }
 
   function snapshotPath(directory: string) {
-    const dirSlug = directory.replace(/\//g, "_").replace(/^_/, "")
+    const dirSlug =
+      process.platform === "win32"
+        ? directory.replace(/[\\/]/g, "_").replace(/:/g, "").replace(/^_/, "")
+        : directory.replace(/\//g, "_").replace(/^_/, "")
     return path.join(Global.Path.home, ".aether", "skill-snapshots", `${dirSlug}.json`)
   }
 

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -160,6 +160,16 @@ export namespace Skill {
     return paths
   }
 
+  async function buildManifest(directory: string, worktree: string, projectId: string): Promise<Record<string, number>> {
+    const paths = await scanAllSkillPaths(directory, worktree, projectId)
+    const manifest: Record<string, number> = {}
+    for (const p of paths) {
+      const stat = await fs.stat(p).catch(() => null)
+      if (stat) manifest[p] = stat.mtimeMs
+    }
+    return manifest
+  }
+
   // Returns false when snapshot is absent or stale (file added/modified/deleted).
   // URL-pulled skills (stored in Global.Path.cache) are not rescanned from source;
   // their local copies are still checked via the snapshot mtime entries.
@@ -300,11 +310,7 @@ export namespace Skill {
     }
 
     // Write mtime snapshot so isFresh() can detect external edits on the next access.
-    const snapshot: Record<string, number> = {}
-    for (const info of Object.values(state.skills)) {
-      const stat = await fs.stat(info.location).catch(() => null)
-      if (stat) snapshot[info.location] = stat.mtimeMs
-    }
+    const snapshot = await buildManifest(directory, worktree, projectId)
     await writeSnapshot(projectId, snapshot)
   }
 

--- a/packages/opencode/src/skill/skill-mtime-cache.test.ts
+++ b/packages/opencode/src/skill/skill-mtime-cache.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { Instance } from "@/project/instance"
+import { ProjectID } from "@/project/schema"
+import { Skill } from "./index"
+
+async function writeSkill(dir: string, name: string, description: string) {
+  await fs.mkdir(dir, { recursive: true })
+  await fs.writeFile(
+    path.join(dir, "SKILL.md"),
+    `---\nname: ${name}\ndescription: ${description}\n---\nContent.\n`,
+  )
+}
+
+async function makeTmp(): Promise<{ path: string; cleanup: () => Promise<void> }> {
+  const p = await fs.mkdtemp(path.join(os.tmpdir(), "skill-mtime-test-"))
+  return { path: p, cleanup: () => fs.rm(p, { recursive: true, force: true }) }
+}
+
+async function withInstance<T>(directory: string, worktree: string, fn: () => Promise<T>): Promise<T> {
+  const project = {
+    id: ProjectID.fromDirectory(directory),
+    worktree,
+    sandboxes: [] as string[],
+    time: { created: Date.now(), updated: Date.now() },
+  }
+  return Instance.provide({ directory, worktree, project, fn: () => fn() })
+}
+
+// Bump a file's mtime by rewriting it with the same content.
+async function touch(filePath: string) {
+  const content = await fs.readFile(filePath, "utf-8")
+  await fs.writeFile(filePath, content, "utf-8")
+}
+
+describe("skill mtime cache invalidation", () => {
+  let tmp: { path: string; cleanup: () => Promise<void> }
+  let origHome: string | undefined
+
+  beforeEach(async () => {
+    tmp = await makeTmp()
+    origHome = process.env.OPENCODE_TEST_HOME
+    process.env.OPENCODE_TEST_HOME = path.join(tmp.path, "home")
+    await fs.mkdir(process.env.OPENCODE_TEST_HOME, { recursive: true })
+  })
+
+  afterEach(async () => {
+    if (origHome === undefined) delete process.env.OPENCODE_TEST_HOME
+    else process.env.OPENCODE_TEST_HOME = origHome
+    await tmp.cleanup()
+  })
+
+  test("initial load populates cache and returns skill", async () => {
+    const worktree = path.join(tmp.path, "project")
+    await writeSkill(path.join(worktree, ".claude", "skills", "greet"), "greet", "initial")
+
+    const skill = await withInstance(worktree, worktree, () => Skill.get("greet"))
+    expect(skill?.description).toBe("initial")
+  })
+
+  test("repeated call within same instance returns cached result without reload", async () => {
+    const worktree = path.join(tmp.path, "project2")
+    await writeSkill(path.join(worktree, ".claude", "skills", "ping"), "ping", "v1")
+
+    await withInstance(worktree, worktree, async () => {
+      const first = await Skill.get("ping")
+      expect(first?.description).toBe("v1")
+      // Second call with unchanged file — still v1
+      const second = await Skill.get("ping")
+      expect(second?.description).toBe("v1")
+    })
+  })
+
+  test("editing SKILL.md is detected on next call via mtime snapshot", async () => {
+    const worktree = path.join(tmp.path, "project3")
+    const skillDir = path.join(worktree, ".claude", "skills", "build")
+    await writeSkill(skillDir, "build", "original")
+
+    // First call — loads skill and writes snapshot
+    const v1 = await withInstance(worktree, worktree, () => Skill.get("build"))
+    expect(v1?.description).toBe("original")
+
+    // Edit SKILL.md externally (new content + updated mtime)
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      `---\nname: build\ndescription: updated\n---\nNew content.\n`,
+    )
+
+    // Next call from a fresh instance context — must pick up the edit
+    const v2 = await withInstance(worktree, worktree, () => Skill.get("build"))
+    expect(v2?.description).toBe("updated")
+  })
+
+  test("touching SKILL.md (mtime bump, same content) triggers cache invalidation", async () => {
+    const worktree = path.join(tmp.path, "project4")
+    const skillDir = path.join(worktree, ".claude", "skills", "lint")
+    await writeSkill(skillDir, "lint", "stable")
+
+    const v1 = await withInstance(worktree, worktree, () => Skill.get("lint"))
+    expect(v1?.description).toBe("stable")
+
+    // Wait 10ms to guarantee a different mtime
+    await new Promise((r) => setTimeout(r, 10))
+    await touch(path.join(skillDir, "SKILL.md"))
+
+    // Should reload (mtime changed) and still return same description
+    const v2 = await withInstance(worktree, worktree, () => Skill.get("lint"))
+    expect(v2?.description).toBe("stable")
+  })
+
+  test("deleting SKILL.md is detected — skill disappears from list", async () => {
+    const worktree = path.join(tmp.path, "project5")
+    const skillDir = path.join(worktree, ".claude", "skills", "remove-me")
+    await writeSkill(skillDir, "remove-me", "transient")
+
+    const before = await withInstance(worktree, worktree, () => Skill.get("remove-me"))
+    expect(before).toBeDefined()
+
+    await fs.rm(skillDir, { recursive: true, force: true })
+
+    const after = await withInstance(worktree, worktree, () => Skill.get("remove-me"))
+    expect(after).toBeUndefined()
+  })
+
+  test("adding a new SKILL.md is detected on next call", async () => {
+    const worktree = path.join(tmp.path, "project6")
+    await fs.mkdir(worktree, { recursive: true })
+
+    // First call — no skills
+    const empty = await withInstance(worktree, worktree, () => Skill.all())
+    expect(empty).toHaveLength(0)
+
+    // Add a new skill externally
+    await writeSkill(path.join(worktree, ".claude", "skills", "fresh"), "fresh", "brand-new")
+
+    // Next call should detect the new file and load it
+    const found = await withInstance(worktree, worktree, () => Skill.get("fresh"))
+    expect(found?.description).toBe("brand-new")
+  })
+})


### PR DESCRIPTION
关联 Issue: #763

## 改动摘要

在 \`packages/opencode/src/skill/index.ts\` 中引入 mtime 快照机制，使 Skill 文件在运行期间被外部编辑后能自动触发缓存失效，无需重启实例。

---

## 侵入性修改（改动旧有代码）

### 1. \`loadSkills\` 函数末尾 — 新增快照写入副作用

每次 \`loadSkills\` 完成后，将所有技能文件路径及 \`mtimeMs\` 持久化到磁盘，以便下次访问时做新鲜度校验。

### 2. \`get\` / \`all\` / \`dirs\` / \`available\` — 调用链从直接读缓存改为经过新鲜度检查

四处同类修改，原来直接调用 \`InstanceState.get(state)\`，现在改为 \`getState()\`。\`getState()\` 在返回缓存前先调用 \`isFresh()\`，若检测到外部变更则通过 \`InstanceState.invalidate()\` 触发重新加载。这是唯一影响已有接口行为的改动，**带来轻微额外 I/O**（读一次 snapshot 文件 + stat 所有 SKILL.md）。

---

## 插入性修改（纯新增，不改动旧有逻辑）

### \`packages/opencode/src/skill/index.ts\`

- 新增 import：\`fs\`（\`fs/promises\`）、\`Instance\`（\`@/project/instance\`）
- 新增内部辅助函数：\`snapshotPath\` / \`readSnapshot\` / \`writeSnapshot\` / \`scanAllSkillPaths\` / \`buildManifest\` / \`isFresh\`
- 新增 Effect 函数：\`getState\`（封装新鲜度检查与缓存失效调用）

### 新增文件

- \`packages/opencode/src/skill/skill-mtime-cache.test.ts\`：覆盖新增/修改/删除技能文件的 mtime 校验逻辑
- \`docs/skill-loading-mechanism.md\`：技能加载机制说明
- \`docs/skill-mtime-cache-design.md\`：mtime 缓存设计文档

---

## 核心流程

\`\`\`
loadSkills()
  └─ 完成后写入 ~/.aether/skill-snapshots/<dir-slug>.json
       { "/path/to/SKILL.md": <mtimeMs>, ... }

get() / all() / dirs() / available()
  └─ getState()
       ├─ isFresh() → 对比当前文件 mtime 与快照
       │    ├─ 快照不存在        → false（重新加载）
       │    ├─ 文件被修改/删除   → false（重新加载）
       │    └─ 有新文件未在快照中 → false（重新加载）
       ├─ fresh=false → InstanceState.invalidate() → 重新触发 loadSkills
       └─ fresh=true  → 直接返回缓存
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)