### PR TITLE
feat: add configurable web UI idle timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ After `aether web` starts, it displays local and network access URLs, and the br
 ./aether web --port 8080              # specify port
 ./aether web --hostname 0.0.0.0       # allow network access
 ./aether web --idle-timeout 120       # idle timeout in seconds, 0 for always-on
+AETHER_IDLE_TIMEOUT=15 ./Aether.sh    # deployment idle timeout override in seconds
 ``` -->
 
 ### Electron Desktop Version

--- a/README.zh.md
+++ b/README.zh.md
@@ -79,6 +79,7 @@ chmod +x aether   # 首次需要
 ./aether web --port 8080              # 指定端口
 ./aether web --hostname 0.0.0.0       # 允许局域网访问
 ./aether web --idle-timeout 120       # 空闲超时（秒），0 表示常驻运行
+AETHER_IDLE_TIMEOUT=15 ./Aether.sh    # 部署时覆盖空闲超时（秒）
 ``` -->
 
 ### Electron 桌面版

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -893,6 +893,8 @@ export const SettingsGeneral: Component = () => {
 
   const ServerSection = () => {
     const idleOptions = createMemo(() => [
+      { value: "15", label: "15 sec" },
+      { value: "30", label: "30 sec" },
       { value: "60", label: "1 min" },
       { value: "300", label: "5 min" },
       { value: "1800", label: "30 min" },

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -1,5 +1,6 @@
 import type { Argv, InferredOptionTypes } from "yargs"
 import { Config } from "../config/config"
+import { Flag } from "../flag/flag"
 
 const options = {
   port: {
@@ -60,7 +61,9 @@ export async function resolveNetworkOptions(args: NetworkOptions) {
   const configCors = config?.server?.cors ?? []
   const argsCors = Array.isArray(args.cors) ? args.cors : args.cors ? [args.cors] : []
   const cors = [...configCors, ...argsCors]
-  const idleTimeout = idleTimeoutExplicitlySet ? args["idle-timeout"] : (config?.server?.idleTimeout ?? 60)
+  const idleTimeout = idleTimeoutExplicitlySet
+    ? args["idle-timeout"]
+    : (Flag.AETHER_IDLE_TIMEOUT ?? config?.server?.idleTimeout ?? 60)
 
   return { hostname, port, mdns, mdnsDomain, cors, idleTimeout }
 }

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -10,7 +10,15 @@ function falsy(key: string) {
   return value === "false" || value === "0"
 }
 
+function number(key: string, min = 1) {
+  const value = process.env[key]
+  if (!value) return undefined
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed >= min ? parsed : undefined
+}
+
 export namespace Flag {
+  export declare const AETHER_IDLE_TIMEOUT: number | undefined
   export const OPENCODE_AUTO_SHARE = truthy("OPENCODE_AUTO_SHARE")
   export const OPENCODE_GIT_BASH_PATH = process.env["OPENCODE_GIT_BASH_PATH"]
   export const OPENCODE_CONFIG = process.env["OPENCODE_CONFIG"]
@@ -75,13 +83,18 @@ export namespace Flag {
   export const OPENCODE_SKIP_MIGRATIONS = truthy("OPENCODE_SKIP_MIGRATIONS")
   export const OPENCODE_STRICT_CONFIG_DEPS = truthy("OPENCODE_STRICT_CONFIG_DEPS")
 
-  function number(key: string) {
-    const value = process.env[key]
-    if (!value) return undefined
-    const parsed = Number(value)
-    return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined
-  }
 }
+
+// Dynamic getter for AETHER_IDLE_TIMEOUT
+// This must be evaluated at access time, not module load time,
+// because tests may set this env var at runtime
+Object.defineProperty(Flag, "AETHER_IDLE_TIMEOUT", {
+  get() {
+    return number("AETHER_IDLE_TIMEOUT", 0)
+  },
+  enumerable: true,
+  configurable: false,
+})
 
 // Dynamic getter for OPENCODE_DISABLE_PROJECT_CONFIG
 // This must be evaluated at access time, not module load time,

--- a/packages/opencode/test/cli/network.test.ts
+++ b/packages/opencode/test/cli/network.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import path from "path"
+import { resolveNetworkOptions, type NetworkOptions } from "../../src/cli/network"
+import { Config } from "../../src/config/config"
+import { Global } from "../../src/global"
+import { tmpdir } from "../fixture/fixture"
+
+const argv = process.argv.slice()
+const env = process.env.AETHER_IDLE_TIMEOUT
+
+const args: NetworkOptions = {
+  port: 0,
+  hostname: "127.0.0.1",
+  mdns: false,
+  "mdns-domain": "opencode.local",
+  cors: [],
+  "idle-timeout": undefined,
+}
+
+afterEach(() => {
+  process.argv = argv.slice()
+  if (env === undefined) delete process.env.AETHER_IDLE_TIMEOUT
+  else process.env.AETHER_IDLE_TIMEOUT = env
+  Config.global.reset()
+})
+
+async function run(cfg: object, fn: () => Promise<void>) {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "aether.json"), JSON.stringify({ $schema: "https://opencode.ai/config.json", ...cfg }))
+    },
+  })
+  const prev = Global.Path.config
+  ;(Global.Path as { config: string }).config = tmp.path
+  Config.global.reset()
+  try {
+    await fn()
+  } finally {
+    ;(Global.Path as { config: string }).config = prev
+    Config.global.reset()
+  }
+}
+
+describe("network options", () => {
+  test("uses AETHER_IDLE_TIMEOUT before config", async () => {
+    process.env.AETHER_IDLE_TIMEOUT = "15"
+    await run({ server: { idleTimeout: 300 } }, async () => {
+      expect((await resolveNetworkOptions(args)).idleTimeout).toBe(15)
+    })
+  })
+
+  test("allows AETHER_IDLE_TIMEOUT to disable auto-exit", async () => {
+    process.env.AETHER_IDLE_TIMEOUT = "0"
+    await run({ server: { idleTimeout: 300 } }, async () => {
+      expect((await resolveNetworkOptions(args)).idleTimeout).toBe(0)
+    })
+  })
+
+  test("uses CLI idle timeout before AETHER_IDLE_TIMEOUT", async () => {
+    process.argv = [...argv, "--idle-timeout"]
+    process.env.AETHER_IDLE_TIMEOUT = "15"
+    await run({ server: { idleTimeout: 300 } }, async () => {
+      expect((await resolveNetworkOptions({ ...args, "idle-timeout": 30 })).idleTimeout).toBe(30)
+    })
+  })
+
+  test("ignores invalid AETHER_IDLE_TIMEOUT", async () => {
+    process.env.AETHER_IDLE_TIMEOUT = "nope"
+    await run({ server: { idleTimeout: 300 } }, async () => {
+      expect((await resolveNetworkOptions(args)).idleTimeout).toBe(300)
+    })
+  })
+})

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -206,6 +206,7 @@ Available options:
 - `mdns` - Enable mDNS service discovery. This allows other devices on the network to discover your OpenCode server.
 - `mdnsDomain` - Custom domain name for mDNS service. Defaults to `opencode.local`. Useful for running multiple instances on the same network.
 - `cors` - Additional origins to allow for CORS when using the HTTP server from a browser-based client. Values must be full origins (scheme + host + optional port), eg `https://app.example.com`.
+- `idleTimeout` - Seconds to wait after all browser connections close before exiting. Defaults to `60`; set to `0` to disable auto-exit. Deployments can override this with `AETHER_IDLE_TIMEOUT`.
 
 [Learn more about the server here](/docs/server).
 


### PR DESCRIPTION
### Issue for this PR

Closes #846

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds shorter web UI auto-shutdown delay options and a deployment-level environment override for the backend idle timeout.

Changes included:

- Adds 15 second and 30 second choices to the Settings page idle timeout options.
- Adds `AETHER_IDLE_TIMEOUT` as an environment override for web server idle shutdown delay.
- Keeps precedence as explicit CLI `--idle-timeout` > `AETHER_IDLE_TIMEOUT` > config `server.idleTimeout` > default `60`.
- Preserves `0` as the value for disabling automatic shutdown.
- Documents the new environment variable in README examples and config docs.
- Adds tests for environment override precedence, `0`, CLI precedence, and invalid env fallback.

### How did you verify your code works?

- `bun install --frozen-lockfile`
- `cd packages/opencode && bun test test/cli/network.test.ts`
- `cd packages/opencode && bun typecheck`
- `cd packages/app && bun typecheck`
- `git diff --check`
- pre-push `bun turbo typecheck`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR