### PR TITLE
Update: version retention 5->100 & split readWebCurrentVersion

### DIFF
--- a/Update/update_darwin.command
+++ b/Update/update_darwin.command
@@ -686,7 +686,7 @@ printf "%s\n" "$ver" >"$target/.aether_web_version"
 rm -f "$work/.aether_web_version" >/dev/null 2>&1 || true
 
 rm -rf "$work/current" >/dev/null 2>&1 || true
-prune_versions "$work" 5 "$target"
+prune_versions "$work" 100 "$target"
 debug_log "PRUNE | work prune=$prune"
 
 copy_target=""
@@ -700,7 +700,7 @@ elif copy_target="$(mirror_dir || true)" && [ -n "$copy_target" ]; then
   copy_note="已复制新版本到当前软件目录附近：$copy_target"
   mirror_root_dir="$(mirror_root || true)"
   if [ -n "$mirror_root_dir" ]; then
-    prune_versions "$mirror_root_dir" 5 "$copy_target"
+    prune_versions "$mirror_root_dir" 100 "$copy_target"
     mirror_prune="$prune"
   fi
 else
@@ -734,9 +734,9 @@ fi
 write_result "installed"
 
 if [ "$prune" -gt 0 ]; then
-  echo "[3/4] 保留最近 5 个版本，已清理 $prune 个旧版本目录"
+  echo "[3/4] 保留最近 100 个版本，已清理 $prune 个旧版本目录"
 else
-  echo "[3/4] 保留最近 5 个版本，无需清理旧版本目录"
+  echo "[3/4] 保留最近 100 个版本，无需清理旧版本目录"
 fi
 
 echo "[4/4] 完成"

--- a/Update/update_linux.sh
+++ b/Update/update_linux.sh
@@ -727,7 +727,7 @@ rm -f "$work/.aether_web_version" 2>/dev/null || true
 rm -rf "$work/current" 2>/dev/null || true
 
 fix_libssl "$target"
-prune_versions "$work" 5 "$target"
+prune_versions "$work" 100 "$target"
 
 copy_target=""
 mirror_prune=""
@@ -737,7 +737,7 @@ elif copy_target="$(mirror_dir || true)" && [ -n "$copy_target" ]; then
   copy_note="[install] Copied the new version near the current app location: $copy_target"
   mirror_root_dir="$(mirror_root || true)"
   if [ -n "$mirror_root_dir" ]; then
-    prune_versions "$mirror_root_dir" 5 "$copy_target"
+    prune_versions "$mirror_root_dir" 100 "$copy_target"
     mirror_prune="$prune"
   fi
 else
@@ -758,9 +758,9 @@ else
 fi
 
 if [ "$prune" -gt 0 ]; then
-  echo "[3/4] Keeping the latest 5 versions; removed $prune older version directories."
+  echo "[3/4] Keeping the latest 100 versions; removed $prune older version directories."
 else
-  echo "[3/4] Keeping the latest 5 versions; no older version directories needed removal."
+  echo "[3/4] Keeping the latest 100 versions; no older version directories needed removal."
 fi
 
 if [ "$restart" = "1" ]; then

--- a/Update/update_windows.bat
+++ b/Update/update_windows.bat
@@ -189,10 +189,10 @@ exit /b 0
 
 :print_prune
 if "%PRUNE%"=="0" (
-  echo [3/4] Keeping the latest 5 versions; no older version directories needed removal.
+  echo [3/4] Keeping the latest 100 versions; no older version directories needed removal.
   exit /b 0
 )
-echo [3/4] Keeping the latest 5 versions; removed %PRUNE% older version directories.
+echo [3/4] Keeping the latest 100 versions; removed %PRUNE% older version directories.
 exit /b 0
 
 :mirror
@@ -301,7 +301,7 @@ if exist "%NEXT%" rmdir /s /q "%NEXT%" >nul 2>nul
 exit /b 0
 
 :prune_versions
-for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "& { $root=$env:WORK; $keep=5; $hold=[IO.Path]::GetFullPath($env:TARGET); $items=Get-ChildItem -Path $root -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { $ver=''; if(Test-Path (Join-Path $_.FullName '.aether_web_version')){ $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim() }; if(-not $ver -and $_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ $ver=$matches[1] }; if($ver){ [PSCustomObject]@{ Dir=$_.FullName; Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending; $keepers=New-Object System.Collections.Generic.List[string]; foreach($dir in @($hold)){ if($dir -and ($items | Where-Object { $_.Dir -eq $dir }) -and -not $keepers.Contains($dir)){ $keepers.Add($dir) } }; foreach($item in $items){ if($keepers.Count -ge $keep){ break }; if(-not $keepers.Contains($item.Dir)){ $keepers.Add($item.Dir) } }; $gone=0; foreach($item in $items){ if($keepers.Contains($item.Dir)){ continue }; Remove-Item $item.Dir -Recurse -Force -ErrorAction SilentlyContinue; if(-not (Test-Path $item.Dir)){ $gone++ } }; Write-Output $gone }"`) do set "PRUNE=%%i"
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "& { $root=$env:WORK; $keep=100; $hold=[IO.Path]::GetFullPath($env:TARGET); $items=Get-ChildItem -Path $root -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { $ver=''; if(Test-Path (Join-Path $_.FullName '.aether_web_version')){ $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim() }; if(-not $ver -and $_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ $ver=$matches[1] }; if($ver){ [PSCustomObject]@{ Dir=$_.FullName; Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending; $keepers=New-Object System.Collections.Generic.List[string]; foreach($dir in @($hold)){ if($dir -and ($items | Where-Object { $_.Dir -eq $dir }) -and -not $keepers.Contains($dir)){ $keepers.Add($dir) } }; foreach($item in $items){ if($keepers.Count -ge $keep){ break }; if(-not $keepers.Contains($item.Dir)){ $keepers.Add($item.Dir) } }; $gone=0; foreach($item in $items){ if($keepers.Contains($item.Dir)){ continue }; Remove-Item $item.Dir -Recurse -Force -ErrorAction SilentlyContinue; if(-not (Test-Path $item.Dir)){ $gone++ } }; Write-Output $gone }"`) do set "PRUNE=%%i"
 if not defined PRUNE set "PRUNE=0"
 exit /b 0
 
@@ -309,7 +309,7 @@ exit /b 0
 if not defined AETHER_CURRENT_DIR exit /b 0
 for %%i in ("%AETHER_CURRENT_DIR%\..") do set "PROOT=%%~fi"
 if not defined PROOT exit /b 0
-for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "& { $root=$env:PROOT; $keep=5; $hold=''; if($env:MIRROR){ $hold=[IO.Path]::GetFullPath($env:MIRROR) }; $items=Get-ChildItem -Path $root -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { $ver=''; if(Test-Path (Join-Path $_.FullName '.aether_web_version')){ $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim() }; if(-not $ver -and $_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)($|_[0-9]{12}$)'){ $ver=$matches[1] }; if($ver){ [PSCustomObject]@{ Dir=$_.FullName; Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending; $keepers=New-Object System.Collections.Generic.List[string]; foreach($dir in @($hold)){ if($dir -and ($items | Where-Object { $_.Dir -eq $dir }) -and -not $keepers.Contains($dir)){ $keepers.Add($dir) } }; foreach($item in $items){ if($keepers.Count -ge $keep){ break }; if(-not $keepers.Contains($item.Dir)){ $keepers.Add($item.Dir) } }; $gone=0; foreach($item in $items){ if($keepers.Contains($item.Dir)){ continue }; Remove-Item $item.Dir -Recurse -Force -ErrorAction SilentlyContinue; if(-not (Test-Path $item.Dir)){ $gone++ } }; Write-Output $gone }"`) do set "MPRUNE=%%i"
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "& { $root=$env:PROOT; $keep=100; $hold=''; if($env:MIRROR){ $hold=[IO.Path]::GetFullPath($env:MIRROR) }; $items=Get-ChildItem -Path $root -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { $ver=''; if(Test-Path (Join-Path $_.FullName '.aether_web_version')){ $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim() }; if(-not $ver -and $_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)($|_[0-9]{12}$)'){ $ver=$matches[1] }; if($ver){ [PSCustomObject]@{ Dir=$_.FullName; Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending; $keepers=New-Object System.Collections.Generic.List[string]; foreach($dir in @($hold)){ if($dir -and ($items | Where-Object { $_.Dir -eq $dir }) -and -not $keepers.Contains($dir)){ $keepers.Add($dir) } }; foreach($item in $items){ if($keepers.Count -ge $keep){ break }; if(-not $keepers.Contains($item.Dir)){ $keepers.Add($item.Dir) } }; $gone=0; foreach($item in $items){ if($keepers.Contains($item.Dir)){ continue }; Remove-Item $item.Dir -Recurse -Force -ErrorAction SilentlyContinue; if(-not (Test-Path $item.Dir)){ $gone++ } }; Write-Output $gone }"`) do set "MPRUNE=%%i"
 if not defined MPRUNE set "MPRUNE=0"
 exit /b 0
 

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -18,6 +18,7 @@ import {
   downloadWebUpdate,
   installWebUpdate,
   readWebCurrentVersion,
+  readWebUpdateHighestVersion,
   retryWebUpdateMirror,
   WebUpdateCheckInput,
   WebUpdateCheckResponse,

--- a/packages/opencode/src/server/web-update.ts
+++ b/packages/opencode/src/server/web-update.ts
@@ -437,7 +437,8 @@ async function fetchManifest(os: z.infer<typeof WebUpdateOS>, version?: string) 
 
 function packageMatch(os: string, ver: string, name: string) {
   const ext = UPDATE_PKG_EXT[os] ?? ".dmg"
-  const prefix = os === "darwin" ? `aether-darwin-${arch()}` : os === "linux" ? `aether-linux-${arch()}` : "aether-windows-x64"
+  const prefix =
+    os === "darwin" ? `aether-darwin-${arch()}` : os === "linux" ? `aether-linux-${arch()}` : "aether-windows-x64"
   return name.startsWith(prefix) && name.includes(ver) && name.toLowerCase().endsWith(ext)
 }
 
@@ -727,6 +728,20 @@ export async function readWebCurrentVersion() {
     .then((x) => x.trim())
     .catch(() => "")
 
+  if (marker) return normalizeVersion(marker)
+
+  const fallback = normalizeVersion(Installation.VERSION)
+  await fs.writeFile(file, `${fallback}\n`, "utf-8").catch(() => undefined)
+  return fallback
+}
+
+export async function readWebUpdateHighestVersion() {
+  const file = path.join(getAppRoot(), ".aether_web_version")
+  const marker = await fs
+    .readFile(file, "utf-8")
+    .then((x) => x.trim())
+    .catch(() => "")
+
   const local = await scanLocalVersions()
   let best = ""
   for (const v of local) {
@@ -744,7 +759,7 @@ export async function readWebCurrentVersion() {
 export async function webCheck(os: z.infer<typeof WebUpdateOS>) {
   if (Flag.OPENCODE_DISABLE_AUTOUPDATE) {
     return {
-      currentVersion: await readWebCurrentVersion(),
+      currentVersion: await readWebUpdateHighestVersion(),
       remoteVersion: "",
       updateAvailable: false,
       downloaded: false,
@@ -755,7 +770,7 @@ export async function webCheck(os: z.infer<typeof WebUpdateOS>) {
       checkError: undefined,
     }
   }
-  const currentVersion = await readWebCurrentVersion()
+  const currentVersion = await readWebUpdateHighestVersion()
   const workDir = getWorkDir(os) ?? ""
   try {
     const meta = await fetchManifest(os)
@@ -817,7 +832,7 @@ export async function downloadWebUpdate(input: z.infer<typeof WebUpdateDownloadI
   if (!file) return failRes(`Update script not configured for ${os}`)
   const meta = await fetchManifest(os, version)
   if (!meta.ok) return failRes(meta.error)
-  const cur = await readWebCurrentVersion()
+  const cur = await readWebUpdateHighestVersion()
   const state = await resolveUpdateStatus(os, cur, meta, workDir)
   if (force) await resetUpdate(os, version, workDir)
   if (!force && state.status === "downloaded") {
@@ -911,7 +926,7 @@ export async function installWebUpdate(input: z.infer<typeof WebUpdateInstallInp
   } catch {
     return await failState(workDir, version ?? "latest", `Update script not found: ${run}`, { action: "recover" })
   }
-  const cur = await readWebCurrentVersion()
+  const cur = await readWebUpdateHighestVersion()
   const state = version && meta?.ok ? await resolveUpdateStatus(os, cur, meta, workDir) : null
   if (version && state?.status !== "downloaded") {
     const message = state?.error || "Update files are not ready. Restart the update from scratch."
@@ -969,7 +984,7 @@ export async function retryWebUpdateMirror(input: z.infer<typeof WebUpdateMirror
     return await failState(workDir, next, `Installed version directory is missing: ${dir}`, { action: "recover" })
   }
   await chmodSafe(run)
-  const cur = await readWebCurrentVersion()
+  const cur = await readWebUpdateHighestVersion()
   log.info("retrying update mirror", { os, updater: run, workDir, version: next, mirrorRoot })
   try {
     await writeUpdateState(
@@ -1000,6 +1015,8 @@ export const WebUpdateTest = {
   parseManifest,
   readResult,
   readUpdateState,
+  readWebCurrentVersion,
+  readWebUpdateHighestVersion,
   resetUpdateBase: () => {
     cachedBaseUrl = undefined
   },

--- a/packages/opencode/test/server/web-update-script.test.ts
+++ b/packages/opencode/test/server/web-update-script.test.ts
@@ -11,7 +11,7 @@ const linux =
   spawnSync("bash", ["-lc", "type mapfile >/dev/null 2>&1"], { encoding: "utf8" }).status === 0
     ? test
     : test.skip
-const darwin = test.skip  // TODO: Need to be re-enabled and fixed on CI
+const darwin = test.skip // TODO: Need to be re-enabled and fixed on CI
 const windows = process.platform === "win32" ? test : test.skip
 
 function run(cmd: string, args: string[], cwd: string, env: Record<string, string | undefined>) {
@@ -210,10 +210,9 @@ describe("web update scripts", () => {
 
       expect(await Bun.file(path.join(work, "aether_1.2.7", "Aether.sh")).exists()).toBe(true)
       const list = await dirs(live)
-      expect(list.length).toBe(5)
+      expect(list.length).toBe(8)
       expect(list.some((x) => /^aether_1\.2\.7_\d{12}$/.test(x))).toBe(true)
-      expect(list.includes("aether_1.2.0")).toBe(false)
-      expect(log).toContain("Mirror cleanup: removed")
+      expect(list.includes("aether_1.2.0")).toBe(true)
     },
     { timeout: 30000 },
   )
@@ -355,10 +354,9 @@ describe("web update scripts", () => {
 
       expect(await Bun.file(path.join(work, "aether_1.2.7", "Aether.command")).exists()).toBe(true)
       const list = await dirs(live)
-      expect(list.length).toBe(5)
+      expect(list.length).toBe(8)
       expect(list.some((x) => /^aether_1\.2\.7_\d{12}$/.test(x))).toBe(true)
-      expect(list.includes("aether_1.2.0")).toBe(false)
-      expect(log).toContain("镜像目录清理")
+      expect(list.includes("aether_1.2.0")).toBe(true)
     },
     { timeout: 30000 },
   )
@@ -468,10 +466,9 @@ describe("web update scripts", () => {
 
         expect(await Bun.file(path.join(work, "aether_1.2.7", "Aether.vbs")).exists()).toBe(true)
         const list = await dirs(live)
-        expect(list.length).toBe(5)
+        expect(list.length).toBe(8)
         expect(list.some((x) => /^aether_1\.2\.7_\d{12}$/.test(x))).toBe(true)
-        expect(list.includes("aether_1.2.0")).toBe(false)
-        expect(log).toContain("Mirror cleanup: removed")
+        expect(list.includes("aether_1.2.0")).toBe(true)
         const launch = pick(log, "Launch entry:")
         expect(launch).toBeTruthy()
         expect(winTarget(launch!)).toContain("aether_1.2.7_")
@@ -541,11 +538,9 @@ describe("web update scripts", () => {
         winZip(src, out)
         await fs.copyFile(path.join(update, "update_windows.bat"), script)
 
-        const child = spawn(
-          process.execPath,
-          ["-e", "setInterval(() => {}, 1000)", path.join(old, "aether.exe")],
-          { stdio: "ignore" },
-        )
+        const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)", path.join(old, "aether.exe")], {
+          stdio: "ignore",
+        })
         try {
           expect(alive(child.pid)).toBe(true)
           run("cmd", ["/c", script, "1.2.7", "--restart"], dl, {


### PR DESCRIPTION
## Summary

- Change update version retention count from 5 to 100 across all three platform update scripts (Linux, Darwin, Windows), including work dir and mirror dir pruning
- Split `readWebCurrentVersion()` into two functions with distinct semantics:
  - `readWebCurrentVersion()` — reads only the `.aether_web_version` marker file in the current executable directory (used by settings page UI and health endpoint to display the "current running version")
  - `readWebUpdateHighestVersion()` — scans all local `aether_*` version directories and returns the highest version (used by auto-update check/download/install/mirror to determine if an update is needed)

This ensures the settings page always shows the version the user is actually running, while auto-update correctly compares against the highest locally installed version.