### PR TITLE
fix: use copy+unlink as rename fallback and add deferred quarantine cleanup

### DIFF
--- a/packages/opencode/src/storage/db-recovery.ts
+++ b/packages/opencode/src/storage/db-recovery.ts
@@ -156,7 +156,7 @@ export function quarantine(dbPath: string, kind: "main" | "project" | "cron", pr
   const recent = readManifest().find(
     (e) => e.originalPath === dbPath && Date.now() - e.timestamp < QUARANTINE_COOLDOWN_MS,
   )
-  if (recent) return recent
+  if (recent && !existsSync(dbPath)) return recent
 
   mkdirSync(corruptDir(), { recursive: true })
 

--- a/packages/opencode/src/storage/db-recovery.ts
+++ b/packages/opencode/src/storage/db-recovery.ts
@@ -1,6 +1,16 @@
 import z from "zod"
 import path from "path"
-import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, unlinkSync, writeFileSync } from "fs"
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs"
 import { Database as BunSqlite } from "bun:sqlite"
 import { Global } from "../global"
 import { Log } from "../util/log"
@@ -156,7 +166,7 @@ export function quarantine(dbPath: string, kind: "main" | "project" | "cron", pr
   const recent = readManifest().find(
     (e) => e.originalPath === dbPath && Date.now() - e.timestamp < QUARANTINE_COOLDOWN_MS,
   )
-  if (recent && !existsSync(dbPath)) return recent
+  if (recent) return recent
 
   mkdirSync(corruptDir(), { recursive: true })
 
@@ -172,7 +182,10 @@ export function quarantine(dbPath: string, kind: "main" | "project" | "cron", pr
       renameSync(src, qPath + suffix)
     } catch {
       try {
-        unlinkSync(src)
+        copyFileSync(src, qPath + suffix)
+        try {
+          unlinkSync(src)
+        } catch {}
       } catch {}
     }
   }
@@ -199,6 +212,27 @@ export function quarantine(dbPath: string, kind: "main" | "project" | "cron", pr
   appendManifest(entry)
   log.info("quarantined corrupted db", { kind, projectId, corruptionType, qPath })
   return entry
+}
+
+export function cleanupQuarantinedOriginals() {
+  const manifest = readManifest()
+  let cleaned = 0
+  for (const entry of manifest) {
+    if (!existsSync(entry.originalPath)) continue
+    if (!existsSync(entry.quarantinePath)) continue
+    const origSize = statSync(entry.originalPath).size
+    const qSize = statSync(entry.quarantinePath).size
+    if (origSize !== qSize) continue
+    for (const suffix of ["", "-wal", "-shm"]) {
+      const src = entry.originalPath + suffix
+      if (!existsSync(src)) continue
+      try {
+        unlinkSync(src)
+      } catch {}
+    }
+    if (!existsSync(entry.originalPath)) cleaned++
+  }
+  if (cleaned > 0) log.info("cleaned up quarantined originals left on disk", { cleaned })
 }
 
 async function findSqlite3Binary(): Promise<string | null> {

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -18,7 +18,7 @@ import { Installation } from "../installation"
 import { Flag } from "../flag/flag"
 import { iife } from "@/util/iife"
 import { init } from "#db"
-import { detectCorruption, quarantine, DbRecovery } from "./db-recovery"
+import { detectCorruption, quarantine, cleanupQuarantinedOriginals, DbRecovery } from "./db-recovery"
 import type { CorruptionType } from "./db-recovery"
 
 declare const OPENCODE_MIGRATIONS: { sql: string; timestamp: number; name: string }[] | undefined
@@ -688,6 +688,8 @@ export namespace Database {
   export function registerUntrackedProjects(db: DrizzleClient) {
     const sqlite = db.$client
 
+    cleanupQuarantinedOriginals()
+
     const recentLookup = new Map<string, any>()
     const recentRows = sqlite.prepare("SELECT * FROM project_recent").all() as any[]
     for (const row of recentRows) {
@@ -707,7 +709,7 @@ export namespace Database {
         const match = pattern.exec(entry)
         if (!match) continue
         const pid = match[1]
-        if (pid === "cron") continue
+        if (pid === "cron" || pid === "memory" || pid === "skill") continue
         existingDbIds.add(pid)
       }
     }

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -728,12 +728,15 @@ export namespace Database {
         }
 
         const pSqlite = new BunSqlite(fullPath)
+        let closed = false
         try {
           const projectRow = pSqlite.prepare("SELECT worktree FROM project WHERE id = ?").get(pid) as
             | { worktree: string }
             | undefined
           const sessionCount = (pSqlite.prepare("SELECT COUNT(*) as cnt FROM session").get() as { cnt: number }).cnt
           if (!projectRow && sessionCount === 0) {
+            pSqlite.close()
+            closed = true
             quarantine(fullPath, "project", pid)
             corruptedIds.add(pid)
             log.info("project db has no sessions and no project row, quarantining", { pid })
@@ -759,7 +762,7 @@ export namespace Database {
 
           synced++
         } finally {
-          pSqlite.close()
+          if (!closed) pSqlite.close()
         }
       } catch (err) {
         log.error("failed to process project db, quarantining", { pid, error: String(err) })


### PR DESCRIPTION
### Issue for this PR

Closes #828

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes two issues with DB quarantine on Windows:

1. When `renameSync` fails to move a DB file (Windows file locking), the quarantine silently leaves the file in place. Now uses `copyFileSync` + `unlinkSync` as fallback so the quarantine copy exists even if the original can't be immediately deleted.
2. Adds `cleanupQuarantinedOriginals()` to delete original files still on disk after quarantine, with a size check to ensure the original hasn't been modified before deleting.
3. Reverts cooldown bypass (`!existsSync(dbPath)`) that caused infinite retry loops when files couldn't be moved.
4. Skips `aether-memory` and `aether-skill` from the project DB scan — these are not project DBs.

### How did you verify your code works?

- `bun typecheck` passes
- Inspected quarantine manifest showing entries were created for empty DBs
- Verified empty DB content via sqlite3 to confirm quarantine trigger condition

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR