### PR TITLE
fix: read serve-port from aether data directory instead of opencode

### DIFF
--- a/packages/app/vite.js
+++ b/packages/app/vite.js
@@ -13,7 +13,7 @@ function readServePort() {
     join(homedir(), "Library", "Application Support"),
   ].filter((x) => typeof x === "string" && x.length > 0)
   for (const dir of dirs) {
-    const file = join(dir, "opencode", "serve-port")
+    const file = join(dir, "aether", "serve-port")
     try {
       const port = readFileSync(file, "utf-8").trim()
       if (port) return port
@@ -41,11 +41,11 @@ function readBasePath() {
   if (/^[A-Za-z]:[\\/]/.test(raw)) {
     const recovered = stripGitBashPrefix(raw)
     if (recovered) {
-      console.warn(`[opencode] detected Git Bash path translation, corrected: "${raw}" → "${recovered}"`)
+      console.warn(`[aether] detected Git Bash path translation, corrected: "${raw}" → "${recovered}"`)
       return recovered
     }
     console.error(
-      `[opencode] VITE_BASE_PATH "${raw}" is a Windows path, likely from Git Bash translation. Run from cmd.exe or set MSYS_NO_PATHCONV=1, or pass base path without leading slash: --basepath my/base/path`,
+      `[aether] VITE_BASE_PATH "${raw}" is a Windows path, likely from Git Bash translation. Run from cmd.exe or set MSYS_NO_PATHCONV=1, or pass base path without leading slash: --basepath my/base/path`,
     )
     return "/"
   }
@@ -64,14 +64,14 @@ const theme = fileURLToPath(new URL("./public/oc-theme-preload.js", import.meta.
  */
 export default [
   {
-    name: "opencode-desktop:config",
+    name: "aether-desktop:config",
     config() {
       const port = readServePort()
       const basePath = readBasePath()
       const routerBase = readRouterBase(basePath)
       const env = port ? { VITE_OPENCODE_SERVER_PORT: port } : {}
-      if (port) console.log(`[opencode] auto-detected backend port: ${port}`)
-      if (routerBase !== "/") console.log(`[opencode] base path: ${routerBase}`)
+      if (port) console.log(`[aether] auto-detected backend port: ${port}`)
+      if (routerBase !== "/") console.log(`[aether] base path: ${routerBase}`)
       env.VITE_BASE_PATH = routerBase
       return {
         ...(basePath ? { base: basePath } : {}),
@@ -89,7 +89,7 @@ export default [
     },
   },
   {
-    name: "opencode-desktop:theme-preload",
+    name: "aether-desktop:theme-preload",
     enforce: "pre",
     transformIndexHtml(html) {
       return html.replace(


### PR DESCRIPTION
### Issue for this PR

Closes #786

### Type of change

- [x] Bug fix

### What does this PR do?

修复前端 Vite 插件 `packages/app/vite.js` 中 `readServePort()` 硬编码 `"opencode"` 数据目录名的问题。将路径从 `~/.local/share/opencode/serve-port` 改为 `~/.local/share/aether/serve-port`，使前端能正确读取后端写入的端口文件。

完整因果链：后端写端口到 `Global.Path.data/serve-port` = `~/.local/share/aether/serve-port`，前端 Vite 插件之前从 `~/.local/share/opencode/serve-port` 读取旧端口，导致连接到不存在的后端进程。

附带更新 Vite 插件 log prefix（`[opencode]` → `[aether]`）和 plugin name（`opencode-desktop:*` → `aether-desktop:*`），保持命名一致性。

### How did you verify your code works?

- `bun typecheck` 在 `packages/app` 通过
- 全项目搜索确认无其他运行时代码错误引用 `~/.local/share/opencode` 数据目录（其余 `"opencode"` 引用均为合法用途：legacy 迁移、CLI binary name、HTTP Auth 默认用户名、npm 包名、provider 服务标识）

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR