### PR TITLE
fix: split assistant collapse and expand actions

### DIFF
--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -447,10 +447,6 @@ export function MessageTimeline(props: {
     delete next[messageID]
     setAssistantCollapse("bySession", id, reconcile(next))
   }
-  const allAssistantCollapsed = createMemo(() => {
-    const ids = collapsibleTurnIDs()
-    return ids.length > 0 && ids.every((messageID) => isAssistantCollapsed(messageID))
-  })
   createEffect(() => {
     const id = sessionID()
     if (!id) return
@@ -968,18 +964,18 @@ export function MessageTimeline(props: {
                                 <DropdownMenu.Item
                                   onSelect={() => {
                                     setTitle("menuOpen", false)
-                                    if (allAssistantCollapsed()) {
-                                      expandAllAssistant()
-                                      return
-                                    }
                                     collapseAllAssistant()
                                   }}
                                 >
-                                  <DropdownMenu.ItemLabel>
-                                    {allAssistantCollapsed()
-                                      ? uiI18n.t("ui.sessionReview.expandAll")
-                                      : uiI18n.t("ui.sessionReview.collapseAll")}
-                                  </DropdownMenu.ItemLabel>
+                                  <DropdownMenu.ItemLabel>{uiI18n.t("ui.sessionReview.collapseAll")}</DropdownMenu.ItemLabel>
+                                </DropdownMenu.Item>
+                                <DropdownMenu.Item
+                                  onSelect={() => {
+                                    setTitle("menuOpen", false)
+                                    expandAllAssistant()
+                                  }}
+                                >
+                                  <DropdownMenu.ItemLabel>{uiI18n.t("ui.sessionReview.expandAll")}</DropdownMenu.ItemLabel>
                                 </DropdownMenu.Item>
                               </Show>
                               <DropdownMenu.Item onSelect={() => void archiveSession(id())}>


### PR DESCRIPTION
### Issue for this PR

Closes #804

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This updates the AI chat sidebar actions so "Collapse all" and "Expand all" are always shown as separate menu items instead of a single toggle.

The previous toggle depended on whether every assistant message was collapsed. Because the sidebar now opens with all assistant messages collapsed except the latest one, that toggle often stayed on "Collapse all" when users actually wanted to expand everything. Splitting the actions keeps the existing collapse state behavior and mode handling, while making both bulk actions directly available.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/app`
- Tested the sidebar menu locally and confirmed:
  - the default open state is unchanged
  - "Collapse all" collapses all assistant messages
  - "Expand all" expands all assistant messages

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR