### PR TITLE
fix: 修复拖入文件后中文输入法第一个字母被吞掉的问题

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1027,6 +1027,14 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
     handleInput()
     closePopover()
+
+    requestAnimationFrame(() => {
+      if (composing()) return
+      editorRef.focus()
+      const cursor = prompt.cursor() ?? promptLength(prompt.current())
+      setCursorPosition(editorRef, cursor)
+    })
+
     return true
   }
 


### PR DESCRIPTION
## 修复问题

关闭 #778

## 问题描述

当用户将文件拖入输入框（prompt input）后，紧接着使用中文输入法输入时，第一个字母会被吞掉，导致输入结果异常。

**复现步骤：**
1. 打开 Aether 的对话页面
2. 将一个文件拖入输入框
3. 文件成功附加后，立即使用中文输入法输入文字（如 `wo` 想打"我"）
4. 实际输出 `w哦` 而非"我"

## 根因分析

`addPart()` 函数在插入文件 pill 时使用了直接 DOM 操作（`deleteContents`、`insertNode`、`setStartAfter` 等），这些操作会破坏浏览器 contenteditable 的 IME 组合上下文。当用户紧接着开始输入中文时，浏览器无法正确触发 `compositionstart` 事件，导致第一个按键被当作普通 `input` 事件处理。

## 修复方案

在 `addPart()` 完成 DOM 操作后，通过 `requestAnimationFrame` 在下一帧重新 `focus()` 编辑器并恢复光标位置，让浏览器有足够时间重建 IME 组合上下文。同时通过 `composing()` 信号检查，避免干扰正在进行的 IME 输入。

## 修改内容

**文件：** `packages/app/src/components/prompt-input.tsx`

- 在 `addPart()` 函数末尾添加 `requestAnimationFrame` 块
- 重新聚焦编辑器并恢复光标位置
- 添加 `composing()` 检查以保护正在进行的 IME 组合

```diff
     handleInput()
     closePopover()
+
+    requestAnimationFrame(() => {
+      if (composing()) return
+      editorRef.focus()
+      const cursor = prompt.cursor() ?? promptLength(prompt.current())
+      setCursorPosition(editorRef, cursor)
+    })
+
     return true
```

## 测试建议

- [ ] 拖入文件后立即输入中文（如 `wo` 应该输出"我"）
- [ ] 拖入文件后立即输入英文（应正常工作）
- [ ] 不拖入文件直接输入中文（应不受影响）
- [ ] 快速连续拖入多个文件后输入（应正常工作）