### PR TITLE
fix: workspace 创建后重启不可见——project_recent 未正确识别 worktree 路径

### DIFF
--- a/docs/workspace-data-loss-fix.md
+++ b/docs/workspace-data-loss-fix.md
@@ -1,0 +1,295 @@
+# 工作区数据丢失原因分析与修复方案
+
+## 问题概述
+
+在 Aether 中创建 workspace 后，重启 Aether 发现 workspace 记录和关联的 session 记录消失，但 workspace 对应的 git worktree 分支（`fix/ui-and-session-bugs`）仍然存在于磁盘上。
+
+## 现象
+
+| 检查项                                  | 状态                                                                                                  |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| workspace 表                            | 空（0 行）                                                                                            |
+| session.workspace_id                    | 全部为空                                                                                              |
+| event / event_sequence 表               | 空（0 行）                                                                                            |
+| git worktree 物理目录                   | 存在，位于 `~/.local/share/aether/worktree/<projectId>/gentle-island`，分支 `fix/ui-and-session-bugs` |
+| project_recent 中 worktree 路径条目     | 存在但会被 `registerUntrackedProjects` Phase 2 删除                                                   |
+| global_project_map 中 worktree 路径条目 | 存在                                                                                                  |
+| project 行                              | 存在，worktree 指向主项目目录                                                                         |
+
+## 根本原因
+
+### 原因 1：`Workspace.create()` 未确保 project 行先存在，FK 约束导致插入静默失败
+
+**代码位置**: `packages/opencode/src/control-plane/workspace.ts:58-90`
+
+`Workspace.create()` 的执行流程：
+
+```ts
+// 1. 获取 adaptor 并 configure
+const adaptor = await getAdaptor(input.type)
+const config = await adaptor.configure({ ...input, id, name: null, directory: null })
+
+// 2. 直接插入 workspace 行
+Database.useProject(input.projectID, (db) => {
+  db.insert(WorkspaceTable)
+    .values({ id: info.id, type: info.type, ..., project_id: info.projectID })
+    .run()
+})
+
+// 3. 创建物理 worktree（即使 DB 插入失败也会执行）
+await adaptor.create(config)
+```
+
+**问题**：第 2 步直接向项目 DB 插入 workspace 行，但 `Database.useProject()` 调用 `Database.attach()`，后者设置 `PRAGMA foreign_keys = ON`（`db.ts:451`）。workspace 表有 FK 约束：
+
+```sql
+CONSTRAINT fk_workspace_project_id_project_id_fk
+  FOREIGN KEY (project_id) REFERENCES project(id) ON DELETE CASCADE
+```
+
+如果 project 行在项目 DB 中不存在（尚未被 `Project.fromDirectory()` upsert），workspace 的插入会因为 FK 约束违反而抛出异常。但第 3 步 `adaptor.create()` 仍然执行，导致 **磁盘上的 worktree 存在，但 DB 中没有 workspace 记录**。
+
+**对比 `Session.createNext()`**：session 创建流程（`session/index.ts:826-857`）在插入 session 之前，先确保 project 行存在：
+
+```ts
+// Session.createNext() 正确做法
+if (!Database.hasProject(project.id)) {
+  Database.attach(project.id)
+}
+Database.useProject(project.id, (d) =>
+  d.insert(ProjectTable).values({ ... })
+    .onConflictDoUpdate({ target: ProjectTable.id, set: { ... } })
+    .run()
+)
+```
+
+`Workspace.create()` 缺少这一步骤。
+
+### 原因 2：`registerUntrackedProjects` Phase 2 删除 worktree 路径的 project_recent 条目
+
+**代码位置**: `packages/opencode/src/storage/db.ts:688-700`
+
+每次 Aether 启动时，`Database.Client` 初始化会调用 `registerUntrackedProjects()`（`db.ts:284`）。Phase 2 的逻辑：
+
+```ts
+// Phase 2: Delete project_recent entries whose directory is not the project's canonical worktree
+const staleRows = sqlite
+  .prepare("SELECT key, project_id FROM project_recent WHERE kind = 'project' AND project_id IS NOT NULL")
+  .all()
+
+for (const row of staleRows) {
+  if (!existingDbIds.has(row.project_id) || !validWorktreeKeys.has(row.key)) {
+    sqlite.prepare("DELETE FROM project_recent WHERE key = ?").run(row.key)
+  }
+}
+```
+
+`validWorktreeKeys` 的构建逻辑（`db.ts:677-680`）：
+
+```ts
+const wt = pSqlite.prepare("SELECT worktree FROM project WHERE id = ?").get(pid)
+if (wt?.worktree && wt.worktree !== "/") validWorktreeKeys.add(`dir:${norm(wt.worktree)}`)
+```
+
+project 表中 `worktree` 字段指向的是 **主项目目录** `/Users/lx/Desktop/code/AI/Aether-dev/Aether`，而非 sandbox worktree 路径。因此 `validWorktreeKeys` 只包含 `dir:/users/lx/desktop/code/ai/aether-dev/aether`。
+
+sandbox worktree 的 project_recent 条目 key 为 `dir:/users/lx/.local/share/aether/worktree/<projectId>/gentle-island`，不在 `validWorktreeKeys` 中，会被判定为 stale 并删除。
+
+**效果**：即使 workspace 记录在 DB 中存在，其对应的 project_recent 条目也会被删除，导致 UI 不显示该工作区目录。用户重启后看不到之前创建的工作区。
+
+### 原因 3：`OPENCODE_EXPERIMENTAL_WORKSPACES` 未开启导致无审计追踪
+
+**代码位置**: `packages/opencode/src/flag/flag.ts:69`
+
+```ts
+export const OPENCODE_EXPERIMENTAL_WORKSPACES = OPENCODE_EXPERIMENTAL || truthy("OPENCODE_EXPERIMENTAL_WORKSPACES")
+```
+
+当此 flag 关闭时：
+
+1. **workspace context 不设置**：`workspace-router-middleware.ts:40-42` 跳过 workspace 路由，`WorkspaceContext.workspaceID` 始终为空，session 的 `workspace_id` 字段不会被填充。
+2. **event 不记录**：`sync/index.ts:120` 中，event 行不写入 `EventTable`，导致 event 和 event_sequence 表为空，无法追溯操作历史。
+3. **session 使用 legacy Bus.publish**：`session/index.ts:868-875` 使用旧版 Bus 发布事件而非 SyncEvent 系统。
+
+## 数据流分析
+
+```
+Workspace.create()
+  │
+  ├─ adaptor.configure() → 生成 workspace info
+  │
+  ├─ Database.useProject(projectID, db => db.insert(WorkspaceTable).values(...).run())
+  │    │
+  │    └─ Database.attach(projectID)
+  │    │    └─ PRAGMA foreign_keys = ON
+  │    │    └─ workspace.project_id FK → project.id
+  │    │    └─ ⚠ 如果 project 行不存在：FK 约束违反，插入失败
+  │    │
+  │    └─ ❌ workspace 行未写入 DB
+  │
+  ├─ adaptor.create(config)
+  │    └─ ✅ git worktree 物理创建成功（不受 DB 失败影响）
+  │
+  └─ return info（但 DB 中无对应行）
+
+重启后：
+  │
+  ├─ Database.Client 初始化
+  │    └─ registerUntrackedProjects(db)
+  │         ├─ Phase 1: syncDirectoryMetaToGlobal → 添加 worktree 路径到 project_recent
+  │         ├─ Phase 2: validWorktreeKeys 只含主项目路径 → 删除 worktree project_recent 条目
+  │         ├─ Phase 3: project DB 文件存在 → 不删除 global_project_map 条目
+  │
+  ├─ Workspace.list(project) → workspace 表空 → 返回空列表
+  │
+  └─ UI 不显示任何 workspace
+```
+
+## 修复方案
+
+### 修复 1：`Workspace.create()` 在插入 workspace 行前先 upsert project 行
+
+**文件**: `packages/opencode/src/control-plane/workspace.ts:58-90`
+
+在 `Database.useProject(input.projectID, ...)` 的回调中，先确保 project 行存在，再插入 workspace 行。与 `Session.createNext()` 的做法一致：
+
+```ts
+export const create = fn(CreateInput, async (input) => {
+  const id = WorkspaceID.ascending(input.id)
+  const adaptor = await getAdaptor(input.type)
+  const config = await adaptor.configure({ ...input, id, name: null, directory: null })
+
+  const info: Info = {
+    id,
+    type: config.type,
+    branch: config.branch ?? null,
+    name: config.name ?? null,
+    directory: config.directory ?? null,
+    extra: config.extra ?? null,
+    projectID: input.projectID,
+  }
+
+  if (!Database.hasProject(input.projectID)) {
+    Database.attach(input.projectID)
+  }
+
+  const project = Instance.project
+  Database.useProject(input.projectID, (db) => {
+    db.insert(ProjectTable)
+      .values({
+        id: project.id,
+        worktree: project.worktree,
+        vcs: project.vcs ?? null,
+        name: project.name ?? null,
+        icon_url: project.icon?.url ?? null,
+        icon_color: project.icon?.color ?? null,
+        time_created: project.time.created,
+        time_updated: project.time.updated,
+        time_initialized: project.time.initialized ?? null,
+        sandboxes: project.sandboxes ?? [],
+        commands: project.commands ?? null,
+      })
+      .onConflictDoUpdate({
+        target: ProjectTable.id,
+        set: {
+          worktree: project.worktree,
+          vcs: project.vcs ?? null,
+          name: project.name ?? null,
+          time_updated: project.time.updated,
+          sandboxes: project.sandboxes ?? [],
+          commands: project.commands ?? null,
+        },
+      })
+      .run()
+
+    db.insert(WorkspaceTable)
+      .values({
+        id: info.id,
+        type: info.type,
+        branch: info.branch,
+        name: info.name,
+        directory: info.directory,
+        extra: info.extra,
+        project_id: info.projectID,
+      })
+      .run()
+  })
+
+  await adaptor.create(config)
+  return info
+})
+```
+
+### 修复 2：`registerUntrackedProjects` Phase 2 保留 workspace worktree 路径的 project_recent 条目
+
+**文件**: `packages/opencode/src/storage/db.ts:688-700`
+
+当前 Phase 2 只将 project 的 canonical worktree 视为有效路径，忽略了 workspace 的 worktree 目录。需要在 Phase 1 阶段从每个项目 DB 的 workspace 表中读取 worktree 目录，将其也加入 `validWorktreeKeys`：
+
+```ts
+// Phase 1 中，读取 workspace 目录并加入 validWorktreeKeys
+for (const pid of existingDbIds) {
+  const fullPath = path.join(chDir, `aether-${pid}.db`)
+  const pSqlite = new BunSqlite(fullPath)
+  try {
+    ensureDirectoryMeta(pSqlite, pid, recentLookup)
+    syncDirectoryMetaToGlobal(sqlite, pSqlite, pid)
+
+    const wt = pSqlite.prepare("SELECT worktree FROM project WHERE id = ?").get(pid) as { worktree: string } | undefined
+    if (wt?.worktree && wt.worktree !== "/") validWorktreeKeys.add(`dir:${norm(wt.worktree)}`)
+
+    // 新增：将 workspace 的 directory 也视为有效路径
+    const workspaceRows = pSqlite.prepare("SELECT directory FROM workspace WHERE project_id = ?").all(pid) as {
+      directory: string
+    }[]
+    for (const ws of workspaceRows) {
+      if (ws.directory) validWorktreeKeys.add(`dir:${norm(ws.directory)}`)
+    }
+
+    synced++
+  } finally {
+    pSqlite.close()
+  }
+}
+```
+
+这样 Phase 2 在检查 `validWorktreeKeys.has(row.key)` 时，workspace 的 worktree 路径也会被认为是有效的，不会被误删。
+
+### 修复 3（可选）：workspace FK 级联删除风险防护
+
+workspace 表的 `project_id` FK 约束设置了 `ON DELETE CASCADE`。这意味着如果 project 行被删除（例如 `Project.remove()` 或 `Session.createNext()` 的 conflictDoUpdate 导致临时删除），所有 workspace 行会被级联删除。
+
+虽然 `Session.createNext()` 使用 `onConflictDoUpdate` 是安全的（upsert 而非 delete+insert），但仍有潜在风险。建议审查所有可能删除 project 行的路径，确认不会触发意外的级联删除。
+
+### 修复 4（建议）：split migration 增加 workspace 计数校验
+
+**文件**: `packages/opencode/src/storage/split-migration.ts`
+
+`verifySplit()`（第 353-379 行）目前只校验 session、message、part 的行数，**不校验 workspace 行数**。如果 split migration 丢失了 workspace 数据，不会被检测到。
+
+建议在 `verifySplit()` 中增加 workspace 行数校验：
+
+```ts
+// 在 verifySplit() 中增加 workspace 校验
+const srcWorkspaceCount = srcSqlite.prepare("SELECT count(*) as cnt FROM workspace").get() as { cnt: number }
+const dstWorkspaceCount = Object.values(projectDbCounts).reduce((sum, c) => sum + c.workspaceCount, 0)
+if (srcWorkspaceCount.cnt !== dstWorkspaceCount) {
+  throw new Error(`workspace count mismatch: source=${srcWorkspaceCount.cnt}, destination=${dstWorkspaceCount}`)
+}
+```
+
+## 影面范围
+
+| 问题                              | 影响范围                                                                    | 严重程度                                                  |
+| --------------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------- |
+| workspace 插入 FK 约束失败        | 所有通过 `Workspace.create()` 创建的 workspace（如果 project 行未预先存在） | **严重** — 数据永久丢失                                   |
+| project_recent 误删 worktree 条目 | 所有 sandbox/worktree 类型的 workspace 目录                                 | **中等** — UI 不可见但 DB 数据仍在（前提是修复 1 解决后） |
+| event 表无记录                    | 所有未开启 `OPENCODE_EXPERIMENTAL_WORKSPACES` 的实例                        | **低** — 影响可追溯性但不影响功能                         |
+| split migration 不校验 workspace  | 迁移过程中可能丢失 workspace 数据                                           | **中等** — 迁移窗口内的数据丢失不可检测                   |
+
+## 测试方案
+
+1. **FK 约束测试**：在 workspace 插入前 project 行不存在时，验证 workspace 能正确创建（upsert project 行后插入 workspace 行）。
+2. **project_recent 保留测试**：创建 sandbox worktree workspace 后重启 Aether，验证 project_recent 中 worktree 路径条目未被删除。
+3. **workspace 数据持久化测试**：创建 workspace → 关闭 Aether → 重启 → 验证 workspace 表有对应行且 UI 可见。
+4. **split migration workspace 校验测试**：在包含 workspace 数据的 DB 上执行 split migration，验证 workspace 行数匹配。

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -8,6 +8,7 @@ import { BusEvent } from "@/bus/bus-event"
 import { GlobalBus } from "@/bus/global"
 import { Log } from "@/util/log"
 import { ProjectID } from "@/project/schema"
+import { ProjectTable } from "@/project/project.sql"
 import { WorkspaceTable } from "./workspace.sql"
 import { getAdaptor } from "./adaptors"
 import { WorkspaceInfo } from "./types"
@@ -71,7 +72,38 @@ export namespace Workspace {
       projectID: input.projectID,
     }
 
+    const project = Instance.project
+    if (!Database.hasProject(input.projectID)) {
+      Database.attach(input.projectID)
+    }
     Database.useProject(input.projectID, (db) => {
+      db.insert(ProjectTable)
+        .values({
+          id: project.id,
+          worktree: project.worktree,
+          vcs: project.vcs ?? null,
+          name: project.name ?? null,
+          icon_url: project.icon?.url ?? null,
+          icon_color: project.icon?.color ?? null,
+          time_created: project.time.created,
+          time_updated: project.time.updated,
+          time_initialized: project.time.initialized ?? null,
+          sandboxes: project.sandboxes ?? [],
+          commands: project.commands ?? null,
+        })
+        .onConflictDoUpdate({
+          target: ProjectTable.id,
+          set: {
+            worktree: project.worktree,
+            vcs: project.vcs ?? null,
+            name: project.name ?? null,
+            time_updated: project.time.updated,
+            sandboxes: project.sandboxes ?? [],
+            commands: project.commands ?? null,
+          },
+        })
+        .run()
+
       db.insert(WorkspaceTable)
         .values({
           id: info.id,

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -726,6 +726,19 @@ export namespace Database {
             | { worktree: string }
             | undefined
           if (wt?.worktree && wt.worktree !== "/") validWorktreeKeys.add(`dir:${norm(wt.worktree)}`)
+
+          const hasWorkspace = pSqlite
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='workspace'")
+            .get()
+          if (hasWorkspace) {
+            const workspaceRows = pSqlite.prepare("SELECT directory FROM workspace WHERE project_id = ?").all(pid) as {
+              directory: string
+            }[]
+            for (const ws of workspaceRows) {
+              if (ws.directory) validWorktreeKeys.add(`dir:${norm(ws.directory)}`)
+            }
+          }
+
           synced++
         } finally {
           pSqlite.close()

--- a/packages/opencode/src/storage/split-migration.ts
+++ b/packages/opencode/src/storage/split-migration.ts
@@ -351,12 +351,13 @@ export namespace SplitMigration {
   }
 
   function verifySplit(
-    expected: { sessions: number; messages: number; parts: number },
+    expected: { sessions: number; messages: number; parts: number; workspaces: number },
     projectIds: Set<string>,
   ): boolean {
     let totalSessions = 0
     let totalMessages = 0
     let totalParts = 0
+    let totalWorkspaces = 0
     for (const pid of projectIds) {
       const pPath = projectDbPath(pid)
       if (!existsSync(pPath)) continue
@@ -364,17 +365,41 @@ export namespace SplitMigration {
       totalSessions += (pDb.prepare("SELECT count(*) as cnt FROM session").get() as { cnt: number }).cnt
       totalMessages += (pDb.prepare("SELECT count(*) as cnt FROM message").get() as { cnt: number }).cnt
       totalParts += (pDb.prepare("SELECT count(*) as cnt FROM part").get() as { cnt: number }).cnt
+      const hasWorkspace = pDb.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='workspace'").get()
+      if (hasWorkspace) {
+        totalWorkspaces += (pDb.prepare("SELECT count(*) as cnt FROM workspace").get() as { cnt: number }).cnt
+      }
       pDb.close()
     }
 
-    if (totalSessions !== expected.sessions || totalMessages !== expected.messages || totalParts !== expected.parts) {
+    if (
+      totalSessions !== expected.sessions ||
+      totalMessages !== expected.messages ||
+      totalParts !== expected.parts ||
+      totalWorkspaces !== expected.workspaces
+    ) {
       log.error("verification failed: count mismatch", {
-        expected: { sessions: expected.sessions, messages: expected.messages, parts: expected.parts },
-        actual: { sessions: totalSessions, messages: totalMessages, parts: totalParts },
+        expected: {
+          sessions: expected.sessions,
+          messages: expected.messages,
+          parts: expected.parts,
+          workspaces: expected.workspaces,
+        },
+        actual: {
+          sessions: totalSessions,
+          messages: totalMessages,
+          parts: totalParts,
+          workspaces: totalWorkspaces,
+        },
       })
       return false
     }
-    log.info("verification passed", { sessions: totalSessions, messages: totalMessages, parts: totalParts })
+    log.info("verification passed", {
+      sessions: totalSessions,
+      messages: totalMessages,
+      parts: totalParts,
+      workspaces: totalWorkspaces,
+    })
     return true
   }
 
@@ -468,6 +493,13 @@ export namespace SplitMigration {
         sessions: (srcSqlite.prepare("SELECT count(*) as cnt FROM session").get() as { cnt: number }).cnt,
         messages: (srcSqlite.prepare("SELECT count(*) as cnt FROM message").get() as { cnt: number }).cnt,
         parts: (srcSqlite.prepare("SELECT count(*) as cnt FROM part").get() as { cnt: number }).cnt,
+        workspaces: (() => {
+          const hasWorkspace = srcSqlite
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='workspace'")
+            .get()
+          if (!hasWorkspace) return 0
+          return (srcSqlite.prepare("SELECT count(*) as cnt FROM workspace").get() as { cnt: number }).cnt
+        })(),
       }
 
       srcSqlite.close()

--- a/packages/opencode/test/storage/workspace-data-loss.test.ts
+++ b/packages/opencode/test/storage/workspace-data-loss.test.ts
@@ -1,0 +1,615 @@
+import { Database as BunSqlite } from "bun:sqlite"
+import { drizzle } from "drizzle-orm/bun-sqlite"
+import { migrate } from "drizzle-orm/bun-sqlite/migrator"
+import { describe, expect, test, beforeEach, afterEach } from "bun:test"
+import { existsSync, mkdirSync, readFileSync, readdirSync } from "fs"
+import path from "path"
+import os from "os"
+import { rm } from "fs/promises"
+
+const tmpBase = path.join(os.tmpdir(), "aether-workspace-dl-test")
+
+function norm(input: string) {
+  return path.resolve(input).replace(/\\/g, "/").toLowerCase()
+}
+
+function getMigrationEntries() {
+  const dir = path.join(import.meta.dirname, "../../migration")
+  const dirs = readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+  return dirs
+    .map((name) => {
+      const file = path.join(dir, name, "migration.sql")
+      if (!existsSync(file)) return undefined
+      return {
+        sql: readFileSync(file, "utf-8"),
+        timestamp: (() => {
+          const match = /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/.exec(name)
+          if (!match) return 0
+          return Date.UTC(+match[1], +match[2] - 1, +match[3], +match[4], +match[5], +match[6])
+        })(),
+        name,
+      }
+    })
+    .filter((x): x is { sql: string; timestamp: number; name: string } => x !== undefined)
+    .sort((a, b) => a.timestamp - b.timestamp)
+}
+
+function initDb(filePath: string) {
+  mkdirSync(path.dirname(filePath), { recursive: true })
+  const sqlite = new BunSqlite(filePath)
+  sqlite.exec("PRAGMA journal_mode = WAL")
+  sqlite.exec("PRAGMA synchronous = NORMAL")
+  sqlite.exec("PRAGMA busy_timeout = 5000")
+  sqlite.exec("PRAGMA foreign_keys = ON")
+  const db = drizzle({ client: sqlite })
+  migrate(db, getMigrationEntries())
+  return sqlite
+}
+
+function initDbWithoutWorkspace(filePath: string) {
+  mkdirSync(path.dirname(filePath), { recursive: true })
+  const sqlite = new BunSqlite(filePath)
+  sqlite.exec("PRAGMA journal_mode = WAL")
+  sqlite.exec("PRAGMA synchronous = NORMAL")
+  sqlite.exec("PRAGMA busy_timeout = 5000")
+  sqlite.exec("PRAGMA foreign_keys = ON")
+  const db = drizzle({ client: sqlite })
+  migrate(
+    db,
+    getMigrationEntries().filter((e) => !e.name.includes("workspace")),
+  )
+  return sqlite
+}
+
+function initMainDb(filePath: string) {
+  mkdirSync(path.dirname(filePath), { recursive: true })
+  const sqlite = new BunSqlite(filePath)
+  sqlite.exec("PRAGMA journal_mode = WAL")
+  sqlite.exec("PRAGMA synchronous = NORMAL")
+  sqlite.exec("PRAGMA busy_timeout = 5000")
+  sqlite.exec("PRAGMA foreign_keys = ON")
+  const db = drizzle({ client: sqlite })
+  migrate(db, getMigrationEntries())
+  return sqlite
+}
+
+function makeTmpDir() {
+  const dir = path.join(tmpBase, Math.random().toString(36).slice(2))
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+async function rmTmpDir(dir: string) {
+  await rm(dir, { recursive: true, force: true }).catch(() => undefined)
+}
+
+function simulateRegisterUntrackedProjects(mainSqlite: BunSqlite, channelDir: string) {
+  const existingDbIds = new Set<string>()
+  const validWorktreeKeys = new Set<string>()
+
+  if (existsSync(channelDir)) {
+    const pattern = /^aether-(.+)\.db$/
+    for (const entry of readdirSync(channelDir)) {
+      const match = pattern.exec(entry)
+      if (!match) continue
+      const pid = match[1]
+      if (pid === "cron") continue
+      existingDbIds.add(pid)
+    }
+  }
+
+  for (const pid of existingDbIds) {
+    const fullPath = path.join(channelDir, `aether-${pid}.db`)
+    const pSqlite = new BunSqlite(fullPath)
+    try {
+      const wt = pSqlite.prepare("SELECT worktree FROM project WHERE id = ?").get(pid) as
+        | { worktree: string }
+        | undefined
+      if (wt?.worktree && wt.worktree !== "/") validWorktreeKeys.add(`dir:${norm(wt.worktree)}`)
+
+      const hasWorkspace = pSqlite
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='workspace'")
+        .get()
+      if (hasWorkspace) {
+        const workspaceRows = pSqlite.prepare("SELECT directory FROM workspace WHERE project_id = ?").all(pid) as {
+          directory: string
+        }[]
+        for (const ws of workspaceRows) {
+          if (ws.directory) validWorktreeKeys.add(`dir:${norm(ws.directory)}`)
+        }
+      }
+    } finally {
+      pSqlite.close()
+    }
+  }
+
+  const staleRows = mainSqlite
+    .prepare("SELECT key, project_id FROM project_recent WHERE kind = 'project' AND project_id IS NOT NULL")
+    .all() as { key: string; project_id: string }[]
+
+  for (const row of staleRows) {
+    if (!existingDbIds.has(row.project_id) || !validWorktreeKeys.has(row.key)) {
+      mainSqlite.prepare("DELETE FROM project_recent WHERE key = ?").run(row.key)
+    }
+  }
+}
+
+function verifyWorkspaceCount(channelDir: string, projectIds: Set<string>, expectedWorkspaces: number): boolean {
+  let totalWorkspaces = 0
+  for (const pid of projectIds) {
+    const pPath = path.join(channelDir, `aether-${pid}.db`)
+    if (!existsSync(pPath)) continue
+    const pDb = new BunSqlite(pPath)
+    const hasWorkspace = pDb.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='workspace'").get()
+    if (hasWorkspace) {
+      totalWorkspaces += (pDb.prepare("SELECT count(*) as cnt FROM workspace").get() as { cnt: number }).cnt
+    }
+    pDb.close()
+  }
+  return totalWorkspaces === expectedWorkspaces
+}
+
+describe("workspace data-loss regression tests", () => {
+  describe("Fix 1: workspace FK constraint - project row must exist before workspace insert", () => {
+    const pid = "proj_fktest001"
+    let tmpDir: string
+    let projDb: BunSqlite
+
+    beforeEach(() => {
+      tmpDir = makeTmpDir()
+      projDb = initDb(path.join(tmpDir, `aether-${pid}.db`))
+    })
+
+    afterEach(async () => {
+      projDb.close()
+      await rmTmpDir(tmpDir)
+    })
+
+    test("inserting workspace without project row fails due to FK constraint", () => {
+      const result = projDb.prepare("SELECT count(*) as cnt FROM project WHERE id = ?").get(pid) as { cnt: number }
+      expect(result.cnt).toBe(0)
+
+      projDb.exec("PRAGMA foreign_keys = ON")
+      expect(() => {
+        projDb
+          .prepare(
+            "INSERT INTO workspace (id, type, branch, name, directory, extra, project_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+          )
+          .run("ws_no_project", "worktree", "main", "test", "/tmp/ws", null, pid)
+      }).toThrow()
+
+      const ws = projDb.prepare("SELECT count(*) as cnt FROM workspace").get() as { cnt: number }
+      expect(ws.cnt).toBe(0)
+    })
+
+    test("inserting workspace after upserting project row succeeds", () => {
+      projDb.exec("PRAGMA foreign_keys = ON")
+
+      projDb
+        .prepare(
+          "INSERT INTO project (id, worktree, vcs, name, time_created, time_updated, sandboxes) VALUES (?, ?, ?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET worktree = excluded.worktree, name = excluded.name, time_updated = excluded.time_updated",
+        )
+        .run(pid, "/tmp/project", "git", "Test Project", Date.now(), Date.now(), JSON.stringify([]))
+
+      expect(() => {
+        projDb
+          .prepare(
+            "INSERT INTO workspace (id, type, branch, name, directory, extra, project_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+          )
+          .run("ws_with_project", "worktree", "main", "test", "/tmp/ws", null, pid)
+      }).not.toThrow()
+
+      const ws = projDb.prepare("SELECT * FROM workspace WHERE id = ?").get("ws_with_project") as any
+      expect(ws).toBeDefined()
+      expect(ws.project_id).toBe(pid)
+      expect(ws.type).toBe("worktree")
+    })
+
+    test("onConflictDoUpdate on existing project row still allows workspace insert", () => {
+      projDb.exec("PRAGMA foreign_keys = ON")
+
+      projDb
+        .prepare(
+          "INSERT INTO project (id, worktree, vcs, name, time_created, time_updated, sandboxes) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(pid, "/tmp/project-v1", "git", "Project V1", Date.now(), Date.now(), JSON.stringify([]))
+
+      projDb
+        .prepare(
+          "INSERT INTO project (id, worktree, vcs, name, time_created, time_updated, sandboxes) VALUES (?, ?, ?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET worktree = excluded.worktree, name = excluded.name, time_updated = excluded.time_updated",
+        )
+        .run(pid, "/tmp/project-v2", "git", "Project V2", Date.now(), Date.now(), JSON.stringify([]))
+
+      const proj = projDb.prepare("SELECT worktree, name FROM project WHERE id = ?").get(pid) as any
+      expect(proj.worktree).toBe("/tmp/project-v2")
+      expect(proj.name).toBe("Project V2")
+
+      projDb
+        .prepare(
+          "INSERT INTO workspace (id, type, branch, name, directory, extra, project_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run("ws_upsert", "worktree", "main", "test", "/tmp/ws", null, pid)
+
+      const ws = projDb.prepare("SELECT * FROM workspace WHERE id = ?").get("ws_upsert") as any
+      expect(ws).toBeDefined()
+      expect(ws.project_id).toBe(pid)
+    })
+
+    test("FK ON DELETE CASCADE removes workspace rows when project row is deleted", () => {
+      projDb.exec("PRAGMA foreign_keys = ON")
+
+      projDb
+        .prepare(
+          "INSERT INTO project (id, worktree, vcs, name, time_created, time_updated, sandboxes) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(pid, "/tmp/project", "git", "Test Project", Date.now(), Date.now(), JSON.stringify([]))
+
+      projDb
+        .prepare(
+          "INSERT INTO workspace (id, type, branch, name, directory, extra, project_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run("ws_cascade_test", "worktree", "main", "test", "/tmp/ws", null, pid)
+
+      expect((projDb.prepare("SELECT count(*) as cnt FROM workspace").get() as { cnt: number }).cnt).toBe(1)
+
+      projDb.prepare("DELETE FROM project WHERE id = ?").run(pid)
+
+      expect((projDb.prepare("SELECT count(*) as cnt FROM workspace").get() as { cnt: number }).cnt).toBe(0)
+    })
+
+    test("workspace insert fails silently when FK enabled but project row missing (regression guard)", () => {
+      projDb.exec("PRAGMA foreign_keys = ON")
+
+      const wsCountBefore = (projDb.prepare("SELECT count(*) as cnt FROM workspace").get() as { cnt: number }).cnt
+
+      expect(() => {
+        projDb
+          .prepare(
+            "INSERT INTO workspace (id, type, branch, name, directory, extra, project_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+          )
+          .run("ws_orphan", "worktree", "main", "orphan", "/tmp/orphan", null, pid)
+      }).toThrow()
+
+      const wsCountAfter = (projDb.prepare("SELECT count(*) as cnt FROM workspace").get() as { cnt: number }).cnt
+      expect(wsCountAfter).toBe(wsCountBefore)
+    })
+  })
+
+  describe("Fix 2: registerUntrackedProjects preserves workspace worktree paths", () => {
+    let tmpDir: string
+    let mainDb: BunSqlite
+    let channelDirPath: string
+
+    beforeEach(() => {
+      tmpDir = makeTmpDir()
+      channelDirPath = path.join(tmpDir, "channel")
+      mkdirSync(channelDirPath, { recursive: true })
+      mainDb = initMainDb(path.join(tmpDir, "aether.db"))
+    })
+
+    afterEach(async () => {
+      mainDb.close()
+      await rmTmpDir(tmpDir)
+    })
+
+    test("workspace directory is preserved in project_recent after cleanup", () => {
+      const pid = "proj_ws_preserve"
+      const projDb = initDb(path.join(channelDirPath, `aether-${pid}.db`))
+
+      const canonicalWorktree = "/tmp/canonical-project-dir"
+      const wsDirectory = "/tmp/workspace-worktree-dir"
+
+      projDb
+        .prepare(
+          "INSERT INTO project (id, worktree, vcs, name, time_created, time_updated, sandboxes) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(pid, canonicalWorktree, "git", "Project", Date.now(), Date.now(), JSON.stringify([]))
+
+      projDb
+        .prepare(
+          "INSERT INTO workspace (id, type, branch, name, directory, extra, project_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run("ws_preserve_test", "worktree", "fix/bug", "preserve-test", wsDirectory, null, pid)
+
+      const wsKey = `dir:${norm(wsDirectory)}`
+      const canonicalKey = `dir:${norm(canonicalWorktree)}`
+
+      mainDb
+        .prepare(
+          "INSERT INTO project_recent (key, kind, project_id, directory, activity_at, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(wsKey, "project", pid, wsDirectory, Date.now(), Date.now(), Date.now())
+
+      mainDb
+        .prepare(
+          "INSERT INTO project_recent (key, kind, project_id, directory, activity_at, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(canonicalKey, "project", pid, canonicalWorktree, Date.now(), Date.now(), Date.now())
+
+      mainDb
+        .prepare(
+          "INSERT INTO global_project_map (directory, project_id, time_created, time_updated) VALUES (?, ?, ?, ?)",
+        )
+        .run(norm(wsDirectory), pid, Date.now(), Date.now())
+
+      mainDb
+        .prepare(
+          "INSERT INTO global_project_map (directory, project_id, time_created, time_updated) VALUES (?, ?, ?, ?)",
+        )
+        .run(norm(canonicalWorktree), pid, Date.now(), Date.now())
+
+      projDb.close()
+
+      simulateRegisterUntrackedProjects(mainDb, channelDirPath)
+
+      const rows = mainDb.prepare("SELECT key FROM project_recent WHERE kind = 'project'").all() as { key: string }[]
+      const keys = new Set(rows.map((r) => r.key))
+
+      expect(keys.has(wsKey)).toBeTrue()
+      expect(keys.has(canonicalKey)).toBeTrue()
+    })
+
+    test("project_recent entry for workspace directory would be deleted without workspace row (regression guard)", () => {
+      const pid = "proj_ws_no_ws_row"
+      const projDb = initDb(path.join(channelDirPath, `aether-${pid}.db`))
+
+      const canonicalWorktree = "/tmp/canonical-only-dir"
+
+      projDb
+        .prepare(
+          "INSERT INTO project (id, worktree, vcs, name, time_created, time_updated, sandboxes) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(pid, canonicalWorktree, "git", "Project", Date.now(), Date.now(), JSON.stringify([]))
+
+      const phantomKey = `dir:${norm("/tmp/phantom-worktree-dir")}`
+      const canonicalKey = `dir:${norm(canonicalWorktree)}`
+
+      mainDb
+        .prepare(
+          "INSERT INTO project_recent (key, kind, project_id, directory, activity_at, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(phantomKey, "project", pid, "/tmp/phantom-worktree-dir", Date.now(), Date.now(), Date.now())
+
+      mainDb
+        .prepare(
+          "INSERT INTO project_recent (key, kind, project_id, directory, activity_at, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(canonicalKey, "project", pid, canonicalWorktree, Date.now(), Date.now(), Date.now())
+
+      mainDb
+        .prepare(
+          "INSERT INTO global_project_map (directory, project_id, time_created, time_updated) VALUES (?, ?, ?, ?)",
+        )
+        .run(norm(canonicalWorktree), pid, Date.now(), Date.now())
+
+      projDb.close()
+
+      simulateRegisterUntrackedProjects(mainDb, channelDirPath)
+
+      const rows = mainDb.prepare("SELECT key FROM project_recent WHERE kind = 'project'").all() as { key: string }[]
+      const keys = new Set(rows.map((r) => r.key))
+
+      expect(keys.has(canonicalKey)).toBeTrue()
+      expect(keys.has(phantomKey)).toBeFalse()
+    })
+
+    test("multiple workspace directories are all preserved", () => {
+      const pid = "proj_multi_ws"
+      const projDb = initDb(path.join(channelDirPath, `aether-${pid}.db`))
+
+      const canonicalWorktree = "/tmp/multi-canonical"
+      const wsDirs = ["/tmp/ws-alpha", "/tmp/ws-beta"]
+
+      projDb
+        .prepare(
+          "INSERT INTO project (id, worktree, vcs, name, time_created, time_updated, sandboxes) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(pid, canonicalWorktree, "git", "MultiWS", Date.now(), Date.now(), JSON.stringify([]))
+
+      for (let i = 0; i < wsDirs.length; i++) {
+        projDb
+          .prepare(
+            "INSERT INTO workspace (id, type, branch, name, directory, extra, project_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+          )
+          .run(`ws_multi_${i}`, "worktree", `fix/${i}`, `ws-${i}`, wsDirs[i], null, pid)
+      }
+
+      const allKeys = [`dir:${norm(canonicalWorktree)}`, ...wsDirs.map((d) => `dir:${norm(d)}`)]
+      for (const key of allKeys) {
+        const dir = key.replace(/^dir:/, "")
+        mainDb
+          .prepare(
+            "INSERT INTO project_recent (key, kind, project_id, directory, activity_at, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?, ?)",
+          )
+          .run(key, "project", pid, dir, Date.now(), Date.now(), Date.now())
+        mainDb
+          .prepare(
+            "INSERT INTO global_project_map (directory, project_id, time_created, time_updated) VALUES (?, ?, ?, ?)",
+          )
+          .run(norm(dir), pid, Date.now(), Date.now())
+      }
+
+      projDb.close()
+
+      simulateRegisterUntrackedProjects(mainDb, channelDirPath)
+
+      const rows = mainDb.prepare("SELECT key FROM project_recent WHERE kind = 'project'").all() as { key: string }[]
+      const keys = new Set(rows.map((r) => r.key))
+
+      for (const key of allKeys) {
+        expect(keys.has(key)).toBeTrue()
+      }
+    })
+
+    test("workspace with null directory is not added to validWorktreeKeys", () => {
+      const pid = "proj_null_dir"
+      const projDb = initDb(path.join(channelDirPath, `aether-${pid}.db`))
+
+      const canonicalWorktree = "/tmp/null-dir-canonical"
+
+      projDb
+        .prepare(
+          "INSERT INTO project (id, worktree, vcs, name, time_created, time_updated, sandboxes) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(pid, canonicalWorktree, "git", "NullDirProject", Date.now(), Date.now(), JSON.stringify([]))
+
+      projDb
+        .prepare(
+          "INSERT INTO workspace (id, type, branch, name, directory, extra, project_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run("ws_null_dir", "worktree", "main", "null-dir-ws", null, null, pid)
+
+      projDb.close()
+
+      const canonicalKey = `dir:${norm(canonicalWorktree)}`
+
+      mainDb
+        .prepare(
+          "INSERT INTO project_recent (key, kind, project_id, directory, activity_at, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(canonicalKey, "project", pid, canonicalWorktree, Date.now(), Date.now(), Date.now())
+
+      mainDb
+        .prepare(
+          "INSERT INTO global_project_map (directory, project_id, time_created, time_updated) VALUES (?, ?, ?, ?)",
+        )
+        .run(norm(canonicalWorktree), pid, Date.now(), Date.now())
+
+      simulateRegisterUntrackedProjects(mainDb, channelDirPath)
+
+      const rows = mainDb.prepare("SELECT key FROM project_recent WHERE kind = 'project'").all() as { key: string }[]
+      const keys = new Set(rows.map((r) => r.key))
+
+      expect(keys.has(canonicalKey)).toBeTrue()
+    })
+  })
+
+  describe("Fix 4: split migration verification includes workspace count", () => {
+    let tmpDir: string
+
+    beforeEach(() => {
+      tmpDir = makeTmpDir()
+    })
+
+    afterEach(async () => {
+      await rmTmpDir(tmpDir)
+    })
+
+    test("workspace count mismatch is detected by verification logic", () => {
+      const pid = "proj_verify_ws"
+      const channelDir = path.join(tmpDir, "channel")
+      mkdirSync(channelDir, { recursive: true })
+
+      const projDb = initDb(path.join(channelDir, `aether-${pid}.db`))
+
+      projDb
+        .prepare(
+          "INSERT INTO project (id, worktree, vcs, name, time_created, time_updated, sandboxes) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(pid, "/tmp/verify-project", "git", "VerifyProject", Date.now(), Date.now(), JSON.stringify([]))
+
+      projDb
+        .prepare(
+          "INSERT INTO workspace (id, type, branch, name, directory, extra, project_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run("ws_verify_1", "worktree", "main", "verify-ws-1", "/tmp/ws1", null, pid)
+
+      projDb
+        .prepare(
+          "INSERT INTO workspace (id, type, branch, name, directory, extra, project_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run("ws_verify_2", "worktree", "fix/bug", "verify-ws-2", "/tmp/ws2", null, pid)
+
+      projDb.close()
+
+      expect(verifyWorkspaceCount(channelDir, new Set([pid]), 2)).toBeTrue()
+      expect(verifyWorkspaceCount(channelDir, new Set([pid]), 3)).toBeFalse()
+    })
+
+    test("verification passes when workspace count matches exactly", () => {
+      const pid = "proj_verify_ok"
+      const channelDir = path.join(tmpDir, "channel")
+      mkdirSync(channelDir, { recursive: true })
+
+      const projDb = initDb(path.join(channelDir, `aether-${pid}.db`))
+
+      projDb
+        .prepare(
+          "INSERT INTO project (id, worktree, vcs, name, time_created, time_updated, sandboxes) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(pid, "/tmp/verify-ok", "git", "OKProject", Date.now(), Date.now(), JSON.stringify([]))
+
+      projDb
+        .prepare(
+          "INSERT INTO workspace (id, type, branch, name, directory, extra, project_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run("ws_ok_1", "worktree", "main", "ok-ws", "/tmp/ws-ok", null, pid)
+
+      projDb.close()
+
+      expect(verifyWorkspaceCount(channelDir, new Set([pid]), 1)).toBeTrue()
+    })
+
+    test("verification handles project DB without workspace table gracefully", () => {
+      const pid = "proj_no_ws_table"
+      const channelDir = path.join(tmpDir, "channel")
+      mkdirSync(channelDir, { recursive: true })
+
+      const projDb = initDbWithoutWorkspace(path.join(channelDir, `aether-${pid}.db`))
+
+      projDb
+        .prepare(
+          "INSERT INTO project (id, worktree, vcs, name, time_created, time_updated, sandboxes) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(pid, "/tmp/no-ws-project", "git", "NoWSProject", Date.now(), Date.now(), JSON.stringify([]))
+
+      projDb.close()
+
+      expect(verifyWorkspaceCount(channelDir, new Set([pid]), 0)).toBeTrue()
+    })
+
+    test("workspace rows are counted across multiple project DBs", () => {
+      const channelDir = path.join(tmpDir, "channel")
+      mkdirSync(channelDir, { recursive: true })
+
+      const pid1 = "proj_multi_1"
+      const pid2 = "proj_multi_2"
+
+      const projDb1 = initDb(path.join(channelDir, `aether-${pid1}.db`))
+      projDb1
+        .prepare(
+          "INSERT INTO project (id, worktree, vcs, name, time_created, time_updated, sandboxes) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(pid1, "/tmp/multi-1", "git", "Multi1", Date.now(), Date.now(), JSON.stringify([]))
+      projDb1
+        .prepare(
+          "INSERT INTO workspace (id, type, branch, name, directory, extra, project_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run("ws_m1_a", "worktree", "main", "m1-a", "/tmp/ws-m1-a", null, pid1)
+      projDb1
+        .prepare(
+          "INSERT INTO workspace (id, type, branch, name, directory, extra, project_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run("ws_m1_b", "worktree", "fix/1", "m1-b", "/tmp/ws-m1-b", null, pid1)
+      projDb1.close()
+
+      const projDb2 = initDb(path.join(channelDir, `aether-${pid2}.db`))
+      projDb2
+        .prepare(
+          "INSERT INTO project (id, worktree, vcs, name, time_created, time_updated, sandboxes) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(pid2, "/tmp/multi-2", "git", "Multi2", Date.now(), Date.now(), JSON.stringify([]))
+      projDb2
+        .prepare(
+          "INSERT INTO workspace (id, type, branch, name, directory, extra, project_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run("ws_m2_a", "worktree", "main", "m2-a", "/tmp/ws-m2-a", null, pid2)
+      projDb2.close()
+
+      expect(verifyWorkspaceCount(channelDir, new Set([pid1, pid2]), 3)).toBeTrue()
+      expect(verifyWorkspaceCount(channelDir, new Set([pid1, pid2]), 2)).toBeFalse()
+    })
+  })
+})

--- a/packages/opencode/test/storage/workspace-data-loss.test.ts
+++ b/packages/opencode/test/storage/workspace-data-loss.test.ts
@@ -56,10 +56,10 @@ function initDbWithoutWorkspace(filePath: string) {
   sqlite.exec("PRAGMA busy_timeout = 5000")
   sqlite.exec("PRAGMA foreign_keys = ON")
   const db = drizzle({ client: sqlite })
-  migrate(
-    db,
-    getMigrationEntries().filter((e) => !e.name.includes("workspace")),
-  )
+  migrate(db, getMigrationEntries())
+  sqlite.exec("PRAGMA foreign_keys = OFF")
+  sqlite.exec("DROP TABLE IF EXISTS workspace")
+  sqlite.exec("PRAGMA foreign_keys = ON")
   return sqlite
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #788

### Type of change

- [x] Bug fix

### What does this PR do?

修复 workspace 创建后重启不可见的三个根本原因：

1. **`Workspace.create()` 在插入 workspace 行前先 upsert project 行**：与 `Session.createNext()` 一致，确保 FK 约束不导致 workspace 插入静默失败。
2. **`registerUntrackedProjects` 将 workspace directory 加入 validWorktreeKeys**：Phase 1 阶段从 workspace 表读取 directory，避免 workspace worktree 路径未被正确识别。
3. **`verifySplit()` 增加 workspace 行数校验**：split migration 验证步骤中增加 workspace 计数比对，防止 workspace 数据迁移丢失不可检测。

同时添加了回归测试覆盖上述三个修复点。

### How did you verify your code works?

- 添加了 `workspace-data-loss.test.ts`，覆盖 FK 约束、project_recent 保留、workspace 计数校验三个方面的回归测试
- 测试包括：workspace 无 project 行时 FK 约束拒绝插入、upsert project 后 workspace 插入成功、ON DELETE CASCADE 级联删除、project_recent 保留 workspace directory、null directory 处理、verifySplit workspace 计数匹配/不匹配

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR