### PR TITLE
fix: prevent skills list scroll reset on toggle

### DIFF
--- a/packages/app/src/components/dialog-default-skills.tsx
+++ b/packages/app/src/components/dialog-default-skills.tsx
@@ -91,7 +91,7 @@ export const DialogDefaultSkills: Component = () => {
       <div class="flex flex-col gap-3 min-h-0">
         {/* Skill list */}
         <SolidSwitch>
-          <Match when={skills.loading}>
+          <Match when={!skills()}>
             <div class="text-12-regular text-text-weak px-1">{language.t("defaultSkills.loading")}</div>
           </Match>
           <Match when={skills()?.length === 0}>


### PR DESCRIPTION
### Issue for this PR

Closes #776

### Type of change

- [x] Bug fix

### What does this PR do?

将 `DialogDefaultSkills` 中 `<Match when={skills.loading}>` 改为 `<Match when={!skills()}>`，使 loading 分支仅在首次加载（`skills()` 为 `undefined`）时匹配，`refetch()` 期间列表 DOM 保持挂载，滚动位置不再丢失。

### How did you verify your code works?

本地运行 dev 服务器，打开默认 Skills 弹窗，向下滚动后切换开关，确认滚动位置保持不变。

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR