### PR TITLE
Improve web auto-update reload fallback

### DIFF
--- a/Update/update_darwin.command
+++ b/Update/update_darwin.command
@@ -599,7 +599,7 @@ boot() {
   debug_log "BOOT | dir=$dir"
   [ -x "$dir/Aether.command" ] || { debug_log "BOOT | Aether.command not executable: $dir/Aether.command"; return 1; }
   debug_log "BOOT | launching $dir/Aether.command via nohup"
-  nohup "$dir/Aether.command" >/dev/null 2>&1 &
+  AETHER_WEB_OPEN_FALLBACK_MS="${AETHER_WEB_OPEN_FALLBACK_MS:-1000}" nohup "$dir/Aether.command" >/dev/null 2>&1 &
   debug_log "BOOT | nohup pid=$!"
 }
 

--- a/Update/update_darwin.command
+++ b/Update/update_darwin.command
@@ -599,7 +599,7 @@ boot() {
   debug_log "BOOT | dir=$dir"
   [ -x "$dir/Aether.command" ] || { debug_log "BOOT | Aether.command not executable: $dir/Aether.command"; return 1; }
   debug_log "BOOT | launching $dir/Aether.command via nohup"
-  AETHER_WEB_OPEN_FALLBACK_MS="${AETHER_WEB_OPEN_FALLBACK_MS:-1000}" nohup "$dir/Aether.command" >/dev/null 2>&1 &
+  AETHER_WEB_OPEN_FALLBACK_MS="${AETHER_WEB_OPEN_FALLBACK_MS:-3000}" nohup "$dir/Aether.command" >/dev/null 2>&1 &
   debug_log "BOOT | nohup pid=$!"
 }
 

--- a/Update/update_darwin.command
+++ b/Update/update_darwin.command
@@ -18,7 +18,9 @@ debug_log() {
 debug_log "========== NEW UPDATE RUN =========="
 
 pgid="$(ps -o pgid= -p $$ 2>/dev/null | tr -d ' ')"
-debug_log "PGID | pid=$$ pgid=${pgid:-unknown} bash=${BASH_VERSION:-unknown}"
+debug_log "PGID | pid=$$ pgid=${pgid:-unknown} ppid=$PPID bash=${BASH_VERSION:-unknown}"
+_pparent_cmd="$(ps -o command= -p $PPID 2>/dev/null || true)"
+debug_log "PGID | parent_cmd=${_pparent_cmd:-unknown}"
 
 if [ "${AETHER_REEXECED:-0}" != "1" ] && [ "${pgid:-}" != "$$" ] && [ -n "${pgid:-}" ]; then
   debug_log "REEXEC | pgid=$pgid != pid=$$, need setsid"
@@ -36,6 +38,9 @@ debug_log "SESSION | pid=$$ pgid=${pgid:-unknown} reexeced=${AETHER_REEXECED:-0}
 trap 'debug_log "SIGNAL | received SIGTERM, pid=$$, ppid=$PPID"; exit 1' SIGTERM
 trap 'debug_log "SIGNAL | received SIGINT, pid=$$, ppid=$PPID"; exit 1' SIGINT
 trap 'debug_log "SIGNAL | received SIGHUP, pid=$$, ppid=$PPID"; exit 1' SIGHUP
+trap 'debug_log "SIGNAL | received SIGQUIT, pid=$$, ppid=$PPID"; exit 1' SIGQUIT
+trap 'debug_log "SIGNAL | received SIGPIPE, pid=$$, ppid=$PPID"; exit 1' SIGPIPE
+trap 'debug_log "EXIT | code=$?"' EXIT
 
 want="${1:-}"
 self="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -75,6 +80,7 @@ write_result() {
     printf 'error=%s\n' "$(flat "${3:-}")"
     printf 'at=%s\n' "$(date +%s)"
   } >"$res"
+  debug_log "RESULT | status=$(flat "$1") version=$(flat "$ver") action=$(flat "${2:-}") error=$(flat "${3:-}")"
 }
 
 case "$(uname -m)" in
@@ -92,6 +98,9 @@ debug_log "START | AETHER_WORK_DIR=${AETHER_WORK_DIR:-}"
 debug_log "START | AETHER_UPDATE_RESULT=${AETHER_UPDATE_RESULT:-}"
 debug_log "START | AETHER_MIRROR_ROOT=${AETHER_MIRROR_ROOT:-}"
 debug_log "START | AETHER_MIRROR_ONLY=$mirror_only"
+debug_log "START | AETHER_DEBUG_LOG=$DEBUG_LOG"
+_disk_avail="$(df -h "$work" 2>/dev/null | tail -1 | awk '{print $4}' || true)"
+debug_log "DISK | work=$work available=${_disk_avail:-unknown}"
 
 ver_from_name() {
   local file name
@@ -336,6 +345,7 @@ build_app() {
   local dest final app bin cmd icon icon_name lsreg
   dest="$1"
   final="$2"
+  debug_log "BUILD_APP | dest=$dest final=$final"
   app="$dest/Aether.app"
   bin="$app/Contents/MacOS/Aether"
   cmd="$final/Aether.command"
@@ -394,6 +404,7 @@ echo "Launch target not found: $cmd"
 exit 1
 EOF
   chmod +x "$bin"
+  debug_log "BUILD_APP | wrote bin=$bin"
   cat >"$app/Contents/Info.plist" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -433,14 +444,17 @@ EOF
 EOF
   if [ -f "$icon" ]; then
     cp "$icon" "$app/Contents/Resources/$icon_name"
+    debug_log "BUILD_APP | copied icon to $app/Contents/Resources/$icon_name"
     touch "$app/Contents/Resources/$icon_name" 2>/dev/null || true
   fi
   touch "$app/Contents/Info.plist" 2>/dev/null || true
   touch "$app"
   xattr -cr "$app" >/dev/null 2>&1 || true
+  debug_log "BUILD_APP | xattr -cr app=$app"
   lsreg="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
   if [ -x "$lsreg" ]; then
     "$lsreg" -f "$app" >/dev/null 2>&1 || true
+    debug_log "BUILD_APP | lsregister app=$app"
   fi
 }
 
@@ -448,17 +462,21 @@ write_launch() {
   local final dest
   final="$1"
   dest="/Applications"
+  debug_log "WRITE_LAUNCH | final=$final trying dest=$dest"
   if build_app "$dest" "$final" 2>/dev/null; then
     launch="$dest/Aether.app"
     launch_note="从 app 启动器中运行Aether。"
+    debug_log "WRITE_LAUNCH | success dest=$dest launch=$launch"
     return 0
   fi
 
   dest="$HOME/Applications"
   mkdir -p "$dest"
+  debug_log "WRITE_LAUNCH | /Applications failed, falling back to dest=$dest"
   build_app "$dest" "$final"
   launch="$dest/Aether.app"
   launch_note="无法写入 /Applications，已回退到 $launch。手动复制该 App 到 /Applications后，从 app 启动器中运行Aether，或在\"$HOME/Applications\"文件夹中双击Aether.app运行。"
+  debug_log "WRITE_LAUNCH | fallback launch=$launch"
 }
 
 stop() {
@@ -608,17 +626,22 @@ mirror_dir() {
   root="$(mirror_root || true)"
   [ -n "$root" ] || return 1
   dst="$(mirror_target "$root")"
+  debug_log "MIRROR_DIR | root=$root dst=$dst"
   tmp="${dst}.copy"
   rm -rf "$tmp" "$dst"
   mkdir -p "$tmp" || return 1
   ditto "$target" "$tmp" || {
+    debug_log "MIRROR_DIR | ditto failed: target=$target tmp=$tmp"
     rm -rf "$tmp"
     return 1
   }
+  debug_log "MIRROR_DIR | ditto success, moving tmp to dst"
   mv "$tmp" "$dst" || {
+    debug_log "MIRROR_DIR | mv failed: tmp=$tmp dst=$dst"
     rm -rf "$tmp"
     return 1
   }
+  debug_log "MIRROR_DIR | mirror complete: $dst"
   printf "%s" "$dst"
 }
 
@@ -653,6 +676,8 @@ mnt="$tmp/mount"
 next="$work/.aether_$ver.next"
 
 cleanup() {
+  debug_log "EXIT | code=$?"
+  debug_log "CLEANUP | detaching mnt=$mnt and removing tmp=$tmp"
   hdiutil detach "$mnt" -quiet >/dev/null 2>&1 || true
   rm -rf "$tmp"
 }
@@ -666,8 +691,11 @@ if [ "$mirror_only" = "1" ]; then
 else
   rm -rf "$next"
   mkdir -p "$next" "$mnt" || fail "准备安装目录失败：$next"
+  debug_log "EXTRACT | mkdir next=$next mnt=$mnt"
 
+  debug_log "EXTRACT | hdiutil attach pkg=$pkg mnt=$mnt"
   hdiutil attach "$pkg" -nobrowse -readonly -mountpoint "$mnt" -quiet || fail "挂载安装包失败：$pkg"
+  debug_log "EXTRACT | hdiutil attach success"
 
   src="$mnt"
   if [ ! -f "$src/aether" ] || [ ! -f "$src/Aether.command" ]; then
@@ -676,17 +704,26 @@ else
     shopt -u nullglob
     if [ "${#dirs[@]}" -eq 1 ] && [ -f "${dirs[0]}aether" ] && [ -f "${dirs[0]}Aether.command" ]; then
       src="${dirs[0]%/}"
+      debug_log "EXTRACT | resolved src inside subdirectory: $src"
+    else
+      debug_log "EXTRACT | no single subdirectory with app files found, using mnt=$mnt"
     fi
+  else
+    debug_log "EXTRACT | app files found at mnt root: $src"
   fi
 
   [ -f "$src/aether" ] || fail "安装包内容缺少 aether"
   [ -f "$src/Aether.command" ] || fail "安装包内容缺少 Aether.command"
 
   echo "[2/4] 解包并安装到: $target"
+  debug_log "INSTALL | ditto src=$src dst=$next"
   ditto "$src" "$next" || fail "解包安装包失败：$pkg"
+  debug_log "INSTALL | ditto success"
 
   rm -rf "$target"
+  debug_log "INSTALL | mv next=$next target=$target"
   mv "$next" "$target" || fail "写入版本目录失败：$target"
+  debug_log "INSTALL | mv success"
 fi
 chflags nohidden "$target" >/dev/null 2>&1 || true
 
@@ -698,6 +735,7 @@ done
 shopt -u nullglob
 
 chmod +x "$target/aether" "$target/Aether.command"
+debug_log "PERM | chmod +x aether Aether.command in $target"
 uv=""
 shopt -s nullglob
 for file in "$target"/wechat-bridge/runtime/uv/uv-*apple-darwin*/uv; do
@@ -708,12 +746,16 @@ done
 shopt -u nullglob
 if [ -f "$uv" ]; then
   chmod +x "$uv"
+  debug_log "PERM | chmod +x uv=$uv"
 fi
 xattr -cr "$target/aether" "$target/Aether.command" >/dev/null 2>&1 || true
+debug_log "PERM | xattr -cr aether Aether.command in $target"
 if [ -f "$uv" ]; then
   xattr -cr "$uv" >/dev/null 2>&1 || true
+  debug_log "PERM | xattr -cr uv=$uv"
 fi
 printf "%s\n" "$ver" >"$target/.aether_web_version"
+debug_log "VERSION | wrote $target/.aether_web_version ver=$ver"
 rm -f "$work/.aether_web_version" >/dev/null 2>&1 || true
 
 rm -rf "$work/current" >/dev/null 2>&1 || true
@@ -733,6 +775,7 @@ elif copy_target="$(mirror_dir || true)" && [ -n "$copy_target" ]; then
   if [ -n "$mirror_root_dir" ]; then
     prune_versions "$mirror_root_dir" 1000 "$copy_target"
     mirror_prune="$prune"
+    debug_log "PRUNE | mirror_root_dir=$mirror_root_dir mirror_prune=$prune"
   fi
 else
   debug_log "MIRROR | mirror_dir failed, AETHER_CURRENT_DIR=${AETHER_CURRENT_DIR:-}"

--- a/Update/update_linux.sh
+++ b/Update/update_linux.sh
@@ -610,10 +610,10 @@ boot() {
   local app="$1/Aether.sh"
   [ -x "$app" ] || return 1
   if command -v setsid >/dev/null 2>&1; then
-    AETHER_WEB_OPEN_FALLBACK_MS="${AETHER_WEB_OPEN_FALLBACK_MS:-1000}" setsid "$app" >/dev/null 2>&1 < /dev/null &
+    AETHER_WEB_OPEN_FALLBACK_MS="${AETHER_WEB_OPEN_FALLBACK_MS:-3000}" setsid "$app" >/dev/null 2>&1 < /dev/null &
     return 0
   fi
-  AETHER_WEB_OPEN_FALLBACK_MS="${AETHER_WEB_OPEN_FALLBACK_MS:-1000}" nohup "$app" >/dev/null 2>&1 < /dev/null &
+  AETHER_WEB_OPEN_FALLBACK_MS="${AETHER_WEB_OPEN_FALLBACK_MS:-3000}" nohup "$app" >/dev/null 2>&1 < /dev/null &
 }
 
 register_protocol() {

--- a/Update/update_linux.sh
+++ b/Update/update_linux.sh
@@ -2,6 +2,21 @@
 
 set -euo pipefail
 
+DEBUG_DIR="$HOME/.cache/aether/update_debug"
+if [ -n "${AETHER_DEBUG_LOG:-}" ]; then
+  DEBUG_LOG="$AETHER_DEBUG_LOG"
+else
+  DEBUG_TS="$(date +%Y%m%d_%H%M%S)"
+  DEBUG_LOG="$DEBUG_DIR/update_${DEBUG_TS}.log"
+fi
+mkdir -p "$DEBUG_DIR" 2>/dev/null || true
+
+debug_log() {
+  printf '%s | %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" >>"$DEBUG_LOG" 2>/dev/null || true
+}
+
+debug_log "========== NEW UPDATE RUN =========="
+
 ok=0
 dl_err=31
 run_err=33
@@ -47,6 +62,20 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 
+_pgid="$(ps -o pgid= -p $$ 2>/dev/null | tr -d ' ')"
+_sid="$(ps -o sid= -p $$ 2>/dev/null | tr -d ' ')"
+debug_log "PGID | pid=$$ pgid=${_pgid:-unknown} ppid=$PPID bash=${BASH_VERSION:-unknown}"
+_pparent_cmd="$(ps -o command= -p $PPID 2>/dev/null || true)"
+debug_log "PGID | parent_cmd=${_pparent_cmd:-unknown}"
+debug_log "PGID | sid=${_sid:-unknown} in_own_session=$([ -n "${_sid:-}" ] && [ "$_sid" = "$$" ] && echo yes || echo no)"
+
+trap 'debug_log "SIGNAL | received SIGTERM, pid=$$, ppid=$PPID"; exit 1' SIGTERM
+trap 'debug_log "SIGNAL | received SIGINT, pid=$$, ppid=$PPID"; exit 1' SIGINT
+trap 'debug_log "SIGNAL | received SIGHUP, pid=$$, ppid=$PPID"; exit 1' SIGHUP
+trap 'debug_log "SIGNAL | received SIGQUIT, pid=$$, ppid=$PPID"; exit 1' SIGQUIT
+trap 'debug_log "SIGNAL | received SIGPIPE, pid=$$, ppid=$PPID"; exit 1' SIGPIPE
+trap 'debug_log "EXIT | code=$?"' EXIT
+
 help() {
   cat <<EOF
 Aether Linux Local Installer
@@ -72,6 +101,8 @@ EOF
 }
 
 clean() {
+  debug_log "EXIT | code=$?"
+  debug_log "CLEANUP | tmp=${tmp:-} next=${next:-}"
   if [ -n "$tmp" ] && [ -d "$tmp" ]; then
     rm -rf "$tmp"
   fi
@@ -94,12 +125,14 @@ write_result() {
     printf 'error=%s\n' "$(flat "${3:-}")"
     printf 'at=%s\n' "$(date +%s)"
   } >"$res"
+  debug_log "RESULT | status=$(flat "$1") version=$(flat "$ver") action=$(flat "${2:-}") error=$(flat "${3:-}")"
 }
 
 fail() {
   local msg="$1"
   local action="${2:-recover}"
   write_result "failed" "$action" "$msg"
+  debug_log "FAIL | error=$msg action=$action"
   echo "$msg"
   clean
   exit "$run_err"
@@ -108,6 +141,7 @@ fail() {
 pick_home() {
   local home="$HOME"
   if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+    debug_log "PICK_HOME | SUDO_USER=$SUDO_USER resolving home"
     if command -v getent >/dev/null 2>&1; then
       home="$(getent passwd "$SUDO_USER" 2>/dev/null | cut -d: -f6)"
     else
@@ -118,6 +152,7 @@ pick_home() {
     fi
     [ -n "$home" ] || home="$HOME"
   fi
+  debug_log "PICK_HOME | resolved=$home"
   printf "%s" "$home"
 }
 
@@ -283,13 +318,15 @@ mirror_root() {
   if [ -n "${AETHER_MIRROR_ROOT:-}" ]; then
     mkdir -p "${AETHER_MIRROR_ROOT}" 2>/dev/null || true
     cd "${AETHER_MIRROR_ROOT}" && pwd
+    debug_log "MIRROR_ROOT | resolved via AETHER_MIRROR_ROOT: $(pwd)"
     return 0
   fi
   local cur
   cur="${AETHER_CURRENT_DIR:-}"
-  [ -n "$cur" ] || return 1
+  [ -n "$cur" ] || { debug_log "MIRROR_ROOT | AETHER_CURRENT_DIR empty, returning 1"; return 1; }
   mkdir -p "$(dirname "$cur")" 2>/dev/null || true
   cd "$cur/.." && pwd
+  debug_log "MIRROR_ROOT | resolved via AETHER_CURRENT_DIR: $(pwd)"
 }
 
 in_work() {
@@ -432,23 +469,30 @@ pick_pair() {
 fix_libssl() {
   local dir="$1"
   [ -d "$dir" ] || return 0
+  debug_log "SSL | checking libssl.so.3 in $dir"
 
   if has_ssl3; then
+    debug_log "SSL | libssl.so.3 found on system, no fix needed"
     return 0
   fi
+  debug_log "SSL | libssl.so.3 NOT found on system, searching for compatible pair"
 
   local ssl=""
   local crypto=""
   if ! pick_pair "$dir" ssl crypto; then
+    debug_log "SSL | no usable libssl/libcrypto pair found"
     echo "[install] Warning: libssl.so.3 is missing, and no usable libssl/libcrypto pair was found."
     echo "[install] Please install libssl3 (preferred) or a compatible OpenSSL runtime and retry."
     return 0
   fi
+  debug_log "SSL | found pair ssl=$ssl crypto=$crypto"
 
   local lib="$dir/lib"
   mkdir -p "$lib"
   ln -sf "$ssl" "$lib/libssl.so.3"
   ln -sf "$crypto" "$lib/libcrypto.so.3"
+  debug_log "SSL | symlink $lib/libssl.so.3 -> $ssl"
+  debug_log "SSL | symlink $lib/libcrypto.so.3 -> $crypto"
   echo "[install] Added compatibility symlinks in $lib"
   echo "[install]   libssl.so.3 -> $ssl"
   echo "[install]   libcrypto.so.3 -> $crypto"
@@ -457,6 +501,7 @@ fix_libssl() {
   local real="$dir/Aether.sh.real"
   if [ -f "$launch" ] && [ ! -f "$real" ]; then
     mv "$launch" "$real"
+    debug_log "SSL | moved Aether.sh -> Aether.sh.real, writing wrapper"
     cat > "$launch" <<'EOF'
 #!/usr/bin/env bash
 DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -467,6 +512,7 @@ fi
 exec "$DIR/aether" web "$@"
 EOF
     chmod +x "$launch"
+    debug_log "SSL | patched Aether.sh with compatibility wrapper"
     echo "[install] Patched Aether.sh with compatibility wrapper."
   fi
 }
@@ -479,6 +525,7 @@ write_launch() {
   home="$(pick_home)"
   local apps="$home/.local/share/applications"
   mkdir -p "$apps" || return 1
+  debug_log "LAUNCH | writing desktop entry apps=$apps/aether.desktop app=$app"
 
   local icon_line=""
   if [ -f "$icon" ]; then
@@ -500,6 +547,7 @@ EOF
 
   if command -v update-desktop-database >/dev/null 2>&1; then
     update-desktop-database "$apps" 2>/dev/null || true
+    debug_log "LAUNCH | update-desktop-database ran"
   fi
 
   local desk="$home/Desktop"
@@ -507,6 +555,7 @@ EOF
   if [ -f "$apps/aether.desktop" ]; then
     cp "$apps/aether.desktop" "$desk/aether.desktop" 2>/dev/null || true
     chmod +x "$desk/aether.desktop" || true
+    debug_log "LAUNCH | copied desktop entry to $desk/aether.desktop"
   fi
 
   printf "%s" "$apps/aether.desktop"
@@ -525,18 +574,23 @@ stop_roots=()
 add_stop_root() {
   local dir item
   dir="${1:-}"
-  [ -n "$dir" ] || return 0
-  [ -d "$dir" ] || return 0
-  dir="$(cd "$dir" 2>/dev/null && pwd)" || return 0
-  for item in "${stop_roots[@]}"; do
-    [ "$item" = "$dir" ] && return 0
-  done
+  debug_log "STOP_ROOT | call: input=${1:-}"
+  [ -n "$dir" ] || { debug_log "STOP_ROOT | skip: empty input"; return 0; }
+  [ -d "$dir" ] || { debug_log "STOP_ROOT | skip: not a dir: $dir"; return 0; }
+  dir="$(cd "$dir" 2>/dev/null && pwd)" || { debug_log "STOP_ROOT | skip: cd failed: ${1:-}"; return 0; }
+  if [ ${#stop_roots[@]} -gt 0 ]; then
+    for item in "${stop_roots[@]}"; do
+      [ "$item" = "$dir" ] && { debug_log "STOP_ROOT | skip: duplicate: $dir"; return 0; }
+    done
+  fi
   stop_roots+=("$dir")
+  debug_log "STOP_ROOT | added: $dir"
 }
 
 collect_stop_roots() {
   local dir root
   stop_roots=()
+  debug_log "COLLECT | old=${old:-} target=${target:-} AETHER_CURRENT_DIR=${AETHER_CURRENT_DIR:-} copy_target=${copy_target:-}"
   add_stop_root "$old"
   add_stop_root "$target"
   add_stop_root "${AETHER_CURRENT_DIR:-}"
@@ -547,45 +601,68 @@ collect_stop_roots() {
   done
   root="$(mirror_root || true)"
   if [ -n "$root" ]; then
+    debug_log "COLLECT | mirror_root=$root"
     for dir in "$root"/aether_*; do
       add_stop_root "$dir"
     done
+  else
+    debug_log "COLLECT | mirror_root: empty or failed"
   fi
   shopt -u nullglob
+  if [ ${#stop_roots[@]} -gt 0 ]; then
+    debug_log "COLLECT | stop_roots count=${#stop_roots[@]} roots=${stop_roots[*]}"
+  else
+    debug_log "COLLECT | stop_roots count=0 roots=(empty)"
+  fi
 }
 
 runtime_pids() {
-  local pid cmd root
+  local pid cmd root matched
+  debug_log "PIDS | scanning processes, stop_roots count=${#stop_roots[@]}"
   ps -axo pid=,command= | while read -r pid cmd; do
     [ -n "$pid" ] || continue
     [ "$pid" = "$$" ] && continue
     case "$cmd" in
       *update_linux.sh*) continue ;;
     esac
+    matched=""
     for root in "${stop_roots[@]}"; do
       case "$cmd" in
         *"$root/"*)
           case "$cmd" in
             *"/aether "*|*"/aether"|*"Aether.command"*|*"Aether.sh"*|*"Aether.sh.real"*)
+              debug_log "PIDS | matched: pid=$pid root=$root cmd=$cmd"
               echo "$pid"
+              matched="1"
               break
+              ;;
+            *)
+              debug_log "PIDS | path_hit_cmd_miss: pid=$pid root=$root cmd=$cmd"
               ;;
           esac
           ;;
       esac
     done
+    if [ -z "$matched" ]; then
+      case "$cmd" in
+        */aether*|*Aether.command*|*Aether.sh*) debug_log "PIDS | aether_no_root: pid=$pid cmd=$cmd" ;;
+      esac
+    fi
   done | sort -u
 }
 
 wait_runtime() {
   local tries pids
   tries="$1"
+  debug_log "WAIT | entering wait_runtime, max tries=$tries"
   while [ "$tries" -gt 0 ]; do
     pids="$(runtime_pids)"
-    [ -z "$pids" ] && return 0
+    [ -z "$pids" ] && { debug_log "WAIT | all processes gone, returning 0"; return 0; }
+    debug_log "WAIT | tries left=$tries, remaining pids: $pids"
     sleep 1
     tries=$((tries - 1))
   done
+  debug_log "WAIT | timed out, returning 1"
   return 1
 }
 
@@ -593,33 +670,48 @@ stop_all_runtime() {
   local pids
   collect_stop_roots
   pids="$(runtime_pids)"
-  [ -n "$pids" ] || return 0
+  debug_log "STOP_ALL | initial pids: ${pids:-none}"
+  [ -n "$pids" ] || { debug_log "STOP_ALL | no processes found, returning"; return 0; }
   echo "[install] Stopping old Aether processes..."
+  debug_log "STOP_ALL | SIGTERM to pids: $pids"
   kill $pids >/dev/null 2>&1 || true
-  wait_runtime 5 && return 0
+  debug_log "STOP_ALL | waiting up to 5s after SIGTERM"
+  wait_runtime 5 && { debug_log "STOP_ALL | all exited after SIGTERM"; return 0; }
   pids="$(runtime_pids)"
+  debug_log "STOP_ALL | remaining pids after SIGTERM+wait: ${pids:-none}"
   if [ -n "$pids" ]; then
+    debug_log "STOP_ALL | SIGKILL to pids: $pids"
     kill -9 $pids >/dev/null 2>&1 || true
   fi
+  debug_log "STOP_ALL | waiting up to 3s after SIGKILL"
   if ! wait_runtime 3; then
+    debug_log "STOP_ALL | WARNING: processes still alive after SIGKILL+wait"
     echo "[install] Warning: old Aether processes are still running; starting the new version anyway."
+  else
+    debug_log "STOP_ALL | all exited after SIGKILL"
   fi
 }
 
 boot() {
   local app="$1/Aether.sh"
-  [ -x "$app" ] || return 1
+  debug_log "BOOT | dir=$1 app=$app"
+  [ -x "$app" ] || { debug_log "BOOT | Aether.sh not executable: $app"; return 1; }
   if command -v setsid >/dev/null 2>&1; then
+    debug_log "BOOT | launching via setsid"
     AETHER_WEB_OPEN_FALLBACK_MS="${AETHER_WEB_OPEN_FALLBACK_MS:-3000}" setsid "$app" >/dev/null 2>&1 < /dev/null &
+    debug_log "BOOT | setsid pid=$!"
     return 0
   fi
+  debug_log "BOOT | setsid unavailable, launching via nohup"
   AETHER_WEB_OPEN_FALLBACK_MS="${AETHER_WEB_OPEN_FALLBACK_MS:-3000}" nohup "$app" >/dev/null 2>&1 < /dev/null &
+  debug_log "BOOT | nohup pid=$!"
 }
 
 register_protocol() {
   local target="$1"
   local handler="$target/aether-protocol-handler.sh"
-  [ -f "$handler" ] || return 0
+  [ -f "$handler" ] || { debug_log "REG | no protocol handler at $handler"; return 0; }
+  debug_log "REG | registering protocol handler=$handler"
   local icon="$target/aether-icon.png"
   local apps="$HOME/.local/share/applications"
   mkdir -p "$apps" || return 0
@@ -640,11 +732,14 @@ NoDisplay=true
 $icon_line
 DEOF
   chmod +x "$desk" || return 0
+  debug_log "REG | wrote desktop entry=$desk"
   if command -v update-desktop-database >/dev/null 2>&1; then
     update-desktop-database "$apps" 2>/dev/null || true
+    debug_log "REG | update-desktop-database ran"
   fi
   if command -v xdg-mime >/dev/null 2>&1; then
     xdg-mime default aether-url-handler.desktop x-scheme-handler/aether 2>/dev/null || true
+    debug_log "REG | xdg-mime default ran"
   fi
 }
 
@@ -653,17 +748,23 @@ mirror_dir() {
   root="$(mirror_root || true)"
   [ -n "$root" ] || return 1
   dst="$(mirror_target "$root")"
+  debug_log "MIRROR_DIR | root=$root dst=$dst"
   tmp="${dst}.copy"
   rm -rf "$tmp" "$dst" 2>/dev/null || true
   mkdir -p "$tmp" || return 1
+  debug_log "MIRROR_DIR | cp -R target=$target tmp=$tmp"
   cp -R "$target"/. "$tmp" || {
+    debug_log "MIRROR_DIR | cp -R failed: target=$target tmp=$tmp"
     rm -rf "$tmp" 2>/dev/null || true
     return 1
   }
+  debug_log "MIRROR_DIR | cp -R success, moving tmp to dst"
   mv "$tmp" "$dst" || {
+    debug_log "MIRROR_DIR | mv failed: tmp=$tmp dst=$dst"
     rm -rf "$tmp" 2>/dev/null || true
     return 1
   }
+  debug_log "MIRROR_DIR | mirror complete: $dst"
   printf "%s" "$dst"
 }
 
@@ -696,6 +797,17 @@ target="$work/aether_$ver"
 next="$work/.aether_$ver.next"
 res="${AETHER_UPDATE_RESULT:-$work/downloads/web-update-result.env}"
 
+debug_log "START | mode=$mode ver=$ver restart=$restart"
+debug_log "START | dl=$dl work=$work target=$target"
+debug_log "START | AETHER_CURRENT_DIR=${AETHER_CURRENT_DIR:-}"
+debug_log "START | AETHER_WORK_DIR=${AETHER_WORK_DIR:-}"
+debug_log "START | AETHER_UPDATE_RESULT=${AETHER_UPDATE_RESULT:-}"
+debug_log "START | AETHER_MIRROR_ROOT=${AETHER_MIRROR_ROOT:-}"
+debug_log "START | AETHER_MIRROR_ONLY=$mirror_only"
+debug_log "START | AETHER_DEBUG_LOG=$DEBUG_LOG"
+_disk_avail="$(df -h "$work" 2>/dev/null | tail -1 | awk '{print $4}' || true)"
+debug_log "DISK | work=$work available=${_disk_avail:-unknown}"
+
 rm -f "$res" 2>/dev/null || true
 
 echo "[0/4] Work directory: $work"
@@ -703,6 +815,7 @@ echo "[0/4] Work directory: $work"
 shopt -s nullglob
 arr=("$dl"/"$pkg_base"-"$ver".*)
 shopt -u nullglob
+debug_log "PICK | searching dl=$dl pattern=$pkg_base-$ver.* count=${#arr[@]}"
 if [ "$mirror_only" != "1" ] && [ "${#arr[@]}" -eq 0 ]; then
   fail "[install] Package not found for version $ver in $dl"
 fi
@@ -712,71 +825,92 @@ for f in "${arr[@]}"; do
   case "$f" in *.zip) pkg="$f"; break ;; esac
 done
 [ -n "$pkg" ] || pkg="${arr[0]:-}"
+debug_log "PICK | selected pkg=${pkg:-none}"
 tmp="$(mktemp -d "${TMPDIR:-/tmp}/aether-install.XXXXXX")"
 ex="$tmp/extract"
 mkdir -p "$ex" || fail "[install] Failed to prepare extract directory"
+debug_log "EXTRACT | tmp=$tmp ex=$ex"
 
 echo "[1/4] Package: $(basename "$pkg")"
 echo "      Target version: $ver"
 
 old="$(active_dir "$work")"
+debug_log "ACTIVE | old=${old:-none} work=$work"
 if [ "$mirror_only" = "1" ]; then
   [ -d "$target" ] || fail "[install] Installed version directory not found for mirror retry: $target"
   echo "[2/4] Reusing installed version at: $target"
+  debug_log "MIRROR_ONLY | reusing installed version at $target"
 else
   case "$pkg" in
     *.zip)
+      debug_log "EXTRACT | method=unzip pkg=$pkg"
       unzip -o "$pkg" -d "$ex" || fail "[install] Failed to extract $pkg"
       ;;
     *.tar.gz|*.tgz)
+      debug_log "EXTRACT | method=tar_gz pkg=$pkg"
       tar -xzf "$pkg" -C "$ex" || fail "[install] Failed to extract $pkg"
       ;;
     *.tar.bz2)
+      debug_log "EXTRACT | method=tar_bz2 pkg=$pkg"
       tar -xjf "$pkg" -C "$ex" || fail "[install] Failed to extract $pkg"
       ;;
     *)
       fail "[install] Unknown package format: $pkg"
       ;;
   esac
+  debug_log "EXTRACT | extraction complete"
 
   src="$(pick_src "$ex")"
+  debug_log "EXTRACT | src=${src:-none}"
   [ -n "$src" ] || fail "[install] Missing app files (aether/Aether.sh) in package"
 
   echo "[2/4] Extracting and installing to: $target"
   rm -rf "$next" "$target" 2>/dev/null || true
   mkdir -p "$next" || fail "[install] Failed to prepare version directory: $next"
+  debug_log "INSTALL | cp -R src=$src next=$next"
   cp -R "$src"/. "$next" || fail "[install] Failed to copy files into $next"
+  debug_log "INSTALL | mv next=$next target=$target"
   mv "$next" "$target" || fail "[install] Failed to finalize install into $target"
+  debug_log "INSTALL | mv success"
 fi
 
 chmod +x "$target/aether" "$target/Aether.sh" 2>/dev/null || true
+debug_log "PERM | chmod +x aether Aether.sh in $target"
 printf "%s\n" "$ver" > "$target/.aether_web_version"
+debug_log "VERSION | wrote $target/.aether_web_version ver=$ver"
 rm -f "$work/.aether_web_version" 2>/dev/null || true
 
 rm -rf "$work/current" 2>/dev/null || true
 
 fix_libssl "$target"
 prune_versions "$work" 1000 "$target"
+debug_log "PRUNE | work prune=$prune"
 
 copy_target=""
 mirror_prune=""
 if in_work "$work"; then
+  debug_log "IN_WORK | AETHER_CURRENT_DIR=${AETHER_CURRENT_DIR:-} is under work=$work, skipping mirror"
   copy_note="[install] Current app already runs inside WorkDir; skipped mirror."
 elif copy_target="$(mirror_dir || true)" && [ -n "$copy_target" ]; then
+  debug_log "MIRROR | copy_target=$copy_target"
   copy_note="[install] Copied the new version near the current app location: $copy_target"
   mirror_root_dir="$(mirror_root || true)"
   if [ -n "$mirror_root_dir" ]; then
     prune_versions "$mirror_root_dir" 1000 "$copy_target"
     mirror_prune="$prune"
+    debug_log "PRUNE | mirror_root_dir=$mirror_root_dir mirror_prune=$prune"
   fi
 else
+  debug_log "MIRROR | mirror_dir failed, AETHER_CURRENT_DIR=${AETHER_CURRENT_DIR:-}"
   fail "[install] Failed to copy the new version near ${AETHER_CURRENT_DIR:-the current app}" mirror
 fi
 start_target="$target"
 if [ -n "$copy_target" ]; then
   start_target="$copy_target"
 fi
+debug_log "LAUNCH | start_target=$start_target target=$target copy_target=${copy_target:-}"
 launch="$(write_launch "$start_target" || true)"
+debug_log "LAUNCH | launch=${launch:-none}"
 register_protocol "$start_target"
 if [ -n "$launch" ]; then
   echo "[install] Desktop launcher: $launch"
@@ -793,14 +927,19 @@ else
 fi
 
 if [ "$restart" = "1" ]; then
+  debug_log "RESTART | entering restart block, restart=1"
   stop_all_runtime
   if [ -n "$copy_target" ]; then
+    debug_log "RESTART | booting copy_target=$copy_target (fallback target=$target)"
     if ! boot "$copy_target" && ! boot "$target"; then
       fail "[install] Failed to restart Aether from $target/Aether.sh"
     fi
   elif ! boot "$target"; then
+    debug_log "RESTART | booting target=$target"
     fail "[install] Failed to restart Aether from $target/Aether.sh"
   fi
+else
+  debug_log "RESTART | restart=0, skipping kill+boot"
 fi
 
 write_result "installed"
@@ -816,4 +955,7 @@ fi
 if [ -n "$copy_note" ]; then
   echo "$copy_note"
 fi
+
+debug_log "END | ver=$ver target=$target copy_target=${copy_target:-} launch=${launch:-} restart=$restart prune=$prune"
+debug_log "========== UPDATE RUN COMPLETE =========="
 exit "$ok"

--- a/Update/update_linux.sh
+++ b/Update/update_linux.sh
@@ -610,10 +610,10 @@ boot() {
   local app="$1/Aether.sh"
   [ -x "$app" ] || return 1
   if command -v setsid >/dev/null 2>&1; then
-    setsid "$app" >/dev/null 2>&1 < /dev/null &
+    AETHER_WEB_OPEN_FALLBACK_MS="${AETHER_WEB_OPEN_FALLBACK_MS:-1000}" setsid "$app" >/dev/null 2>&1 < /dev/null &
     return 0
   fi
-  nohup "$app" >/dev/null 2>&1 < /dev/null &
+  AETHER_WEB_OPEN_FALLBACK_MS="${AETHER_WEB_OPEN_FALLBACK_MS:-1000}" nohup "$app" >/dev/null 2>&1 < /dev/null &
 }
 
 register_protocol() {

--- a/Update/update_windows.bat
+++ b/Update/update_windows.bat
@@ -2,14 +2,19 @@
 chcp 65001 >nul
 setlocal EnableExtensions EnableDelayedExpansion
 
-set "DEBUG_DIR=%LOCALAPPDATA%\aether\update_debug"
+if defined LOCALAPPDATA (
+  set "DEBUG_DIR=%LOCALAPPDATA%\aether\update_debug"
+) else (
+  set "DEBUG_DIR=%TEMP%\aether\update_debug"
+)
 if defined AETHER_DEBUG_LOG (
   set "DEBUG_LOG=%AETHER_DEBUG_LOG%"
+  for %%i in ("%DEBUG_LOG%\..") do set "DEBUG_DIR=%%~fi"
 ) else (
   for /f "usebackq delims=" %%t in (`powershell -NoProfile -Command "Get-Date -Format 'yyyyMMdd_HHmmss'"`) do set "DEBUG_TS=%%t"
+  if not defined DEBUG_TS set "DEBUG_TS=%RANDOM%%RANDOM%"
   set "DEBUG_LOG=%DEBUG_DIR%\update_%DEBUG_TS%.log"
 )
-if not exist "%DEBUG_DIR%" mkdir "%DEBUG_DIR%" >nul 2>nul
 
 call :debug_log "========== NEW UPDATE RUN =========="
 
@@ -392,5 +397,15 @@ exit /b 0
 
 :debug_log
 if not defined DEBUG_LOG exit /b 0
->>"%DEBUG_LOG%" echo %DATE% %TIME: =0% ^| %~1 2>nul
+setlocal DisableDelayedExpansion
+set "LOG=%DEBUG_LOG%"
+set "DIR=%DEBUG_DIR%"
+set "MSG=%~1"
+if not defined DIR for %%i in ("%LOG%\..") do set "DIR=%%~fi"
+if not exist "%DIR%" mkdir "%DIR%" >nul 2>nul
+set "STAMP=%DATE% %TIME: =0%"
+setlocal EnableDelayedExpansion
+>>"!LOG!" echo(!STAMP! ^| !MSG! 2>nul
+endlocal
+endlocal
 exit /b 0

--- a/Update/update_windows.bat
+++ b/Update/update_windows.bat
@@ -240,7 +240,7 @@ exit /b 1
 :restart
 call :stop_runtime
 timeout /t 1 /nobreak >nul
-set "AETHER_WEB_OPEN_FALLBACK_MS=1000"
+set "AETHER_WEB_OPEN_FALLBACK_MS=3000"
 start "" "%START%\Aether.vbs"
 exit /b 0
 

--- a/Update/update_windows.bat
+++ b/Update/update_windows.bat
@@ -9,7 +9,7 @@ if defined LOCALAPPDATA (
 )
 if defined AETHER_DEBUG_LOG (
   set "DEBUG_LOG=%AETHER_DEBUG_LOG%"
-  for %%i in ("%DEBUG_LOG%\..") do set "DEBUG_DIR=%%~fi"
+  for %%i in ("%DEBUG_LOG%") do set "DEBUG_DIR=%%~dpi"
 ) else (
   for /f "usebackq delims=" %%t in (`powershell -NoProfile -Command "Get-Date -Format 'yyyyMMdd_HHmmss'"`) do set "DEBUG_TS=%%t"
   if not defined DEBUG_TS set "DEBUG_TS=%RANDOM%%RANDOM%"
@@ -401,7 +401,7 @@ setlocal DisableDelayedExpansion
 set "LOG=%DEBUG_LOG%"
 set "DIR=%DEBUG_DIR%"
 set "MSG=%~1"
-if not defined DIR for %%i in ("%LOG%\..") do set "DIR=%%~fi"
+if not defined DIR for %%i in ("%LOG%") do set "DIR=%%~dpi"
 if not exist "%DIR%" mkdir "%DIR%" >nul 2>nul
 set "STAMP=%DATE% %TIME: =0%"
 setlocal EnableDelayedExpansion

--- a/Update/update_windows.bat
+++ b/Update/update_windows.bat
@@ -240,6 +240,7 @@ exit /b 1
 :restart
 call :stop_runtime
 timeout /t 1 /nobreak >nul
+set "AETHER_WEB_OPEN_FALLBACK_MS=1000"
 start "" "%START%\Aether.vbs"
 exit /b 0
 

--- a/Update/update_windows.bat
+++ b/Update/update_windows.bat
@@ -2,6 +2,17 @@
 chcp 65001 >nul
 setlocal EnableExtensions EnableDelayedExpansion
 
+set "DEBUG_DIR=%LOCALAPPDATA%\aether\update_debug"
+if defined AETHER_DEBUG_LOG (
+  set "DEBUG_LOG=%AETHER_DEBUG_LOG%"
+) else (
+  for /f "usebackq delims=" %%t in (`powershell -NoProfile -Command "Get-Date -Format 'yyyyMMdd_HHmmss'"`) do set "DEBUG_TS=%%t"
+  set "DEBUG_LOG=%DEBUG_DIR%\update_%DEBUG_TS%.log"
+)
+if not exist "%DEBUG_DIR%" mkdir "%DEBUG_DIR%" >nul 2>nul
+
+call :debug_log "========== NEW UPDATE RUN =========="
+
 set "WANT=%~1"
 set "RESTART=0"
 if /I "%~2"=="--restart" set "RESTART=1"
@@ -22,6 +33,14 @@ set "RESULT=%AETHER_UPDATE_RESULT%"
 if not defined RESULT set "RESULT=%WORK%\downloads\web-update-result.env"
 set "MIRROR_ONLY=%AETHER_MIRROR_ONLY%"
 
+call :debug_log "ENVR | AETHER_CURRENT_DIR=%AETHER_CURRENT_DIR%"
+call :debug_log "ENVR | AETHER_WORK_DIR=%AETHER_WORK_DIR%"
+call :debug_log "ENVR | AETHER_UPDATE_RESULT=%AETHER_UPDATE_RESULT%"
+call :debug_log "ENVR | AETHER_MIRROR_ROOT=%AETHER_MIRROR_ROOT%"
+call :debug_log "ENVR | AETHER_MIRROR_ONLY=%MIRROR_ONLY%"
+call :debug_log "ENVR | AETHER_DEBUG_LOG=%DEBUG_LOG%"
+call :debug_log "START | WANT=%WANT% RESTART=%RESTART% SELF=%SELF% BASE=%BASE% WORK=%WORK%"
+
 if /I not "%BASE%"=="downloads" (
   echo Spec error: update_windows.bat must be placed in ...\aether\downloads. Current: %SELF%
   exit /b 1
@@ -34,25 +53,32 @@ if /I not "%WORK_NAME%"=="aether" (
 
 echo [0/4] Work directory: %WORK%
 
+call :debug_log "DISK | checking disk space on WORK=%WORK%"
+for /f "usebackq delims=" %%d in (`powershell -NoProfile -Command "(Get-PSDrive -Name ([IO.Path]::GetPathRoot($env:WORK).Substring(0,1)) -ErrorAction SilentlyContinue).Free / 1MB"`) do call :debug_log "DISK | free_mb=%%d"
+
 if exist "%RESULT%" del /f /q "%RESULT%" >nul 2>nul
 
 call :pick_pkg "%SELF%" "%WANT%"
 if "%MIRROR_ONLY%"=="1" goto :pick_pkg_done
 if errorlevel 1 (
+  call :debug_log "PICK | FAILED no usable zip found"
   echo No usable zip found in ...\aether\downloads; filename must include a version
   call :write_result "failed" "recover" "No usable zip found in ...\aether\downloads; filename must include a version"
   exit /b 1
 )
 :pick_pkg_done
+call :debug_log "PICK | PKG=%PKG% VER=%VER% PKG_NAME=%PKG_NAME%"
 
 if "%VER%"=="" set "VER=%WANT%"
 
 set "TARGET=%WORK%\aether_%VER%"
+call :debug_log "START | VER=%VER% TARGET=%TARGET%"
 echo [1/4] Package: %PKG_NAME%
 echo       Target version: %VER%
 
 call :installed "%WORK%" CUR
 call :active_dir
+call :debug_log "ACTIVE | CUR=%CUR% OLD=%OLD%"
 if defined CUR (
   call :cmp "%CUR%" "%VER%"
   if /I "!CMP!"=="eq" (
@@ -78,6 +104,7 @@ if "%MIRROR_ONLY%"=="1" (
     echo !MSG!
     goto :fail
   )
+  call :debug_log "MIRROR_ONLY | reusing installed version at %TARGET%"
   echo [2/4] Reusing installed version at: %TARGET%
 ) else (
   mkdir "%EX%" || (
@@ -89,13 +116,17 @@ if "%MIRROR_ONLY%"=="1" (
     goto :fail
   )
 
+  call :debug_log "EXTRACT | Expand-Archive PKG=%PKG% EX=%EX%"
   powershell -NoProfile -Command "& { Expand-Archive -Path $env:PKG -DestinationPath $env:EX -Force; $hit=Get-ChildItem -Path $env:EX -Filter 'aether.exe' -File -Recurse | Where-Object { Test-Path (Join-Path $_.DirectoryName 'Aether.vbs') } | Sort-Object { $_.DirectoryName.Length } | Select-Object -First 1; if(-not $hit){ throw 'missing app files' }; [IO.File]::WriteAllText($env:SRC_FILE, $hit.DirectoryName) }" || (
     call :write_result "failed" "recover" "Failed to extract %PKG%"
+    call :debug_log "EXTRACT | FAILED Expand-Archive"
     goto :fail
   )
+  call :debug_log "EXTRACT | Expand-Archive success"
 
   set "SRC="
   if exist "%SRC_FILE%" set /p SRC=<"%SRC_FILE%"
+  call :debug_log "EXTRACT | SRC=!SRC!"
   if "!SRC!"=="" (
     call :write_result "failed" "recover" "Package contents missing aether.exe or Aether.vbs"
     echo Package contents missing aether.exe or Aether.vbs
@@ -103,49 +134,66 @@ if "%MIRROR_ONLY%"=="1" (
   )
 
 echo [2/4] Extracting and installing to: %TARGET%
+  call :debug_log "INSTALL | robocopy SRC=!SRC! NEXT=%NEXT%"
   robocopy "!SRC!" "!NEXT!" /MIR /NFL /NDL /NJH /NJS /NP >nul
   set "RC=!ERRORLEVEL!"
+  call :debug_log "INSTALL | robocopy RC=!RC!"
   if !RC! GEQ 8 (
     call :write_result "failed" "recover" "Failed to copy files into %NEXT%"
+    call :debug_log "INSTALL | robocopy failed RC=!RC!"
     goto :fail
   )
 
   if exist "%TARGET%" rmdir /s /q "%TARGET%" >nul 2>nul
+  call :debug_log "INSTALL | move NEXT=%NEXT% TARGET=%TARGET%"
   move "%NEXT%" "%TARGET%" >nul || (
     call :write_result "failed" "recover" "Failed to finalize install into %TARGET%"
+    call :debug_log "INSTALL | move failed"
     goto :fail
   )
+  call :debug_log "INSTALL | move success"
 )
 
 :post_install
 >"%TARGET%\.aether_web_version" echo(%VER%
+call :debug_log "VERSION | wrote %TARGET%\.aether_web_version ver=%VER%"
 if exist "%WORK%\.aether_web_version" del /f /q "%WORK%\.aether_web_version" >nul 2>nul
 
 if exist "%WORK%\current" rmdir "%WORK%\current" >nul 2>nul
 if exist "%WORK%\current" rmdir /s /q "%WORK%\current" >nul 2>nul
 
 call :prune_versions || goto :fail
+call :debug_log "PRUNE | PRUNE=%PRUNE%"
 call :in_work "%WORK%"
 if errorlevel 1 (
+  call :debug_log "IN_WORK | AETHER_CURRENT_DIR not under WORK, attempting mirror"
   call :mirror || (
     set "MSG=!COPY_NOTE!"
     if not defined MSG set "MSG=Failed to mirror the new version near %AETHER_CURRENT_DIR%"
     call :write_result "failed" "mirror" "!MSG!"
+    call :debug_log "MIRROR | FAILED: !MSG!"
     echo !MSG!
     goto :fail
   )
+  call :debug_log "MIRROR | success MIRROR=%MIRROR%"
 ) else (
+  call :debug_log "IN_WORK | AETHER_CURRENT_DIR under WORK, skipping mirror"
   set "COPY_NOTE=Current app already runs inside WorkDir; skipped mirror."
 )
 if defined MIRROR set "START=%MIRROR%"
 if defined MIRROR call :prune_mirror
 if not defined START set "START=%TARGET%"
+call :debug_log "LAUNCH | START=%START% TARGET=%TARGET% MIRROR=%MIRROR%"
 call :write_launch "%START%"
+call :debug_log "LAUNCH | LAUNCH=%LAUNCH% NOTE=%NOTE%"
 call :register_protocol "%START%"
+call :debug_log "REG | protocol handler registered for %START%"
 
+if "%RESTART%"=="1" call :debug_log "RESTART | entering restart block"
 if "%RESTART%"=="1" call :restart
 
 call :write_result "installed" "" ""
+call :debug_log "RESULT | status=installed version=%VER%"
 
 call :print_prune
 
@@ -159,6 +207,8 @@ if defined NOTE echo %NOTE%
 if defined COPY_NOTE echo %COPY_NOTE%
 
 call :clean_tmp
+call :debug_log "END | ver=%VER% target=%TARGET% mirror=%MIRROR% launch=%LAUNCH% restart=%RESTART% prune=%PRUNE%"
+call :debug_log "========== UPDATE RUN COMPLETE =========="
 exit /b 0
 
 :write_launch
@@ -185,6 +235,7 @@ set "RESULT_STATUS=%~1"
 set "RESULT_ACTION=%~2"
 set "RESULT_ERROR=%~3"
 if not defined RESULT exit /b 0
+call :debug_log "RESULT | status=%RESULT_STATUS% version=%VER% action=%RESULT_ACTION% error=%RESULT_ERROR%"
 powershell -NoProfile -Command "$file=$env:RESULT; $dir=Split-Path -Parent $file; if($dir){ [IO.Directory]::CreateDirectory($dir) | Out-Null }; $err=$env:RESULT_ERROR; if($null -eq $err){ $err='' }; $err=($err -replace [char]10,' ' -replace [char]13,' '); $lines=@(('status=' + $env:RESULT_STATUS),('version=' + $env:VER),('action=' + $env:RESULT_ACTION),('error=' + $err),('at=' + [DateTimeOffset]::UtcNow.ToUnixTimeSeconds())); [IO.File]::WriteAllLines($file, $lines)" >nul
 exit /b 0
 
@@ -197,6 +248,7 @@ echo [3/4] Keeping the latest 1000 versions; removed %PRUNE% older version direc
 exit /b 0
 
 :mirror
+call :debug_log "MIRROR_DIR | starting, AETHER_MIRROR_ROOT=%AETHER_MIRROR_ROOT% AETHER_CURRENT_DIR=%AETHER_CURRENT_DIR%"
 if defined AETHER_MIRROR_ROOT set "MROOT=%AETHER_MIRROR_ROOT%" & goto mirror_have_root
 if not defined AETHER_CURRENT_DIR exit /b 1
 for %%i in ("%AETHER_CURRENT_DIR%\..") do set "MROOT=%%~fi"
@@ -204,26 +256,34 @@ for %%i in ("%AETHER_CURRENT_DIR%\..") do set "MROOT=%%~fi"
 if not defined MROOT exit /b 1
 set "MIRROR=%MROOT%\aether_%VER%"
 if exist "%MIRROR%" call :stamp TS & set "MIRROR=%MROOT%\aether_%VER%_!TS!"
+call :debug_log "MIRROR_DIR | MROOT=%MROOT% MIRROR=%MIRROR%"
 set "MCOPY=%MIRROR%.copy"
 if exist "%MCOPY%" rmdir /s /q "%MCOPY%" >nul 2>nul
 if exist "%MIRROR%" rmdir /s /q "%MIRROR%" >nul 2>nul
 mkdir "%MCOPY%" >nul 2>nul || (
   set "COPY_NOTE=Warning: failed to prepare mirror directory near %AETHER_CURRENT_DIR%"
+  call :debug_log "MIRROR_DIR | mkdir MCOPY failed"
   exit /b 1
 )
+call :debug_log "MIRROR_DIR | robocopy TARGET=%TARGET% MCOPY=%MCOPY%"
 robocopy "%TARGET%" "%MCOPY%" /MIR /NFL /NDL /NJH /NJS /NP >nul
 set "RC=!ERRORLEVEL!"
+call :debug_log "MIRROR_DIR | robocopy RC=!RC!"
 if !RC! GEQ 8 (
   set "COPY_NOTE=Warning: failed to copy the new version near %AETHER_CURRENT_DIR%"
+  call :debug_log "MIRROR_DIR | robocopy failed RC=!RC!"
   if exist "%MCOPY%" rmdir /s /q "%MCOPY%" >nul 2>nul
   exit /b 1
 )
+call :debug_log "MIRROR_DIR | move MCOPY=%MCOPY% MIRROR=%MIRROR%"
 move "%MCOPY%" "%MIRROR%" >nul || (
   set "COPY_NOTE=Warning: failed to finalize the copied version near %AETHER_CURRENT_DIR%"
+  call :debug_log "MIRROR_DIR | move failed"
   if exist "%MCOPY%" rmdir /s /q "%MCOPY%" >nul 2>nul
   exit /b 1
 )
 set "COPY_NOTE=Copied the new version near the current app location: %MIRROR%"
+call :debug_log "MIRROR_DIR | success MIRROR=%MIRROR%"
 exit /b 0
 
 :stamp
@@ -238,13 +298,17 @@ if "!IN_WORK!"=="1" exit /b 0
 exit /b 1
 
 :restart
+call :debug_log "RESTART | stopping runtime"
 call :stop_runtime
 timeout /t 1 /nobreak >nul
 set "AETHER_WEB_OPEN_FALLBACK_MS=3000"
+call :debug_log "BOOT | launching %START%\Aether.vbs"
 start "" "%START%\Aether.vbs"
+call :debug_log "BOOT | start command issued"
 exit /b 0
 
 :stop_runtime
+call :debug_log "STOP | starting stop_runtime OLD=%OLD% TARGET=%TARGET% AETHER_CURRENT_DIR=%AETHER_CURRENT_DIR% MIRROR=%MIRROR%"
 powershell -NoProfile -Command "& { $roots=New-Object System.Collections.Generic.List[string]; function AddRoot([string]$p){ if([string]::IsNullOrWhiteSpace($p)){ return }; try { $full=[IO.Path]::GetFullPath($p); if((Test-Path -LiteralPath $full) -and -not $roots.Contains($full)){ [void]$roots.Add($full) } } catch {} }; AddRoot $env:OLD; AddRoot $env:TARGET; AddRoot $env:AETHER_CURRENT_DIR; AddRoot $env:MIRROR; if($env:WORK -and (Test-Path -LiteralPath $env:WORK)){ Get-ChildItem -LiteralPath $env:WORK -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { AddRoot $_.FullName } }; $base=''; if($env:AETHER_MIRROR_ROOT){ $base=$env:AETHER_MIRROR_ROOT } elseif($env:AETHER_CURRENT_DIR){ try { $base=[IO.Directory]::GetParent([IO.Path]::GetFullPath($env:AETHER_CURRENT_DIR)).FullName } catch {} }; if($base -and (Test-Path -LiteralPath $base)){ Get-ChildItem -LiteralPath $base -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { AddRoot $_.FullName } }; $names=@('aether.exe','wscript.exe','cscript.exe','node.exe','bun.exe'); function Hits { Get-CimInstance Win32_Process | Where-Object { $n=$_.Name.ToLowerInvariant(); if($names -notcontains $n){ return $false }; $cmd=$_.CommandLine; $exe=$_.ExecutablePath; foreach($r in $roots){ if(($cmd -and $cmd.IndexOf($r,[StringComparison]::OrdinalIgnoreCase) -ge 0) -or ($exe -and $exe.StartsWith($r,[StringComparison]::OrdinalIgnoreCase))){ return $true } }; return $false } }; $hits=@(Hits); if($hits.Count -gt 0){ Write-Host 'Stopping old Aether processes...'; $hits | Sort-Object ProcessId -Descending | ForEach-Object { Stop-Process -Id $_.ProcessId -ErrorAction SilentlyContinue } }; for($i=0; $i -lt 5; $i++){ Start-Sleep -Seconds 1; if(@(Hits).Count -eq 0){ exit 0 } }; $hits=@(Hits); if($hits.Count -gt 0){ $hits | Sort-Object ProcessId -Descending | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue } }; for($i=0; $i -lt 3; $i++){ Start-Sleep -Seconds 1; if(@(Hits).Count -eq 0){ exit 0 } }; if(@(Hits).Count -gt 0){ Write-Host 'Warning: old Aether processes are still running; starting the new version anyway.' } }"
 exit /b 0
 
@@ -293,11 +357,13 @@ for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$root=$env:DI
 exit /b 0
 
 :fail
+call :debug_log "FAIL | update failed"
 echo Update failed.
 call :clean_tmp
 exit /b 1
 
 :clean_tmp
+call :debug_log "CLEANUP | TMP=%TMP% NEXT=%NEXT%"
 if exist "%TMP%" rmdir /s /q "%TMP%" >nul 2>nul
 if exist "%NEXT%" rmdir /s /q "%NEXT%" >nul 2>nul
 exit /b 0
@@ -318,6 +384,13 @@ exit /b 0
 :register_protocol
 set "PROT_DIR=%~1"
 set "PROT_HANDLER=%PROT_DIR%\aether-protocol-handler.vbs"
-if not exist "%PROT_HANDLER%" exit /b 0
+if not exist "%PROT_HANDLER%" (call :debug_log "REG | no protocol handler at %PROT_HANDLER%" & exit /b 0)
+call :debug_log "REG | registering protocol handler=%PROT_HANDLER%"
 powershell -NoProfile -Command "& { $hkcu='HKCU:\Software\Classes\aether'; $handler=$env:PROT_HANDLER; if(-not (Test-Path $hkcu)){ New-Item -Path $hkcu -Force | Out-Null }; Set-ItemProperty -Path $hkcu -Name '(Default)' -Value 'URL:Aether Protocol' -Force; Set-ItemProperty -Path $hkcu -Name 'URL Protocol' -Value '' -Force; $cmd=$hkcu+'\shell\open\command'; if(-not (Test-Path $cmd)){ New-Item -Path $cmd -Force | Out-Null }; Set-ItemProperty -Path $cmd -Name '(Default)' -Value ('wscript.exe \"' + $handler + '\"') -Force }" >nul 2>nul
+call :debug_log "REG | registry write done"
+exit /b 0
+
+:debug_log
+if not defined DEBUG_LOG exit /b 0
+>>"%DEBUG_LOG%" echo %DATE% %TIME: =0% ^| %~1 2>nul
 exit /b 0

--- a/packages/app/src/utils/web-update.ts
+++ b/packages/app/src/utils/web-update.ts
@@ -63,6 +63,7 @@ const cmp = (a: string, b: string) => {
 }
 
 const wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+const reloadPollMs = 200
 
 const statusOf = (value: unknown): WebUpdate["status"] => {
   if (value === "downloading") return "downloading"
@@ -154,7 +155,26 @@ export const createWebUpdate = (req: Req, detectOS: () => string) => {
 
   const finish = async (data: Pick<WebUpdate, "os" | "version">) => {
     await install(data)
+    await waitForReload(data.version)
     await waitFor(data.version)
+  }
+
+  const waitForReload = async (ver: string) => {
+    for (let i = 0; i < 225; i++) {
+      const ok = await req(`/global/health?t=${Date.now()}`, { cache: "no-store" })
+        .then((res) => res.json())
+        .then((data: unknown) => {
+          if (!data || typeof data !== "object") return false
+          const version = (data as Record<string, unknown>).version
+          return typeof version === "string" && cmp(version, ver) >= 0
+        })
+        .catch(() => false)
+      if (ok) {
+        window.location.reload()
+        return
+      }
+      await wait(reloadPollMs)
+    }
   }
 
   return {

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -42,7 +42,7 @@ function browserOpenFallbackMs() {
   if (!raw) return
   const parsed = Number.parseInt(raw, 10)
   if (!Number.isFinite(parsed) || parsed < 0) return
-  return Math.min(parsed, 3_000)
+  return Math.min(parsed, 5_000)
 }
 
 async function openBrowserWithFallback(input: { url: string; server: unknown; sse: () => number }) {

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -37,6 +37,33 @@ function getNetworkIPs() {
   return results
 }
 
+function browserOpenFallbackMs() {
+  const raw = process.env.AETHER_WEB_OPEN_FALLBACK_MS
+  if (!raw) return
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || parsed < 0) return
+  return Math.min(parsed, 3_000)
+}
+
+async function openBrowserWithFallback(input: { url: string; server: unknown; sse: () => number }) {
+  const fallbackMs = browserOpenFallbackMs()
+  if (fallbackMs === undefined || fallbackMs <= 0) {
+    open(input.url).catch(() => {})
+    return
+  }
+  const connected = () => {
+    const pending = (input.server as any).pendingRequests as number
+    return pending > 0 || input.sse() > 0 || Lease.count() > 0
+  }
+  const deadline = Date.now() + fallbackMs
+  while (Date.now() < deadline) {
+    if (connected()) return
+    await new Promise((resolve) => setTimeout(resolve, 200))
+  }
+  if (connected()) return
+  open(input.url).catch(() => {})
+}
+
 export const WebCommand = cmd({
   command: "web",
   builder: (yargs) => withNetworkOptions(yargs),
@@ -134,11 +161,11 @@ export const WebCommand = cmd({
       }
 
       // Open localhost in browser
-      open(localhostUrl.toString()).catch(() => {})
+      await openBrowserWithFallback({ url: localhostUrl.toString(), server, sse: () => sse })
     } else {
       const displayUrl = server.url.toString()
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Web interface:    ", UI.Style.TEXT_NORMAL, displayUrl)
-      open(displayUrl).catch(() => {})
+      await openBrowserWithFallback({ url: displayUrl, server, sse: () => sse })
     }
 
     await new Promise(() => {})

--- a/packages/opencode/test/server/web-update-script.test.ts
+++ b/packages/opencode/test/server/web-update-script.test.ts
@@ -520,6 +520,44 @@ describe("web update scripts", () => {
   )
 
   windows(
+    "windows script debug log handles cmd metacharacters",
+    async () => {
+      const links = winLinks()
+      const prev = await stash(links)
+      try {
+        await using tmp = await tmpdir()
+        const work = path.join(tmp.path, "aether")
+        const dl = path.join(work, "downloads")
+        const cur = path.join(work, "aether_1.2.6")
+        const src = path.join(tmp.path, "src-windows")
+        const out = path.join(dl, "aether-windows-x64-1.2.7.zip")
+        const script = path.join(dl, "update_windows.bat")
+        const debug = path.join(tmp.path, "debug", "update.log")
+
+        await fs.mkdir(dl, { recursive: true })
+        await ver(cur, "1.2.6")
+        await winApp(src)
+        winZip(src, out)
+        await fs.copyFile(path.join(update, "update_windows.bat"), script)
+
+        run("cmd", ["/c", script, "1.2.7"], dl, {
+          ...process.env,
+          AETHER_CURRENT_DIR: cur,
+          AETHER_WORK_DIR: "alpha & beta | gamma > delta < epsilon",
+          AETHER_DEBUG_LOG: debug,
+        })
+
+        const text = await Bun.file(debug).text()
+        expect(text).toContain("ENVR | AETHER_WORK_DIR=alpha & beta | gamma > delta < epsilon")
+        expect(text).toContain("UPDATE RUN COMPLETE")
+      } finally {
+        await restore(prev)
+      }
+    },
+    { timeout: 30000 },
+  )
+
+  windows(
     "windows script stops old runtime before restart",
     async () => {
       const links = winLinks()


### PR DESCRIPTION
## Summary
- reload the existing web tab after update when the new same-origin server is healthy
- delay browser opening for update restarts with a 1s fallback grace, capped at 3s
- pass the fallback delay through macOS, Linux, and Windows update restart paths

## Tests
- bun run typecheck (packages/app)
- bun run typecheck (packages/opencode)
- bash -n Update/update_linux.sh && bash -n Update/update_darwin.command
- git push pre-push turbo typecheck