### PR TITLE
feat: add /skill-scan-paths command and document Instance.directory/worktree semantics

### DIFF
--- a/docs/customization-scan-paths.zh-CN.md
+++ b/docs/customization-scan-paths.zh-CN.md
@@ -9,6 +9,127 @@
    - 指令型规则：支持 `AGENTS.md` / `CLAUDE.md` / `CONTEXT.md` 与 `instructions`
    - 通用 IDE 规则目录：不支持自动扫描 `.cursor/rules`、`.windsurf/rules.md`、`.github/copilot-instructions.md` 这类目录/文件作为运行时规则源
 
+## 0. 前置概念：Instance.directory 与 Instance.worktree
+
+文档后续多处引用两个运行时概念，它们由 `Instance` 模块（`packages/opencode/src/project/instance.ts`）在每次请求进入时确定，并绑定到当前请求的上下文中。所有扫描、缓存、配置查找都以它们为基准。
+
+### Instance.directory
+
+当前请求、会话或 CLI 命令所在的工作目录，是一个绝对路径。在服务端场景下，它来自 HTTP 请求的 `?directory=` 查询参数或 `x-opencode-directory` 请求头，经 `Filesystem.resolve()` 规范化。它不一定是项目根目录，可以是项目内的任意子目录。
+
+### Instance.worktree
+
+当前项目的工作区根目录。由 `ProjectIdentity.resolve()`（`packages/opencode/src/project/identity.ts`）从 `Instance.directory` 向上查找 `.git` 来确定，规则如下：
+
+1. 找不到 `.git`：`worktree` 与 `directory` 相同，表示无 git 项目。
+2. 找到 `.git` 是一个**目录**（普通 git 仓库）：`worktree` 就是 `.git` 所在目录，即仓库根目录。
+3. 找到 `.git` 是一个**文件**（git worktree）：读取文件内容，解析 `gitdir:` 指向的实际 `.git` 位置，`worktree` 为该 `.git` 文件所在目录。
+
+注意区分：`Project.Info.worktree`（主仓库根）与 `Instance.worktree`（`.git` 所在目录，即 sandbox）是两个不同字段。对普通 git 仓库两者相同；对 git worktree，`Instance.worktree` 是 worktree 检出目录，而 `Project.Info.worktree` 是主仓库目录。
+
+### 举例
+
+假设项目结构为：
+
+```
+/home/user/projects/my-app/        ← git 仓库根（有 .git/ 目录）
+├── .git/
+├── src/
+│   └── components/
+│       └── Button.tsx
+└── packages/
+    └── core/
+```
+
+| 场景 | `Instance.directory` | `Instance.worktree` |
+|------|---------------------|---------------------|
+| 在项目根目录打开 Aether | `/home/user/projects/my-app` | `/home/user/projects/my-app` |
+| `cd src/components/` 后打开 | `/home/user/projects/my-app/src/components` | `/home/user/projects/my-app` |
+| `cd packages/core/` 后打开 | `/home/user/projects/my-app/packages/core` | `/home/user/projects/my-app` |
+
+git worktree 场景：
+
+```
+/home/user/projects/my-app/           ← 主仓库（.git/ 是目录）
+├── .git/
+└── ...
+
+/home/user/projects/my-app-feature/   ← git worktree（.git 是文件）
+├── .git                              ← 内容：gitdir: /home/user/projects/my-app/.git/worktrees/my-app-feature
+└── src/
+    └── ...
+```
+
+| 场景 | `Instance.directory` | `Instance.worktree` |
+|------|---------------------|---------------------|
+| 在 worktree 根目录打开 | `/home/user/projects/my-app-feature` | `/home/user/projects/my-app-feature` |
+| `cd src/` 后打开 | `/home/user/projects/my-app-feature/src` | `/home/user/projects/my-app-feature` |
+
+（此时 `Project.Info.worktree = "/home/user/projects/my-app"`，与 `Instance.worktree` 不同。）
+
+无 git 项目：
+
+```
+/home/user/notes/                     ← 没有 .git
+├── todo.md
+└── ideas/
+```
+
+| 场景 | `Instance.directory` | `Instance.worktree` |
+|------|---------------------|---------------------|
+| 在此目录打开 Aether | `/home/user/notes` | `/home/user/notes` |
+
+（此时 `Project.Info.worktree = "/"`，表示无 git 项目。）
+
+### 对扫描的影响
+
+Skills、Rules 等模块中频繁出现的 `Filesystem.up({ start: directory, stop: worktree })` 含义是：从用户当前所在目录向上一级级查找到项目根为止，逐级检查每层是否有目标目录或文件。这意味着：
+
+- 如果用户在子目录工作，中间层级放置的配置或 skill 也能被发现。
+- 如果用户就在项目根工作，则只扫描根目录一级。
+- 扫描不会越过 `worktree` 向上到更外层的目录。
+
+### 两点补充说明
+
+#### `worktree` 语义差异：Instance vs Project
+
+`worktree` 这个名字在两个上下文中指向不同的路径，容易混淆。
+
+`ProjectIdentity.resolve()` 返回两个字段：`root`（主仓库根）和 `sandbox`（`.git` 所在目录）。它们被分别映射到：
+
+| 源字段 | 目标 | 含义 |
+|--------|------|------|
+| `root` | `Project.Info.worktree` | 项目身份锚点，用于计算 Project ID |
+| `sandbox` | `Instance.worktree` | 当前工作区根，用于扫描边界和缓存 key |
+
+在普通 git 仓库中 `root === sandbox`，差异被掩盖；在 git worktree 中两者不同：
+
+| 字段 | 普通 git 仓库 | git worktree |
+|------|-------------|--------------|
+| `Instance.worktree`（= sandbox） | `.git` 所在目录 = 仓库根 | `.git` 文件所在目录 = worktree 检出目录 |
+| `Project.Info.worktree`（= root） | 同上 = 仓库根 | 主仓库目录 |
+
+这导致两个重要后果：
+
+1. **Project ID 与 DB 共享**：ID 由 `Hash.fast(norm(root))` 计算，即基于 `Project.Info.worktree`（主仓库根）。因此主仓库与其所有 worktree 共享同一个 Project ID 和同一个 per-project 数据库（`aether-{projectId}.db`）。
+2. **扫描边界不同**：skill 等模块的 `Filesystem.up({ start: directory, stop: worktree })` 用的是 `Instance.worktree`（sandbox）。worktree 中扫描上界是 worktree 检出目录，不会向上越过到主仓库目录。
+
+#### Project ID 的计算与 DB 命名
+
+Project ID 由 `ProjectID.fromDirectory()`（`packages/opencode/src/project/schema.ts`）计算，流程为 `Hash.fast(norm(root))`，其中 `Hash.fast` 是 SHA-1，`norm` 做规范化（`path.resolve` + 反斜杠转正斜杠 + 去尾斜杠 + 全小写）。per-project 数据库文件名为 `aether-{projectId}.db`，存放在 channel 目录下。
+
+`root` 的取值决定了哪些目录被视为同一项目：
+
+| 场景 | `root` 的值 | 是否共享 DB |
+|------|------------|------------|
+| 同一普通 git 仓库的不同子目录 | 都是仓库根 | 共享 |
+| 主仓库与其 git worktree | 都是主仓库根 | 共享 |
+| 不同的 git 仓库 | 各自的仓库根 | 不共享 |
+| 无 git 的不同目录 | 各自的 `directory`（没有向上聚合） | 不共享 |
+| 无 git 的父子目录（如 `/home/user/notes` 与 `/home/user/notes/ideas`） | 各自的 `directory` | 不共享 |
+
+最后一条需要特别注意：无 git 场景下，`root = path.resolve(directory)`，没有向上查找机制，因此两个不同目录即使有父子关系也是不同的项目。这与有 git 仓库时子目录向上聚合到仓库根的行为不同。
+
 ## 1. 统一配置装载顺序
 
 许多自定义能力最终都依赖统一配置装载链。核心实现位于：
@@ -52,171 +173,150 @@
 
 ### 2.2 扫描路径
 
-按实际装载顺序，低到高为：
+`Skill.loadSkills()` 的实际扫描顺序如下。skill 的覆盖规则是“同名后加载覆盖先加载”，因此这里也是从低优先级到高优先级排列：
 
 1. 全局外部 skills
-   - `~/.claude/skills/**/SKILL.md`
+   - 依次扫描 `Global.Path.home` 下的：
    - `~/.agents/skills/**/SKILL.md`
-2. 项目内外部 skills
-   - 从当前目录向上到 `worktree` 查找：
-   - `.claude/skills/**/SKILL.md`
+   - `~/.claude/skills/**/SKILL.md`
+   - `~/.opencode/skills/**/SKILL.md`
+   - `~/.aether/skills/**/SKILL.md`
+   - 同名时，上述顺序中越靠后的目录优先级越高，即全局 `.aether` 覆盖全局 `.opencode`，再覆盖全局 `.claude` / `.agents`。
+2. 项目隔离的 skill-sessions
+   - `~/.aether/skill-sessions/<projectId>/skills/**/SKILL.md`
+   - 这是 AI 后台评审/自进化相关的项目级落盘位置。
+   - 它晚于全局外部 skills、早于项目目录 skills，因此可覆盖全局同名 skill，但会被任何项目内用户来源覆盖。
+3. 项目内外部 skills
+   - 从当前 `Instance.directory` 向上到 `Instance.worktree` 查找以下目录：
    - `.agents/skills/**/SKILL.md`
-3. 配置目录内的 skills
+   - `.claude/skills/**/SKILL.md`
+   - `.opencode/skills/**/SKILL.md`
+   - `.aether/skills/**/SKILL.md`
+   - 实现细节是先用 `Filesystem.up()` 从内到外收集，再 `toReversed()` 后扫描。因此在这一阶段中，外层目录先扫、内层目录后扫，内层同名 skill 会覆盖外层；同一层级内的类型优先级为 `.agents < .claude < .opencode < .aether`。
+4. 配置目录内的 skills
    - 对每个 `Config.directories()` 根目录扫描：
    - `{skill,skills}/**/SKILL.md`
-   - 典型路径如：
-     - `.aether/skill/**/SKILL.md`
-     - `.aether/skills/**/SKILL.md`
-     - `.opencode/skill/**/SKILL.md`
-     - `.opencode/skills/**/SKILL.md`
-   - 注意：`Config.directories()` 还包含 home 目录下的 `.aether` / `.opencode` 以及 binary 目录下的 `.aether` / `.opencode`，这些都属于此阶段的扫描源
-4. `config.skills.paths`
-   - 每个目录扫描 `**/SKILL.md`
-   - 相对路径相对于当前项目目录
-5. `config.skills.urls`
-   - 拉取远端 `index.json`
-   - 下载到缓存目录后再扫描
-6. `config.skills.disabled`
-   - 最后按技能名删除
+   - 典型路径包括：
+     - `Global.Path.config/{skill,skills}/**/SKILL.md`：用户全局配置目录下的 `skill/` 或 `skills/`，通常是 `~/.config/aether/{skill,skills}`，也可能是 legacy 的全局 opencode 配置目录。
+     - `<某级>.aether/{skill,skills}/**/SKILL.md`：从当前 `Instance.directory` 向上到 `Instance.worktree` 途中发现的某一级项目配置目录，例如 `<project>/.aether/skills/foo/SKILL.md` 或 `<project>/subdir/.aether/skill/foo/SKILL.md`。
+     - `<某级>.opencode/{skill,skills}/**/SKILL.md`：同上，但使用 legacy 项目配置目录 `.opencode`。
+     - `<binaryDir>/.aether/{skill,skills}/**/SKILL.md`：Aether 可执行文件所在目录旁边的 `.aether/skill` 或 `.aether/skills`，用于打包发行版随 binary 携带默认配置/skills。
+     - `<binaryDir>/.opencode/{skill,skills}/**/SKILL.md`：同上，但使用 legacy binary 旁 `.opencode` 目录。
+     - `<OPENCODE_CONFIG_DIR>/{skill,skills}/**/SKILL.md`：环境变量 `OPENCODE_CONFIG_DIR` 指向的自定义配置目录下的 `skill/` 或 `skills/`。
+   - 这些配置目录本身的扫描顺序也是低到高：
+     1. `Global.Path.config`
+     2. 项目路径从当前 `Instance.directory` 向上到 `Instance.worktree` 途中发现的 `.aether` / `.opencode`
+     3. `Global.Path.home` 下的 `.aether` / `.opencode`
+     4. `<binaryDir>` 下的 `.aether` / `.opencode`
+     5. `OPENCODE_CONFIG_DIR`
+   - 若 `OPENCODE_DISABLE_PROJECT_CONFIG=true`，第 2 段项目路径配置目录不会加入；若未设置 `OPENCODE_CONFIG_DIR`，第 5 段不存在。
+   - 项目路径这一段要特别注意：`Filesystem.up()` 从当前目录开始向父目录枚举，且同一级按 `.aether` 再 `.opencode` 的顺序 yield；`Skill.loadSkills()` 在配置目录阶段不反转这个列表。因此同名 skill 在这一阶段的覆盖方向是：
+     - 更靠近 `Instance.worktree` 的外层项目配置目录覆盖更靠近 `Instance.directory` 的内层项目配置目录。
+     - 同一目录层级中，`.opencode` 覆盖 `.aether`。
+   - 但对 skills 来说，`Global.Path.home` 下的 `.aether` / `.opencode` 会被下面的例外跳过，所以它们不会在这个配置目录阶段获得覆盖权；全局 home 外部 skills 已在第 1 阶段按 `.agents < .claude < .opencode < .aether` 处理。
+   - 这里有一个重要例外：`~/.agents`、`~/.claude`、`~/.opencode`、`~/.aether` 这四个 home 外部目录会在此阶段被跳过，避免它们借助较晚的 `Config.directories()` 扫描覆盖项目级 skill。因此 `~/.aether/skills/**/SKILL.md` 和 `~/.opencode/skills/**/SKILL.md` 来自第 1 阶段，而不是此阶段；`~/.aether/skill/**/SKILL.md` 和 `~/.opencode/skill/**/SKILL.md` 当前不会被扫描。
+5. `config.skills.paths`
+   - 指配置文件中的 `skills.paths` 数组，例如 `aether.jsonc` / `opencode.jsonc` 里可以写：
+     ```jsonc
+     {
+       "skills": {
+         "paths": ["./my-skills", "~/shared-skills", "/absolute/path/to/skills"]
+       }
+     }
+     ```
+   - 对每个配置项解析出目录后扫描 `**/SKILL.md`。
+   - `~/` 会按 `os.homedir()` 展开。
+   - 绝对路径直接使用。
+   - 相对路径相对于当前 `Instance.directory`，不是相对于配置文件所在目录。
+   - 不存在的目录只记录 warn，不中断加载。
+6. `config.skills.urls`
+   - 对每个 URL 拉取远端 `index.json`。
+   - `index.json` 中每个 skill 必须声明包含 `SKILL.md` 的 `files` 列表，否则跳过。
+   - 文件下载到 `Global.Path.cache/skills/<skill-name>/`，再对该缓存目录扫描 `**/SKILL.md`。
+   - 下载时如果目标文件已存在会直接复用，不会覆盖本地缓存文件。
+7. `config.skills.disabled`
+   - 所有来源加载结束后，按 skill 名删除。
+   - 这是最终关闭层，不是扫描源。
+
+注意：第 3 阶段已经会扫描项目内 `.aether/skills` / `.opencode/skills`，第 4 阶段又会通过 `Config.directories()` 扫描项目内 `.aether/{skill,skills}` / `.opencode/{skill,skills}`。同一个 `SKILL.md` 可能被命中两次；最终仍然遵循“后加载覆盖先加载”。
+
+⚠ 警示：项目路径上的 `.aether/skills/**/SKILL.md` 与 `.opencode/skills/**/SKILL.md` 会被重复扫描和重复加载。对从当前 `Instance.directory` 向上到 `Instance.worktree` 的每一级目录 `D`，以下路径既会在第 3 阶段作为项目内外部 skills 被扫描，也会在第 4 阶段作为配置目录内 skills 被扫描，而且第 4 阶段不会跳过它们：
+
+```text
+D/.aether/skills/**/SKILL.md
+D/.opencode/skills/**/SKILL.md
+```
+
+必须特别强调：重复进入第 4 阶段后，同一目录层级里的 `.aether/skills` 会先扫，`.opencode/skills` 会后扫；因此同名 skill 的最终结果是 `.opencode` 覆盖 `.aether`。
+
+这些相似路径不会重复：
+
+```text
+D/.agents/skills/**/SKILL.md     # 只在第 3 阶段扫描
+D/.claude/skills/**/SKILL.md     # 只在第 3 阶段扫描
+D/.aether/skill/**/SKILL.md      # 只在第 4 阶段扫描
+D/.opencode/skill/**/SKILL.md    # 只在第 4 阶段扫描
+```
+
+全局 home 下的 `~/.aether/skills/**/SKILL.md` 和 `~/.opencode/skills/**/SKILL.md` 也不会在第 4 阶段重复，因为 `Skill.loadSkills()` 会跳过 `Global.Path.home` 下的 `.agents` / `.claude` / `.opencode` / `.aether`。如果设置 `OPENCODE_DISABLE_EXTERNAL_SKILLS=true`，第 3 阶段不执行，重复消失；如果设置 `OPENCODE_DISABLE_PROJECT_CONFIG=true`，第 4 阶段的项目配置目录不加入，重复也消失。
 
 ### 2.3 覆盖规则
 
-1. skill 以 frontmatter 的 `name` 为主键。
-2. 同名 skill 后发现者覆盖先前 skill。
-3. `skills.disabled` 在最后执行，因此拥有最终关闭权。
-4. 若启用 `OPENCODE_DISABLE_EXTERNAL_SKILLS=true`，则 `.claude` / `.agents` 外部 skill 来源整体失效。
-   需要注意级联关系：`OPENCODE_DISABLE_CLAUDE_CODE` 是总开关，为 true 时会隐式激活 `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS`，进而隐式激活 `OPENCODE_DISABLE_EXTERNAL_SKILLS`，所以设置 `OPENCODE_DISABLE_CLAUDE_CODE=true` 也等同于关闭外部 skills。
+1. skill 以 frontmatter 的 `name` 为主键，不以目录名或文件名为主键。
+2. 只有 frontmatter 至少满足 `name: string` 和 `description: string` 的 `SKILL.md` 才会登记为有效 skill。
+3. 同名 skill 后发现者覆盖先前 skill；覆盖时只保留后一条的 `name`、`description`、`location`、`content`。
+4. 被成功登记的 skill 目录会写入 `state.dirs`，供 agent 默认权限把 skill 附带资源目录加入可读白名单。
+5. `skills.disabled` 在最后执行，因此拥有最终关闭权。
+6. `Skill.available(agent)` 还会按 agent 的 `permission.skill` 做二次过滤；这只影响某个 agent 可见/可用的列表，不改变全局扫描结果。
 
-### 2.4 运行时加载与缓存机制
+按当前代码，可以把主要覆盖层理解为：
 
-扫描路径只回答“哪些地方有可能被发现”。运行时还必须回答另一个问题：程序启动后，文件系统里发生变化时，Aether 会不会马上重新扫描、重新加载？
+1. 全局 home 外部目录：`.agents < .claude < .opencode < .aether`。
+2. skill-sessions：覆盖全局 home 外部目录，但低于项目目录。
+3. 项目外部阶段：外层 < 内层；同层 `.agents < .claude < .opencode < .aether`。
+4. 配置目录阶段：按 `Config.directories()` 返回顺序加载；同层 `.aether` 先于 `.opencode`，所以同层 `.opencode` 在此阶段覆盖 `.aether`。项目内 `.aether/.opencode` 的 `skills/` 会在这一阶段再次参与覆盖。
+5. `skills.paths`：覆盖前面所有本地发现来源。
+6. `skills.urls`：覆盖 `skills.paths` 及前面所有来源。
+7. `skills.disabled`：按名称最终删除。
 
-结论是：**Aether 当前没有针对 skill 目录的热更新监听**。skill 的“发现结果”会按当前工作目录缓存在内存里；文件系统变化本身不会自动清掉这份缓存。
+### 2.4 禁用开关
 
-为了理解这一点，需要先区分几个运行时概念：
+若启用 `OPENCODE_DISABLE_EXTERNAL_SKILLS=true`，`Skill.loadSkills()` 中的外部阶段整体失效，具体包括：
 
-| 名称 | 含义 | 和 skills 的关系 |
-| --- | --- | --- |
-| `Instance.directory` | 当前请求、会话或 CLI 命令所在的工作目录。服务端会根据请求里的 `directory`、请求头里的目录，或默认的 `process.cwd()` 建立当前 instance。 | skill 缓存以它为 key。同一个目录会复用同一份 skill 列表；不同目录会各自初始化、各自缓存。 |
-| `Instance.worktree` | 当前项目的工作区根目录，通常是 git worktree 根。 | 扫描项目内 `.claude/skills` 和 `.agents/skills` 时，会从 `Instance.directory` 向上查找到 `Instance.worktree` 为止。 |
-| `loadSkills(state, discovery, directory, worktree)` | skill 模块中真正执行扫描的函数。 | 它按 2.2 的顺序扫描所有来源，解析每个 `SKILL.md`，并把结果写入内存状态。 |
-| `state.skills` | skill 模块的内存表，形如 `skill 名 -> skill 信息`。 | 每条记录保存 `name`、`description`、`location`、`content`。其中 `location` 是 `SKILL.md` 的绝对路径，`content` 是扫描当时读到的正文快照。 |
-| `state.dirs` | 当前已发现 skill 所在目录的集合。 | 后续会被 agent 权限初始化逻辑使用，让 skill 目录里的资源文件更容易被读取。 |
-| `InstanceState` | 按 `Instance.directory` 缓存运行时状态的通用机制。 | skill 模块把 `state.skills` 和 `state.dirs` 放进 `InstanceState`。因此同一个目录里，第一次需要 skills 时会扫描；之后再读 skills 时通常只读缓存。 |
-| `Skill.all()` | 返回当前目录的全部 skills。 | 如果当前目录还没有 skill 缓存，会触发首次扫描；如果已有缓存，则只读缓存，不重新扫描文件系统。 |
-| `Skill.available(agent)` | 返回当前 agent 可用的 skills。 | 如果当前目录还没有 skill 缓存，会触发首次扫描；如果已有缓存，则先读缓存，再按该 agent 的 skill 权限过滤。系统提示和 `skill` 工具描述都用它。 |
-| `Skill.get(name)` | 从当前目录的 skill 表里按名字取一个 skill。 | 如果当前目录还没有 skill 缓存，会触发首次扫描；如果已有缓存，则不会因为文件系统刚新增了同名或新名 skill 而重新扫描。 |
-| `Skill.dirs()` | 返回当前目录的 skill 目录列表。 | 如果当前目录还没有 skill 缓存，会触发首次扫描；如果已有缓存，则只读缓存。主要用于权限系统允许读取 skill 附带资源。 |
-| `SkillTool.execute()` | agent 真正调用内置 `skill` 工具时执行的逻辑。 | 它先用 `Skill.get(name)` 找缓存记录，再按缓存记录里的 `location` 重新读取该 `SKILL.md` 的正文。 |
-| `Discovery.pull(url)` | 处理 `config.skills.urls` 的远端下载逻辑。 | 它会拉取远端 `index.json`，把远端 skill 文件下载到 `Global.Path.cache/skills/<skill-name>`，然后让 `loadSkills()` 扫描这个缓存目录。 |
+1. 全局 home 外部目录 `~/.agents/skills`、`~/.claude/skills`、`~/.opencode/skills`、`~/.aether/skills`。
+2. `~/.aether/skill-sessions/<projectId>/skills`。
+3. 从当前目录向上查找的项目内 `.agents/skills`、`.claude/skills`、`.opencode/skills`、`.aether/skills` 外部阶段扫描。
 
-这意味着，程序里有两类“加载”必须分开看：
+但这个开关不会关闭后续的 `Config.directories()`、`skills.paths`、`skills.urls`。因此项目内 `.aether/{skill,skills}` / `.opencode/{skill,skills}` 仍可能通过配置目录阶段被扫描；若要连项目配置目录也关闭，需要另看 `OPENCODE_DISABLE_PROJECT_CONFIG` 对 `Config.directories()` 的影响。
 
-1. **发现并登记 skill 列表**：扫描路径、解析 frontmatter、确定 `name` / `description` / `location` / `content`、处理同名覆盖和禁用。这一步会被缓存。
-2. **真正调用某个 skill 工具时注入正文**：agent 调用 `skill({ name })` 后，程序会根据缓存中的 `location` 再读一次这个 `SKILL.md` 的正文。这一步可以读到已登记 skill 的最新正文。
+需要注意级联关系：`OPENCODE_DISABLE_CLAUDE_CODE` 是总开关，为 true 时会隐式激活 `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS`，进而隐式激活 `OPENCODE_DISABLE_EXTERNAL_SKILLS`，所以设置 `OPENCODE_DISABLE_CLAUDE_CODE=true` 也等同于关闭上述外部 skills 阶段。
 
-### 2.5 一个 skill 从被扫描到使用完成的完整链路
+### 2.5 运行时缓存与变更感知
 
-无论 skill 来自哪一种路径，最终都会收敛到同一套运行时流程。也就是说，`~/.claude/skills/foo/SKILL.md`、项目内 `.aether/skills/foo/SKILL.md`、`config.skills.paths` 下的 `foo/SKILL.md`、远端 URL 下载到缓存后的 `foo/SKILL.md`，只要被扫描到，后续处理逻辑都是一样的。
+skills 使用 `InstanceState` 按当前 `Instance.directory` 缓存。首次调用 `Skill.get()`、`Skill.all()`、`Skill.dirs()` 或 `Skill.available()` 时会执行 `loadSkills()`；之后再次访问前，会先用 mtime snapshot 检查磁盘状态。
 
-完整链路如下：
+当前实现的缓存校验链路是：
 
-| 阶段 | 发生了什么 | 结果 |
-| --- | --- | --- |
-| 1. 建立当前 instance | 请求、会话或 CLI 命令进入后，Aether 确定当前 `Instance.directory` 和 `Instance.worktree`。 | 后续所有 skill 扫描和缓存都绑定到这个目录上下文。 |
-| 2. 某个入口第一次需要 skills | 常见入口包括：构建系统提示里的 `<available_skills>`、初始化 `skill` 工具描述、调用 `/skill` API、构建 skill-as-command、初始化 agent 的 skill 目录权限白名单。 | 程序开始读取当前目录对应的 skill 状态。 |
-| 3. 查询 `InstanceState` | skill 模块通过 `InstanceState.get()` 按 `Instance.directory` 查缓存。 | 如果这个目录已有缓存，直接复用；如果没有，进入首次扫描。 |
-| 4. 扫描所有 skill 来源 | `loadSkills()` 按 2.2 的顺序扫描外部目录、配置目录、`skills.paths`、`skills.urls`。 | 得到一批候选 `SKILL.md` 文件。 |
-| 5. 解析 `SKILL.md` | 每个候选文件由 `ConfigMarkdown.parse()` 解析 frontmatter 和正文。 | 只有 frontmatter 至少满足 `name` 和 `description` 的文件会被登记为有效 skill。 |
-| 6. 写入内存表 | 有效 skill 被写入 `state.skills[name]`。 | 每条记录包含 `name`、`description`、`location`、`content`。 |
-| 7. 处理同名覆盖 | 如果两个 skill 的 frontmatter `name` 相同，后扫描到的记录覆盖先扫描到的记录。 | 最终缓存表里每个 `name` 只保留一条记录。 |
-| 8. 处理禁用项 | 所有来源扫描完后，再读取 `config.skills.disabled`，按名字从 `state.skills` 里删除。 | 被禁用的 skill 不会进入后续可用列表。 |
-| 9. 缓存扫描结果 | 完整的 `state.skills` 和 `state.dirs` 被保存在当前目录的 `InstanceState` 中。 | 后续同目录读取 skills 时不再重新扫描文件系统。 |
-| 10. 暴露给模型 | `SystemPrompt.skills(agent)` 调用 `Skill.available(agent)`，把可用 skill 的 `name`、`description`、`location` 写入系统提示；`SkillTool.init()` 也用 `Skill.available(agent)` 生成工具描述。 | 模型知道“有哪些 skills 可以用”，但还没有拿到完整正文。 |
-| 11. 模型决定调用 skill 工具 | 当模型判断任务匹配某个 skill 时，会调用内置工具 `skill({ name })`。 | 程序进入 `SkillTool.execute()`。 |
-| 12. 从缓存取目标 skill | `SkillTool.execute()` 调用 `Skill.get(name)`，从缓存的 `state.skills` 里取这个名字。 | 如果缓存里没有这个名字，则报错并列出当前缓存里有哪些 skill。 |
-| 13. 检查文件是否仍存在 | 程序检查缓存记录里的 `location` 是否还能访问。 | 如果文件已经被删除或不可访问，会报 “Skill not found”。注意：缓存列表里可能仍有旧名字，但调用时会失败。 |
-| 14. 重新读取正文 | 程序重新解析 `location` 指向的 `SKILL.md`，取最新正文；如果解析失败，则回退到扫描时缓存的旧 `content`。 | 已登记 skill 的正文修改，通常可以在下一次 `skill` 工具调用时生效。 |
-| 15. 申请 skill 权限 | 程序通过权限系统请求 `permission: "skill"`，匹配目标 skill 名。 | 权限允许后才继续返回 skill 内容；权限拒绝则不会把 skill 内容注入上下文。 |
-| 16. 枚举 skill 附带文件 | 程序在 skill 所在目录下采样最多 10 个非 `SKILL.md` 文件。 | 输出里会提示 `scripts/`、`references/` 等资源路径以 skill 基础目录为准。 |
-| 17. 返回工具输出 | 工具返回 `<skill_content name="...">`，其中包含 skill 正文、base directory、采样文件列表。 | 这段输出进入对话上下文，模型之后就可以按 skill 的完整说明继续工作。 |
+1. `loadSkills()` 完成扫描、覆盖和禁用处理后，调用 `buildManifest()`。
+2. `buildManifest()` 复用 `scanAllSkillPaths()`，收集除 `skills.urls` 之外的所有本地扫描来源中的 `SKILL.md` 路径，并记录 `mtimeMs`。
+3. snapshot 写入 `~/.aether/skill-snapshots/<directory-slug>.json`。
+4. 下次访问 skill state 前，`isFresh()` 先读取 snapshot。
+5. snapshot 中已有路径被删除或 mtime 改变时，判定不 fresh。
+6. 重新扫描本地路径时发现新增 `SKILL.md` 不在 snapshot 中，也判定不 fresh。
+7. 不 fresh 时先 `InstanceState.invalidate()`，随后重新执行 `loadSkills()`。
 
-这里还要特别区分 `skill` 工具路径和 skill-as-command 路径：
+这意味着手动新增、删除或修改本地扫描路径里的 `SKILL.md`，会在下一次访问 skills 时触发重新扫描，不需要重启进程。`skills.urls` 不参与 `scanAllSkillPaths()`，因此远端源变化和 `Global.Path.cache/skills/<name>` 下的缓存文件变化都不会触发 mtime snapshot 重扫；已登记的 URL skill 若通过内置 `skill` 工具执行，正文仍会按缓存中的 `location` 重新读取。
 
-| 使用方式 | 用户/模型看到的形式 | 走不走 `SkillTool.execute()` | 正文来源 | 运行中修改正文后是否立刻生效 |
-| --- | --- | --- | --- | --- |
-| 内置 `skill` 工具 | 模型调用 `skill({ name: "foo" })` | 走 | 先通过缓存找到 `location`，再重新读取 `SKILL.md` 正文 | 通常生效，因为执行时会重新读正文 |
-| skill-as-command | 用户输入 `/foo`，其中 `foo` 来自 skill 名 | 不走 | `Command.state` 构建命令表时使用扫描时缓存的 `skill.content` | 不会立刻生效，需要重新扫描后命令模板才更新 |
+### 2.6 使用入口
 
-skill-as-command 的存在容易造成误解。它只是 command 层把已发现的 skill 补充注册成同名 slash command；它不改变 skill 本身的发现、缓存和覆盖规则。执行 `/foo` 时，程序走的是 command 模板展开流程，而不是 `skill` 工具的执行流程，因此不会像 `skill({ name: "foo" })` 那样重新读取 `SKILL.md` 正文。
+被扫描到的 skill 会进入多个运行时入口：
 
-### 2.6 什么时候会放弃旧缓存并重新扫描
+1. `SystemPrompt.skills(agent)` 调用 `Skill.available(agent)`，把可用 skill 的 `name`、`description`、`location` 写入系统提示。
+2. `SkillTool` 初始化工具描述时调用 `Skill.available(agent)`，让模型知道可以加载哪些 skill。
+3. agent 默认权限初始化会调用 `Skill.dirs()`，把已发现 skill 目录下的资源文件加入 `external_directory` allow 列表。
+4. command 层会遍历 `Skill.all()`，把未被已有 command 占用的 skill 名注册为同名 slash command。
 
-对用户来说，判断规则可以概括为：
-
-1. **第一次访问某个目录的 skills**：会扫描。
-2. **访问一个还没有缓存过的新目录**：会扫描。
-3. **当前目录的 instance 被 dispose / reload 后再次访问 skills**：会扫描。
-4. **仅仅新增、修改、删除 `SKILL.md` 文件**：不会自动扫描。
-5. **修改已登记 skill 的正文并通过 `skill` 工具调用**：不需要重新扫描也可能读到新正文，因为工具执行阶段会重新读缓存 `location` 对应的文件。
-
-更具体地说：
-
-| 用户可感知场景 | 是否会重新扫描 skills | 说明 |
-| --- | --- | --- |
-| 第一次在某个目录里发送会触发 skill 列表的请求 | 会 | 当前 `Instance.directory` 还没有 skill 缓存，第一次访问会跑 `loadSkills()`。 |
-| 在 Web/App/TUI 中切换到一个从未访问过的项目目录 | 会 | 新目录对应新的 `Instance.directory`，没有旧缓存。 |
-| 切回之前访问过、且未被清理的目录 | 不会 | 之前的 `InstanceState` 仍在内存里，会复用旧 skill 列表。 |
-| 重启 Aether 服务端、桌面端、TUI worker 或 CLI 进程 | 会 | 运行时内存消失，下次访问时重新初始化。 |
-| 服务端调用 `/instance/dispose` | 会，但发生在下次访问当前目录时 | 该接口清理当前 `Instance.directory` 的 instance 状态。清理后，下次需要 skills 才重新扫描。 |
-| 服务端调用 `/global/dispose` | 会，但发生在下次访问各目录时 | 该接口清理所有目录的 instance 状态。 |
-| PATCH `/config` 更新当前项目配置 | 会 | `Config.update()` 写入当前目录的 `config.json` 后调用 `Instance.dispose()`。 |
-| PATCH `/global` 更新全局配置 | 会，但清理是异步触发 | `Config.updateGlobal()` 会触发 `Instance.disposeAll()`，用于让全局配置变化影响所有目录。 |
-| `/config/skills/toggle` 启用或禁用默认 skill | 会，但清理是异步触发 | 该接口最终更新全局 `skills.disabled`，走 `Config.updateGlobal()`。 |
-| `/config/skills/defaults` 复制了至少一个默认 skill 到当前项目 | 会 | `addDefaultSkills()` 只有实际复制了新 skill 时才调用 `Instance.dispose()`。 |
-| `/config/skills/defaults` 没有复制任何新 skill | 不会 | 没有新目录被复制，函数不会清理 instance。 |
-| `/config/skills` 保存或更新默认 skill 文件 | 不会 | `saveDefaultSkill()` 只写 `SKILL.md`，不清理当前 instance。若这个 skill 已在缓存中，通过 `skill` 工具调用时可能读到新正文；但列表、描述、名字不会刷新。 |
-| DELETE `/config/skills/:name` 删除默认 skill 文件 | 不会 | `deleteDefaultSkill()` 只删文件，不清理当前 instance。缓存列表可能仍显示旧 skill，但调用时会因文件不存在失败。 |
-| 手动在任意扫描路径下新增 `SKILL.md` | 不会自动扫描 | 新文件还没有进入 `state.skills`，需要 dispose / reload / 重启 / 切到未缓存目录后才会被发现。 |
-| 手动修改已发现 skill 的正文 | 不会重新扫描列表；通过 `skill` 工具调用时通常能读到新正文 | 因为 `SkillTool.execute()` 会重新读取缓存 `location` 指向的文件正文。 |
-| 手动修改已发现 skill 的 `name` | 不会自动生效 | 缓存键仍是旧 `name`；新名字不会可用，直到重新扫描。 |
-| 手动修改已发现 skill 的 `description` | 不会自动更新系统提示和工具描述 | `description` 是扫描时缓存的 frontmatter 字段。 |
-| 手动修改 `skills.paths` 或 `skills.urls` 配置文件，但没有通过配置 API 触发 dispose | 不会自动生效 | 配置内容和 skill 扫描结果都已经缓存在当前 instance 中。 |
-| git 初始化导致项目 worktree 信息变化 | 会 | 项目状态变化时相关路径会调用 `Instance.reload()`，随后重新建立 instance。 |
-| 飞书集成中切换到新项目且触发项目初始化 | 会 | 对非 git 项目初始化后会调用 `Instance.reload()`。 |
-
-需要注意两个细节：
-
-1. `Instance.dispose()` / `Instance.disposeAll()` / `Instance.reload()` 本身只是清掉旧状态；真正重新扫描发生在清理之后，下一次有代码调用 `Skill.all()`、`Skill.available()`、`Skill.get()` 或 `Skill.dirs()` 时。
-2. `Config.updateGlobal()` 触发的 `Instance.disposeAll()` 是异步的。一般用户会感知为“全局配置更新后后续请求会刷新”，但严格说，接口返回和清理完成之间可能有很短的时间差。
-
-### 2.7 运行中修改 skills 的具体效果
-
-把 2.4 到 2.6 合在一起，可以得到下面这些直接结论：
-
-| 运行中发生的变化 | 当前已缓存 instance 能否立刻看到 | 具体原因 |
-| --- | --- | --- |
-| 新增一个 skill | 不能 | 新文件没有进入缓存的 `state.skills`。需要重新扫描。 |
-| 删除一个已发现 skill | 列表可能仍显示；调用会失败 | 缓存里还保留旧记录，但 `SkillTool.execute()` 会检查 `location` 是否存在。 |
-| 修改已发现 skill 的正文 | 通过 `skill` 工具调用通常能看到；通过 skill-as-command 不能立刻看到 | `skill` 工具执行时会重新读正文；skill-as-command 使用扫描时缓存的 `content`。 |
-| 修改已发现 skill 的 `description` | 不能立刻看到 | 系统提示和工具描述里的描述来自扫描时缓存。 |
-| 修改已发现 skill 的 `name` | 新名字不能立刻使用 | 缓存的索引键仍是旧名字。 |
-| 修改 `skills.disabled` | 需要重新扫描后才稳定生效 | 禁用逻辑只在 `loadSkills()` 最后执行。 |
-| 修改 `skills.paths` | 需要重新扫描后才稳定生效 | 额外路径只在 `loadSkills()` 中读取。 |
-| 修改 `skills.urls` | 需要重新扫描后才会重新拉取远端 index | 远端发现逻辑只在 `loadSkills()` 中执行。 |
-| 修改远端 skill 文件内容 | 不一定会更新 | 远端文件下载到本地缓存；如果目标文件已存在，下载逻辑会直接复用，不覆盖。 |
-
-因此，对于用户最关心的两个问题，可以明确回答：
-
-1. **运行过程中加入新的 skills，Aether 能否检测到并使用？**
-   - 当前已缓存目录下，不能自动检测。
-   - 需要重新扫描，方式包括重启、切到未缓存目录、调用 dispose / reload、或通过会触发 dispose 的配置更新路径。
-   - 重新扫描后，只要新 `SKILL.md` 位于支持的扫描路径中，frontmatter 有合法 `name` 和 `description`，且没有被 `skills.disabled` 禁用，就可以被发现并使用。
-
-2. **运行过程中修改已有 skill，Aether 能否使用修改后的版本？**
-   - 如果只是修改正文，并且模型通过内置 `skill` 工具调用这个已登记 skill，通常可以读到修改后的正文。
-   - 如果修改的是 `name`、`description`、禁用状态、扫描路径，或通过 `/skill-name` 这种 skill-as-command 使用，则需要重新扫描。
-   - 如果修改后 `SKILL.md` 解析失败，`skill` 工具会回退到扫描时缓存的旧正文。
+内置 `skill` 工具执行时会先用 `Skill.get(name)` 找到缓存记录，再重新解析该 `location` 指向的 `SKILL.md` 正文；如果重新解析失败，则回退到扫描时缓存的旧 `content`。skill-as-command 不走 `SkillTool.execute()`，它使用 command state 初始化时捕获的 `skill.content`。
 
 ## 3. Commands
 
@@ -452,7 +552,7 @@ markdown 命令文件在 `loadCommand()` 中通过 patterns 列表提取相对�
 
 | 能力 | 是否支持用户自定义 | 主扫描/来源方式 | 覆盖规则 |
 | --- | --- | --- | --- |
-| skills | 支持 | 外部目录 + `.aether` / `.opencode/{skill,skills}` + `skills.paths` + `skills.urls` | 同名后加载覆盖先加载；`skills.disabled` 最终删除 |
+| skills | 支持 | home/project 外部目录 + skill-sessions + config roots `{skill,skills}` + `skills.paths` + `skills.urls` | 同名后加载覆盖先加载；`skills.disabled` 最终删除；本地 `SKILL.md` 变更由 mtime snapshot 触发重扫 |
 | commands | 支持 | `config.command` + `.aether` / `.opencode/{command,commands}` + MCP + skill-as-command | 内建 < config.command < MCP；skill 只能补位不能覆盖 |
 | subagents | 支持 | `config.agent` + `.aether` / `.opencode/{agent,agents}` | 内建 agents 先建，`config.agent` 后覆盖；`disable: true` 可删除 |
 | rules | 支持部分形式 | `AGENTS/CLAUDE/CONTEXT` + `instructions` + permission config | 指令文件按固定顺序装载；permission 采用最后匹配生效 |
@@ -463,7 +563,7 @@ markdown 命令文件在 `loadCommand()` 中通过 patterns 列表提取相对�
 
 结论先行：
 
-1. `skills`：兼容最广，显式支持 `.claude` / `.agents` 外部 skills，以及 `.aether` / `.opencode`、额外路径、远端 URL。
+1. `skills`：兼容最广，显式支持 `.agents` / `.claude` / `.opencode` / `.aether` 外部 skills、skill-sessions、config roots、额外路径、远端 URL。
 2. `commands`：不兼容 `.claude` / `.agents` 外部 command 目录，只走统一 config roots（含 `.aether` / `.opencode`）、`config.command`、MCP 与 skill-as-command。
 3. `subagents`：没有 `.claude` / `.agents` 外部目录兼容，只走统一 config roots（含 `.aether` / `.opencode`）与 `config.agent`。
 4. `rules`：属于“部分兼容”。
@@ -476,31 +576,38 @@ markdown 命令文件在 `loadCommand()` 中通过 patterns 列表提取相对�
 
 | 来源/生态 | 是否支持 | 实际扫描/接入方式 | 优先级/覆盖判定 | 备注 |
 | --- | --- | --- | --- | --- |
-| `~/.claude/skills/**/SKILL.md` | 支持 | `Skill.loadSkills()` 显式扫描全局外部目录 `.claude` | 在 skills 装载链最前部之一；同名后发现覆盖先发现 | 可被 `OPENCODE_DISABLE_EXTERNAL_SKILLS` 或 `OPENCODE_DISABLE_CLAUDE_CODE` 整体关闭 |
-| `~/.agents/skills/**/SKILL.md` | 支持 | 同上 | 同上 | 与 `~/.claude/skills` 同级 |
-| 项目内 `.claude/skills/**/SKILL.md` | 支持 | 从当前目录向上到 `worktree`，逐级找 `.claude` 后扫描其 `skills/**/SKILL.md` | 在外部 skills 阶段按发现顺序覆盖 | 这是显式目录兼容，不是偶然命中 |
-| 项目内 `.agents/skills/**/SKILL.md` | 支持 | 同上 | 同上 | 与项目内 `.claude/skills` 同级 |
+| `~/.agents/skills/**/SKILL.md` | 支持 | `Skill.loadSkills()` 显式扫描全局 home 外部目录 `.agents` | 全局外部目录最低层；同名可被后续全局 `.claude/.opencode/.aether` 覆盖 | 可被 `OPENCODE_DISABLE_EXTERNAL_SKILLS` 或 `OPENCODE_DISABLE_CLAUDE_CODE` 整体关闭 |
+| `~/.claude/skills/**/SKILL.md` | 支持 | `Skill.loadSkills()` 显式扫描全局 home 外部目录 `.claude` | 高于全局 `.agents`，低于全局 `.opencode/.aether` | 同上 |
+| `~/.opencode/skills/**/SKILL.md` | 支持 | `Skill.loadSkills()` 显式扫描全局 home 外部目录 `.opencode` | 高于全局 `.agents/.claude`，低于全局 `.aether` | 这里是外部阶段扫描的 `skills/`，不是 `Config.directories()` 的 `{skill,skills}` |
+| `~/.aether/skills/**/SKILL.md` | 支持 | `Skill.loadSkills()` 显式扫描全局 home 外部目录 `.aether` | 全局 home 外部目录中最高 | 同上 |
+| `~/.aether/skill-sessions/<projectId>/skills/**/SKILL.md` | 支持 | `Skill.loadSkills()` 在全局外部目录之后扫描当前项目 ID 对应目录 | 覆盖全局 home 外部 skill，低于项目内用户 skill | AI 后台评审/自进化的项目隔离目录；也受 external skills 开关影响 |
+| 项目内 `.agents/skills/**/SKILL.md` | 支持 | 从当前 `Instance.directory` 向上到 `Instance.worktree` 收集后反向扫描 | 项目外部阶段中同层最低；内层覆盖外层 | 这是显式目录兼容，不是偶然命中 |
+| 项目内 `.claude/skills/**/SKILL.md` | 支持 | 同上 | 高于同层 `.agents`，低于同层 `.opencode/.aether` | 同上 |
+| 项目内 `.opencode/skills/**/SKILL.md` | 支持 | 外部阶段扫描 `skills/**/SKILL.md`；随后还可能被 config roots 阶段再次扫描 | 项目外部阶段中高于 `.agents/.claude`，低于 `.aether`；config roots 阶段还会参与后续覆盖 | legacy 目录名 |
+| 项目内 `.aether/skills/**/SKILL.md` | 支持 | 外部阶段扫描 `skills/**/SKILL.md`；随后还可能被 config roots 阶段再次扫描 | 项目外部阶段同层最高；config roots 阶段仍按 `Config.directories()` 顺序参与覆盖 | 新品牌目录名 |
 | `.aether/skill/**/*.md` | 不支持 | 无此模式 | 不参与 | skills 只认 `SKILL.md` 文件名，不认任意 markdown |
 | `.aether/skill/**/SKILL.md` | 支持 | 对每个 `Config.directories()` 根目录扫描 `{skill,skills}/**/SKILL.md` | 晚于外部 skills，故可覆盖前面同名 skill；同层级 `.aether` 在 `.opencode` 之前 yield，同名时 `.opencode` 覆盖权更高 | 新品牌目录名 |
 | `.aether/skills/**/SKILL.md` | 支持 | 同上 | 同上 | 与 `skill/` 等价 |
 | `.opencode/skill/**/*.md` | 不支持 | 无此模式 | 不参与 | skills 只认 `SKILL.md` 文件名，不认任意 markdown |
 | `.opencode/skill/**/SKILL.md` | 支持 | 同上扫描方式 | 晚于外部 skills；同层级 `.opencode` 在 `.aether` 之后 yield，覆盖权更高 | legacy 目录名 |
 | `.opencode/skills/**/SKILL.md` | 支持 | 同上 | 同上 | 与 `skill/` 等价 |
-| `~/.aether/skills/**/SKILL.md` | 支持 | home 目录下的 `.aether` 属于 `Config.directories()` 的一员 | 在 directories 列表中位于项目级之后 | home 目录扫描 |
-| `~/.opencode/skills/**/SKILL.md` | 支持 | home 目录下的 `.opencode` 属于 `Config.directories()` 的一员 | 同上 | legacy home 目录扫描 |
-| `<binaryDir>/.aether/skills/**/SKILL.md` | 支持 | binary 目录下的 `.aether` 属于 `Config.directories()` 的一员 | 在 directories 列表中位于 home 目录之后 | 打包发行版专用 |
-| `<binaryDir>/.opencode/skills/**/SKILL.md` | 支持 | 同上 | 同上 | legacy 打包发行版 |
-| `config.skills.paths` | 支持 | 每个目录递归扫描 `**/SKILL.md` | 晚于 `.aether` / `.opencode` skills | 相对路径相对当前项目目录 |
-| `config.skills.urls` | 支持 | 拉取远端索引到缓存目录后再扫描 `**/SKILL.md` | 晚于本地路径；同名继续后发现覆盖 | 属于当前四类能力里唯一内建远端发现 |
+| `~/.aether/skill/**/SKILL.md` | 不支持 | home 外部 `.aether` 会在 config roots 阶段被跳过 | 不参与 | 当前 home `.aether` 只通过外部阶段扫描 `skills/` |
+| `~/.opencode/skill/**/SKILL.md` | 不支持 | home 外部 `.opencode` 会在 config roots 阶段被跳过 | 不参与 | 当前 home `.opencode` 只通过外部阶段扫描 `skills/` |
+| `Global.Path.config/{skill,skills}/**/SKILL.md` | 支持 | `Global.Path.config` 是 `Config.directories()` 的第一项 | config roots 阶段中较低；会被后续项目、binary、`OPENCODE_CONFIG_DIR` 同名 skill 覆盖 | 典型为 `~/.config/aether/{skill,skills}` 或 legacy config 路径 |
+| `<binaryDir>/.aether/{skill,skills}/**/SKILL.md` | 支持 | binary 目录下的 `.aether` 属于 `Config.directories()` 的一员 | 在 directories 列表中位于 home 目录之后 | 打包发行版专用 |
+| `<binaryDir>/.opencode/{skill,skills}/**/SKILL.md` | 支持 | 同上 | 同上 | legacy 打包发行版 |
+| `<OPENCODE_CONFIG_DIR>/{skill,skills}/**/SKILL.md` | 支持 | `OPENCODE_CONFIG_DIR` 属于 `Config.directories()` 的最后一项 | 在 config roots 阶段最高 | 不受 external skills 开关影响 |
+| `config.skills.paths` | 支持 | 每个目录递归扫描 `**/SKILL.md` | 晚于所有内建本地扫描来源 | `~/` 展开到 `os.homedir()`；相对路径相对当前 `Instance.directory` |
+| `config.skills.urls` | 支持 | 拉取远端索引到缓存目录后再扫描 `**/SKILL.md` | 晚于本地路径；同名继续后发现覆盖 | 属于当前四类能力里唯一内建远端发现；已存在的缓存文件不会被覆盖下载 |
 | `config.skills.disabled` | 支持 | 在 skills 全部装载完成后按名字删除 | 拥有最终关闭权 | 优先级高于前面所有来源 |
 | skill 自动暴露为 command | 支持，但属于 command 侧行为 | skill 装好后，命令层再把 skill 注册成同名 command | 不改变 skill 本身覆盖规则 | 这是跨能力映射，不是 skill 发现来源 |
 
 补充说明：
 
-1. `skills` 是四类能力里兼容最丰富的一类，既支持外部生态目录，也支持 `.aether` / `.opencode`、本地附加路径和远端 URL。
+1. `skills` 是四类能力里兼容最丰富的一类，既支持外部生态目录，也支持 `.aether` / `.opencode`、skill-sessions、本地附加路径和远端 URL。
 2. skill 的主键是 frontmatter 的 `name`，不是目录名，也不是文件夹名。
 3. `SKILL.md` 正文会同时作为 skill content 保留；后续若被自动暴露为 command，则正文会变成该 command 的模板。
-4. 上表只说明“哪些路径会在扫描时被纳入候选”。运行中是否会自动看到新增、删除、修改后的 skill，取决于 2.4 到 2.7 描述的 `InstanceState` 缓存与 instance dispose / reload 机制。当前没有 skill 目录文件监听热更新。
+4. 上表只说明“哪些路径会在扫描时被纳入候选”。运行中非 URL 本地来源的 `SKILL.md` 新增、删除、修改会通过 2.5 描述的 mtime snapshot 在下一次访问 skills 时触发重扫；远端 URL 源和下载缓存不会因此重新拉取或重扫。
 
 ### 7.2 Commands 兼容矩阵
 
@@ -591,7 +698,7 @@ markdown 命令文件在 `loadCommand()` 中通过 patterns 列表提取相对�
 | `packages/opencode/src/config/markdown.ts` | 解析 `.md` frontmatter | skills, commands, subagents |
 | `packages/opencode/src/skill/index.ts` | skill 主发现器、去重、禁用、可用性过滤 | skills |
 | `packages/opencode/src/skill/discovery.ts` | 远端 `skills.urls` 下载与缓存 | skills |
-| `packages/opencode/src/effect/instance-state.ts` | 按当前 `Instance.directory` 缓存运行时状态，并在 instance dispose / reload 时失效 | skills, commands, subagents 等运行时状态 |
+| `packages/opencode/src/effect/instance-state.ts` | 按当前 `Instance.directory` 缓存运行时状态；skills 会在读取缓存前额外做 mtime snapshot 校验 | skills, commands, subagents 等运行时状态 |
 | `packages/opencode/src/project/instance.ts` | 建立当前目录 instance，提供 `directory` / `worktree` 上下文，并实现 `dispose` / `reload` / `disposeAll` | skills, commands, subagents, rules |
 | `packages/opencode/src/server/server.ts` | 服务端请求入口；根据请求目录建立 instance，并提供 `/instance/dispose` | skills |
 | `packages/opencode/src/server/routes/config.ts` | 配置与默认 skills API；不同接口对 skill 缓存的清理行为不同 | skills |
@@ -609,6 +716,8 @@ markdown 命令文件在 `loadCommand()` 中通过 patterns 列表提取相对�
 | `packages/opencode/src/util/filesystem.ts` | `findUp` / `up` / `globUp` 等向上扫描基础设施 | skills, rules, config roots |
 | `packages/opencode/test/skill/skill.test.ts` | skill 本地/外部目录发现测试 | skills |
 | `packages/opencode/test/skill/discovery.test.ts` | 远端 skills 下载、缓存测试 | skills |
+| `packages/opencode/src/skill/skill-priority.test.ts` | skill 优先级、skill-sessions、shadow `.aether` 覆盖测试 | skills |
+| `packages/opencode/src/skill/skill-mtime-cache.test.ts` | skill mtime snapshot 失效测试 | skills |
 | `packages/opencode/test/config/config.test.ts` | config 合并优先级、commands/agents/instructions 等装载测试 | commands, subagents, rules |
 | `packages/opencode/test/session/instruction.test.ts` | `AGENTS.md`/全局 rules 优先级测试 | rules |
 | `packages/opencode/test/permission-task.test.ts` | permission.task 与最后匹配生效测试 | rules |
@@ -617,8 +726,8 @@ markdown 命令文件在 `loadCommand()` 中通过 patterns 列表提取相对�
 
 当前程序对用户自定义 `skills`、`commands`、`subagents`、`指令型 rules` 都是支持的，但这四者并不是四套完全对称的插件系统：
 
-1. `skills` 的发现机制最丰富，支持本地、外部目录、额外路径、远端 URL。
+1. `skills` 的发现机制最丰富，支持外部目录、skill-sessions、config roots、额外路径、远端 URL，并通过 mtime snapshot 在下一次访问时感知本地 `SKILL.md` 变化。
 2. `commands` 与 `subagents` 主要依附统一 config roots 扫描；该扫描现同时搜索 `.aether` 和 `.opencode`，且还包含 home 目录和 binary 目录。
 3. `rules` 的核心不是“任意 rules 目录自动接入”，而是固定的 `AGENTS.md` / `CLAUDE.md` / `CONTEXT.md` + `instructions`。
 4. IDE 生态的 `.cursor/rules`、`.windsurf/rules.md`、`.github/copilot-instructions.md` 当前不会被核心运行时自动扫描，只能通过人工汇总进 `AGENTS.md` 或 `config.instructions` 来间接纳入。
-5. 项目已从 `opencode` 品牌迁移至 `aether` 品牌。所有扫描逻辑采取“双名并行”策略：`.aether` 和 `.opencode`（`aether.*` 和 `opencode.*`）始终同时被搜索和装载。项目级迁移代码（仅覆盖 skills 子目录）已定义但未激活。同一层级中 `.opencode` 版同名定义拥有更高覆盖权。
+5. 项目已从 `opencode` 品牌迁移至 `aether` 品牌。多数 config roots 采取“双名并行”策略：`.aether` 和 `.opencode`（`aether.*` 和 `opencode.*`）同时被搜索和装载；但 skills 的外部阶段还额外支持 `.agents` / `.claude`，且同层外部目录优先级为 `.agents < .claude < .opencode < .aether`。项目级迁移代码（仅覆盖 skills 子目录）已定义但未激活。

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -63,6 +63,7 @@ export namespace Command {
   export const Default = {
     INIT: "init",
     REVIEW: "review",
+    SKILL_SCAN_PATHS: "skill-scan-paths",
   } as const
 
   export interface Interface {
@@ -98,8 +99,16 @@ export namespace Command {
           subtask: true,
           hints: hints(PROMPT_REVIEW),
         }
+        commands[Default.SKILL_SCAN_PATHS] = {
+          name: Default.SKILL_SCAN_PATHS,
+          description: "print live skill scan paths",
+          source: "command",
+          template: "",
+          hints: [],
+        }
 
         for (const [name, command] of Object.entries(cfg.command ?? {})) {
+          if (name === Default.SKILL_SCAN_PATHS) continue
           commands[name] = {
             name,
             agent: command.agent,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -33,6 +33,7 @@ import { Flag } from "../flag/flag"
 import { ulid } from "ulid"
 import { spawn } from "child_process"
 import { Command } from "../command"
+import { Skill } from "../skill"
 import { pathToFileURL, fileURLToPath } from "url"
 import { ConfigMarkdown } from "../config/markdown"
 import { SessionSummary } from "./summary"
@@ -1834,6 +1835,79 @@ NOTE: At any point in time through this workflow you should feel free to ask the
    * Does not match when preceded by word characters or backticks (to avoid email addresses and quoted references)
    */
 
+  function fmtSources(list: Skill.Source[]) {
+    if (list.length === 0) return "No skill scan paths are currently active."
+    return [
+      "Skill scan paths (low -> high priority)",
+      "",
+      ...list.map((item, i) => `${i + 1}. [${item.scope}] ${path.join(item.dir, item.pattern)}`),
+    ].join("\n")
+  }
+
+  async function scan(input: CommandInput) {
+    assertNotBusy(input.sessionID)
+    await SessionRevert.awaitPending(input.sessionID)
+    await SessionRevert.cleanup(await Session.get(input.sessionID))
+
+    const text = input.arguments.trim() ? `/${input.command} ${input.arguments}` : `/${input.command}`
+    const user = await createUserMessage({
+      sessionID: input.sessionID,
+      messageID: input.messageID,
+      agent: input.agent,
+      model: input.model ? Provider.parseModel(input.model) : undefined,
+      variant: input.variant,
+      parts: [{ type: "text", text }],
+    })
+
+    const now = Date.now()
+    const msg: MessageV2.Assistant = {
+      id: MessageID.ascending(),
+      sessionID: input.sessionID,
+      parentID: user.info.id,
+      mode: user.info.agent,
+      agent: user.info.agent,
+      cost: 0,
+      path: {
+        cwd: Instance.directory,
+        root: Instance.worktree,
+      },
+      time: {
+        created: now,
+        completed: now,
+      },
+      role: "assistant",
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+      modelID: user.info.model.modelID,
+      providerID: user.info.model.providerID,
+      variant: user.info.variant,
+      finish: "stop",
+    }
+    const part: MessageV2.TextPart = {
+      type: "text",
+      id: PartID.ascending(),
+      messageID: msg.id,
+      sessionID: input.sessionID,
+      text: fmtSources(await Skill.sources()),
+    }
+
+    await Session.updateMessage(msg)
+    await Session.updatePart(part)
+    await Session.touch(input.sessionID)
+    Bus.publish(Command.Event.Executed, {
+      name: input.command,
+      sessionID: input.sessionID,
+      arguments: input.arguments,
+      messageID: msg.id,
+    })
+
+    return { info: msg, parts: [part] }
+  }
+
   export async function command(input: CommandInput) {
     log.info("command", input)
     const command = await Command.get(input.command)
@@ -1847,6 +1921,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       })
       throw error
     }
+    if (input.command === Command.Default.SKILL_SCAN_PATHS) return scan(input)
     const agentName = command.agent ?? input.agent ?? (await Agent.defaultAgent())
 
     const raw = input.arguments.match(argsRegex) ?? []

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -55,15 +55,24 @@ export namespace Skill {
     }),
   )
 
+  export type Scope = "global" | "project" | "config-root" | "paths" | "urls"
+  export type Source = {
+    dir: string
+    pattern: string
+    scope: Scope
+  }
+
   type State = {
     skills: Record<string, Info>
     dirs: Set<string>
+    sources: Source[]
   }
 
   export interface Interface {
     readonly get: (name: string) => Effect.Effect<Info | undefined>
     readonly all: () => Effect.Effect<Info[]>
     readonly dirs: () => Effect.Effect<string[]>
+    readonly sources: () => Effect.Effect<Source[]>
     readonly available: (agent?: Agent.Info) => Effect.Effect<Info[]>
   }
 
@@ -253,12 +262,14 @@ export namespace Skill {
       for (const dir of EXTERNAL_DIRS) {
         const root = path.join(Global.Path.home, dir)
         if (!(await Filesystem.isDir(root))) continue
+        state.sources.push({ dir: root, pattern: EXTERNAL_SKILL_PATTERN, scope: "global" })
         await scan(state, root, EXTERNAL_SKILL_PATTERN, { dot: true, scope: "global" })
       }
 
       // AI background-review skills: project-scope but lowest priority (overridden by any user source)
       const skillSessionsDir = path.join(Global.Path.home, ".aether", "skill-sessions", projectId, "skills")
       if (await Filesystem.isDir(skillSessionsDir)) {
+        state.sources.push({ dir: skillSessionsDir, pattern: SKILL_PATTERN, scope: "project" })
         await scan(state, skillSessionsDir, SKILL_PATTERN, { dot: true, scope: "project" })
       }
 
@@ -270,6 +281,7 @@ export namespace Skill {
         projectDirs.push(root)
       }
       for (const root of projectDirs.toReversed()) {
+        state.sources.push({ dir: root, pattern: EXTERNAL_SKILL_PATTERN, scope: "project" })
         await scan(state, root, EXTERNAL_SKILL_PATTERN, { dot: true, scope: "project" })
       }
     }
@@ -280,6 +292,7 @@ export namespace Skill {
     const globalExternalDirs = new Set(EXTERNAL_DIRS.map((dir) => path.join(Global.Path.home, dir)))
     for (const dir of await Config.directories()) {
       if (globalExternalDirs.has(dir)) continue
+      state.sources.push({ dir, pattern: OPENCODE_SKILL_PATTERN, scope: "config-root" })
       await scan(state, dir, OPENCODE_SKILL_PATTERN)
     }
 
@@ -292,12 +305,14 @@ export namespace Skill {
         continue
       }
 
+      state.sources.push({ dir, pattern: SKILL_PATTERN, scope: "paths" })
       await scan(state, dir, SKILL_PATTERN)
     }
 
     for (const url of cfg.skills?.urls ?? []) {
       for (const dir of await Effect.runPromise(discovery.pull(url))) {
         state.dirs.add(dir)
+        state.sources.push({ dir, pattern: SKILL_PATTERN, scope: "urls" })
         await scan(state, dir, SKILL_PATTERN)
       }
     }
@@ -327,7 +342,7 @@ export namespace Skill {
       const state = yield* InstanceState.make(
         Effect.fn("Skill.state")((ctx) =>
           Effect.gen(function* () {
-            const s: State = { skills: {}, dirs: new Set() }
+            const s: State = { skills: {}, dirs: new Set(), sources: [] }
             yield* Effect.promise(() => loadSkills(s, discovery, ctx.directory, ctx.worktree, String(ctx.project.id)))
             return s
           }),
@@ -359,6 +374,11 @@ export namespace Skill {
         return Array.from(s.dirs)
       })
 
+      const sources = Effect.fn("Skill.sources")(function* () {
+        const s = yield* getState()
+        return s.sources
+      })
+
       const available = Effect.fn("Skill.available")(function* (agent?: Agent.Info) {
         const s = yield* getState()
         const list = Object.values(s.skills).toSorted((a, b) => a.name.localeCompare(b.name))
@@ -366,7 +386,7 @@ export namespace Skill {
         return list.filter((skill) => Permission.evaluate("skill", skill.name, agent.permission).action !== "deny")
       })
 
-      return Service.of({ get, all, dirs, available })
+      return Service.of({ get, all, dirs, sources, available })
     }),
   )
 
@@ -404,6 +424,10 @@ export namespace Skill {
 
   export async function dirs() {
     return runPromise((skill) => skill.dirs())
+  }
+
+  export async function sources() {
+    return runPromise((skill) => skill.sources())
   }
 
   export async function available(agent?: Agent.Info) {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -285,4 +285,51 @@ describe("session.agent-resolution", () => {
       },
     })
   }, 30000)
+
+  test("skill-scan-paths command returns scan paths without model lookup", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        agent: {
+          build: {
+            model: "missing-provider/missing-model",
+          },
+        },
+      },
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, ".aether", "skills", "demo", "SKILL.md"),
+          `---
+name: demo
+description: Demo skill.
+---
+
+# Demo
+`,
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const result = await SessionPrompt.command({
+          sessionID: session.id,
+          command: "skill-scan-paths",
+          arguments: "",
+          agent: "build",
+          model: "missing-provider/missing-model",
+        })
+        const text = result.parts
+          .filter((part): part is MessageV2.TextPart => part.type === "text")
+          .map((part) => part.text)
+          .join("\n")
+
+        expect(result.info.role).toBe("assistant")
+        expect(text).toContain("Skill scan paths (low -> high priority)")
+        expect(text).toContain(path.join(tmp.path, ".aether", "{skill,skills}", "**", "SKILL.md"))
+      },
+    })
+  }, 30000)
 })

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -390,3 +390,41 @@ description: A skill in the .opencode/skills directory.
     },
   })
 })
+
+test("returns live skill scan sources in priority order", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    config: {
+      skills: {
+        paths: ["team-skills"],
+      },
+    },
+    init: async (dir) => {
+      await Promise.all(
+        [".agents", ".claude", ".opencode", ".aether", "team-skills"].map((name) =>
+          fs.mkdir(path.join(dir, name), { recursive: true }),
+        ),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const srcs = await Skill.sources()
+      const local = srcs
+        .filter((item) => item.dir.startsWith(tmp.path))
+        .map((item) => `${path.relative(tmp.path, item.dir)}:${item.pattern}`)
+
+      expect(local).toEqual([
+        ".agents:skills/**/SKILL.md",
+        ".claude:skills/**/SKILL.md",
+        ".opencode:skills/**/SKILL.md",
+        ".aether:skills/**/SKILL.md",
+        ".aether:{skill,skills}/**/SKILL.md",
+        ".opencode:{skill,skills}/**/SKILL.md",
+        `team-skills:**/SKILL.md`,
+      ])
+    },
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #781

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

1. Adds a built-in `/skill-scan-paths` slash command that prints the current session's live skill scan paths from low to high priority, without model inference. The sources list is recorded inside `loadSkills()` via `state.sources.push(...)` alongside each `scan()` call, so it is guaranteed to stay in sync with actual skill loading behavior — no separate path-construction logic that could drift.

2. Documents `Instance.directory` and `Instance.worktree` with precise definitions, resolution rules, and examples (normal git repo, git worktree, no-git). Clarifies the semantic difference between `Instance.worktree` (sandbox = `.git` location) and `Project.Info.worktree` (root = main repo root for Project ID), and their consequences for scan boundaries vs DB sharing. Documents Project ID computation (`Hash.fast(norm(root))`) and per-project DB naming, with a table showing which directories share or don't share a DB.

### How did you verify your code works?

- `bun test test/skill/skill.test.ts` — 12 pass
- `bun test test/session/prompt.test.ts` — 8 pass
- `bun test src/skill/skill-priority.test.ts` — 7 pass
- `bun test src/skill/skill-mtime-cache.test.ts` — 6 pass
- `bun test test/config/` — 132 pass
- No typecheck errors in changed files

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR