### PR TITLE
feat: add Run script button to sidebar workspace row

### DIFF
--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -549,6 +549,15 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         resize(height: number) {
           setStore("terminal", "height", height)
         },
+        open() {
+          const current = store.terminal
+          if (!current) {
+            setStore("terminal", { height: DEFAULT_TERMINAL_HEIGHT, opened: true })
+            return
+          }
+          if (current.opened) return
+          setStore("terminal", "opened", true)
+        },
       },
       review: {
         diffStyle: createMemo(() => store.review?.diffStyle ?? "split"),

--- a/packages/app/src/context/terminal.tsx
+++ b/packages/app/src/context/terminal.tsx
@@ -1,11 +1,27 @@
 import { createStore, produce } from "solid-js/store"
 import { createSimpleContext } from "@opencode-ai/ui/context"
-import { batch, createEffect, createMemo, createRoot, on, onCleanup } from "solid-js"
+import { batch, createEffect, createMemo, createRoot, createSignal, on, onCleanup } from "solid-js"
 import { useParams } from "@solidjs/router"
 import { useSDK } from "./sdk"
 import type { Platform } from "./platform"
 import { defaultTitle, titleNumber } from "./terminal-title"
 import { Persist, persisted, removePersisted } from "@/utils/persist"
+
+type PendingRun = {
+  command: string
+  args: string[]
+  title: string
+}
+
+const pendingRuns = new Map<string, PendingRun>()
+const [pendingTrigger, setPendingTrigger] = createSignal(0)
+
+export { pendingTrigger, pendingRuns }
+
+export function enqueueRun(slug: string, command: string, args: string[], title: string) {
+  pendingRuns.set(slug, { command, args, title })
+  setPendingTrigger((n) => n + 1)
+}
 
 export type LocalPTY = {
   id: string
@@ -239,10 +255,13 @@ function createWorkspaceTerminalSession(sdk: ReturnType<typeof useSDK>, dir: str
     })
   }
 
+  const [running, setRunning] = createSignal(false)
+
   return {
     ready,
     all: createMemo(() => store.all),
     active: createMemo(() => store.active),
+    running,
     clear() {
       batch(() => {
         setStore("active", undefined)
@@ -250,6 +269,7 @@ function createWorkspaceTerminalSession(sdk: ReturnType<typeof useSDK>, dir: str
       })
     },
     new() {
+      if (running()) return
       const nextNumber = pickNextTerminalNumber()
 
       sdk.client.pty
@@ -285,24 +305,29 @@ function createWorkspaceTerminalSession(sdk: ReturnType<typeof useSDK>, dir: str
       })
     },
     async run(command: string, args: string[], title: string) {
-      const result = await sdk.client.pty
-        .create({ command, args, title })
-        .catch((error: unknown) => {
-          console.error("Failed to run command in terminal", error)
-          return undefined
+      setRunning(true)
+      try {
+        const result = await sdk.client.pty
+          .create({ command, args, title })
+          .catch((error: unknown) => {
+            console.error("Failed to run command in terminal", error)
+            return undefined
+          })
+        const data = result?.data
+        const id = data?.id
+        if (!id || !data) return undefined
+        batch(() => {
+          setStore("all", store.all.length, {
+            id,
+            title: data.title ?? title,
+            titleNumber: 0,
+          })
+          setStore("active", id)
         })
-      const data = result?.data
-      const id = data?.id
-      if (!id || !data) return undefined
-      batch(() => {
-        setStore("all", store.all.length, {
-          id,
-          title: data.title ?? title,
-          titleNumber: 0,
-        })
-        setStore("active", id)
-      })
-      return id
+        return id
+      } finally {
+        setRunning(false)
+      }
     },
     async clone(id: string) {
       await clone(sdk.client, id)
@@ -437,10 +462,21 @@ export const { use: useTerminal, provider: TerminalProvider } = createSimpleCont
       ),
     )
 
+    createEffect(() => {
+      pendingTrigger()
+      const dir = params.dir
+      if (!dir) return
+      const pending = pendingRuns.get(dir)
+      if (!pending) return
+      pendingRuns.delete(dir)
+      workspace().run(pending.command, pending.args, pending.title)
+    })
+
     return {
       ready: () => workspace().ready(),
       all: () => workspace().all(),
       active: () => workspace().active(),
+      running: () => workspace().running(),
       new: () => workspace().new(),
       run: (command: string, args: string[], title: string) => workspace().run(command, args, title),
       update: (pty: Partial<LocalPTY> & { id: string }) => workspace().update(pty),

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -1401,6 +1401,8 @@ export const dict = {
   "workspace.reset.archived.many": "{{count}} sessions will be archived.",
   "workspace.reset.note": "This will reset the workspace to match the default branch.",
   "workspace.switchBranch": "Switch Branch",
+  "workspace.run": "Run",
+  "workspace.runScript": "Run: {{name}}",
 
   "knowledge.title": "Knowledge Base",
 

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -1270,6 +1270,8 @@ export const dict = {
   "workspace.reset.archived.many": "将归档 {{count}} 个会话。",
   "workspace.reset.note": "这将把工作区重置为与默认分支一致。",
   "workspace.switchBranch": "切换分支",
+  "workspace.run": "运行",
+  "workspace.runScript": "运行：{{name}}",
   "common.open": "打开",
   "dialog.releaseNotes.action.getStarted": "开始",
   "dialog.releaseNotes.action.next": "下一步",

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -746,7 +746,7 @@ export const NewSessionItem = (props: {
     <A
       href={`/${props.slug}/session`}
       end
-      class={`flex items-center gap-1 min-w-0 w-full text-left focus:outline-none ${props.dense ? "py-0.5" : "py-1"}`}
+      class={`flex items-center gap-1 min-w-0 text-left focus:outline-none ${props.dense ? "py-0.5" : "py-1"}`}
       onClick={() => {
         props.setHoverSession(undefined)
         if (layout.sidebar.opened()) return
@@ -761,7 +761,7 @@ export const NewSessionItem = (props: {
   )
 
   return (
-    <div class="group/session relative w-full min-w-0 rounded-md cursor-default transition-colors pl-2 pr-3 hover:bg-surface-raised-base-hover [&:has(:focus-visible)]:bg-surface-raised-base-hover has-[.active]:bg-surface-base-active">
+    <div class="group/session relative shrink-0 min-w-0 rounded-md cursor-default transition-colors pl-2 pr-3 hover:bg-surface-raised-base-hover [&:has(:focus-visible)]:bg-surface-raised-base-hover has-[.active]:bg-surface-base-active">
       <Show
         when={!tooltip()}
         fallback={

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -1,5 +1,5 @@
-import { useParams } from "@solidjs/router"
-import { createEffect, createMemo, createSignal, For, on, Show, type Accessor, type JSX, untrack } from "solid-js"
+import { useNavigate, useParams } from "@solidjs/router"
+import { createEffect, createMemo, createSignal, For, on, onMount, Show, type Accessor, type JSX, untrack } from "solid-js"
 import { createStore } from "solid-js/store"
 import { createSortable } from "@thisbeyond/solid-dnd"
 import { createMediaQuery } from "@solid-primitives/media"
@@ -7,6 +7,7 @@ import { base64Encode } from "@opencode-ai/util/encode"
 import { getFilename } from "@opencode-ai/util/path"
 import { Button } from "@opencode-ai/ui/button"
 import { Collapsible } from "@opencode-ai/ui/collapsible"
+import { ContextMenu } from "@opencode-ai/ui/context-menu"
 import { Dialog } from "@opencode-ai/ui/dialog"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { DropdownMenu } from "@opencode-ai/ui/dropdown-menu"
@@ -16,12 +17,13 @@ import { Spinner } from "@opencode-ai/ui/spinner"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { showToast } from "@opencode-ai/ui/toast"
 import { type Session } from "@opencode-ai/sdk/v2/client"
-import { type LocalProject } from "@/context/layout"
+import { type LocalProject, useLayout } from "@/context/layout"
 import { useGlobalSync } from "@/context/global-sync"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { loadDescendantsForRoots } from "@/context/global-sync/session-load"
 import { useLanguage } from "@/context/language"
 import { useSettings } from "@/context/settings"
+import { enqueueRun } from "@/context/terminal"
 import { NewSessionItem, SessionItem, SessionSkeleton } from "./sidebar-items"
 import { childMapByParent, errorMessage, sortedRootSessions, workspaceKey } from "./helpers"
 import { SidebarBranchView } from "@/pages/session/branch/sidebar-branch-view"
@@ -181,6 +183,107 @@ export const WorkspaceDragOverlay = (props: {
         </div>
       )}
     </Show>
+  )
+}
+
+const RunScriptButton = (props: {
+  directory: string
+  slug: Accessor<string>
+  sessions: Accessor<Session[]>
+  createSession: (directory: string) => Promise<void>
+}) => {
+  const globalSdk = useGlobalSDK()
+  const language = useLanguage()
+  const layout = useLayout()
+  const navigate = useNavigate()
+  const params = useParams()
+  const [scripts, setScripts] = createSignal<string[]>([])
+  const [selected, setSelected] = createSignal<string | undefined>(undefined)
+
+  const fetchScripts = async () => {
+    const client = globalSdk.createClient({ directory: props.directory })
+    try {
+      const result = await client.file.list({ path: ".aether/.bin" })
+      const names = (result.data ?? [])
+        .filter((n) => n.type === "file")
+        .map((n) => n.name)
+        .sort()
+      setScripts(names)
+      const stored = localStorage.getItem(`aether:run-script:${props.directory}`)
+      if (stored && names.includes(stored)) {
+        setSelected(stored)
+      } else if (names.length > 0) {
+        setSelected(names[0])
+      } else {
+        setSelected(undefined)
+      }
+    } catch {
+      setScripts([])
+      setSelected(undefined)
+    }
+  }
+
+  onMount(fetchScripts)
+
+  createEffect(() => {
+    const name = selected()
+    if (name) localStorage.setItem(`aether:run-script:${props.directory}`, name)
+  })
+
+  const run = async () => {
+    const name = selected()
+    if (!name) return
+    const scriptPath = `.aether/.bin/${name}`
+    const slug = props.slug()
+    enqueueRun(slug, "bash", ["-c", `${scriptPath}; exec bash --noediting`], scriptPath)
+    if (params.dir !== slug || !params.id) {
+      const s = props.sessions()
+      if (s.length > 0) {
+        navigate(`/${slug}/session/${s[0].id}`)
+      } else {
+        await props.createSession(props.directory)
+      }
+    }
+    layout.terminal.open()
+  }
+
+  const disabled = createMemo(() => scripts().length === 0)
+  const label = createMemo(() => {
+    const name = selected()
+    return name ? language.t("workspace.runScript", { name }) : language.t("workspace.run")
+  })
+
+  return (
+    <ContextMenu onOpenChange={(open) => open && fetchScripts()}>
+      <ContextMenu.Trigger as="div" class="shrink-0">
+        <Button
+          variant="ghost"
+          size="small"
+          icon="terminal"
+          disabled={disabled()}
+          onClick={run}
+          class="h-6 px-1.5 text-12-regular text-text-weak gap-0.5"
+        >
+          {label()}
+        </Button>
+      </ContextMenu.Trigger>
+      <Show when={scripts().length > 0}>
+        <ContextMenu.Portal>
+          <ContextMenu.Content>
+            <ContextMenu.RadioGroup value={selected()} onChange={setSelected}>
+              <For each={scripts()}>
+                {(name) => (
+                  <ContextMenu.RadioItem value={name}>
+                    <ContextMenu.ItemIndicator>✓</ContextMenu.ItemIndicator>
+                    <ContextMenu.ItemLabel>{name}</ContextMenu.ItemLabel>
+                  </ContextMenu.RadioItem>
+                )}
+              </For>
+            </ContextMenu.RadioGroup>
+          </ContextMenu.Content>
+        </ContextMenu.Portal>
+      </Show>
+    </ContextMenu>
   )
 }
 
@@ -760,6 +863,8 @@ const WorkspaceSessionList = (props: {
   onBatchArchive: () => Promise<void>
   onBatchDelete: () => void
   onCancelSelect: () => void
+  directory: string
+  createSession: (directory: string) => Promise<void>
 }) => {
   const selectedCount = createMemo(() => props.selectedIds().size)
   const allSelected = createMemo(
@@ -812,13 +917,22 @@ const WorkspaceSessionList = (props: {
       </Show>
       <nav class="flex flex-col gap-1">
         <Show when={props.showNew() && !props.selectMode()}>
-          <NewSessionItem
-            slug={props.slug()}
-            mobile={props.mobile}
-            sidebarExpanded={props.ctx.sidebarExpanded}
-            clearHoverProjectSoon={props.ctx.clearHoverProjectSoon}
-            setHoverSession={props.ctx.setHoverSession}
-          />
+          <div class="flex items-center gap-1 pl-2 pr-3">
+            <NewSessionItem
+              slug={props.slug()}
+              mobile={props.mobile}
+              sidebarExpanded={props.ctx.sidebarExpanded}
+              clearHoverProjectSoon={props.ctx.clearHoverProjectSoon}
+              setHoverSession={props.ctx.setHoverSession}
+            />
+            <div class="flex-1" />
+            <RunScriptButton
+              directory={props.directory}
+              slug={props.slug}
+              sessions={props.rootSessions}
+              createSession={props.createSession}
+            />
+          </div>
         </Show>
         <Show when={props.loading()}>
           <SessionSkeleton />
@@ -1057,6 +1171,8 @@ export const SortableWorkspace = (props: {
             onBatchArchive={batchArchive}
             onBatchDelete={batchDelete}
             onCancelSelect={cancelSelect}
+            directory={props.directory}
+            createSession={props.ctx.createSession}
           />
           <ArchivedSessionList
             directory={props.directory}
@@ -1129,6 +1245,8 @@ export const LocalWorkspace = (props: {
         onBatchArchive={batchArchive}
         onBatchDelete={batchDelete}
         onCancelSelect={cancelSelect}
+        directory={props.project.worktree}
+        createSession={props.ctx.createSession}
       />
       <ArchivedSessionList
         directory={props.project.worktree}

--- a/packages/app/src/pages/session/terminal-panel.tsx
+++ b/packages/app/src/pages/session/terminal-panel.tsx
@@ -13,7 +13,7 @@ import { Terminal } from "@/components/terminal"
 import { useCommand } from "@/context/command"
 import { useLanguage } from "@/context/language"
 import { useLayout } from "@/context/layout"
-import { useTerminal } from "@/context/terminal"
+import { useTerminal, pendingTrigger, pendingRuns } from "@/context/terminal"
 import { terminalTabLabel } from "@/pages/session/terminal-label"
 import { createSizing, focusTerminalById } from "@/pages/session/helpers"
 import { getTerminalHandoff, setTerminalHandoff } from "@/pages/session/handoff"
@@ -64,7 +64,8 @@ export function TerminalPanel() {
       return
     }
 
-    if (!terminal.ready() || terminal.all().length !== 0 || store.autoCreated) return
+    pendingTrigger()
+    if (!terminal.ready() || terminal.all().length !== 0 || store.autoCreated || terminal.running() || pendingRuns.has(params.dir!)) return
     terminal.new()
     setStore("autoCreated", true)
   })


### PR DESCRIPTION
### Issue for this PR

Closes #794

### Type of change

- [x] New feature

### What does this PR do?

Adds a "Run: \<script\>" button to each workspace's session list row in the sidebar, allowing users to execute scripts from `.aether/.bin/` via terminal without leaving the sidebar.

Key changes:
- **RunScriptButton component**: left-click runs the selected script, right-click opens context menu to switch scripts (with ✓ indicator). Script selection persists via localStorage.
- **Pending queue mechanism** (`enqueueRun`): bridges the sidebar (outside TerminalProvider scope) to the workspace terminal session, deferring PTY creation until the correct workspace is active.
- **Race condition prevention**: `running` signal + `pendingTrigger`/`pendingRuns` guard in the auto-create effect, plus `running()` check in `new()`, prevent duplicate `bash -l` terminals from being created when `run()` is in progress.
- **Fix double login shell prompt**: uses `bash -c` (not `bash -lc`) because the backend auto-appends `-l` when command ends with "sh", avoiding a double login shell that prints `logout` on exit.
- **`layout.terminal.open()`**: programmatic method to open the terminal panel.
- **i18n**: keys for `workspace.run` / `workspace.runScript` (en + zh).

### How did you verify your code works?

- `bun typecheck` passes in both `packages/app` and the full repo (pre-push hook)
- Manual testing: clicking Run creates a single terminal tab with correct script output, no duplicate terminals, no `logout` from stray login shells, right-click context menu works for script switching

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR