### PR TITLE
fix: pass parent project info to worktree sandbox instance to prevent orphan DB creation

### DIFF
--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -280,6 +280,8 @@ export namespace Worktree {
           Instance.provide({
             directory: info.directory,
             init: InstanceBootstrap,
+            project: Instance.project,
+            worktree: Instance.worktree,
             fn: () => undefined,
           })
             .then(() => true)


### PR DESCRIPTION
## Summary
- Worktree sandbox directories without `.git` (e.g. `aether worktree/.../silent-pixel`) are incorrectly treated as independent non-git projects by `ProjectIdentity.resolve()`, causing a separate empty per-project DB (`aether-{sandbox-hash}.db`) to be created.
- The fix passes the parent instance's `project` and `worktree` to `Instance.provide()` when booting a worktree sandbox, so `boot()` uses the parent project identity directly and skips `Project.fromDirectory()` → `ProjectIdentity.resolve()` → `Database.attach()`.

## Changes
- `packages/opencode/src/worktree/index.ts`: Added `project: Instance.project, worktree: Instance.worktree` to the `Instance.provide()` call in the worktree `boot()` function.