### PR TITLE
fix: create release tag after publish succeeds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -264,7 +264,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        if: inputs.upload_downloadbeta || inputs.release_electron
+        with:
+          fetch-depth: 0
 
       - uses: ./.github/actions/setup-bun
         if: inputs.upload_downloadbeta || inputs.release_electron
@@ -311,3 +312,23 @@ jobs:
           DOWNLOAD_ADMIN_PASSWORD: ${{ secrets.DOWNLOAD_ADMIN_PASSWORD }}
           DOWNLOAD_BETA_VERSION: ${{ needs.release.outputs.version }}
         run: bun .github/scripts/upload-downloadbeta.ts
+
+      - name: Create release tag
+        run: |
+          tag="${{ needs.release.outputs.tag }}"
+          sha="${{ github.sha }}"
+
+          git fetch origin "refs/tags/$tag:refs/tags/$tag" || true
+
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            current="$(git rev-list -n 1 "$tag")"
+            if [ "$current" != "$sha" ]; then
+              echo "Tag $tag already points to $current, expected $sha"
+              exit 1
+            fi
+            echo "Tag $tag already points to $sha"
+            exit 0
+          fi
+
+          git tag "$tag" "$sha"
+          git push origin "refs/tags/$tag"


### PR DESCRIPTION
### Issue for this PR

Closes #773

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Creates the release version tag at the end of the `publish` workflow after all required build, upload, and optional publish steps have succeeded.

The tag uses the existing release output, so a version input like `x.y.z` creates `vx.y.z`. It targets the workflow commit via `github.sha`.

The tag step is rerun-safe:
- if the tag already points to the workflow commit, the step succeeds
- if the tag points to another commit, the step fails without moving it

### How did you verify your code works?

- `git diff --check -- .github/workflows/publish.yml`
- Ruby YAML parse check for `.github/workflows/publish.yml`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR