### PR TITLE
fix: sidebar session click - toggle only for active session, navigate for others

### DIFF
--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -167,6 +167,7 @@ const SessionRow = (props: {
   hasChildren: boolean
   expanded: boolean
   onToggleChildren?: () => void
+  active?: boolean
 }): JSX.Element => (
   <A
     href={sessionHref(props.slug, props.targetSession)}
@@ -182,7 +183,7 @@ const SessionRow = (props: {
         return
       }
       props.setHoverSession(undefined)
-      if (props.hasChildren) props.onToggleChildren?.()
+      if (props.active && props.hasChildren) props.onToggleChildren?.()
       if (props.sidebarOpened()) return
       props.clearHoverProjectSoon()
     }}
@@ -463,6 +464,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
       hasChildren={hasChildren()}
       expanded={expanded()}
       onToggleChildren={props.onToggleChildren}
+      active={isActive()}
     />
   )
 


### PR DESCRIPTION
## Summary

- 点击当前活跃会话名字时依然切换展开/隐藏分支树（保持原行为）
- 点击非活跃会话名字时只导航切换到该会话，不再意外切换其分支树展开状态

## Changes

- `SessionRow` 新增 `active?: boolean` 属性
- `onClick` 中仅在 `props.active` 为 `true` 时调用 `onToggleChildren`
- `SessionItem` 传入 `active={isActive()}`

## Test Plan

- 验证当前活跃会话点击名字仍能切换分支树展开/隐藏
- 验证非活跃会话点击名字仅导航切换，分支树状态不变
- 验证 TreeToggle 按钮（+/- 小图标）仍独立工作不受影响