### PR TITLE
fix: 修复拖入文件后中文输入法第一个字母被吞掉的问题

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1027,6 +1027,14 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
     handleInput()
     closePopover()
+
+    requestAnimationFrame(() => {
+      if (composing()) return
+      editorRef.focus()
+      const cursor = prompt.cursor() ?? promptLength(prompt.current())
+      setCursorPosition(editorRef, cursor)
+    })
+
     return true
   }
 


### PR DESCRIPTION
### Issue for this PR

Closes #778

### Type of change

- [x] Bug fix

### What does this PR do?

拖入文件到输入框后，紧接着使用中文输入法输入时，第一个字母会被吞掉（如输入 `wo` 想打"我"，实际输出 `w哦`）。

根因：`addPart()` 中的直接 DOM 操作（`deleteContents`、`insertNode` 等）破坏了浏览器 contenteditable 的 IME 组合上下文。

修复：在 `addPart()` 末尾通过 `requestAnimationFrame` 在下一帧重新 `focus()` 编辑器并恢复光标位置，让浏览器重建 IME 组合上下文。通过 `composing()` 信号检查避免干扰正在进行的 IME 输入。

修改文件：`packages/app/src/components/prompt-input.tsx`（+8 行）

### How did you verify your code works?

已通过 TypeScript 类型检查（`bun typecheck`）。

### Screenshots / recordings

无 UI 变更。

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR