### PR TITLE
fix: prevent project.sandboxes from being overwritten by stale snapshot

### DIFF
--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -98,7 +98,6 @@ export namespace Workspace {
             vcs: project.vcs ?? null,
             name: project.name ?? null,
             time_updated: project.time.updated,
-            sandboxes: project.sandboxes ?? [],
             commands: project.commands ?? null,
           },
         })

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -421,15 +421,6 @@ export namespace Project {
           !result.sandboxes.some((s) => norm(s) === norm(data.sandbox))
         )
           result.sandboxes.push(data.sandbox)
-        result.sandboxes = yield* Effect.forEach(
-          result.sandboxes,
-          (s) =>
-            fsys.exists(s).pipe(
-              Effect.orDie,
-              Effect.map((exists) => (exists ? s : undefined)),
-            ),
-          { concurrency: "unbounded" },
-        ).pipe(Effect.map((arr) => arr.filter((x): x is string => x !== undefined)))
 
         const aliases = [...new Set([directory, data.worktree, data.sandbox].map((dir) => norm(dir)))]
         for (const dir of aliases) {
@@ -479,7 +470,6 @@ export namespace Project {
                 icon_color: result.icon?.color,
                 time_updated: result.time.updated,
                 time_initialized: result.time.initialized,
-                sandboxes: result.sandboxes,
                 commands: result.commands,
               },
             })

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -849,7 +849,6 @@ export namespace Session {
             vcs: project.vcs ?? null,
             name: project.name ?? null,
             time_updated: project.time.updated,
-            sandboxes: project.sandboxes ?? [],
             commands: project.commands ?? null,
           },
         })


### PR DESCRIPTION
## Summary

- Remove `sandboxes` from `onConflictDoUpdate.set` in 3 locations so that DB sandbox references are never overwritten by stale `Instance.project.sandboxes`
- Remove `fsys.exists` filtering in `fromDirectory` — sandbox references should be preserved in DB even if directories are temporarily unavailable

## Root Cause

`Instance.project` is cached at bootstrap and never refreshed. When `addSandbox` updates the DB, `Instance.project.sandboxes` remains stale. Any subsequent session creation, workspace creation, or `fromDirectory` call would overwrite the DB's `sandboxes` column with the stale snapshot, permanently losing sandbox references that were added after bootstrap.

Additionally, `fromDirectory` filtered sandbox references by `fsys.exists()`, removing DB entries when directories were temporarily inaccessible (disk latency, mount issues). This filtering should only happen at the query/API level (`Project.sandboxes()`), not at the persistence level.

## Changes

Only `addSandbox` and `removeSandbox` are now the authoritative writers of `project.sandboxes`:

| File | Change |
|---|---|
| `packages/opencode/src/session/index.ts` | Remove `sandboxes` from `onConflictDoUpdate.set` |
| `packages/opencode/src/control-plane/workspace.ts` | Remove `sandboxes` from `onConflictDoUpdate.set` |
| `packages/opencode/src/project/project.ts` | Remove `sandboxes` from `onConflictDoUpdate.set`; remove `fsys.exists` sandbox filtering |