### PR TITLE
feat: stop existing backends before launcher starts new one

### DIFF
--- a/packages/opencode/launcher/Aether.command
+++ b/packages/opencode/launcher/Aether.command
@@ -1,3 +1,6 @@
 #!/bin/bash
 DIR="$(cd "$(dirname "$0")" && pwd)"
+pkill -f 'aether web' >/dev/null 2>&1 || true
+pkill -f 'aether serve' >/dev/null 2>&1 || true
+sleep 1
 "$DIR/aether" web

--- a/packages/opencode/launcher/Aether.sh
+++ b/packages/opencode/launcher/Aether.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 DIR="$(cd "$(dirname "$0")" && pwd)"
+pkill -f 'aether web' >/dev/null 2>&1 || true
+pkill -f 'aether serve' >/dev/null 2>&1 || true
+sleep 1
 "$DIR/aether" web

--- a/packages/opencode/launcher/Aether.vbs
+++ b/packages/opencode/launcher/Aether.vbs
@@ -8,6 +8,22 @@ If Not fso.FileExists(exePath) Then
     WScript.Quit 1
 End If
 
+' Stop all existing Aether backend processes (any version/directory)
+Dim stopCmd
+stopCmd = "powershell -NoProfile -ExecutionPolicy Bypass -Command """ & _
+    "$h=@(Get-CimInstance Win32_Process|Where-Object{$_.Name -eq 'aether.exe'});" & _
+    "if($h.Count-gt 0){" & _
+        "$h|Sort-Object ProcessId -Descending|ForEach-Object{Stop-Process -Id $_.ProcessId -ErrorAction SilentlyContinue};" & _
+        "for($i=0;$i-lt 5;$i++){Start-Sleep -Seconds 1;" & _
+            "if(@(Get-CimInstance Win32_Process|Where-Object{$_.Name -eq 'aether.exe'}).Count-eq 0){exit 0}};" & _
+        "$r=@(Get-CimInstance Win32_Process|Where-Object{$_.Name -eq 'aether.exe'});" & _
+        "if($r.Count-gt 0){" & _
+            "$r|Sort-Object ProcessId -Descending|ForEach-Object{Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue};" & _
+            "Start-Sleep -Seconds 2}" & _
+    "}" & _
+    """"
+CreateObject("WScript.Shell").Run stopCmd, 0, True
+
 Dim logPath
 logPath = scriptDir & "\aether-log.txt"
 


### PR DESCRIPTION
## Summary
- When launching Aether via launcher scripts (VBS/command/sh), first stop all existing `aether` backend processes before starting a new one
- Avoids port conflicts when user clicks to open Aether while a previous version's backend is still running

## Changes
- **Aether.vbs** (Windows): PowerShell kills all `aether.exe` processes with graceful then force stop
- **Aether.command** (macOS): `pkill -f 'aether web'` / `pkill -f 'aether serve'` before starting
- **Aether.sh** (Linux): same as macOS