### PR TITLE
fix: isolate serve-port per channel to prevent cross-channel port conflicts

### DIFF
--- a/Update/update_darwin.command
+++ b/Update/update_darwin.command
@@ -350,7 +350,17 @@ set -euo pipefail
 cmd="$cmd"
 port=""
 aether_dir="\$HOME/Library/Application Support/aether"
+# Prefer prod channel, then any other responding instance
+ch_dirs=()
 for ch_dir in "\$aether_dir"/*/; do
+  base="\$(basename "\$ch_dir")"
+  if [ "\$base" = "prod" ]; then
+    ch_dirs=("\$ch_dir" "\${ch_dirs[@]}")
+  else
+    ch_dirs+=("\$ch_dir")
+  fi
+done
+for ch_dir in "\${ch_dirs[@]}"; do
   pf="\${ch_dir}serve-port"
   if [ -f "\$pf" ]; then
     p="\$(head -1 "\$pf" 2>/dev/null || true)"

--- a/Update/update_darwin.command
+++ b/Update/update_darwin.command
@@ -348,16 +348,23 @@ build_app() {
 set -euo pipefail
 
 cmd="$cmd"
-portfile="\$HOME/Library/Application Support/aether/serve-port"
 port=""
-if [ -f "\$portfile" ]; then
-  port="\$(head -1 "\$portfile" 2>/dev/null || true)"
-fi
-if [ -n "\$port" ]; then
-  if curl -s -o /dev/null --max-time 2 "http://127.0.0.1:\$port/" >/dev/null 2>&1; then
-    open "http://127.0.0.1:\$port/"
-    exit 0
+aether_dir="\$HOME/Library/Application Support/aether"
+for ch_dir in "\$aether_dir"/*/; do
+  pf="\${ch_dir}serve-port"
+  if [ -f "\$pf" ]; then
+    p="\$(head -1 "\$pf" 2>/dev/null || true)"
+    if [ -n "\$p" ]; then
+      if curl -s -o /dev/null --max-time 2 "http://127.0.0.1:\$p/" >/dev/null 2>&1; then
+        port="\$p"
+        break
+      fi
+    fi
   fi
+done
+if [ -n "\$port" ]; then
+  open "http://127.0.0.1:\$port/"
+  exit 0
 fi
 
 if [ -x "\$cmd" ]; then

--- a/packages/app/vite.js
+++ b/packages/app/vite.js
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs"
+import { readFileSync, readdirSync } from "node:fs"
 import solidPlugin from "vite-plugin-solid"
 import tailwindcss from "@tailwindcss/vite"
 import { fileURLToPath } from "url"
@@ -12,11 +12,26 @@ function readServePort() {
     join(homedir(), ".local", "share"),
     join(homedir(), "Library", "Application Support"),
   ].filter((x) => typeof x === "string" && x.length > 0)
+  const channel = process.env.VITE_OPENCODE_CHANNEL || "local"
   for (const dir of dirs) {
-    const file = join(dir, "aether", "serve-port")
+    const chDir = join(dir, "aether", channel)
+    const file = join(chDir, "serve-port")
     try {
       const port = readFileSync(file, "utf-8").trim()
       if (port) return port
+    } catch {}
+  }
+  for (const dir of dirs) {
+    try {
+      const aetherDir = join(dir, "aether")
+      for (const entry of readdirSync(aetherDir, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue
+        const file = join(aetherDir, entry.name, "serve-port")
+        try {
+          const port = readFileSync(file, "utf-8").trim()
+          if (port) return port
+        } catch {}
+      }
     } catch {}
   }
   return undefined

--- a/packages/app/vite.js
+++ b/packages/app/vite.js
@@ -24,12 +24,21 @@ function readServePort() {
   for (const dir of dirs) {
     try {
       const aetherDir = join(dir, "aether")
-      for (const entry of readdirSync(aetherDir, { withFileTypes: true })) {
-        if (!entry.isDirectory()) continue
+      const entries = readdirSync(aetherDir, { withFileTypes: true }).filter((e) => e.isDirectory())
+      const sorted = entries.sort((a, b) => {
+        if (a.name === channel) return -1
+        if (b.name === channel) return 1
+        return 0
+      })
+      for (const entry of sorted) {
         const file = join(aetherDir, entry.name, "serve-port")
         try {
           const port = readFileSync(file, "utf-8").trim()
-          if (port) return port
+          if (port) {
+            if (entry.name !== channel)
+              console.warn(`[aether] fallback: channel "${channel}" not found, using "${entry.name}"`)
+            return port
+          }
         } catch {}
       }
     } catch {}

--- a/packages/opencode/launcher/aether-protocol-handler.sh
+++ b/packages/opencode/launcher/aether-protocol-handler.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 dir="$(cd "$(dirname "$0")" && pwd)"
-portfile="${XDG_DATA_HOME:-$HOME/.local/share}/aether/serve-port"
+portfile="${XDG_DATA_HOME:-$HOME/.local/share}/aether/__AETHER_CHANNEL__/serve-port"
 port=""
 if [ -f "$portfile" ]; then
   port="$(head -1 "$portfile" 2>/dev/null || true)"

--- a/packages/opencode/launcher/aether-protocol-handler.vbs
+++ b/packages/opencode/launcher/aether-protocol-handler.vbs
@@ -3,7 +3,7 @@ Dim fso, scriptDir, portFile, port, wsh, url
 Set fso = CreateObject("Scripting.FileSystemObject")
 scriptDir = fso.GetParentFolderName(WScript.ScriptFullName)
 
-portFile = CreateObject("WScript.Shell").ExpandEnvironmentStrings("%APPDATA%") & "\aether\serve-port"
+portFile = CreateObject("WScript.Shell").ExpandEnvironmentStrings("%APPDATA%") & "\aether\__AETHER_CHANNEL__\serve-port"
 port = ""
 
 If fso.FileExists(portFile) Then

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -302,21 +302,28 @@ for (const item of targets) {
     }
   }
 
+  function patchLauncher(src: string, channel: string): string {
+    return fs.readFileSync(src, "utf-8").replace(/__AETHER_CHANNEL__/g, channel)
+  }
+
   // Copy launcher
   if (item.os === "win32") {
-    fs.copyFileSync(path.resolve(dir, "launcher/Aether.vbs"), `dist/${name}/bin/Aether.vbs`)
+    fs.writeFileSync(
+      `dist/${name}/bin/Aether.vbs`,
+      patchLauncher(path.resolve(dir, "launcher/Aether.vbs"), Script.channel),
+    )
     const phDest = `dist/${name}/bin/aether-protocol-handler.vbs`
-    fs.copyFileSync(path.resolve(dir, "launcher/aether-protocol-handler.vbs"), phDest)
+    fs.writeFileSync(phDest, patchLauncher(path.resolve(dir, "launcher/aether-protocol-handler.vbs"), Script.channel))
   } else if (item.os === "darwin") {
     const dest = `dist/${name}/bin/Aether.command`
-    fs.copyFileSync(path.resolve(dir, "launcher/Aether.command"), dest)
+    fs.writeFileSync(dest, patchLauncher(path.resolve(dir, "launcher/Aether.command"), Script.channel))
     fs.chmodSync(dest, 0o755)
   } else if (item.os === "linux") {
     const dest = `dist/${name}/bin/Aether.sh`
-    fs.copyFileSync(path.resolve(dir, "launcher/Aether.sh"), dest)
+    fs.writeFileSync(dest, patchLauncher(path.resolve(dir, "launcher/Aether.sh"), Script.channel))
     fs.chmodSync(dest, 0o755)
     const phDest = `dist/${name}/bin/aether-protocol-handler.sh`
-    fs.copyFileSync(path.resolve(dir, "launcher/aether-protocol-handler.sh"), phDest)
+    fs.writeFileSync(phDest, patchLauncher(path.resolve(dir, "launcher/aether-protocol-handler.sh"), Script.channel))
     fs.chmodSync(phDest, 0o755)
   }
 

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -6,6 +6,7 @@ import { Workspace } from "../../control-plane/workspace"
 import { Project } from "../../project/project"
 import { Installation } from "../../installation"
 import { Global } from "../../global"
+import { Database } from "../../storage/db"
 import path from "path"
 
 export const ServeCommand = cmd({
@@ -19,7 +20,7 @@ export const ServeCommand = cmd({
     }
     const opts = await resolveNetworkOptions(args)
     const server = Server.listen(opts)
-    const portfile = path.join(Global.Path.data, "serve-port")
+    const portfile = path.join(Database.ensureChannelDir(), "serve-port")
     await Bun.write(portfile, String(server.port))
     console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
 

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -6,6 +6,7 @@ import { Flag } from "../../flag/flag"
 import open from "open"
 import { networkInterfaces } from "os"
 import { Global } from "../../global"
+import { Database } from "../../storage/db"
 import nodePath from "path"
 import { Lease } from "../../server/lease"
 import { Instance } from "../../project/instance"
@@ -101,7 +102,7 @@ export const WebCommand = cmd({
         }
       }, 1_000)
     }
-    const portfile = nodePath.join(Global.Path.data, "serve-port")
+    const portfile = nodePath.join(Database.ensureChannelDir(), "serve-port")
     await Bun.write(portfile, String(server.port))
     UI.empty()
     UI.println(UI.logo("  "))

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -60,7 +60,7 @@ export namespace Database {
     return path.join(Global.Path.data, `aether-${channel()}.db`)
   }
 
-  function ensureChannelDir() {
+  export function ensureChannelDir() {
     const dir = channelDir()
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
     return dir


### PR DESCRIPTION
## Summary

- Different channels (local/prod/dev) previously shared a single `serve-port` file at `<data>/serve-port`, causing port conflicts when multiple channels run simultaneously
- Now each channel writes its serve-port to `<data>/<channel>/serve-port`, consistent with the existing DB path layout (`aether-<channel>.db`, project/cron DBs in channel subdirectories)

## Changes

| File | Change |
|------|--------|
| `storage/db.ts` | Export `ensureChannelDir()` for use in port file writing |
| `cli/cmd/serve.ts` | Write to `Database.channelDir()/serve-port` instead of `Global.Path.data/serve-port` |
| `cli/cmd/web.ts` | Same as above |
| `launcher/aether-protocol-handler.sh` | Use `__AETHER_CHANNEL__` placeholder for channel-specific path |
| `launcher/aether-protocol-handler.vbs` | Same as above |
| `script/build.ts` | Replace `__AETHER_CHANNEL__` with `Script.channel` during build via `patchLauncher()` |
| `app/vite.js` | Search channel subdirectories for serve-port (`VITE_OPENCODE_CHANNEL` env override supported) |
| `Update/update_darwin.command` | Dynamically iterate channel subdirs to find active serve-port |

## Path layout (example on Windows)

```
%APPDATA%\aether\prod\serve-port     ← prod channel
%APPDATA%\aether\local\serve-port    ← local dev channel
%APPDATA%\aether\latest\serve-port   ← latest/beta channel
```

This mirrors the existing DB directory structure where project/cron DBs already live in `channelDir()`.