### PR TITLE
fix: trimSessions 按更新时间而非创建时间选取 base 切片

### DIFF
--- a/packages/app/src/context/global-sync/session-trim.test.ts
+++ b/packages/app/src/context/global-sync/session-trim.test.ts
@@ -14,18 +14,35 @@ const session = (input: { id: string; parentID?: string; created: number; update
   }) as Session
 
 describe("trimSessions", () => {
-  test("keeps base roots and recent roots beyond the limit", () => {
+  test("keeps base roots selected by update time, not creation time", () => {
     const now = 1_000_000
     const list = [
       session({ id: "a", created: now - 100_000 }),
       session({ id: "b", created: now - 90_000 }),
       session({ id: "c", created: now - 80_000 }),
-      session({ id: "d", created: now - 70_000, updated: now - 1_000 }),
+      session({ id: "d", created: now - 70_000, updated: now - 500 }),
       session({ id: "e", created: now - 60_000, archived: now - 10 }),
     ]
 
     const result = trimSessions(list, { limit: 2, permission: {}, now })
     expect(result.map((x) => x.id)).toEqual(["a", "b", "c", "d"])
+  })
+
+  test("prioritizes recently-updated session over newer-created but stale one", () => {
+    const now = 1_000_000
+    const list = [
+      session({ id: "ses_new1", created: now - 1_000 }),
+      session({ id: "ses_new2", created: now - 2_000 }),
+      session({ id: "ses_new3", created: now - 3_000 }),
+      session({ id: "ses_old_updated", created: now - 100_000, updated: now - 500 }),
+      session({ id: "ses_new4", created: now - 4_000 }),
+    ]
+
+    const result = trimSessions(list, { limit: 3, permission: {}, now })
+    const ids = result.map((x) => x.id)
+    expect(ids).toContain("ses_old_updated")
+    expect(ids).toContain("ses_new1")
+    expect(ids).toContain("ses_new2")
   })
 
   test("keeps children when root is kept, permission exists, or child is recent", () => {

--- a/packages/app/src/context/global-sync/session-trim.ts
+++ b/packages/app/src/context/global-sync/session-trim.ts
@@ -42,8 +42,11 @@ export function trimSessions(
     .sort((a, b) => cmp(a.id, b.id))
   const roots = all.filter((s) => !s.parentID)
   const children = all.filter((s) => !!s.parentID)
-  const base = roots.slice(0, limit)
-  const recent = takeRecentSessions(roots.slice(limit), SESSION_RECENT_LIMIT, cutoff)
+  const rootsByActivity = roots.slice().sort(compareSessionRecent)
+  const base = rootsByActivity.slice(0, limit)
+  const baseIds = new Set(base.map((s) => s.id))
+  const remaining = roots.filter((s) => !baseIds.has(s.id))
+  const recent = takeRecentSessions(remaining, SESSION_RECENT_LIMIT, cutoff)
   const keepRoots = [...base, ...recent]
   const keepRootIds = new Set(keepRoots.map((s) => s.id))
   const keepChildren = children.filter((s) => {


### PR DESCRIPTION
### Issue for this PR

Closes #807

### Type of change

- [x] Bug fix

### What does this PR do?

`trimSessions` 原先通过 `roots.slice(0, limit)` 按 ID（降序编码，即创建时间）选取 base 切片，导致较早创建但最近更新的会话被裁剪掉，用户需点击"加载更多"才能看到。改为先按 `compareSessionRecent`（更新时间降序）排序再取前 `limit` 个，确保最近活跃的会话优先保留。

### How did you verify your code works?

- 新增测试 "prioritizes recently-updated session over newer-created but stale one"，验证较早创建但最近更新的 session 被包含在 base 中
- `bun test src/context/global-sync/session-trim.test.ts` — 3 tests pass
- `bun test src/context/global-sync/` — 15 tests pass
- `bun typecheck` — no errors

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR