### PR TITLE
fix: 配置变更不再终止所有运行中的任务

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1303,7 +1303,10 @@ export namespace Config {
             .object({
               enabled: z.boolean().optional().describe("Enable scheduled daily memory reflection (default: true)"),
               time: z.string().optional().describe("Daily memory reflection time in HH:mm format (default: 03:00)"),
-              timezone: z.string().optional().describe("Daily memory reflection timezone. Defaults to the system timezone."),
+              timezone: z
+                .string()
+                .optional()
+                .describe("Daily memory reflection timezone. Defaults to the system timezone."),
             })
             .optional(),
           search: z
@@ -1696,6 +1699,26 @@ export namespace Config {
     })
   }
 
+  const SAFE_CONFIG_KEYS = new Set([
+    "model",
+    "small_model",
+    "disabled_models",
+    "disabled_providers",
+    "server",
+    "cron",
+    "memory",
+    "logLevel",
+    "autoupdate",
+    "username",
+    "share",
+    "autoshare",
+    "watcher",
+    "snapshot",
+    "enterprise",
+    "experimental",
+    "skills",
+  ])
+
   export async function updateGlobal(config: Info) {
     const filepath = globalConfigFile()
     const found = existsSync(filepath)
@@ -1745,17 +1768,22 @@ export namespace Config {
 
     global.reset()
 
-    void Instance.disposeAll()
-      .catch(() => undefined)
-      .finally(() => {
-        GlobalBus.emit("event", {
-          directory: "global",
-          payload: {
-            type: Event.Disposed.type,
-            properties: {},
-          },
+    const hasUnsafeKey = Object.keys(config).some((k) => !SAFE_CONFIG_KEYS.has(k))
+    if (hasUnsafeKey) {
+      void Instance.disposeAll()
+        .catch(() => undefined)
+        .finally(() => {
+          GlobalBus.emit("event", {
+            directory: "global",
+            payload: {
+              type: Event.Disposed.type,
+              properties: {},
+            },
+          })
         })
-      })
+    } else {
+      state.reset()
+    }
 
     return next
   }

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -86,19 +86,19 @@ export const Instance = {
         }),
       )
     }
-      if (!existing) {
-        if (input.create === false) {
-          const info = ProjectIdentity.resolve(directory)
-          const browseCtx: Shape = {
-            directory,
-            worktree: info.sandbox,
-            project: {
-              id: info.id,
-              worktree: info.root,
-              vcs: info.vcs,
-              sandboxes: [],
-              time: { created: Date.now(), updated: Date.now() },
-            },
+    if (!existing) {
+      if (input.create === false) {
+        const info = ProjectIdentity.resolve(directory)
+        const browseCtx: Shape = {
+          directory,
+          worktree: info.sandbox,
+          project: {
+            id: info.id,
+            worktree: info.root,
+            vcs: info.vcs,
+            sandboxes: [],
+            time: { created: Date.now(), updated: Date.now() },
+          },
         }
         return context.provide(browseCtx, async () => input.fn())
       }
@@ -157,7 +157,7 @@ export const Instance = {
     const ctx = context.use()
     return ((...args: any[]) => context.provide(ctx, () => fn(...args))) as F
   },
-  state<S>(init: () => S, dispose?: (state: Awaited<S>) => Promise<void>): () => S {
+  state<S>(init: () => S, dispose?: (state: Awaited<S>) => Promise<void>): State.StateFn<S> {
     return State.create(() => Instance.directory, init, dispose)
   },
   async reload(input: { directory: string; init?: () => Promise<any>; project?: Project.Info; worktree?: string }) {

--- a/packages/opencode/src/project/state.ts
+++ b/packages/opencode/src/project/state.ts
@@ -9,8 +9,17 @@ export namespace State {
   const log = Log.create({ service: "state" })
   const recordsByKey = new Map<string, Map<any, Entry>>()
 
-  export function create<S>(root: () => string, init: () => S, dispose?: (state: Awaited<S>) => Promise<void>) {
-    return () => {
+  export interface StateFn<S> {
+    (): S
+    reset(): void
+  }
+
+  export function create<S>(
+    root: () => string,
+    init: () => S,
+    dispose?: (state: Awaited<S>) => Promise<void>,
+  ): StateFn<S> {
+    const fn = (() => {
       const key = root()
       let entries = recordsByKey.get(key)
       if (!entries) {
@@ -25,7 +34,15 @@ export namespace State {
         dispose,
       })
       return state
+    }) as StateFn<S>
+
+    fn.reset = () => {
+      for (const entries of recordsByKey.values()) {
+        entries.delete(init)
+      }
     }
+
+    return fn
   }
 
   export async function dispose(key: string) {


### PR DESCRIPTION
### Issue for this PR

Closes #758

### Type of change

- [x] Bug fix

### What does this PR do?

修复了设置页面和技能面板中多个操作会意外中断正在运行任务的问题。

**根因：** `Config.updateGlobal()` 对所有配置变更都无条件调用 `Instance.disposeAll()`，杀死所有项目中正在进行的任务。

**修改方案：**
1. 新增 `SAFE_CONFIG_KEYS` 白名单，包含 model、skills、cron、memory 等不需要 dispose 的配置字段
2. 安全字段变更时仅调用 `state.reset()` 清除配置缓存，不触发 `disposeAll()`
3. 非安全字段（provider、mcp）保留原有 `disposeAll()` 行为
4. 为 `State.create()` 返回的函数添加 `.reset()` 方法，支持定向清除配置缓存

**效果：** 12 个设置操作中，9 个不再中断任务，3 个（断开/连接/编辑提供商）保留 dispose 行为。

### How did you verify your code works?

- 通过 TypeScript 类型检查（`bun typecheck`）
- 打包 web 前端和二进制文件成功
- 本地测试 skill 开关按钮可正常切换，不再卡住

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR