### PR TITLE
fix: change Electron window title from OpenCode to Aether Desktop

### DIFF
--- a/packages/desktop-electron/src/main/windows.ts
+++ b/packages/desktop-electron/src/main/windows.ts
@@ -66,7 +66,7 @@ export function createMainWindow(globals: Globals) {
     width: state.width,
     height: state.height,
     show: true,
-    title: app.getName(),
+    title: "Aether Desktop",
     icon: iconPath(),
     backgroundColor,
     ...(process.platform === "darwin"

--- a/packages/desktop-electron/src/renderer/index.html
+++ b/packages/desktop-electron/src/renderer/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>OpenCode</title>
+    <title>Aether Desktop</title>
     <link rel="icon" type="image/png" href="./favicon-96x96-v3.png" sizes="96x96" />
     <link rel="icon" type="image/svg+xml" href="./favicon-v3.svg" />
     <link rel="shortcut icon" href="./favicon-v3.ico" />

--- a/packages/desktop-electron/src/renderer/loading.html
+++ b/packages/desktop-electron/src/renderer/loading.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>OpenCode</title>
+    <title>Aether Desktop</title>
     <link rel="icon" type="image/png" href="./favicon-96x96-v3.png" sizes="96x96" />
     <link rel="icon" type="image/svg+xml" href="./favicon-v3.svg" />
     <link rel="shortcut icon" href="./favicon-v3.ico" />


### PR DESCRIPTION
### Issue for this PR

Closes #832

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

修复 Electron 桌面版窗口标题显示为 "OpenCode" 的问题，改为 "Aether Desktop"。

**修改内容：**
- `packages/desktop-electron/src/renderer/index.html:6` — 将 `<title>` 从 OpenCode 改为 Aether Desktop
- `packages/desktop-electron/src/renderer/loading.html:6` — 同上，修复加载页标题
- `packages/desktop-electron/src/main/windows.ts:69` — 将初始窗口标题从 `app.getName()` 硬编码为 "Aether Desktop"，确保 HTML 加载前的过渡态也显示正确名称

### How did you verify your code works?

本地 typecheck 通过。修改为纯文本替换，不影响运行时逻辑。

### Screenshots / recordings

不适用。

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR