### PR TITLE
fix: harden memory reflection cancellation

### DIFF
--- a/packages/app/src/components/settings-memory.tsx
+++ b/packages/app/src/components/settings-memory.tsx
@@ -31,6 +31,7 @@ export const SettingsMemory: Component = () => {
   const [searching, setSearching] = createSignal(false)
   const [reflecting, setReflecting] = createSignal(false)
   const [initializing, setInitializing] = createSignal(false)
+  const [stoppingInitialize, setStoppingInitialize] = createSignal(false)
   const [results, setResults] = createSignal<MemorySearchResult[]>([])
 
   const [status, statusActions] = createResource(async () => {
@@ -72,6 +73,9 @@ export const SettingsMemory: Component = () => {
   })
   const initializationStatus = createMemo(() => stringValue(initialization().status) || "idle")
   const initializationStarted = createMemo(() => initializationStatus() !== "idle")
+  const initializationRunning = createMemo(
+    () => initializing() || initializationStatus() === "running" || initializationStatus() === "reflecting",
+  )
 
   const updateMemoryConfig = async (patch: Record<string, unknown>) => {
     ;(globalSync.set as (...input: unknown[]) => unknown)("config", (prev: unknown) => ({
@@ -125,6 +129,7 @@ export const SettingsMemory: Component = () => {
 
   const startInitialize = async () => {
     setInitializing(true)
+    setStoppingInitialize(false)
     startProgressPolling()
     showToast({ title: "Memory initialization started", description: "Progress is shown in Settings > Memory." })
     await sdk.client.memory.initialize
@@ -141,7 +146,22 @@ export const SettingsMemory: Component = () => {
       .finally(() => {
         stopProgressPolling()
         setInitializing(false)
+        setStoppingInitialize(false)
         void statusActions.refetch()
+      })
+  }
+
+  const stopInitialize = async () => {
+    setStoppingInitialize(true)
+    await sdk.client.memory.initialize
+      .cancel()
+      .then(() => {
+        showToast({ title: "Memory initialization stopping", description: "The current import will stop at the next cancellation point." })
+        void statusActions.refetch()
+      })
+      .catch((error: unknown) => {
+        setStoppingInitialize(false)
+        showToast({ title: "Memory initialization stop failed", description: error instanceof Error ? error.message : String(error) })
       })
   }
 
@@ -188,9 +208,16 @@ export const SettingsMemory: Component = () => {
               </div>
             </Show>
           </div>
-          <Button size="small" disabled={initializing()} onClick={startInitialize}>
-            {initializing() ? "Importing..." : "Import memories"}
-          </Button>
+          <div class="flex flex-wrap gap-2">
+            <Button size="small" disabled={initializing()} onClick={startInitialize}>
+              {initializing() ? "Importing..." : "Import memories"}
+            </Button>
+            <Show when={initializationRunning()}>
+              <Button size="small" variant="secondary" disabled={stoppingInitialize()} onClick={stopInitialize}>
+                {stoppingInitialize() ? "Stopping..." : "Stop import"}
+              </Button>
+            </Show>
+          </div>
         </div>
 
         <section class="rounded-lg border border-border-weak-base bg-surface-raised-base p-4 flex flex-col gap-3">

--- a/packages/app/src/components/settings-memory.vitest.tsx
+++ b/packages/app/src/components/settings-memory.vitest.tsx
@@ -8,6 +8,9 @@ const state = vi.hoisted(() => ({
   reflectCalls: [] as Array<{ mode: string; reason?: string }>,
   syncCalls: 0,
   initializeCalls: 0,
+  cancelCalls: 0,
+  initializePending: false,
+  resolveInitialize: undefined as undefined | (() => void),
   toasts: [] as Array<{ title?: string; description?: string }>,
   status: {
     needs_initialization: true,
@@ -82,9 +85,17 @@ vi.mock("@/context/global-sdk", () => ({
         initialize: {
           start: async () => {
             state.initializeCalls += 1
+            if (state.initializePending) {
+              await new Promise<void>((resolve) => {
+                state.resolveInitialize = resolve
+              })
+            }
             return { data: { status: "succeeded", scanned: 1, imported: 1 } }
           },
-          cancel: async () => ({ data: { ok: true } }),
+          cancel: async () => {
+            state.cancelCalls += 1
+            return { data: { ok: true } }
+          },
         },
       },
     },
@@ -140,6 +151,9 @@ beforeEach(() => {
   state.reflectCalls = []
   state.syncCalls = 0
   state.initializeCalls = 0
+  state.cancelCalls = 0
+  state.initializePending = false
+  state.resolveInitialize = undefined
   state.toasts = []
   state.status = {
     needs_initialization: true,
@@ -195,6 +209,28 @@ describe("settings memory", () => {
     expect(host.textContent).toContain("Imported: 2")
     expect(host.textContent).toContain("session-progress")
 
+    off()
+  })
+
+  test("can request cancellation while initialization is running", async () => {
+    state.initializePending = true
+    const { host, off } = mount()
+    await flush()
+
+    const initialize = [...host.querySelectorAll("button")].find((button) => button.textContent === "Import memories")
+    initialize?.click()
+    await flush()
+
+    const stop = [...host.querySelectorAll("button")].find((button) => button.textContent === "Stop import")
+    expect(stop).toBeTruthy()
+    stop?.click()
+    await flush()
+
+    expect(state.cancelCalls).toBe(1)
+    expect(state.toasts.some((toast) => toast.title === "Memory initialization stopping")).toBe(true)
+
+    state.resolveInitialize?.()
+    await flush()
     off()
   })
 

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -337,7 +337,7 @@ export namespace Agent {
 
           const system = [PROMPT_GENERATE]
           yield* Effect.promise(() =>
-            Plugin.trigger("experimental.chat.system.transform", { model: resolved }, { system }),
+            Plugin.trigger("experimental.chat.system.transform", { model: resolved, purpose: "agent_generation" }, { system }),
           )
           const existing = yield* InstanceState.useEffect(state, (s) => s.list())
 

--- a/packages/opencode/src/memory/index.ts
+++ b/packages/opencode/src/memory/index.ts
@@ -62,6 +62,13 @@ type Paths = {
   globalMemoryDir: string
   channelRootDir: string
   channelID: string
+  settings?: Partial<MemorySettings>
+}
+
+type MemorySettings = {
+  enabled: boolean
+  dailyReflectEnabled: boolean
+  dailyReflectTime: string
 }
 
 type SessionForInitialization = {
@@ -87,16 +94,25 @@ type ReflectionCandidate = {
   evidence: string
 }
 
+type ReflectionMode = "quick" | "daily" | "manual"
+type ReflectionInput = {
+  events: MemoryEvent[]
+  doc: MemoryDocument
+  mode: ReflectionMode
+  signal?: AbortSignal
+}
+
 let overridePaths: Paths | undefined
+let settingsForTest: MemorySettings | undefined
 let documentCache: { path: string; mtimeMs: number; doc: MemoryDocument } | undefined
 let db: BunSqlite | undefined
 let initializeCancelled = false
+let initializeAbortController: AbortController | undefined
 let scannerForTest: (() => AsyncGenerator<SessionForInitialization>) | undefined
-let extractorForTest: ((session: SessionForInitialization) => Promise<InitializerCandidate[]>) | undefined
+let extractorForTest: ((session: SessionForInitialization, signal?: AbortSignal) => Promise<InitializerCandidate[]>) | undefined
 let startupCatchupStarted = false
-let reflectorForTest:
-  | ((input: { events: MemoryEvent[]; doc: MemoryDocument; mode: "quick" | "daily" | "manual" }) => Promise<ReflectionCandidate[]>)
-  | undefined
+let reflectorForTest: ((input: ReflectionInput) => Promise<ReflectionCandidate[]>) | undefined
+let reflectionQueue: Promise<void> = Promise.resolve()
 
 const ReflectionOutput = z.object({
   candidates: z.array(
@@ -135,6 +151,59 @@ function defaultPaths(): Paths {
     channelRootDir: Global.Path.data,
     channelID: path.basename(Database.channelDir()),
   }
+}
+
+function throwIfAborted(signal?: AbortSignal) {
+  signal?.throwIfAborted()
+}
+
+function isAbortLike(error: unknown) {
+  if (error instanceof DOMException && error.name === "AbortError") return true
+  if (error instanceof Error && /abort|cancel/i.test(`${error.name} ${error.message}`)) return true
+  return false
+}
+
+function initializationWasCancelled(signal?: AbortSignal) {
+  return initializeCancelled || signal?.aborted === true
+}
+
+function abortReason(signal: AbortSignal) {
+  return signal.reason instanceof Error ? signal.reason : new DOMException("Aborted", "AbortError")
+}
+
+function combinedSignal(...signals: Array<AbortSignal | undefined>) {
+  const active = signals.filter((signal): signal is AbortSignal => signal !== undefined)
+  if (active.length === 0) return undefined
+  if (active.length === 1) return active[0]
+  return AbortSignal.any(active)
+}
+
+function runSerializedReflection<T>(signal: AbortSignal | undefined, fn: () => Promise<T>) {
+  let done = false
+  const run = reflectionQueue.catch(() => undefined).then(async () => {
+    throwIfAborted(signal)
+    return fn()
+  })
+  reflectionQueue = run.then(
+    () => {
+      done = true
+    },
+    () => {
+      done = true
+    },
+  )
+  if (!signal) return run
+  if (signal.aborted) return Promise.reject(abortReason(signal))
+  return Promise.race([
+    run,
+    new Promise<never>((_, reject) => {
+      const abort = () => {
+        if (!done) reject(abortReason(signal))
+      }
+      signal.addEventListener("abort", abort, { once: true })
+      run.finally(() => signal.removeEventListener("abort", abort)).catch(() => undefined)
+    }),
+  ])
 }
 
 function paths() {
@@ -257,6 +326,19 @@ async function readDocumentWithOptions(input: { createIfMissing: boolean }) {
 async function writeDocument(doc: MemoryDocument) {
   await ensureDirs()
   using _ = await Lock.write(memoryLockPath())
+  await writeDocumentUnlocked(doc)
+}
+
+async function readDocumentForLockedMutation() {
+  await ensureDirs()
+  const file = mdPath()
+  const stat = await fs.stat(file).catch(() => undefined)
+  if (!stat) return emptyMemoryDocument()
+  return parseMemoryMarkdown(await fs.readFile(file, "utf8"))
+}
+
+async function writeDocumentUnlocked(doc: MemoryDocument) {
+  await ensureDirs()
   const file = mdPath()
   const tmp = `${file}.${process.pid}.${Date.now()}.tmp`
   const rendered = renderMemoryDocument({ ...doc, updated_at: new Date().toISOString() })
@@ -374,11 +456,17 @@ function extractRuleMemoryCandidates(session: SessionForInitialization): Initial
   return candidates.slice(0, 8)
 }
 
-async function extractMemoryCandidates(session: SessionForInitialization): Promise<InitializerCandidate[]> {
+async function extractMemoryCandidates(session: SessionForInitialization, signal?: AbortSignal): Promise<InitializerCandidate[]> {
+  throwIfAborted(signal)
   const ruleCandidates = extractRuleMemoryCandidates(session)
   if (ruleCandidates.length > 0) return ruleCandidates
   if (!sessionLooksWorthLLMInitialization(session)) return []
-  return llmInitializeExtractor(session).catch(() => [])
+  try {
+    return await llmInitializeExtractor(session, signal)
+  } catch (error) {
+    if (isAbortLike(error) || signal?.aborted) throw error
+    return []
+  }
 }
 
 async function sleep(ms: number) {
@@ -506,12 +594,29 @@ function conflictsWith(existing: MemoryBlock, candidate: ReflectionCandidate) {
   return true
 }
 
-function buildShortcut(candidate: ReflectionCandidate) {
-  const words = candidate.memory
-    .split(/[\s,，;；、|/\\]+/g)
-    .map((item) => item.trim())
-    .filter((item) => item.length >= 2)
-    .slice(0, 6)
+function shortcutTerms(...texts: Array<string | undefined>) {
+  const terms: string[] = []
+  for (const text of texts) {
+    if (!text) continue
+    terms.push(
+      ...text
+        .split(/[\s,，;；、|/\\]+/g)
+        .map((item) => item.trim())
+        .filter((item) => item.length >= 2),
+    )
+    for (const match of text.matchAll(/[\u3400-\u9fff]{2,}/g)) {
+      const chars = Array.from(match[0])
+      if (chars.length <= 12) terms.push(match[0])
+      for (const size of [2, 3]) {
+        for (let i = 0; i <= chars.length - size; i++) terms.push(chars.slice(i, i + size).join(""))
+      }
+    }
+  }
+  return [...new Set(terms)].slice(0, 12)
+}
+
+function buildShortcut(candidate: ReflectionCandidate, sourceText?: string) {
+  const words = shortcutTerms(candidate.memory, sourceText)
   return {
     shortcut: `${candidate.type}:${candidate.scope}`,
     triggers: [...new Set(words.length ? words : [candidate.type])],
@@ -576,8 +681,10 @@ function normalizeLLMScope(value: string, fallback: MemoryScope) {
 async function llmReflector(input: {
   events: MemoryEvent[]
   doc: MemoryDocument
-  mode: "quick" | "daily" | "manual"
+  mode: ReflectionMode
+  signal?: AbortSignal
 }): Promise<ReflectionCandidate[]> {
+  throwIfAborted(input.signal)
   if (!input.events.length) return []
   const model = await Provider.defaultModel()
   const resolved = await Provider.getModel(model.providerID, model.modelID)
@@ -590,6 +697,8 @@ async function llmReflector(input: {
     "Allowed scopes: global or project:<project_id>.",
     "Do not create a candidate for one-off questions, transient chat, or low-confidence guesses.",
     "Do not create a candidate from sensitive observed data such as IDs, passwords, addresses, phone numbers, medical, political, or religious information unless the user explicitly asked to remember it.",
+    "For explicit remember events, preserve concrete details aggressively: names, institutions, roles, relationships, project names, dates, constraints, negations, and qualifiers must not be dropped.",
+    "For explicit remember events, you may rewrite, split, or merge the memory into cleaner durable candidates, but the candidate set must retain the same important facts as the raw text.",
     "Prefer global for user-level preferences and profile-like facts.",
     "Prefer project:<project_id> for project constraints, project facts, and project tasks.",
     "Merge duplicates conceptually by returning the cleanest concise memory text.",
@@ -598,7 +707,7 @@ async function llmReflector(input: {
       : "Heavy mode: organize memories by topic. For each type/scope/topic combination, emit at most one candidate. When multiple events or existing memories concern the same theme, merge complementary details into one coherent topical memory instead of separate fragmented entries.",
     input.mode === "quick"
       ? "Quick mode: do not rely on current memory context; it is intentionally omitted to save tokens."
-      : "Heavy mode: use current_memory to group related preferences, facts, and tasks under stable themes such as response style, language, tools, project workflow, research interests, and recurring tasks. If two candidate memories would share the same theme, combine them before returning JSON.",
+      : "Heavy mode: use current_memory to infer stable themes from the memory content itself. If two candidate memories would share the same inferred theme, combine them before returning JSON.",
     "Do not expose raw event IDs inside memory or evidence; use event_id only in the structured field.",
   ].join("\n")
   const userMessage: ModelMessage = {
@@ -628,16 +737,19 @@ async function llmReflector(input: {
     model: language,
     temperature: 0,
     schema: ReflectionOutput,
+    abortSignal: input.signal,
     messages: [
       { role: "system", content: system },
       userMessage,
     ],
   } satisfies Parameters<typeof generateObject>[0]
+  throwIfAborted(input.signal)
 
   const authInfo = await Auth.get(model.providerID)
   const object =
     model.providerID === "openai" && authInfo?.type === "oauth"
       ? await (async () => {
+          throwIfAborted(input.signal)
           const result = streamObject({
             ...params,
             messages: [userMessage],
@@ -648,33 +760,45 @@ async function llmReflector(input: {
             onError: () => {},
           })
           for await (const part of result.fullStream) {
+            throwIfAborted(input.signal)
             if (part.type === "error") throw part.error
           }
+          throwIfAborted(input.signal)
           return result.object
         })()
       : await generateObject(params).then((result) => result.object)
+  throwIfAborted(input.signal)
 
   const byID = new Map(input.events.map((event) => [event.id, event]))
-  return object.candidates
+  const candidates = object.candidates
     .map((candidate) => {
       const event = byID.get(candidate.event_id)
       if (!event) return
-      const type = classifyType(candidate.memory, candidate.type)
-      const fallbackScope = inferScope({ text: candidate.memory, type, projectID: event.project_id, sourceJson: event.source_json })
+      const memory = sanitizeMemoryText(candidate.memory)
+      const type = classifyType(memory, candidate.type ?? event.type)
+      const fallbackScope = inferScope({ text: memory, type, projectID: event.project_id, sourceJson: event.source_json })
       return {
         eventID: event.id,
         type,
         scope: normalizeLLMScope(candidate.scope, fallbackScope),
-        memory: sanitizeMemoryText(candidate.memory),
+        memory,
         confidence: clamp01(candidate.confidence, event.intent === "explicit" ? 0.86 : 0.68),
         weight: clamp01(candidate.weight, event.intent === "explicit" ? 0.82 : 0.55),
         evidence: (candidate.evidence || (event.intent === "explicit" ? "用户明确请求记住。" : "由 LLM 反思提取。")).slice(0, 180),
       } satisfies ReflectionCandidate
     })
     .filter((item): item is ReflectionCandidate => item !== undefined && item.memory.length > 0)
+  const covered = new Set(candidates.map((candidate) => candidate.eventID))
+  for (const event of input.events) {
+    if (event.intent !== "explicit" || covered.has(event.id)) continue
+    const fallback = reflectEvent(event)
+    if (fallback) candidates.push(fallback)
+  }
+  return candidates
 }
 
-async function llmInitializeExtractor(session: SessionForInitialization): Promise<InitializerCandidate[]> {
+async function llmInitializeExtractor(session: SessionForInitialization, signal?: AbortSignal): Promise<InitializerCandidate[]> {
+  throwIfAborted(signal)
   const model = await Provider.defaultModel()
   const resolved = await Provider.getModel(model.providerID, model.modelID)
   const language = await Provider.getLanguage(resolved)
@@ -716,15 +840,18 @@ async function llmInitializeExtractor(session: SessionForInitialization): Promis
     model: language,
     temperature: 0,
     schema: InitializationOutput,
+    abortSignal: signal,
     messages: [
       { role: "system", content: system },
       userMessage,
     ],
   } satisfies Parameters<typeof generateObject>[0]
+  throwIfAborted(signal)
   const authInfo = await Auth.get(model.providerID)
   const object =
     model.providerID === "openai" && authInfo?.type === "oauth"
       ? await (async () => {
+          throwIfAborted(signal)
           const result = streamObject({
             ...params,
             messages: [userMessage],
@@ -735,11 +862,14 @@ async function llmInitializeExtractor(session: SessionForInitialization): Promis
             onError: () => {},
           })
           for await (const part of result.fullStream) {
+            throwIfAborted(signal)
             if (part.type === "error") throw part.error
           }
+          throwIfAborted(signal)
           return result.object
         })()
       : await generateObject(params).then((result) => result.object)
+  throwIfAborted(signal)
 
   return object.candidates
     .map((candidate): InitializerCandidate | undefined => {
@@ -756,7 +886,8 @@ async function llmInitializeExtractor(session: SessionForInitialization): Promis
     .slice(0, 8)
 }
 
-async function llmForgetDecide(input: { query: string; candidates: MemoryBlock[] }) {
+async function llmForgetDecide(input: { query: string; candidates: MemoryBlock[]; signal?: AbortSignal }) {
+  throwIfAborted(input.signal)
   const model = await Provider.defaultModel()
   const resolved = await Provider.getModel(model.providerID, model.modelID)
   const language = await Provider.getLanguage(resolved)
@@ -787,15 +918,18 @@ async function llmForgetDecide(input: { query: string; candidates: MemoryBlock[]
     model: language,
     temperature: 0,
     schema: ForgetDecisionOutput,
+    abortSignal: input.signal,
     messages: [
       { role: "system", content: system },
       userMessage,
     ],
   } satisfies Parameters<typeof generateObject>[0]
+  throwIfAborted(input.signal)
   const authInfo = await Auth.get(model.providerID)
   const result =
     model.providerID === "openai" && authInfo?.type === "oauth"
       ? await (async () => {
+          throwIfAborted(input.signal)
           const stream = streamObject({
             ...params,
             messages: [userMessage],
@@ -806,11 +940,14 @@ async function llmForgetDecide(input: { query: string; candidates: MemoryBlock[]
             onError: () => {},
           })
           for await (const part of stream.fullStream) {
+            throwIfAborted(input.signal)
             if (part.type === "error") throw part.error
           }
+          throwIfAborted(input.signal)
           return stream.object
         })()
       : await generateObject(params).then((output) => output.object)
+  throwIfAborted(input.signal)
   const allowed = new Set(input.candidates.map((candidate) => candidate.id))
   const deleteIDs = result.delete_ids.filter((id) => allowed.has(id))
   const keepIDs = (result.keep_ids ?? []).filter((id) => allowed.has(id))
@@ -821,33 +958,42 @@ async function llmForgetDecide(input: { query: string; candidates: MemoryBlock[]
   }
 }
 
-async function defaultForgetDecision(input: { query: string; candidates: MemoryBlock[] }) {
-  try {
-    return await llmForgetDecide(input)
-  } catch {
-    return { deleteIDs: input.candidates.map((candidate) => candidate.id), keepIDs: [], reason: "matched candidates" }
-  }
+async function defaultForgetDecision(input: { query: string; candidates: MemoryBlock[]; signal?: AbortSignal }) {
+  return await llmForgetDecide(input)
 }
 
-async function runReflector(input: { events: MemoryEvent[]; doc: MemoryDocument; mode: "quick" | "daily" | "manual" }) {
+async function runReflector(input: ReflectionInput) {
+  throwIfAborted(input.signal)
   if (reflectorForTest) return reflectorForTest(input)
-  try {
-    return await llmReflector(input)
-  } catch (error) {
-    if (input.mode === "quick") throw error
-    // Keep full reflection usable when model configuration is unavailable; the
-    // deterministic fallback preserves the same schema boundary for scheduled maintenance.
-  }
-  return deterministicReflector(input)
+  return await llmReflector(input)
 }
 
-function mergeCandidates(doc: MemoryDocument, candidates: ReflectionCandidate[]) {
+function mergeCandidates(doc: MemoryDocument, candidates: ReflectionCandidate[], events: MemoryEvent[] = []) {
   const now = new Date().toISOString()
   const byKey = new Map<string, MemoryBlock>()
+  const rawByEvent = new Map(events.map((event) => [event.id, event.raw_text]))
   for (const memory of doc.memories) byKey.set(candidateKey(memory), memory)
   const updatedIDs: string[] = []
   const eventResults: Record<string, string> = {}
   let shortcutChanged = false
+  const upsertShortcut = (id: string, candidate: ReflectionCandidate) => {
+    const shortcut = buildShortcut(candidate, rawByEvent.get(candidate.eventID))
+    const existingShortcut = doc.shortcuts.find(
+      (item) => item.shortcut === shortcut.shortcut && item.instruction === shortcut.instruction,
+    )
+    if (existingShortcut) {
+      const activeIDs = new Set(doc.memories.filter((memory) => memory.status === "active").map((memory) => memory.id))
+      existingShortcut.target_ids = existingShortcut.target_ids.filter((target) => activeIDs.has(target))
+      if (!existingShortcut.target_ids.includes(id)) existingShortcut.target_ids.push(id)
+      existingShortcut.triggers = [...new Set([...existingShortcut.triggers, ...shortcut.triggers])].slice(0, 16)
+      existingShortcut.weight = Math.max(existingShortcut.weight, shortcut.weight)
+      shortcutChanged = true
+    } else {
+      shortcut.target_ids.push(id)
+      doc.shortcuts.push(shortcut)
+      shortcutChanged = true
+    }
+  }
 
   for (const candidate of candidates) {
     const key = candidateKey(candidate)
@@ -860,6 +1006,7 @@ function mergeCandidates(doc: MemoryDocument, candidates: ReflectionCandidate[])
       existing.status = "active"
       updatedIDs.push(existing.id)
       eventResults[candidate.eventID] = existing.id
+      upsertShortcut(existing.id, candidate)
       continue
     }
     for (const memory of doc.memories) {
@@ -884,23 +1031,7 @@ function mergeCandidates(doc: MemoryDocument, candidates: ReflectionCandidate[])
     byKey.set(key, block)
     updatedIDs.push(id)
     eventResults[candidate.eventID] = id
-
-    const shortcut = buildShortcut(candidate)
-    const existingShortcut = doc.shortcuts.find(
-      (item) => item.shortcut === shortcut.shortcut && item.instruction === shortcut.instruction,
-    )
-    if (existingShortcut) {
-      const activeIDs = new Set(doc.memories.filter((memory) => memory.status === "active").map((memory) => memory.id))
-      existingShortcut.target_ids = existingShortcut.target_ids.filter((target) => activeIDs.has(target))
-      if (!existingShortcut.target_ids.includes(id)) existingShortcut.target_ids.push(id)
-      shortcutChanged = true
-      existingShortcut.triggers = [...new Set([...existingShortcut.triggers, ...shortcut.triggers])].slice(0, 12)
-      existingShortcut.weight = Math.max(existingShortcut.weight, shortcut.weight)
-    } else {
-      shortcut.target_ids.push(id)
-      doc.shortcuts.push(shortcut)
-      shortcutChanged = true
-    }
+    upsertShortcut(id, candidate)
   }
 
   return { updatedIDs: [...new Set(updatedIDs)], eventResults, shortcutChanged }
@@ -963,21 +1094,32 @@ export namespace Memory {
   export function configureForTest(input: Paths) {
     overridePaths = input
     stop()
+    settingsForTest = {
+      enabled: input.settings?.enabled ?? true,
+      dailyReflectEnabled: input.settings?.dailyReflectEnabled ?? true,
+      dailyReflectTime: input.settings?.dailyReflectTime ?? "03:00",
+    }
     reflectorForTest = (reflectInput) => deterministicReflector(reflectInput)
   }
 
   export async function stop() {
+    initializeAbortController?.abort()
+    initializeAbortController = undefined
     db?.close()
     db = undefined
     invalidateDocumentCache()
     initializeCancelled = false
+    reflectionQueue = Promise.resolve()
     startupCatchupStarted = false
     scannerForTest = undefined
     extractorForTest = undefined
+    settingsForTest = undefined
   }
 
   export async function purge() {
+    const testSettings = settingsForTest
     await stop()
+    settingsForTest = testSettings
     await fs.rm(paths().globalMemoryDir, { recursive: true, force: true })
     await fs.rm(dbPath(), { force: true }).catch(() => undefined)
     await fs.rm(`${dbPath()}-wal`, { force: true }).catch(() => undefined)
@@ -987,13 +1129,13 @@ export namespace Memory {
   export async function status() {
     const stat = await fs.stat(mdPath()).catch(() => undefined)
     const doc = await readDocumentWithOptions({ createIfMissing: false })
-    const cfg = await Config.get().catch(() => ({} as Awaited<ReturnType<typeof Config.get>>))
+    const cfg = await settings()
     const state = await readReflectionState()
     const hasHistorySessions = Boolean(Session.listGlobal({ limit: 1, archivedMode: "exclude" }).next().value)
     return {
-      enabled: cfg.memory?.enabled ?? true,
-      dailyReflectEnabled: cfg.memory?.dailyReflect?.enabled ?? true,
-      dailyReflectTime: cfg.memory?.dailyReflect?.time ?? "03:00",
+      enabled: cfg.enabled,
+      dailyReflectEnabled: cfg.dailyReflectEnabled,
+      dailyReflectTime: cfg.dailyReflectTime,
       markdown_exists: Boolean(stat),
       markdown_updated_at: stat?.mtimeMs ?? null,
       memory_count: doc.memories.length,
@@ -1016,17 +1158,23 @@ export namespace Memory {
     scannerForTest = scanner
   }
 
-  export function setInitializerExtractorForTest(extractor: (session: SessionForInitialization) => Promise<InitializerCandidate[]>) {
+  export function setInitializerExtractorForTest(
+    extractor: (session: SessionForInitialization, signal?: AbortSignal) => Promise<InitializerCandidate[]>,
+  ) {
     extractorForTest = extractor
   }
 
-  export function setReflectorForTest(
-    reflector: (input: { events: MemoryEvent[]; doc: MemoryDocument; mode: "quick" | "daily" | "manual" }) => Promise<ReflectionCandidate[]>,
-  ) {
+  export function setReflectorForTest(reflector: (input: ReflectionInput) => Promise<ReflectionCandidate[]>) {
     reflectorForTest = reflector
   }
 
   export async function search(input: MemorySearchInput) {
+    if (!(await isEnabled())) {
+      return {
+        results: [],
+        ranking_note: "Memory is disabled; no memory results were returned.",
+      }
+    }
     const doc = await readDocument()
     return {
       results: searchMemoryDocument(doc, input),
@@ -1039,8 +1187,10 @@ export namespace Memory {
     type?: MemoryType
     intent: "explicit" | "observed"
     source: Parameters<typeof insertEvent>[0]["source"]
+    signal?: AbortSignal
   }) {
     if (!(await isEnabled())) return { eventID: "", status: "ignored" as const, reason: "memory disabled" }
+    throwIfAborted(input.signal)
     await ensureDirs()
     const gate = shouldQuickReflect({ text: input.text, intent: input.intent, op: "remember", shortcutTriggers: [] })
     const event = insertEvent({
@@ -1053,10 +1203,13 @@ export namespace Memory {
     })
     if (gate.priority === "important") {
       openDb().prepare("UPDATE memory_event SET status = ? WHERE id = ?").run("pending_important", event.id)
-      const reflected = await reflect({ mode: "quick", reason: gate.reason, eventIDs: [event.id] }).catch((error) => ({
-        changed: false,
-        summary: error instanceof Error ? error.message : String(error),
-      }))
+      const reflected = await reflect({ mode: "quick", reason: gate.reason, eventIDs: [event.id], signal: input.signal }).catch((error) => {
+        if (isAbortLike(error) || input.signal?.aborted) throw error
+        return {
+          changed: false,
+          summary: error instanceof Error ? error.message : String(error),
+        }
+      })
       return {
         eventID: event.id,
         status: reflected.changed ? ("applied" as const) : ("queued" as const),
@@ -1071,12 +1224,14 @@ export namespace Memory {
     ids?: string[]
     type?: MemoryType
     source: Parameters<typeof insertEvent>[0]["source"]
+    signal?: AbortSignal
     decide?: (input: {
       query: string
       candidates: MemoryBlock[]
     }) => Promise<{ deleteIDs: string[]; keepIDs: string[]; reason: string }>
   }) {
     if (!(await isEnabled())) return { eventID: "", deletedIDs: [], status: "not_found" as const }
+    throwIfAborted(input.signal)
     const doc = await readDocument()
     let candidates = input.ids?.length
       ? doc.memories.filter((memory) => input.ids!.includes(memory.id))
@@ -1094,26 +1249,30 @@ export namespace Memory {
     const decision = input.decide
       ? await input.decide({ query: input.query ?? input.ids?.join(", ") ?? "", candidates })
       : broadFallback
-        ? await llmForgetDecide({ query: input.query ?? input.ids?.join(", ") ?? "", candidates }).catch(() => ({
+        ? await llmForgetDecide({ query: input.query ?? input.ids?.join(", ") ?? "", candidates, signal: input.signal }).catch(() => ({
             deleteIDs: [],
             keepIDs: candidates.map((candidate) => candidate.id),
             reason: "No keyword candidates and LLM forget decision failed.",
           }))
-        : await defaultForgetDecision({ query: input.query ?? input.ids?.join(", ") ?? "", candidates })
+        : await defaultForgetDecision({ query: input.query ?? input.ids?.join(", ") ?? "", candidates, signal: input.signal })
     const deleteSet = new Set(decision.deleteIDs)
-    const deletedIDs = doc.memories.filter((memory) => deleteSet.has(memory.id)).map((memory) => memory.id)
+    throwIfAborted(input.signal)
+    let deletedIDs: string[] = []
+    using _ = await Lock.write(memoryLockPath())
+    const latest = await readDocumentForLockedMutation()
+    deletedIDs = latest.memories.filter((memory) => deleteSet.has(memory.id)).map((memory) => memory.id)
     if (!deletedIDs.length) return { eventID: "", deletedIDs: [], status: "not_found" as const }
     const next = {
-      ...doc,
-      memories: doc.memories.filter((memory) => !deleteSet.has(memory.id)),
-      shortcuts: doc.shortcuts
+      ...latest,
+      memories: latest.memories.filter((memory) => !deleteSet.has(memory.id)),
+      shortcuts: latest.shortcuts
         .map((shortcut) => ({
           ...shortcut,
           target_ids: shortcut.target_ids.filter((id) => !deleteSet.has(id)),
         }))
         .filter((shortcut) => shortcut.target_ids.length > 0),
     }
-    await writeDocument(next)
+    await writeDocumentUnlocked(next)
     const event = insertEvent({
       op: "forget",
       intent: "explicit",
@@ -1126,15 +1285,17 @@ export namespace Memory {
   }
 
   export async function reflect(input: {
-    mode: "quick" | "daily" | "manual"
+    mode: ReflectionMode
     reason?: string
     eventIDs?: string[]
+    signal?: AbortSignal
   }) {
+    throwIfAborted(input.signal)
     if (!(await isEnabled())) {
       return { runID: "", changed: false, updatedIDs: [], deletedIDs: [], shortcutChanged: false, summary: "Memory is disabled." }
     }
-    const cfg = await Config.get().catch(() => ({} as Awaited<ReturnType<typeof Config.get>>))
-    if (input.mode === "daily" && input.reason === "cron" && cfg.memory?.dailyReflect?.enabled === false) {
+    const cfg = await settings()
+    if (input.mode === "daily" && input.reason === "cron" && !cfg.dailyReflectEnabled) {
       return {
         runID: "",
         changed: false,
@@ -1144,59 +1305,93 @@ export namespace Memory {
         summary: "Daily memory reflection is disabled.",
       }
     }
-    const started = Date.now()
-    const id = `refl_${ulid()}`
-    const events = await pendingEvents({ mode: input.mode, eventIDs: input.eventIDs })
-    const before = await readDocument()
-    const candidates = await runReflector({ events, doc: before, mode: input.mode })
-    const next: MemoryDocument = {
-      ...before,
-      shortcuts: before.shortcuts.map((shortcut) => ({ ...shortcut, target_ids: [...shortcut.target_ids] })),
-      memories: before.memories.map((memory) => ({ ...memory })),
-    }
-    const merged = mergeCandidates(next, candidates)
-    const changed = merged.updatedIDs.length > 0
-    if (changed) await writeDocument(next)
-    const now = Date.now()
-    for (const event of events) {
-      const memoryID = merged.eventResults[event.id]
-      updateEventStatus(event, {
-        status: memoryID ? "applied" : "ignored",
-        reflectedAt: now,
-        result: { memoryID: memoryID ?? null, runID: id },
-      })
-    }
-    openDb()
-      .prepare(
-        "INSERT INTO reflection_run (id, mode, started_at, completed_at, input_event_ids_json, summary_json) VALUES (?, ?, ?, ?, ?, ?)",
-      )
-      .run(
-        id,
-        input.mode,
-        started,
-        Date.now(),
-        JSON.stringify(events.map((event) => event.id)),
-        JSON.stringify({ reason: input.reason ?? "", updatedIDs: merged.updatedIDs }),
-      )
-    if (input.mode === "daily") {
-      await writeReflectionState({
-        last_successful_daily_reflect_at: Date.now(),
-        last_daily_reflect_run_id: id,
-      })
-    }
-    return {
-      runID: id,
-      changed,
-      updatedIDs: merged.updatedIDs,
-      deletedIDs: [],
-      shortcutChanged: merged.shortcutChanged,
-      summary: changed ? `Applied ${merged.updatedIDs.length} memory update(s).` : "No changes.",
-    }
+    return runSerializedReflection(input.signal, async () => {
+      throwIfAborted(input.signal)
+      const started = Date.now()
+      const id = `refl_${ulid()}`
+      let events: MemoryEvent[] = []
+      try {
+        events = await pendingEvents({ mode: input.mode, eventIDs: input.eventIDs })
+        throwIfAborted(input.signal)
+        const before = await readDocument()
+        const candidates = await runReflector({ events, doc: before, mode: input.mode, signal: input.signal })
+        throwIfAborted(input.signal)
+        let merged: ReturnType<typeof mergeCandidates> = { updatedIDs: [], eventResults: {}, shortcutChanged: false }
+        if (candidates.length) {
+          using _ = await Lock.write(memoryLockPath())
+          throwIfAborted(input.signal)
+          const latest = await readDocumentForLockedMutation()
+          const next: MemoryDocument = {
+            ...latest,
+            shortcuts: latest.shortcuts.map((shortcut) => ({ ...shortcut, target_ids: [...shortcut.target_ids] })),
+            memories: latest.memories.map((memory) => ({ ...memory })),
+          }
+          merged = mergeCandidates(next, candidates, events)
+          if (merged.updatedIDs.length > 0) await writeDocumentUnlocked(next)
+        }
+        const changed = merged.updatedIDs.length > 0
+        const now = Date.now()
+        for (const event of events) {
+          const memoryID = merged.eventResults[event.id]
+          updateEventStatus(event, {
+            status: memoryID ? "applied" : "ignored",
+            reflectedAt: now,
+            result: { memoryID: memoryID ?? null, runID: id },
+          })
+        }
+        openDb()
+          .prepare(
+            "INSERT INTO reflection_run (id, mode, started_at, completed_at, input_event_ids_json, summary_json) VALUES (?, ?, ?, ?, ?, ?)",
+          )
+          .run(
+            id,
+            input.mode,
+            started,
+            Date.now(),
+            JSON.stringify(events.map((event) => event.id)),
+            JSON.stringify({ reason: input.reason ?? "", updatedIDs: merged.updatedIDs }),
+          )
+        if (input.mode === "daily") {
+          await writeReflectionState({
+            last_successful_daily_reflect_at: Date.now(),
+            last_daily_reflect_run_id: id,
+          })
+        }
+        return {
+          runID: id,
+          changed,
+          updatedIDs: merged.updatedIDs,
+          deletedIDs: [],
+          shortcutChanged: merged.shortcutChanged,
+          summary: changed ? `Applied ${merged.updatedIDs.length} memory update(s).` : "No changes.",
+        }
+      } catch (error) {
+        openDb()
+          .prepare(
+            "INSERT INTO reflection_run (id, mode, started_at, completed_at, input_event_ids_json, summary_json, error) VALUES (?, ?, ?, ?, ?, ?, ?)",
+          )
+          .run(
+            id,
+            input.mode,
+            started,
+            Date.now(),
+            JSON.stringify(events.map((event) => event.id)),
+            JSON.stringify({ reason: input.reason ?? "" }),
+            error instanceof Error ? error.message : String(error),
+          )
+        throw error
+      }
+    })
   }
 
-  export async function initialize(input: { confirm: boolean }) {
+  export async function initialize(input: { confirm: boolean; signal?: AbortSignal }) {
     if (!(await isEnabled())) return { status: "cancelled" as const, scanned: 0, imported: 0 }
     if (!input.confirm) return { status: "cancelled" as const, scanned: 0, imported: 0 }
+    if (input.signal?.aborted) return { status: "cancelled" as const, scanned: 0, imported: 0 }
+    const controller = new AbortController()
+    initializeAbortController?.abort()
+    initializeAbortController = controller
+    const signal = combinedSignal(input.signal, controller.signal)
     initializeCancelled = false
     await ensureDirs()
     const startedAt = Date.now()
@@ -1216,47 +1411,63 @@ export namespace Memory {
 
     await writeInitializationProgress()
     const scanner = scannerForTest ?? defaultSessionScanner
-    for await (const session of scanner()) {
-      if (initializeCancelled) break
-      scanned++
-      if (!sessionHasMemorySignal(session)) {
+    try {
+      for await (const session of scanner()) {
+        if (initializationWasCancelled(signal)) break
+        scanned++
+        if (!sessionHasMemorySignal(session)) {
+          await writeInitializationProgress({
+            current_session_id: session.sessionID,
+            current_project_id: session.projectID ?? null,
+          })
+          await sleep(250)
+          continue
+        }
+        throwIfAborted(signal)
+        const candidates = extractorForTest ? await extractorForTest(session, signal) : await extractMemoryCandidates(session, signal)
+        throwIfAborted(signal)
+        for (const candidate of candidates) {
+          insertEvent({
+            op: "remember",
+            type: candidate.type,
+            intent: "observed",
+            text: candidate.text,
+            status: "new",
+            source: {
+              createdAt: Date.now(),
+              channelID: session.channelID,
+              projectID: session.projectID,
+              sessionID: session.sessionID,
+              role: "user",
+              scope: candidate.scope,
+            },
+          })
+          imported++
+        }
         await writeInitializationProgress({
           current_session_id: session.sessionID,
           current_project_id: session.projectID ?? null,
         })
         await sleep(250)
-        continue
       }
-      const candidates = extractorForTest ? await extractorForTest(session) : await extractMemoryCandidates(session)
-      for (const candidate of candidates) {
-        insertEvent({
-          op: "remember",
-          type: candidate.type,
-          intent: "observed",
-          text: candidate.text,
-          status: "new",
-          source: {
-            createdAt: Date.now(),
-            channelID: session.channelID,
-            projectID: session.projectID,
-            sessionID: session.sessionID,
-            role: "user",
-            scope: candidate.scope,
-          },
-        })
-        imported++
+    } catch (error) {
+      if (!isAbortLike(error) && !signal?.aborted) {
+        if (initializeAbortController === controller) initializeAbortController = undefined
+        throw error
       }
-      await writeInitializationProgress({
-        current_session_id: session.sessionID,
-        current_project_id: session.projectID ?? null,
-      })
-      await sleep(250)
+      initializeCancelled = true
     }
     if (imported > 0) {
       await writeInitializationProgress({ status: "reflecting" })
-      await reflect({ mode: "daily", reason: "initialize" })
+      await reflect({ mode: "daily", reason: "initialize", signal }).catch((error) => {
+        if (!isAbortLike(error) && !signal?.aborted) {
+          if (initializeAbortController === controller) initializeAbortController = undefined
+          throw error
+        }
+        initializeCancelled = true
+      })
     }
-    const status = initializeCancelled ? ("cancelled" as const) : ("succeeded" as const)
+    const status = initializationWasCancelled(signal) ? ("cancelled" as const) : ("succeeded" as const)
     await writeReflectionState({
       initialization: {
         status,
@@ -1266,6 +1477,7 @@ export namespace Memory {
         imported,
       },
     })
+    if (initializeAbortController === controller) initializeAbortController = undefined
     return { status, scanned, imported }
   }
 
@@ -1273,8 +1485,8 @@ export namespace Memory {
     if (startupCatchupStarted) return { started: false, reason: "already checked this startup" }
     startupCatchupStarted = true
     if (!(await isEnabled())) return { started: false, reason: "memory disabled" }
-    const cfg = await Config.get().catch(() => ({} as Awaited<ReturnType<typeof Config.get>>))
-    if (cfg.memory?.dailyReflect?.enabled === false) return { started: false, reason: "daily reflect disabled" }
+    const cfg = await settings()
+    if (!cfg.dailyReflectEnabled) return { started: false, reason: "daily reflect disabled" }
     const state = await readReflectionState()
     const last = typeof state.last_successful_daily_reflect_at === "number" ? state.last_successful_daily_reflect_at : 0
     if (last && dateKey(last) === dateKey(Date.now())) return { started: false, reason: "already reflected today" }
@@ -1296,6 +1508,7 @@ export namespace Memory {
 
   export async function cancelInitialize() {
     initializeCancelled = true
+    initializeAbortController?.abort()
     return { ok: true }
   }
 
@@ -1304,8 +1517,26 @@ export namespace Memory {
   }
 
   export async function isEnabled() {
-    const cfg = await Config.get().catch(() => ({} as Awaited<ReturnType<typeof Config.get>>))
-    return cfg.memory?.enabled ?? true
+    const cfg = await settings()
+    return cfg.enabled
+  }
+
+  export async function settings() {
+    if (settingsForTest) return settingsForTest
+    try {
+      const cfg = await Config.get()
+      return {
+        enabled: cfg.memory?.enabled ?? true,
+        dailyReflectEnabled: cfg.memory?.dailyReflect?.enabled ?? true,
+        dailyReflectTime: cfg.memory?.dailyReflect?.time ?? "03:00",
+      }
+    } catch {
+      return {
+        enabled: false,
+        dailyReflectEnabled: false,
+        dailyReflectTime: "03:00",
+      }
+    }
   }
 
   export async function shortcutSystemPrompt() {
@@ -1315,6 +1546,7 @@ export namespace Memory {
     const lines = [
       "<user_memory_shortcuts>",
       "These are memory shortcuts, not full memories. Use them only to decide whether memory_search is needed.",
+      "When the current task depends on durable user or project context, preferences, facts, past commitments, or previously stated constraints, call memory_search with concise keywords from the task and relevant shortcut triggers.",
       "",
     ]
     for (const shortcut of doc.shortcuts) {

--- a/packages/opencode/src/memory/installer.ts
+++ b/packages/opencode/src/memory/installer.ts
@@ -1,5 +1,4 @@
 import { Cron } from "@/cron"
-import { Config } from "@/config/config"
 import { Memory } from "."
 
 export const MEMORY_DAILY_REFLECT_ACTION = "memory.reflect.daily"
@@ -23,9 +22,9 @@ function scheduleFromTime(time: string | undefined) {
 }
 
 export async function syncDailyReflectJob(input?: { preserveExisting?: boolean }) {
-  const cfg = await Config.get().catch(() => ({} as Awaited<ReturnType<typeof Config.get>>))
-  const enabled = (cfg.memory?.enabled ?? true) && (cfg.memory?.dailyReflect?.enabled ?? true)
-  const schedule = scheduleFromTime(cfg.memory?.dailyReflect?.time)
+  const cfg = await Memory.settings()
+  const enabled = cfg.enabled && cfg.dailyReflectEnabled
+  const schedule = scheduleFromTime(cfg.dailyReflectTime)
   const existing = await Cron.getJob(MEMORY_DAILY_REFLECT_JOB_ID).catch(() => undefined)
   if (existing && input?.preserveExisting !== false) return existing
   if (existing) {
@@ -52,19 +51,23 @@ export async function syncDailyReflectJob(input?: { preserveExisting?: boolean }
   })
 }
 
-export async function installMemory(): Promise<InstalledMemory> {
+export function registerMemoryDirectActions() {
   Cron.registerDirectAction(MEMORY_DAILY_REFLECT_ACTION, async () => {
     const result = await Memory.reflect({ mode: "daily", reason: "cron" })
     return {
       output_summary: result.summary,
     }
   })
-  await syncDailyReflectJob({ preserveExisting: true })
+}
+
+export async function installMemory(): Promise<InstalledMemory> {
+  registerMemoryDirectActions()
+  await syncDailyReflectJob({ preserveExisting: false })
   await Memory.startupCatchup()
   return {
     service: Memory,
     start: async () => {
-      await syncDailyReflectJob({ preserveExisting: true })
+      await syncDailyReflectJob({ preserveExisting: false })
       await Memory.startupCatchup()
     },
     stop: Memory.stop,

--- a/packages/opencode/src/memory/plugin.ts
+++ b/packages/opencode/src/memory/plugin.ts
@@ -1,5 +1,8 @@
 import type { Hooks, PluginInput } from "@opencode-ai/plugin"
 import { Memory } from "."
+import { Log } from "@/util/log"
+
+const log = Log.create({ service: "memory.plugin" })
 
 function textFromParts(parts: Array<{ type?: string; text?: string }>) {
   return parts
@@ -10,12 +13,18 @@ function textFromParts(parts: Array<{ type?: string; text?: string }>) {
 }
 
 export async function MemoryPlugin(input: PluginInput): Promise<Hooks> {
+  function schedule(task: Promise<unknown>) {
+    void task.catch((error) => {
+      log.warn("memory hook failed", { error })
+    })
+  }
+
   return {
     async "chat.message"(ctx, output) {
       const text = textFromParts(output.parts as Array<{ type?: string; text?: string }>)
       if (!text) return
       if (Memory.detectForgetIntent(text)) {
-        await Memory.forget({
+        schedule(Memory.forget({
           query: text,
           source: {
             createdAt: Date.now(),
@@ -24,10 +33,10 @@ export async function MemoryPlugin(input: PluginInput): Promise<Hooks> {
             messageID: ctx.messageID,
             role: "user",
           },
-        })
+        }))
         return
       }
-      await Memory.remember({
+      schedule(Memory.remember({
         text,
         intent: "observed",
         source: {
@@ -37,9 +46,10 @@ export async function MemoryPlugin(input: PluginInput): Promise<Hooks> {
           messageID: ctx.messageID,
           role: "user",
         },
-      })
+      }))
     },
-    async "experimental.chat.system.transform"(_ctx, output) {
+    async "experimental.chat.system.transform"(ctx, output) {
+      if ((ctx as { purpose?: string }).purpose !== "chat") return
       const prompt = await Memory.shortcutSystemPrompt()
       if (prompt) output.system.push(prompt)
     },

--- a/packages/opencode/src/memory/search.ts
+++ b/packages/opencode/src/memory/search.ts
@@ -5,6 +5,7 @@ export type MemorySearchInput = {
   types?: MemoryType[]
   limit?: number
   currentProjectID?: string
+  mode?: "search" | "overview"
 }
 
 export type MemorySearchResult = MemoryBlock & {
@@ -14,6 +15,7 @@ export type MemorySearchResult = MemoryBlock & {
 }
 
 const SPLIT_RE = /[\s,，;；、|/\\]+/g
+const MIN_TEXT_MATCH = 0.08
 
 export function splitSearchTerms(query: string) {
   return query
@@ -92,12 +94,13 @@ export function searchMemoryDocument(doc: MemoryDocument, input: MemorySearchInp
   const limit = Math.max(0, input.limit ?? 5)
   if (limit <= 0) return []
   const terms = splitSearchTerms(input.query)
-  if (!terms.length) return []
+  if (!terms.length && input.mode !== "overview") return []
   const allowed = input.types ? new Set(input.types) : undefined
+  const overview = input.mode === "overview"
   const shortcutTargets = new Map<string, number>()
   for (const shortcut of doc.shortcuts) {
     const haystack = [shortcut.shortcut, ...shortcut.triggers, shortcut.instruction].join(" ")
-    const matched = terms.some((term) => textScore(term, haystack) > 0)
+    const matched = terms.some((term) => textScore(term, haystack) >= MIN_TEXT_MATCH)
     if (!matched) continue
     for (const id of shortcut.target_ids) shortcutTargets.set(id, Math.max(shortcutTargets.get(id) ?? 0, shortcut.weight || 0.8))
   }
@@ -111,13 +114,17 @@ export function searchMemoryDocument(doc: MemoryDocument, input: MemorySearchInp
       const shortcut = shortcutTargets.get(memory.id) ?? 0
       const scope = scopeRelevance(memory.scope, input.currentProjectID)
       const recency = recencyScore(memory.updated_at)
-      const score = match * 0.45 + shortcut * 0.25 + memory.weight * 0.2 + recency * 0.05 + scope * 0.05
+      const score = overview
+        ? memory.weight * 0.4 + memory.confidence * 0.2 + recency * 0.25 + scope * 0.15
+        : match * 0.45 + shortcut * 0.25 + memory.weight * 0.2 + recency * 0.05 + scope * 0.05
       return {
         ...memory,
-        matched: match > 0 || shortcut > 0,
+        matched: overview || match >= MIN_TEXT_MATCH || shortcut > 0,
         score,
         markdown: renderSnippet(memory),
-        ranking_note: "结果按相关度、scope、权重和新近程度综合排序。",
+        ranking_note: overview
+          ? "概览查询：结果按权重、置信度、新近程度和scope综合排序。"
+          : "结果按相关度、scope、权重和新近程度综合排序。",
       }
     })
     .filter((memory) => memory.matched)

--- a/packages/opencode/src/server/routes/memory.ts
+++ b/packages/opencode/src/server/routes/memory.ts
@@ -7,6 +7,7 @@ import { syncDailyReflectJob } from "@/memory/installer"
 
 const SearchBody = z.object({
   query: z.string().min(1),
+  mode: z.enum(["search", "overview"]).optional(),
   types: z.array(z.enum(["preference", "fact", "task"])).optional(),
   limit: z.number().int().optional(),
   currentProjectID: z.string().optional(),
@@ -61,7 +62,14 @@ export const MemoryRoutes = lazy(() =>
         },
       }),
       validator("json", ReflectBody),
-      async (c) => c.json(await Memory.reflect({ mode: c.req.valid("json").mode ?? "quick", reason: c.req.valid("json").reason })),
+      async (c) =>
+        c.json(
+          await Memory.reflect({
+            mode: c.req.valid("json").mode ?? "quick",
+            reason: c.req.valid("json").reason,
+            signal: c.req.raw.signal,
+          }),
+        ),
     )
     .post(
       "/initialize/start",
@@ -75,7 +83,7 @@ export const MemoryRoutes = lazy(() =>
           },
         },
       }),
-      async (c) => c.json(await Memory.initialize({ confirm: true })),
+      async (c) => c.json(await Memory.initialize({ confirm: true, signal: c.req.raw.signal })),
     )
     .post(
       "/initialize/cancel",

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -161,7 +161,8 @@ import { lazy } from "@/util/lazy"
 import { initProjectors } from "./projectors"
 import { SessionPreference } from "@/session/preference"
 import { Cron } from "@/cron"
-import { installMemory } from "@/memory/installer"
+import { Memory } from "@/memory"
+import { installMemory, registerMemoryDirectActions } from "@/memory/installer"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -197,6 +198,7 @@ export namespace Server {
     onBrowserConnectionChange?: (count: number) => void
   }): Hono<ServerEnv> => {
     SessionPreference.clear()
+    registerMemoryDirectActions()
     void Cron.start().catch((error) => {
       log.error("cron start failed", { error })
     })
@@ -1026,9 +1028,14 @@ export namespace Server {
       process.on(signal, () => {
         setTimeout(() => process.exit(0), 10_000).unref()
         Promise.all(
-          [Instance.disposeAll(), Cron.stop(), FeishuManager.stop(), QQManager.stop(), WeChatManager.stop()].map((p) =>
-            p.catch(() => {}),
-          ),
+          [
+            Instance.disposeAll(),
+            Cron.stop(),
+            Memory.stop(),
+            FeishuManager.stop(),
+            QQManager.stop(),
+            WeChatManager.stop(),
+          ].map((p) => p.catch(() => {})),
         )
           .then(() => server.stop(true).catch(() => {}))
           .then(() => process.exit(0))

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -214,6 +214,7 @@ When constructing the summary, try to stick to this template:
       sessionID: input.sessionID,
       tools: {},
       system: [],
+      purpose: "compaction",
       messages: [
         ...MessageV2.toModelMessages(msgs, model, { stripMedia: true }),
         {

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -42,6 +42,7 @@ export namespace LLM {
     tools: Record<string, Tool>
     retries?: number
     toolChoice?: "auto" | "required" | "none"
+    purpose?: "chat" | "title" | "compaction"
   }
 
   export type StreamOutput = StreamTextResult<ToolSet, unknown>
@@ -117,7 +118,7 @@ export namespace LLM {
     const header = system[0]
     await Plugin.trigger(
       "experimental.chat.system.transform",
-      { sessionID: input.sessionID, model: input.model },
+      { sessionID: input.sessionID, model: input.model, purpose: input.purpose ?? "chat" },
       { system },
     )
     // rejoin to maintain 2-part structure for caching if header unchanged

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2111,6 +2111,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       abort: new AbortController().signal,
       sessionID: input.session.id,
       retries: 2,
+      purpose: "title",
       messages: [
         {
           role: "user",

--- a/packages/opencode/src/tool/memory.ts
+++ b/packages/opencode/src/tool/memory.ts
@@ -23,10 +23,12 @@ function renderResults(results: Awaited<ReturnType<typeof Memory.search>>["resul
 export const MemorySearchTool = Tool.define("memory_search", {
   description: [
     "Search Aether long-term memory. Use this when a memory shortcut suggests relevant user preferences, facts, or tasks.",
+    "Use mode=overview when the user asks for a broad summary of remembered context instead of a narrow keyword lookup.",
     "Search only reads AETHER_MEMORY.md and does not read raw session files or aether-memory.db events.",
   ].join("\n"),
   parameters: z.object({
     query: z.string().min(1),
+    mode: z.enum(["search", "overview"]).optional(),
     types: z.array(MemoryType).optional(),
     limit: z.number().int().optional(),
     currentProjectID: z.string().optional(),
@@ -64,6 +66,7 @@ export const MemoryRememberTool = Tool.define("memory_remember", {
         messageID: ctx.messageID,
         role: "user",
       },
+      signal: ctx.abort,
     })
     return {
       title: `Memory event ${result.status}`,
@@ -91,6 +94,7 @@ export const MemoryForgetTool = Tool.define("memory_forget", {
         messageID: ctx.messageID,
         role: "user",
       },
+      signal: ctx.abort,
     })
     return {
       title: result.status === "deleted" ? "Memory forgotten" : "No matching memory",
@@ -112,8 +116,8 @@ export const MemoryReflectTool = Tool.define("memory_reflect", {
     mode: z.enum(["quick", "daily", "manual"]).optional(),
     reason: z.string().optional(),
   }),
-  async execute(input) {
-    const result = await Memory.reflect({ mode: input.mode ?? "quick", reason: input.reason ?? "tool" })
+  async execute(input, ctx) {
+    const result = await Memory.reflect({ mode: input.mode ?? "quick", reason: input.reason ?? "tool", signal: ctx.abort })
     return {
       title: `Memory reflect: ${result.summary}`,
       output: result.summary,

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -124,6 +124,7 @@ export namespace ToolRegistry {
       async function all(custom: Tool.Info[]): Promise<Tool.Info[]> {
         const cfg = await Config.get()
         const question = ["app", "cli", "desktop"].includes(Flag.OPENCODE_CLIENT) || Flag.OPENCODE_ENABLE_QUESTION_TOOL
+        const memory = cfg.memory?.enabled ?? true
 
         return [
           InvalidTool,
@@ -149,10 +150,7 @@ export namespace ToolRegistry {
           CronRunNowTool,
           CronRunsTool,
           CronSetGlobalEnabledTool,
-          MemoryRememberTool,
-          MemoryForgetTool,
-          MemorySearchTool,
-          MemoryReflectTool,
+          ...(memory ? [MemoryRememberTool, MemoryForgetTool, MemorySearchTool, MemoryReflectTool] : []),
           KnowledgeTool,
           ...(Flag.OPENCODE_EXPERIMENTAL_LSP_TOOL ? [LspTool] : []),
           ...(cfg.experimental?.batch_tool === true ? [BatchTool] : []),

--- a/packages/opencode/test/memory/memory.test.ts
+++ b/packages/opencode/test/memory/memory.test.ts
@@ -5,6 +5,8 @@ import { tmpdir } from "../fixture/fixture"
 import { Memory } from "../../src/memory"
 import { installMemory } from "../../src/memory/installer"
 import { Cron } from "../../src/cron"
+import { Config } from "../../src/config/config"
+import { MemoryPlugin } from "../../src/memory/plugin"
 import { MemoryReflectTool, MemorySearchTool } from "../../src/tool/memory"
 import { ToolRegistry } from "../../src/tool/registry"
 import { Instance } from "../../src/project/instance"
@@ -18,6 +20,7 @@ async function memorydir() {
     globalMemoryDir: path.join(tmp.path, "global-memory"),
     channelRootDir: path.join(tmp.path, "channels"),
     channelID: "latest",
+    settings: { enabled: true, dailyReflectEnabled: true, dailyReflectTime: "03:00" },
   })
   await Memory.purge()
   return {
@@ -152,6 +155,82 @@ describe("memory search", () => {
 
     expect(results).toHaveLength(0)
   })
+
+  test("overview queries can return durable user context without exact keyword matches", () => {
+    const overview = parseMemoryMarkdown(`# Aether Memory
+
+## Shortcut Directory
+
+- shortcut: task:project
+  triggers: 我想在想继续开发Science-Discovery, Aether这个项目, 你觉得我现在应该从哪开始？
+  types: task
+  target_ids: TASK-unrelated
+  weight: 0.9
+  instruction: Call memory_search before related project tasks.
+
+## Preferences
+
+## Facts
+
+## Tasks
+
+### TASK-unrelated
+- type: task
+- scope: project:project-a
+- memory: 我想在想继续开发Science-Discovery/Aether这个项目，你觉得我现在应该从哪开始？
+- confidence: 0.68
+- weight: 0.55
+- evidence: 从用户会话中提取到的长期信号。
+- updated_at: 2026-05-14T20:00:02.196Z
+- status: active
+`)
+
+    const results = searchMemoryDocument(overview, {
+      query: "你记得我什么",
+      mode: "overview",
+      limit: 5,
+    })
+
+    expect(results[0]?.id).toBe("TASK-unrelated")
+    expect(results[0]?.ranking_note).toContain("概览查询")
+  })
+
+  test("ignores extremely weak CJK fuzzy overlaps for ordinary searches", () => {
+    const weak = parseMemoryMarkdown(`# Aether Memory
+
+## Shortcut Directory
+
+- shortcut: task:project
+  triggers: 我想在想继续开发Science-Discovery, Aether这个项目, 你觉得我现在应该从哪开始？
+  types: task
+  target_ids: TASK-unrelated
+  weight: 0.9
+  instruction: Call memory_search before related project tasks.
+
+## Preferences
+
+## Facts
+
+## Tasks
+
+### TASK-unrelated
+- type: task
+- scope: project:project-a
+- memory: 我想在想继续开发Science-Discovery/Aether这个项目，你觉得我现在应该从哪开始？
+- confidence: 0.68
+- weight: 0.55
+- evidence: 从用户会话中提取到的长期信号。
+- updated_at: 2026-05-14T20:00:02.196Z
+- status: active
+`)
+
+    const results = searchMemoryDocument(weak, {
+      query: "你记得我什么",
+      limit: 5,
+    })
+
+    expect(results).toHaveLength(0)
+  })
 })
 
 describe("quick reflect gate", () => {
@@ -224,6 +303,7 @@ describe("memory service", () => {
 
   beforeEach(async () => {
     tmp = await tmpdir()
+    await Config.updateGlobal({ memory: { enabled: true, dailyReflect: { enabled: true, time: "03:00" } } } as any)
     Memory.configureForTest({
       globalMemoryDir: path.join(tmp.path, "global-memory"),
       channelRootDir: path.join(tmp.path, "channels"),
@@ -290,6 +370,63 @@ describe("memory service", () => {
     expect(notFound.status).toBe("not_found")
   })
 
+  test("forget does not overwrite a concurrent reflected memory write", async () => {
+    await Memory.writeDocumentForTest(
+      parseMemoryMarkdown(`# Aether Memory
+
+## Shortcut Directory
+
+## Preferences
+
+### PREF-answer-language
+- type: preference
+- scope: global
+- memory: 用户偏好默认用中文回答。
+- confidence: 0.95
+- weight: 0.9
+- evidence: 用户明确要求默认中文回答。
+- updated_at: 2026-05-13T00:00:00.000Z
+- status: active
+
+## Facts
+
+## Tasks
+`),
+    )
+
+    let releaseDecision!: () => void
+    let decisionStarted!: () => void
+    const started = new Promise<void>(resolve => {
+      decisionStarted = resolve
+    })
+    const release = new Promise<void>(resolve => {
+      releaseDecision = resolve
+    })
+    const deleting = Memory.forget({
+      query: "忘掉中文回答这个偏好",
+      source: { createdAt: Date.now(), role: "user" },
+      decide: async () => {
+        decisionStarted()
+        await release
+        return { deleteIDs: ["PREF-answer-language"], keepIDs: [], reason: "user requested forget" }
+      },
+    })
+    await started
+
+    const remembered = await Memory.remember({
+      text: "Please remember that my current project codename is Borealis.",
+      type: "fact",
+      intent: "explicit",
+      source: { createdAt: Date.now(), role: "user" },
+    })
+    expect(remembered.status).toBe("applied")
+
+    releaseDecision()
+    expect((await deleting).status).toBe("deleted")
+    expect((await Memory.search({ query: "中文回答", limit: 5 })).results).toHaveLength(0)
+    expect((await Memory.search({ query: "Borealis", limit: 5 })).results[0]?.memory).toContain("Borealis")
+  })
+
   test("status does not create markdown before initialization", async () => {
     const before = await Memory.status()
     expect(before.markdown_exists).toBe(false)
@@ -297,6 +434,18 @@ describe("memory service", () => {
 
     const markdownPath = path.join(tmp.path, "global-memory", "AETHER_MEMORY.md")
     expect(await fs.stat(markdownPath).catch(() => undefined)).toBeUndefined()
+  })
+
+  test("memory fails closed when config cannot be read", async () => {
+    await Memory.stop()
+    expect(await Memory.isEnabled()).toBe(false)
+  })
+
+  test("reflect aborts before starting LLM work when its signal is already aborted", async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(Memory.reflect({ mode: "daily", reason: "test", signal: controller.signal } as any)).rejects.toThrow()
   })
 
   test("explicit remember is quickly reflected into searchable markdown", async () => {
@@ -315,6 +464,167 @@ describe("memory service", () => {
 
     const events = await Memory.eventsForTest()
     expect(events[0]?.status).toBe("applied")
+  })
+
+  test("chat.message hook schedules quick reflection without blocking the chat pipeline", async () => {
+    let release!: () => void
+    const blocker = new Promise<[]>(resolve => {
+      release = () => resolve([])
+    })
+    Memory.setReflectorForTest(async () => blocker)
+
+    const plugin = await MemoryPlugin({ project: { id: "project-a" } } as any)
+    const done = plugin["chat.message"]!(
+      { sessionID: "session-a", messageID: "message-a" } as any,
+      { parts: [{ type: "text", text: "请记住我默认喜欢中文回答" }] } as any,
+    )
+    const raced = await Promise.race([
+      done.then(() => "returned"),
+      new Promise(resolve => setTimeout(() => resolve("blocked"), 25)),
+    ])
+
+    release()
+    await done
+    expect(raced).toBe("returned")
+  })
+
+  test("quick reflections are serialized and do not overwrite each other", async () => {
+    let active = 0
+    let maxActive = 0
+    Memory.setReflectorForTest(async ({ events }) => {
+      active++
+      maxActive = Math.max(maxActive, active)
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      active--
+      return events.map((event) => ({
+        eventID: event.id,
+        type: "fact" as const,
+        scope: "global" as const,
+        memory: event.raw_text,
+        confidence: 0.95,
+        weight: 0.9,
+        evidence: "explicit user memory",
+      }))
+    })
+
+    const [handle, project] = await Promise.all([
+      Memory.remember({
+        text: "User's preferred handle is Atlas.",
+        type: "fact",
+        intent: "explicit",
+        source: { createdAt: Date.now(), role: "user" },
+      }),
+      Memory.remember({
+        text: "User's current project codename is Borealis.",
+        type: "fact",
+        intent: "explicit",
+        source: { createdAt: Date.now(), role: "user" },
+      }),
+    ])
+
+    expect(handle.status).toBe("applied")
+    expect(project.status).toBe("applied")
+    expect(maxActive).toBe(1)
+    const found = await Memory.search({ query: "User", limit: 10 })
+    expect(found.results.map((item) => item.memory)).toContain("User's preferred handle is Atlas.")
+    expect(found.results.map((item) => item.memory)).toContain("User's current project codename is Borealis.")
+  })
+
+  test("queued reflection rejects promptly when its signal is aborted", async () => {
+    let releaseFirst!: () => void
+    let firstStarted!: () => void
+    const started = new Promise<void>((resolve) => {
+      firstStarted = resolve
+    })
+    const release = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    let calls = 0
+    Memory.setReflectorForTest(async () => {
+      calls++
+      if (calls === 1) {
+        firstStarted()
+        await release
+      }
+      return []
+    })
+
+    const first = Memory.remember({
+      text: "Please remember that the first reflection is intentionally slow.",
+      type: "fact",
+      intent: "explicit",
+      source: { createdAt: Date.now(), role: "user" },
+    })
+    await started
+
+    const controller = new AbortController()
+    const second = Memory.reflect({ mode: "daily", reason: "queued-abort-test", signal: controller.signal })
+    controller.abort()
+    await expect(Promise.race([second, new Promise((resolve) => setTimeout(() => resolve("timeout"), 30))])).rejects.toThrow()
+
+    releaseFirst()
+    await first
+    expect(calls).toBe(1)
+  })
+
+  test("explicit quick reflection may split one raw memory into multiple durable candidates", async () => {
+    Memory.setReflectorForTest(async ({ events }) => [
+      {
+        eventID: events[0]!.id,
+        type: "fact" as const,
+        scope: "global" as const,
+        memory: "User's preferred handle is Atlas.",
+        confidence: 0.96,
+        weight: 0.9,
+        evidence: "explicit user memory",
+      },
+      {
+        eventID: events[0]!.id,
+        type: "fact" as const,
+        scope: "global" as const,
+        memory: "User's current project codename is Borealis.",
+        confidence: 0.96,
+        weight: 0.9,
+        evidence: "explicit user memory",
+      },
+    ])
+
+    const remembered = await Memory.remember({
+      text: "Please remember that my preferred handle is Atlas and my current project codename is Borealis.",
+      type: "fact",
+      intent: "explicit",
+      source: { createdAt: Date.now(), role: "user" },
+    })
+
+    expect(remembered.status).toBe("applied")
+    const found = await Memory.search({ query: "User", limit: 10 })
+    expect(found.results.map((item) => item.memory)).toContain("User's preferred handle is Atlas.")
+    expect(found.results.map((item) => item.memory)).toContain("User's current project codename is Borealis.")
+  })
+
+  test("shortcut triggers preserve source wording even when reflection rewrites the memory", async () => {
+    Memory.setReflectorForTest(async ({ events }) => [
+      {
+        eventID: events[0]!.id,
+        type: "fact" as const,
+        scope: "global" as const,
+        memory: "User's advisor is Zhang Yang.",
+        confidence: 0.96,
+        weight: 0.9,
+        evidence: "explicit user memory",
+      },
+    ])
+
+    const remembered = await Memory.remember({
+      text: "请记住我的导师是张扬老师。",
+      type: "fact",
+      intent: "explicit",
+      source: { createdAt: Date.now(), role: "user" },
+    })
+
+    expect(remembered.status).toBe("applied")
+    const found = await Memory.search({ query: "导师", limit: 5 })
+    expect(found.results[0]?.memory).toBe("User's advisor is Zhang Yang.")
   })
 
   test("low-signal observed events are not left pending for daily reflection", async () => {
@@ -519,8 +829,50 @@ describe("memory service", () => {
     const prompt = await Memory.shortcutSystemPrompt()
     expect(prompt).toContain("response-style")
     expect(prompt).toContain("memory_search")
+    expect(prompt).toContain("durable user or project context")
     expect(prompt).not.toContain("PREF-answer-language")
     expect(prompt).not.toContain("用户偏好默认用中文回答")
+  })
+
+  test("memory shortcut hook only injects into chat streams", async () => {
+    await Memory.writeDocumentForTest(
+      parseMemoryMarkdown(`# Aether Memory
+
+## Shortcut Directory
+
+- shortcut: response-style
+  triggers: 中文, answer style
+  types: preference
+  target_ids: PREF-answer-language
+  weight: 0.9
+  instruction: Search response style preferences before answering.
+
+## Preferences
+
+### PREF-answer-language
+- type: preference
+- scope: global
+- memory: 用户偏好默认用中文回答。
+- confidence: 0.95
+- weight: 0.9
+- evidence: 用户明确要求默认中文回答。
+- updated_at: 2026-05-13T00:00:00.000Z
+- status: active
+
+## Facts
+
+## Tasks
+`),
+    )
+
+    const plugin = await MemoryPlugin({ project: { id: "project-a" } } as any)
+    const titleOutput = { system: ["base"] }
+    await plugin["experimental.chat.system.transform"]!({ purpose: "title" } as any, titleOutput)
+    expect(titleOutput.system).toEqual(["base"])
+
+    const chatOutput = { system: ["base"] }
+    await plugin["experimental.chat.system.transform"]!({ purpose: "chat" } as any, chatOutput)
+    expect(chatOutput.system.join("\n")).toContain("memory_search")
   })
 
   test("initialize scans sessions serially and stops after cancellation", async () => {
@@ -556,7 +908,64 @@ describe("memory service", () => {
 
     expect(result.status).toBe("cancelled")
     expect(visited).toEqual(["one"])
-    expect((await Memory.eventsForTest()).length).toBe(1)
+    expect((await Memory.eventsForTest()).length).toBe(0)
+  })
+
+  test("initialize respects an already aborted signal", async () => {
+    let scanned = false
+    Memory.setSessionScannerForTest(async function* () {
+      scanned = true
+      yield {
+        channelID: "latest",
+        projectID: "project-a",
+        sessionID: "one",
+        messages: [{ role: "user" as const, text: "请记住我喜欢中文回答", createdAt: 1 }],
+      }
+    })
+    const controller = new AbortController()
+    controller.abort()
+
+    const result = await Memory.initialize({ confirm: true, signal: controller.signal } as any)
+
+    expect(result).toEqual({ status: "cancelled", scanned: 0, imported: 0 })
+    expect(scanned).toBe(false)
+  })
+
+  test("initialize cancel aborts the running extractor signal", async () => {
+    let extractorStarted!: () => void
+    const started = new Promise<void>((resolve) => {
+      extractorStarted = resolve
+    })
+    let sawAbort = false
+    Memory.setSessionScannerForTest(async function* () {
+      yield {
+        channelID: "latest",
+        projectID: "project-a",
+        sessionID: "one",
+        messages: [{ role: "user" as const, text: "请记住我喜欢中文回答", createdAt: 1 }],
+      }
+    })
+    Memory.setInitializerExtractorForTest(async (_session, signal) => {
+      extractorStarted()
+      await new Promise<never>((_resolve, reject) => {
+        signal?.addEventListener(
+          "abort",
+          () => {
+            sawAbort = true
+            reject(signal.reason ?? new Error("aborted"))
+          },
+          { once: true },
+        )
+      })
+      return []
+    })
+
+    const running = Memory.initialize({ confirm: true })
+    await started
+    await Memory.cancelInitialize()
+
+    expect(await running).toEqual({ status: "cancelled", scanned: 1, imported: 0 })
+    expect(sawAbort).toBe(true)
   })
 
   test("initialize imports matching user messages with the production extractor", async () => {
@@ -666,6 +1075,13 @@ describe("memory agent tools", () => {
     expect(ids).toContain("memory_reflect")
   })
 
+  test("tool registry hides memory tools when memory is disabled", async () => {
+    await using tmp = await tmpdir({ config: { memory: { enabled: false } } as any })
+    const ids = await Instance.provide({ directory: tmp.path, fn: () => ToolRegistry.ids() })
+    expect(ids).not.toContain("memory_search")
+    expect(ids).not.toContain("memory_reflect")
+  })
+
   test("memory_search tool returns markdown memory block ids", async () => {
     await using _ = await memorydir()
     await Memory.writeDocumentForTest(
@@ -700,23 +1116,114 @@ describe("memory agent tools", () => {
     const reflected = await reflect.execute({ mode: "quick" }, {} as any)
     expect(reflected.output).toContain("No changes")
   })
+
+  test("memory_reflect tool forwards tool abort signal to reflection", async () => {
+    await using _ = await memorydir()
+    await Memory.remember({
+      text: "我希望回答先给结论",
+      type: "preference",
+      intent: "observed",
+      source: { createdAt: Date.now(), role: "user" },
+    })
+    const controller = new AbortController()
+    let sawToolSignal = false
+    Memory.setReflectorForTest(async (input: any) => {
+      sawToolSignal = input.signal === controller.signal
+      controller.abort()
+      input.signal?.throwIfAborted()
+      return []
+    })
+    const reflect = await MemoryReflectTool.init()
+
+    await expect(reflect.execute({ mode: "daily" }, { abort: controller.signal } as any)).rejects.toThrow()
+    expect(sawToolSignal).toBe(true)
+  })
+
+  test("memory_search returns no results when memory is disabled", async () => {
+    await using tmp = await tmpdir({ config: { memory: { enabled: false } } as any })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        Memory.configureForTest({
+          globalMemoryDir: path.join(tmp.path, "global-memory"),
+          channelRootDir: path.join(tmp.path, "channels"),
+          channelID: "latest",
+          settings: { enabled: false },
+        })
+        await Memory.purge()
+        await Memory.writeDocumentForTest(
+          parseMemoryMarkdown(`# Aether Memory
+
+## Shortcut Directory
+
+## Preferences
+
+### PREF-answer-language
+- type: preference
+- scope: global
+- memory: 用户偏好默认用中文回答。
+- confidence: 0.95
+- weight: 0.9
+- evidence: 用户明确要求默认中文回答。
+- updated_at: 2026-05-13T00:00:00.000Z
+- status: active
+
+## Facts
+
+## Tasks
+`),
+        )
+
+        const found = await Memory.search({ query: "中文回答", limit: 5 })
+        expect(found.results).toHaveLength(0)
+        expect(found.ranking_note).toContain("disabled")
+      },
+    })
+  })
 })
 
 describe("memory installer", () => {
-  test("registers daily reflect direct action and creates builtin cron job once", async () => {
-    await using _ = await memorydir()
+  test("registers daily reflect direct action and creates builtin cron job from current config", async () => {
+    await using tmp = await tmpdir()
+    Memory.configureForTest({
+      globalMemoryDir: path.join(tmp.path, "global-memory"),
+      channelRootDir: path.join(tmp.path, "channels"),
+      channelID: "latest",
+      settings: { enabled: true, dailyReflectEnabled: true, dailyReflectTime: "03:00" },
+    })
+    await Memory.purge()
+    Memory.configureForTest({
+      globalMemoryDir: path.join(tmp.path, "global-memory"),
+      channelRootDir: path.join(tmp.path, "channels"),
+      channelID: "latest",
+      settings: { enabled: true, dailyReflectEnabled: true, dailyReflectTime: "03:00" },
+    })
     await installMemory()
     const job = await Cron.getJob("builtin.memory.daily_reflect")
     expect(job.definition.payload).toEqual({ action: "memory.reflect.daily" })
     expect(job.definition.schedule_value).toBe("0 3 * * *")
 
-    await Cron.updateJob({ id: "builtin.memory.daily_reflect", patch: { schedule_value: "0 4 * * *" } })
+    Memory.configureForTest({
+      globalMemoryDir: path.join(tmp.path, "global-memory"),
+      channelRootDir: path.join(tmp.path, "channels"),
+      channelID: "latest",
+      settings: { enabled: true, dailyReflectEnabled: true, dailyReflectTime: "04:00" },
+    })
     await installMemory()
-    const preserved = await Cron.getJob("builtin.memory.daily_reflect")
-    expect(preserved.definition.schedule_value).toBe("0 4 * * *")
+    const updated = await Cron.getJob("builtin.memory.daily_reflect")
+    expect(updated.definition.schedule_value).toBe("0 4 * * *")
 
     await Cron.runJobNow({ id: "builtin.memory.daily_reflect" })
     const runs = await Cron.listRuns({ id: "builtin.memory.daily_reflect", count: 1 })
     expect(runs[0]?.status).toBe("success")
+  })
+})
+
+describe("memory server lifecycle", () => {
+  test("server startup registers memory direct actions before cron start and shutdown closes memory db", async () => {
+    const serverSource = await fs.readFile(path.join(import.meta.dir, "../../src/server/server.ts"), "utf8")
+    expect(serverSource.indexOf("registerMemoryDirectActions()")).toBeGreaterThanOrEqual(0)
+    expect(serverSource.indexOf("registerMemoryDirectActions()")).toBeLessThan(serverSource.indexOf("Cron.start()"))
+    expect(serverSource).toContain("Memory.stop()")
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #809

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Hardens the memory system around cancellation and concurrent writes.

- Serializes memory reflection writes and rejects queued reflection promptly when its abort signal fires.
- Passes abort signals through memory tools, memory routes, LLM reflection, forget decisions, and initialization extraction.
- Adds a Settings > Memory stop-import button that cancels the active initialization extractor/LLM call.
- Re-reads `AETHER_MEMORY.md` under the write lock before `memory_forget` mutates it, avoiding stale snapshot overwrite.
- Removes degraded fallback behavior for daily/manual reflection so reflection is either success or failed.

Small integration changes outside the memory package are limited to memory hook/tool registration, chat-purpose tagging, server lifecycle cleanup, and the Memory settings UI.

### How did you verify your code works?

- `PATH=/home/liuyuanche/.bun/bin:$PATH bun run --cwd packages/opencode test test/memory/memory.test.ts test/cron/cron.test.ts --timeout 60000`
- `PATH=/home/liuyuanche/.bun/bin:$PATH bun run --cwd packages/app ./script/vitest.ts run --config ./vitest.config.ts src/components/settings-memory.vitest.tsx`
- `PATH=/home/liuyuanche/.bun/bin:$PATH bun run --cwd packages/opencode typecheck`
- `PATH=/home/liuyuanche/.bun/bin:$PATH bun run --cwd packages/app typecheck`
- `PATH=/home/liuyuanche/.bun/bin:$PATH git push -u origin fix/memory-reflect-abort-concurrency` ran the repository pre-push `bun turbo typecheck` hook successfully.

### Screenshots / recordings

Not included. The UI change is a small stop-import button in Settings > Memory and is covered by component tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR