### PR TITLE
refactor: rename memory.db to aether-memory.db for consistent naming

### DIFF
--- a/packages/opencode/src/memory/index.ts
+++ b/packages/opencode/src/memory/index.ts
@@ -147,7 +147,7 @@ function currentChannelDir() {
 }
 
 function dbPath(channelID = paths().channelID) {
-  return path.join(paths().channelRootDir, channelID, "memory.db")
+  return path.join(paths().channelRootDir, channelID, "aether-memory.db")
 }
 
 function mdPath() {

--- a/packages/opencode/src/memory/markdown.ts
+++ b/packages/opencode/src/memory/markdown.ts
@@ -172,7 +172,7 @@ export function renderMemoryDocument(input: MemoryDocument): string {
     "<!--",
     `schema_version: ${input.schema_version || 1}`,
     `updated_at: ${now}`,
-    "source: memory.db",
+    "source: aether-memory.db",
     "search_target: true",
     "-->",
     "",

--- a/packages/opencode/src/tool/memory.ts
+++ b/packages/opencode/src/tool/memory.ts
@@ -23,7 +23,7 @@ function renderResults(results: Awaited<ReturnType<typeof Memory.search>>["resul
 export const MemorySearchTool = Tool.define("memory_search", {
   description: [
     "Search Aether long-term memory. Use this when a memory shortcut suggests relevant user preferences, facts, or tasks.",
-    "Search only reads AETHER_MEMORY.md and does not read raw session files or memory.db events.",
+    "Search only reads AETHER_MEMORY.md and does not read raw session files or aether-memory.db events.",
   ].join("\n"),
   parameters: z.object({
     query: z.string().min(1),


### PR DESCRIPTION
### Issue for this PR

Closes #799

### Type of change

- [x] Refactor / code improvement

### What does this PR do?

Rename `memory.db` to `aether-memory.db` to align with the project's `aether-*.db` naming convention.

### How did you verify your code works?

- Confirmed via grep that all 3 occurrences of `memory.db` are updated
- `dbPath()` is the single source of truth for the database path; all callers use it, no other changes needed

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR