### PR TITLE
feat: discover git worktrees and sync missing sandbox references at startup

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -258,6 +258,7 @@ export namespace Project {
     readonly sandboxes: (id: ProjectID) => Effect.Effect<string[]>
     readonly addSandbox: (id: ProjectID, directory: string) => Effect.Effect<void>
     readonly removeSandbox: (id: ProjectID, directory: string) => Effect.Effect<void>
+    readonly syncWorktrees: (id: ProjectID, worktree: string) => Effect.Effect<void>
   }
 
   export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/Project") {}
@@ -530,7 +531,44 @@ export namespace Project {
         )
 
         yield* emitUpdated(result)
+
+        if (result.vcs === "git" && data.sandbox === data.worktree) {
+          yield* syncWorktrees(result.id, result.worktree).pipe(
+            Effect.catch(() => Effect.void),
+            Effect.forkIn(scope),
+          )
+        }
+
         return { project: result, sandbox: data.sandbox }
+      })
+
+      const syncWorktrees = Effect.fn("Project.syncWorktrees")(function* (pid: ProjectID, worktree: string) {
+        const result = yield* git(["worktree", "list", "--porcelain"], { cwd: worktree })
+        if (result.code !== 0) return
+
+        const entries: { path?: string }[] = result.text
+          .split("\n")
+          .map((line) => line.trim())
+          .reduce<{ path?: string }[]>((acc, line) => {
+            if (!line) return acc
+            if (line.startsWith("worktree ")) {
+              acc.push({ path: line.slice("worktree ".length).trim() })
+              return acc
+            }
+            return acc
+          }, [])
+
+        const row = yield* dbProject(pid, (d) => d.select().from(ProjectTable).where(eq(ProjectTable.id, pid)).get())
+        if (!row) return
+        const known = fromRow(row).sandboxes
+
+        for (const entry of entries) {
+          if (!entry.path) continue
+          const p = entry.path
+          if (norm(p) === norm(worktree)) continue
+          if (known.some((s) => norm(s) === norm(p))) continue
+          yield* addSandbox(pid, p)
+        }
       })
 
       const discover = Effect.fn("Project.discover")(function* (input: Info) {
@@ -696,6 +734,7 @@ export namespace Project {
       return Service.of({
         fromDirectory,
         discover,
+        syncWorktrees,
         list,
         recent: recentList,
         get,
@@ -781,6 +820,10 @@ export namespace Project {
 
   export function removeSandbox(id: ProjectID, directory: string) {
     return runPromise((svc) => svc.removeSandbox(id, directory))
+  }
+
+  export function syncWorktrees(id: ProjectID, worktree: string) {
+    return runPromise((svc) => svc.syncWorktrees(id, worktree))
   }
 
   export function sessionCount(id: ProjectID): number {


### PR DESCRIPTION
## Summary
- Add `Project.syncWorktrees` which runs `git worktree list --porcelain` at project bootstrap and calls `addSandbox` for any worktree not yet tracked in `project.sandboxes`
- Prevent stale `Instance.project.sandboxes` from overwriting DB values by removing `sandboxes` from `onConflictDoUpdate` in session creation, workspace creation, and `fromDirectory`
- Remove `fsys.exists` filtering in `fromDirectory` that could lose sandbox references on transient filesystem issues

## Root Cause
`Instance.project` is cached at bootstrap and never refreshed. When `addSandbox` updates the DB, `Instance.project.sandboxes` remains stale. Any subsequent session/workspace creation would overwrite the DB's `sandboxes` column with the stale snapshot, permanently losing references.

Additionally, git worktree directories that existed on disk but were not in `project.sandboxes` (e.g. due to prior DB corruption or migration issues) were never re-discovered at startup.

## Changes
| File | Change |
|---|---|
| `project/project.ts` | Add `syncWorktrees` Effect function; call it forked as background task in `fromDirectory`; remove `sandboxes` from `onConflictDoUpdate`; remove `fsys.exists` filtering |
| `session/index.ts` | Remove `sandboxes` from `onConflictDoUpdate` |
| `control-plane/workspace.ts` | Remove `sandboxes` from `onConflictDoUpdate` |

Only `addSandbox` and `removeSandbox` are now the authoritative writers of `project.sandboxes`.