### PR TITLE
fix: improve memory search trigger guidance

### DIFF
--- a/docs/memory-system.zh-CN.md
+++ b/docs/memory-system.zh-CN.md
@@ -249,6 +249,11 @@ search_target: true
 - 搜索长期记忆
 - 只读 `AETHER_MEMORY.md`
 - 返回按相关度、scope、权重和新近程度排序的结果
+- 当请求可能依赖长期用户或项目上下文时，应优先调用：
+  - 用户身份、画像、偏好
+  - 项目事实、历史决策、既往约束
+  - recurring tasks 或用户曾经要求长期遵循的规则
+  - “你记得什么”“按我之前说的来”这类宽泛记忆问题
 
 参数：
 
@@ -414,13 +419,26 @@ Settings > Memory 中的 daily reflection 开关和时间会同步到该 cron jo
 
 当前 memory 系统不把完整长期记忆注入 system prompt。
 
-注入内容只包含 `Shortcut Directory` 的精简提示：
+注入内容只包含 `Shortcut Directory` 生成的精简主题目录：
 
 - shortcut
-- triggers
-- instruction
+- topics/triggers
+
+注入时不会包含：
+
+- `target_ids`
+- `instruction`
+- 具体 memory 正文
 
 这些内容只用于提醒 Agent 判断是否应该调用 `memory_search`。Agent 不应把 shortcut 当作完整事实使用。
+
+触发原则：
+
+- 不要求 topic 精确匹配；只要问题可能因为长期记忆而改变答案，就应先调用 `memory_search`
+- 对宽泛画像问题使用简短的概览式关键词查询，例如 `user profile preference project constraints`
+- 对普通无上下文问题不需要调用，例如纯算术或完全自包含的问题
+
+Shortcut topic 的生成会优先保留用户原始表达中的主题词，再补充 reflection 后的 memory 文本。这样可以避免 LLM 在整理记忆时改写措辞后，把原始可召回主题丢掉。
 
 ## 11. 生命周期接口
 

--- a/packages/opencode/src/memory/index.ts
+++ b/packages/opencode/src/memory/index.ts
@@ -612,11 +612,11 @@ function shortcutTerms(...texts: Array<string | undefined>) {
       }
     }
   }
-  return [...new Set(terms)].slice(0, 12)
+  return [...new Set(terms)].slice(0, 32)
 }
 
 function buildShortcut(candidate: ReflectionCandidate, sourceText?: string) {
-  const words = shortcutTerms(candidate.memory, sourceText)
+  const words = shortcutTerms(sourceText, candidate.memory)
   return {
     shortcut: `${candidate.type}:${candidate.scope}`,
     triggers: [...new Set(words.length ? words : [candidate.type])],
@@ -985,7 +985,7 @@ function mergeCandidates(doc: MemoryDocument, candidates: ReflectionCandidate[],
       const activeIDs = new Set(doc.memories.filter((memory) => memory.status === "active").map((memory) => memory.id))
       existingShortcut.target_ids = existingShortcut.target_ids.filter((target) => activeIDs.has(target))
       if (!existingShortcut.target_ids.includes(id)) existingShortcut.target_ids.push(id)
-      existingShortcut.triggers = [...new Set([...existingShortcut.triggers, ...shortcut.triggers])].slice(0, 16)
+      existingShortcut.triggers = [...new Set([...existingShortcut.triggers, ...shortcut.triggers])].slice(0, 32)
       existingShortcut.weight = Math.max(existingShortcut.weight, shortcut.weight)
       shortcutChanged = true
     } else {
@@ -1544,22 +1544,19 @@ export namespace Memory {
     const doc = await readDocument()
     if (!doc.shortcuts.length) return undefined
     const lines = [
-      "<user_memory_shortcuts>",
-      "These are memory shortcuts, not full memories. Use them only to decide whether memory_search is needed.",
-      "When the current task depends on durable user or project context, preferences, facts, past commitments, or previously stated constraints, call memory_search with concise keywords from the task and relevant shortcut triggers.",
+      "<user_memory_guide>",
+      "Long-term user and project memory is available through the memory_search tool. The topics below are only a compact directory, not facts.",
+      "Before answering, call memory_search when the request may depend on durable user or project context: identity, preferences, profile, facts, prior instructions, past decisions, recurring tasks, or previously stated constraints.",
+      "Do not wait for an exact topic match. If the user asks what you remember, asks for broad context, or the current task could be personalized by memory, call memory_search first.",
+      "For broad memory or profile questions, search with concise overview-style keywords.",
       "",
     ]
     for (const shortcut of doc.shortcuts) {
-      lines.push(
-        `- shortcut: ${shortcut.shortcut}`,
-        `  triggers: ${shortcut.triggers.join(", ")}`,
-        `  instruction: ${shortcut.instruction}`,
-        "",
-      )
+      lines.push(`- ${shortcut.shortcut} topics: ${shortcut.triggers.join(", ")}`)
     }
     lines.push(
-      "If a shortcut matches the current task, call memory_search. Do not treat shortcut text as factual memory.",
-      "</user_memory_shortcuts>",
+      "Never treat these topics as factual memory; they are only routing hints for memory_search.",
+      "</user_memory_guide>",
     )
     return lines.join("\n")
   }

--- a/packages/opencode/src/tool/memory.ts
+++ b/packages/opencode/src/tool/memory.ts
@@ -22,7 +22,9 @@ function renderResults(results: Awaited<ReturnType<typeof Memory.search>>["resul
 
 export const MemorySearchTool = Tool.define("memory_search", {
   description: [
-    "Search Aether long-term memory. Use this when a memory shortcut suggests relevant user preferences, facts, or tasks.",
+    "Search Aether long-term memory before answering when the request may depend on durable user or project context: identity, preferences, profile, facts, prior instructions, past decisions, recurring tasks, or previously stated constraints.",
+    "Do not wait for an exact shortcut match; use this proactively when memory could personalize or disambiguate the answer.",
+    "For broad memory or profile questions, search with concise overview-style keywords instead of raw session reads.",
     "Use mode=overview when the user asks for a broad summary of remembered context instead of a narrow keyword lookup.",
     "Search only reads AETHER_MEMORY.md and does not read raw session files or aether-memory.db events.",
   ].join("\n"),

--- a/packages/opencode/test/memory/memory.test.ts
+++ b/packages/opencode/test/memory/memory.test.ts
@@ -627,6 +627,34 @@ describe("memory service", () => {
     expect(found.results[0]?.memory).toBe("User's advisor is Zhang Yang.")
   })
 
+  test("shortcut triggers retain broad source topics beyond the first dozen terms", async () => {
+    Memory.setReflectorForTest(async ({ events }) => [
+      {
+        eventID: events[0]!.id,
+        type: "fact" as const,
+        scope: "global" as const,
+        memory: "User has a broad durable research context that should be discoverable by related topics.",
+        confidence: 0.96,
+        weight: 0.9,
+        evidence: "explicit user memory",
+      },
+    ])
+
+    await Memory.remember({
+      text: [
+        "Please remember these related topics for future recall:",
+        "topic01 topic02 topic03 topic04 topic05 topic06 topic07 topic08 topic09 topic10",
+        "topic11 topic12 topic13 topic14 topic15 topic16 topic17 topic18 topic19 topic20",
+      ].join(" "),
+      type: "fact",
+      intent: "explicit",
+      source: { createdAt: Date.now(), role: "user" },
+    })
+
+    const found = await Memory.search({ query: "topic20", limit: 5 })
+    expect(found.results[0]?.memory).toContain("broad durable research context")
+  })
+
   test("low-signal observed events are not left pending for daily reflection", async () => {
     const remembered = await Memory.remember({
       text: "这个命令是什么意思？",
@@ -802,7 +830,7 @@ describe("memory service", () => {
 ## Shortcut Directory
 
 - shortcut: response-style
-  triggers: 中文, answer style
+  triggers: 中文, answer style, language
   types: preference
   target_ids: PREF-answer-language
   weight: 0.9
@@ -830,6 +858,9 @@ describe("memory service", () => {
     expect(prompt).toContain("response-style")
     expect(prompt).toContain("memory_search")
     expect(prompt).toContain("durable user or project context")
+    expect(prompt).toContain("Before answering, call memory_search")
+    expect(prompt).toContain("topics: 中文, answer style, language")
+    expect(prompt).not.toContain("instruction:")
     expect(prompt).not.toContain("PREF-answer-language")
     expect(prompt).not.toContain("用户偏好默认用中文回答")
   })


### PR DESCRIPTION
### Issue for this PR

Closes #818

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Improves how the memory system prompts agents to use `memory_search`.

The old shortcut prompt made agents wait for close shortcut matches, so broader durable-memory cases such as user identity, prior project decisions, recurring tasks, or "continue with the previous plan" could skip memory search even when the tool was available.

This PR keeps full memory content out of the system prompt, but makes the injected shortcut guide more explicit that topics are routing hints and that `memory_search` should be called before answering when durable user or project context may affect the response. It also preserves more source-topic terms when generating shortcut triggers, so user wording is less likely to be lost after reflection rewrites a memory.

### How did you verify your code works?

- `PATH=/home/liuyuanche/.bun/bin:$PATH bun run --cwd packages/opencode test test/memory/memory.test.ts --timeout 60000`
- `PATH=/home/liuyuanche/.bun/bin:$PATH bun run --cwd packages/opencode test test/memory/memory.test.ts test/cron/cron.test.ts --timeout 60000`
- `PATH=/home/liuyuanche/.bun/bin:$PATH bun run --cwd packages/opencode typecheck`
- `PATH=/home/liuyuanche/.bun/bin:$PATH bun run --cwd packages/app typecheck`
- `git diff --check`
- Pre-push hook: `bun turbo typecheck` completed successfully.

### Screenshots / recordings

N/A. This is a backend memory prompt/tooling change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
