### PR TITLE
fix: web版点击外部链接在新tab打开

### DIFF
--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -329,8 +329,17 @@ const platform: Platform = {
   },
 }
 
+function handleClick(e: MouseEvent) {
+  const link = (e.target as HTMLElement).closest("a.external-link") as HTMLAnchorElement | null
+  if (link?.href) {
+    e.preventDefault()
+    platform.openLink(link.href)
+  }
+}
+
 const boot = async () => {
   if (!(root instanceof HTMLElement)) return
+  document.addEventListener("click", handleClick)
   platform.version = (await readWebVersion()) || undefined
   let stop = start()
   await sync()


### PR DESCRIPTION
### Issue for this PR

Closes #769

### Type of change

- [x] Bug fix

### What does this PR do?

Web版缺少`a.external-link`的全局click拦截器（桌面版在`packages/desktop/src/index.tsx`有此拦截器），导致点击markdown中的外部链接时页面被替换。添加与桌面版一致的`handleClick`拦截器，调用`e.preventDefault()`阻止默认导航，然后委托`platform.openLink()`（即`window.open(url, "_blank")`)在新tab打开。

### How did you verify your code works?

`bun typecheck` 通过。

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR