### PR TITLE
fix(app): 修复模型供应商总开关并发写配置

### DIFF
--- a/packages/app/src/components/dialog-batch-pdf-convert.tsx
+++ b/packages/app/src/components/dialog-batch-pdf-convert.tsx
@@ -145,6 +145,7 @@ export const DialogBatchPdfConvert: Component<{
     },
     visible: (item: ModelKey) => models.visible(item),
     setVisibility: (item: ModelKey, visible: boolean) => models.setVisibility(item, visible),
+    setManyVisibility: (items: ModelKey[], visible: boolean) => models.setManyVisibility(items, visible),
     variant: {
       configured: () => undefined,
       selected: () => undefined,

--- a/packages/app/src/components/dialog-manage-models.tsx
+++ b/packages/app/src/components/dialog-manage-models.tsx
@@ -23,9 +23,10 @@ export const DialogManageModels: Component = () => {
   const providerVisible = (providerID: string) =>
     providerList(providerID).every((x) => local.model.visible({ modelID: x.id, providerID: x.provider.id }))
   const setProviderVisibility = (providerID: string, checked: boolean) => {
-    providerList(providerID).forEach((x) => {
-      local.model.setVisibility({ modelID: x.id, providerID: x.provider.id }, checked)
-    })
+    local.model.setManyVisibility(
+      providerList(providerID).map((x) => ({ modelID: x.id, providerID: x.provider.id })),
+      checked,
+    )
   }
 
   return (

--- a/packages/app/src/components/dialog-pdf-to-markdown.tsx
+++ b/packages/app/src/components/dialog-pdf-to-markdown.tsx
@@ -195,6 +195,7 @@ export const DialogPdfToMarkdown: Component<{
     },
     visible: (item: ModelKey) => models.visible(item),
     setVisibility: (item: ModelKey, visible: boolean) => models.setVisibility(item, visible),
+    setManyVisibility: (items: ModelKey[], visible: boolean) => models.setManyVisibility(items, visible),
     variant: {
       configured: () => undefined,
       selected: () => undefined,

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -390,6 +390,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       setVisibility(item: ModelKey, visible: boolean) {
         models.setVisibility(item, visible)
       },
+      setManyVisibility(items: ModelKey[], visible: boolean) {
+        models.setManyVisibility(items, visible)
+      },
       variant: {
         configured,
         selected,

--- a/packages/app/src/context/models-visibility.ts
+++ b/packages/app/src/context/models-visibility.ts
@@ -1,0 +1,35 @@
+export type ModelKey = { providerID: string; modelID: string }
+
+function disabledModelID(model: ModelKey) {
+  return `${model.providerID}/${model.modelID}`
+}
+
+function uniqueList(list: string[]) {
+  return Array.from(new Set(list))
+}
+
+export function setModelsVisibilityInDisabledList(before: string[], models: ModelKey[], state: boolean) {
+  const seen = new Set<string>()
+  const keys = models.filter((model) => {
+    const id = disabledModelID(model)
+    if (seen.has(id)) return false
+    seen.add(id)
+    return true
+  })
+  if (keys.length === 0) return uniqueList(before)
+
+  if (state) {
+    const remove = new Set(keys.flatMap((model) => [disabledModelID(model), model.modelID]))
+    return uniqueList(before.filter((item) => !remove.has(item)))
+  }
+
+  const next = uniqueList(before)
+  const disabled = new Set(next)
+  for (const model of keys) {
+    const id = disabledModelID(model)
+    if (disabled.has(id) || disabled.has(model.modelID)) continue
+    next.push(id)
+    disabled.add(id)
+  }
+  return next
+}

--- a/packages/app/src/context/models.test.ts
+++ b/packages/app/src/context/models.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test"
+import { setModelsVisibilityInDisabledList } from "./models-visibility"
+
+describe("model visibility config", () => {
+  test("disables multiple provider models in one update", () => {
+    const next = setModelsVisibilityInDisabledList(
+      ["openai/gpt-5"],
+      [
+        { providerID: "alibaba", modelID: "qwen-max" },
+        { providerID: "alibaba", modelID: "qwen-plus" },
+      ],
+      false,
+    )
+
+    expect(next).toEqual(["openai/gpt-5", "alibaba/qwen-max", "alibaba/qwen-plus"])
+  })
+
+  test("does not duplicate disabled models", () => {
+    const next = setModelsVisibilityInDisabledList(
+      ["alibaba/qwen-max"],
+      [
+        { providerID: "alibaba", modelID: "qwen-max" },
+        { providerID: "alibaba", modelID: "qwen-max" },
+      ],
+      false,
+    )
+
+    expect(next).toEqual(["alibaba/qwen-max"])
+  })
+
+  test("enables provider models by removing provider and legacy bare ids", () => {
+    const next = setModelsVisibilityInDisabledList(
+      ["alibaba/qwen-max", "qwen-plus", "openai/gpt-5"],
+      [
+        { providerID: "alibaba", modelID: "qwen-max" },
+        { providerID: "alibaba", modelID: "qwen-plus" },
+      ],
+      true,
+    )
+
+    expect(next).toEqual(["openai/gpt-5"])
+  })
+})

--- a/packages/app/src/context/models.tsx
+++ b/packages/app/src/context/models.tsx
@@ -5,8 +5,9 @@ import { useProviders } from "@/hooks/use-providers"
 import { useGlobalSync } from "@/context/global-sync"
 import { Persist, persisted } from "@/utils/persist"
 import { uniqueBy } from "remeda"
+import { setModelsVisibilityInDisabledList, type ModelKey } from "./models-visibility"
 
-export type ModelKey = { providerID: string; modelID: string }
+export type { ModelKey }
 
 type User = ModelKey & { favorite?: boolean }
 type Store = {
@@ -21,8 +22,9 @@ function modelKey(model: ModelKey) {
   return `${model.providerID}:${model.modelID}`
 }
 
-function disabledModelID(model: ModelKey) {
-  return `${model.providerID}/${model.modelID}`
+function sameList(a: string[], b: string[]) {
+  if (a.length !== b.length) return false
+  return a.every((item, index) => item === b[index])
 }
 
 export const { use: useModels, provider: ModelsProvider } = createSimpleContext({
@@ -73,31 +75,30 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
     const find = (key: ModelKey) => list().find((m) => m.id === key.modelID && m.provider.id === key.providerID)
 
     const visible = (model: ModelKey) => {
-      const id = disabledModelID(model)
+      const id = `${model.providerID}/${model.modelID}`
       return !disabledModelsSet().has(id) && !disabledModelsSet().has(model.modelID)
     }
 
     const setVisibility = (model: ModelKey, state: boolean) => {
-      const id = disabledModelID(model)
       const before = globalSync.data.config.disabled_models ?? []
-      const isCurrentlyDisabled = before.includes(id) || before.includes(model.modelID)
-      if (state && !isCurrentlyDisabled) return
-      if (!state && isCurrentlyDisabled) return
-      if (state) {
-        const next = before.filter((x) => x !== id && x !== model.modelID)
-        globalSync.set("config", "disabled_models", next)
-        globalSync.updateConfig({ disabled_models: next }).catch((err: unknown) => {
-          globalSync.set("config", "disabled_models", before)
-          console.error("Failed to enable model", err)
-        })
-      } else {
-        const next = [...before, id]
-        globalSync.set("config", "disabled_models", next)
-        globalSync.updateConfig({ disabled_models: next }).catch((err: unknown) => {
-          globalSync.set("config", "disabled_models", before)
-          console.error("Failed to disable model", err)
-        })
-      }
+      const next = setModelsVisibilityInDisabledList(before, [model], state)
+      if (sameList(before, next)) return
+      globalSync.set("config", "disabled_models", next)
+      globalSync.updateConfig({ disabled_models: next }).catch((err: unknown) => {
+        globalSync.set("config", "disabled_models", before)
+        console.error(state ? "Failed to enable model" : "Failed to disable model", err)
+      })
+    }
+
+    const setManyVisibility = (models: ModelKey[], state: boolean) => {
+      const before = globalSync.data.config.disabled_models ?? []
+      const next = setModelsVisibilityInDisabledList(before, models, state)
+      if (sameList(before, next)) return
+      globalSync.set("config", "disabled_models", next)
+      globalSync.updateConfig({ disabled_models: next }).catch((err: unknown) => {
+        globalSync.set("config", "disabled_models", before)
+        console.error(state ? "Failed to enable models" : "Failed to disable models", err)
+      })
     }
 
     const toggleFavorite = (model: ModelKey, state: boolean) => {
@@ -135,6 +136,7 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       find,
       visible,
       setVisibility,
+      setManyVisibility,
       isFavorite,
       toggleFavorite,
       recent: {


### PR DESCRIPTION
### Issue for this PR

Closes #850

Windows 用户反馈：在“管理模型”弹窗中点击“阿里巴巴”供应商总开关后，Aether 可能崩溃。之后通过 `.vbs` 启动表现为无响应，直接运行 `.exe` 可能闪退。

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

这次修复管理模型弹窗里的供应商总开关逻辑。

之前点击供应商总开关时，会对该供应商下的每个模型逐个调用 `setVisibility`，每个模型都会触发一次 `globalSync.updateConfig`。像阿里巴巴这类模型数量较多的供应商，一次点击会产生大量并发配置写入和配置刷新，Windows 下更容易导致后台进程崩溃或启动后立即退出。

现在供应商总开关会先批量计算该供应商所有模型对应的 `disabled_models` 最终状态，然后只调用一次配置更新。单个模型开关仍保持原来的使用方式。

同时新增了 `models-visibility` 纯函数和单元测试，覆盖批量禁用、去重、重新启用并兼容历史裸 `modelID` 禁用项。

### How did you verify your code works?

- `bun test --preload ./happydom.ts ./src/context/models.test.ts`
- `bun run typecheck`
- `git diff --cached --check`
- `git push` 触发的 `bun turbo typecheck` 通过，12 个 typecheck task 成功
- 已检查当前分支相对 `origin/dev` 无合并冲突

### Screenshots / recordings

不适用。该改动主要修复配置更新流程，没有视觉变化。

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR