### PR TITLE
fix: create .aether in opened directory instead of git root

### DIFF
--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -19,8 +19,7 @@ import { DbRecovery } from "@/storage/db-recovery"
 
 export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
-  const root = Instance.project.worktree === "/" ? Instance.directory : Instance.project.worktree
-  await fs.mkdir(path.join(root, PROJECT), { recursive: true })
+  await fs.mkdir(path.join(Instance.directory, PROJECT), { recursive: true })
   await Plugin.init()
   ShareNext.init()
   Format.init()

--- a/packages/opencode/test/project/bootstrap.test.ts
+++ b/packages/opencode/test/project/bootstrap.test.ts
@@ -10,7 +10,7 @@ import path from "path"
 Log.init({ print: false })
 
 describe("InstanceBootstrap creates .aether directory", () => {
-  test("creates .aether in git project root", async () => {
+  test("creates .aether in the opened directory, not git root", async () => {
     await using tmp = await tmpdir({ git: true })
 
     const aetherDir = path.join(tmp.path, PROJECT)
@@ -19,6 +19,24 @@ describe("InstanceBootstrap creates .aether directory", () => {
     await Instance.provide({ directory: tmp.path, init: InstanceBootstrap, fn: async () => {} })
 
     expect(await fs.stat(aetherDir).then(() => true).catch(() => false)).toBe(true)
+  })
+
+  test("creates .aether in git subdirectory without leaking to git root", async () => {
+    await using tmp = await tmpdir({ git: true, init: async (dir) => {
+      const sub = path.join(dir, "packages", "my-pkg")
+      await fs.mkdir(sub, { recursive: true })
+      return sub
+    }})
+
+    const subAether = path.join(tmp.extra, PROJECT)
+    const rootAether = path.join(tmp.path, PROJECT)
+    expect(await fs.stat(subAether).catch(() => null)).toBeNull()
+    expect(await fs.stat(rootAether).catch(() => null)).toBeNull()
+
+    await Instance.provide({ directory: tmp.extra, init: InstanceBootstrap, fn: async () => {} })
+
+    expect(await fs.stat(subAether).then(() => true).catch(() => false)).toBe(true)
+    expect(await fs.stat(rootAether).then(() => true).catch(() => false)).toBe(false)
   })
 
   test("creates .aether in non-git directory", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #838

### Type of change

- [x] Bug fix

### What does this PR do?

PR #415 introduced `InstanceBootstrap()` creating `.aether` using `Instance.project.worktree` as the target directory. For git repos, `worktree` resolves to the git root, which may be an ancestor of the directory the user actually opened. This causes spurious `.aether` directories in unrelated parent paths.

Fix: replace the `worktree`-based logic with `Instance.directory` — the directory the user opened. This is always the correct location regardless of git status or worktree configuration.

Change is 1 line in `bootstrap.ts`: the two-line `root` calculation + conditional `mkdir` is replaced with a single `mkdir` using `Instance.directory`.

### How did you verify your code works?

- `bun typecheck` passes
- 4/4 tests pass in `test/project/bootstrap.test.ts`, including new test: "creates .aether in git subdirectory without leaking to git root"

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR