### PR TITLE
fix: prevent empty project DBs for Aether install directories

### DIFF
--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -62,6 +62,14 @@ export default function Layout(props: ParentProps) {
     navigate("/", { replace: true })
   })
 
+  createEffect(() => {
+    const dir = resolved()
+    if (!dir) return
+    if (/aether[/\\]aether_\d+\.\d+\.\d+\.\d+/i.test(dir)) {
+      navigate("/", { replace: true })
+    }
+  })
+
   return (
     <Show when={resolved()} keyed>
       {(resolved) => (

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -753,7 +753,7 @@ export default function Layout(props: ParentProps) {
         const last = server.projects.last()
 
         if (value.list.length === 0) {
-          if (!last) return
+          if (!last || /aether[/\\]aether_\d+\.\d+\.\d+\.\d+/i.test(last)) return
           openProject(last, false)
           // IMPORTANT: Do NOT set autoselect=false synchronously before navigateToProject completes.
           // Setting it early causes autoselecting() to become false immediately, which makes the
@@ -766,7 +766,7 @@ export default function Layout(props: ParentProps) {
         }
 
         const next = value.list.find((project) => project.worktree === last) ?? value.list[0]
-        if (!next) return
+        if (!next || /aether[/\\]aether_\d+\.\d+\.\d+\.\d+/i.test(next.worktree)) return
         openProject(next.worktree, false)
         // Same reasoning as above: defer autoselect=false until navigation completes.
         void navigateToProject(next.worktree).finally(() => setState("autoselect", false))

--- a/packages/app/src/pages/layout/install-dir-detect.test.ts
+++ b/packages/app/src/pages/layout/install-dir-detect.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test"
+
+const INSTALL_DIR_RE = /aether[/\\]aether_\d+\.\d+\.\d+\.\d+/i
+
+function shouldRedirect(dir: string): boolean {
+  return INSTALL_DIR_RE.test(dir)
+}
+
+describe("install directory detection", () => {
+  test("matches Windows Aether install path", () => {
+    expect(shouldRedirect("C:\\Users\\user\\AppData\\Local\\Programs\\aether\\aether_0.6.2.33")).toBe(true)
+    expect(shouldRedirect("C:\\Users\\user\\AppData\\Local\\Programs\\aether\\aether_0.6.2.44")).toBe(true)
+  })
+
+  test("matches forward-slash normalized install path", () => {
+    expect(shouldRedirect("C:/Users/user/AppData/Local/Programs/aether/aether_0.6.2.33")).toBe(true)
+  })
+
+  test("matches lowercase install path", () => {
+    expect(shouldRedirect("c:/users/user/appdata/local/programs/aether/aether_0.6.2.33")).toBe(true)
+  })
+
+  test("matches install dir nested inside longer path", () => {
+    expect(shouldRedirect("/some/prefix/aether/aether_1.2.3.4/more")).toBe(true)
+  })
+
+  test("does not match normal project directory", () => {
+    expect(shouldRedirect("E:\\work\\AI\\Aether\\session-preference")).toBe(false)
+    expect(shouldRedirect("E:\\work\\AI\\Aether\\debug")).toBe(false)
+    expect(shouldRedirect("C:\\Users\\user\\projects\\my-app")).toBe(false)
+  })
+
+  test("does not match aether dir without version subdir", () => {
+    expect(shouldRedirect("/usr/local/aether")).toBe(false)
+    expect(shouldRedirect("C:\\aether\\data")).toBe(false)
+  })
+
+  test("does not match version string without aether parent", () => {
+    expect(shouldRedirect("/tmp/aether_0.6.2.33")).toBe(false)
+  })
+
+  test("does not match empty string", () => {
+    expect(shouldRedirect("")).toBe(false)
+  })
+})

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -431,6 +431,28 @@ export namespace Project {
           { concurrency: "unbounded" },
         ).pipe(Effect.map((arr) => arr.filter((x): x is string => x !== undefined)))
 
+        const aliases = [...new Set([directory, data.worktree, data.sandbox].map((dir) => norm(dir)))]
+        for (const dir of aliases) {
+          yield* db((d) =>
+            d
+              .insert(GlobalProjectMapTable)
+              .values({
+                directory: dir,
+                project_id: result.id,
+                time_created: Date.now(),
+                time_updated: Date.now(),
+              })
+              .onConflictDoUpdate({
+                target: GlobalProjectMapTable.directory,
+                set: { project_id: result.id, time_updated: Date.now() },
+              })
+              .run(),
+          )
+        }
+
+        const touchDir = data.worktree !== "/" ? data.worktree : directory
+        yield* touch({ project: result, directory: touchDir })
+
         yield* dbProject(data.id, (d) =>
           d
             .insert(ProjectTable)
@@ -489,25 +511,6 @@ export namespace Project {
           }
         }
 
-        const aliases = [...new Set([directory, data.worktree, data.sandbox].map((dir) => norm(dir)))]
-        for (const dir of aliases) {
-          yield* db((d) =>
-            d
-              .insert(GlobalProjectMapTable)
-              .values({
-                directory: dir,
-                project_id: result.id,
-                time_created: Date.now(),
-                time_updated: Date.now(),
-              })
-              .onConflictDoUpdate({
-                target: GlobalProjectMapTable.directory,
-                set: { project_id: result.id, time_updated: Date.now() },
-              })
-              .run(),
-          )
-        }
-
         yield* dbProject(data.id, (d) =>
           d
             .insert(DirectoryMetaTable)
@@ -537,8 +540,6 @@ export namespace Project {
         )
 
         yield* emitUpdated(result)
-        const touchDir = data.worktree !== "/" ? data.worktree : directory
-        yield* touch({ project: result, directory: touchDir })
         return { project: result, sandbox: data.sandbox }
       })
 
@@ -573,11 +574,13 @@ export namespace Project {
       })
 
       const get = Effect.fn("Project.get")(function* (id: ProjectID) {
+        if (!Database.hasProject(id)) return undefined
         const row = yield* dbProject(id, (d) => d.select().from(ProjectTable).where(eq(ProjectTable.id, id)).get())
         return row ? fromRow(row) : undefined
       })
 
       const update = Effect.fn("Project.update")(function* (input: UpdateInput) {
+        if (!Database.hasProject(input.projectID)) throw new Error(`Project not found: ${input.projectID}`)
         const result = yield* dbProject(input.projectID, (d) =>
           d
             .update(ProjectTable)
@@ -750,6 +753,7 @@ export namespace Project {
   }
 
   export function get(id: ProjectID): Info | undefined {
+    if (!Database.hasProject(id)) return undefined
     const row = Database.useProject(id, (db) => db.select().from(ProjectTable).where(eq(ProjectTable.id, id)).get())
     if (!row) return undefined
     return fromRow(row)

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -479,6 +479,15 @@ export namespace Database {
     const existing = projectClients.get(projectId)
     if (existing) return existing
     const p = projectPath(projectId)
+
+    if (!existsSync(p) && projectId !== "global") {
+      const mainSqlite = Client().$client
+      const registered = mainSqlite.prepare("SELECT 1 FROM global_project_map WHERE project_id = ?").get(projectId)
+      if (!registered) {
+        throw new Error(`Cannot create project database: ${projectId} is not registered`)
+      }
+    }
+
     log.info("opening project database", { projectId, path: p })
 
     try {

--- a/packages/opencode/test/project/project-fromdirectory-order.test.ts
+++ b/packages/opencode/test/project/project-fromdirectory-order.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test"
+import { Project } from "../../src/project/project"
+import { Instance } from "../../src/project/instance"
+import { Database } from "../../src/storage/db"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+import { existsSync } from "fs"
+import { ProjectTable } from "../../src/project/project.sql"
+import { eq } from "drizzle-orm"
+
+Log.init({ print: false })
+
+describe("Project.fromDirectory ordering", () => {
+  test("writes global_project_map, project_recent, and creates per-project DB", async () => {
+    await using tmp = await tmpdir()
+    const { project } = await Project.fromDirectory(tmp.path)
+
+    const mainSqlite = Database.Client().$client
+
+    const gpm = mainSqlite.prepare("SELECT directory FROM global_project_map WHERE project_id = ?").all(project.id) as {
+      directory: string
+    }[]
+    expect(gpm.length).toBeGreaterThan(0)
+
+    const recent = mainSqlite.prepare("SELECT directory FROM project_recent WHERE project_id = ?").get(project.id) as
+      | { directory: string }
+      | undefined
+    expect(recent).toBeDefined()
+
+    const dbPath = Database.projectPath(project.id)
+    expect(existsSync(dbPath)).toBe(true)
+
+    const row = Database.useProject(project.id, (d) =>
+      d.select().from(ProjectTable).where(eq(ProjectTable.id, project.id)).get(),
+    )
+    expect(row).toBeDefined()
+  })
+
+  test("registers worktree and sandbox aliases in global_project_map", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const { project } = await Project.fromDirectory(tmp.path)
+
+    const gpm = Database.Client()
+      .$client.prepare("SELECT directory FROM global_project_map WHERE project_id = ?")
+      .all(project.id) as { directory: string }[]
+
+    const dirs = gpm.map((r) => r.directory)
+    const wt = project.worktree.replace(/\\/g, "/").toLowerCase()
+    const raw = tmp.path.replace(/\\/g, "/").toLowerCase()
+
+    expect(dirs.some((d) => d === wt)).toBe(true)
+    expect(dirs.some((d) => d === raw)).toBe(true)
+  })
+
+  test("project_recent entry has matching directory", async () => {
+    await using tmp = await tmpdir()
+    const { project } = await Project.fromDirectory(tmp.path)
+
+    const recent = Database.Client()
+      .$client.prepare("SELECT directory FROM project_recent WHERE project_id = ?")
+      .get(project.id) as { directory: string } | undefined
+
+    expect(recent).toBeDefined()
+    const expected = tmp.path.replace(/\\/g, "/").toLowerCase()
+    expect(recent!.directory.replace(/\\/g, "/").toLowerCase()).toBe(expected)
+  })
+})

--- a/packages/opencode/test/storage/db-project-guard.test.ts
+++ b/packages/opencode/test/storage/db-project-guard.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test"
+import { Database } from "../../src/storage/db"
+import { Project } from "../../src/project/project"
+import { Instance } from "../../src/project/instance"
+import { Log } from "../../src/util/log"
+import { ProjectID } from "../../src/project/schema"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+describe("Database.attach() guard", () => {
+  test("attach() throws when project_id is not in global_project_map", async () => {
+    const unregistered = ProjectID.fromDirectory(
+      "/opencode-test-guard-nonexistent-" + Math.random().toString(36).slice(2),
+    )
+
+    expect(() => Database.attach(unregistered)).toThrow(
+      `Cannot create project database: ${unregistered} is not registered`,
+    )
+  })
+
+  test("attach() succeeds for project registered via fromDirectory", async () => {
+    await using tmp = await tmpdir()
+    const { project } = await Project.fromDirectory(tmp.path)
+
+    Database.detach(project.id)
+    const reopened = Database.attach(project.id)
+    expect(reopened).toBeDefined()
+  })
+
+  test("attach() succeeds for git project registered via fromDirectory", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const { project } = await Project.fromDirectory(tmp.path)
+
+    Database.detach(project.id)
+    const reopened = Database.attach(project.id)
+    expect(reopened).toBeDefined()
+  })
+
+  test("global_project_map has entry after fromDirectory", async () => {
+    await using tmp = await tmpdir()
+    const { project } = await Project.fromDirectory(tmp.path)
+
+    const row = Database.Client()
+      .$client.prepare("SELECT 1 FROM global_project_map WHERE project_id = ?")
+      .get(project.id) as { 1: number } | undefined
+    expect(row).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary
Fixes auto-update creating a new empty project database for each Aether install directory version.

## Changes

### Backend
1. **Reorder `fromDirectory` writes**: Register project in `global_project_map` and `project_recent` BEFORE creating the per-project DB via `attach()`.
2. **Guard `attach()`**: Check `global_project_map` before creating a new DB file. Unregistered project IDs are rejected.

### Frontend
3. **Redirect install dir URLs**: Detect Aether install directories (matching `/aether/aether_X.Y.Z.W`) and redirect to Home. Guard autoselect logic.

### Tests
- `test/storage/db-project-guard.test.ts` — 4 tests for attach() guard
- `test/project/project-fromdirectory-order.test.ts` — 3 tests for write ordering
- `app/src/pages/layout/install-dir-detect.test.ts` — 8 tests for regex detection