### PR TITLE
feat(app): add a dev-only debug bar toggle

### DIFF
--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -435,6 +435,17 @@ export const SettingsGeneral: Component = () => {
           </div>
         </SettingsRow>
 
+        <Show when={import.meta.env.DEV}>
+          <SettingsRow
+            title={language.t("settings.general.row.debugBar.title")}
+            description={language.t("settings.general.row.debugBar.description")}
+          >
+            <div data-action="settings-debug-bar">
+              <Switch checked={settings.general.debugBar()} onChange={(checked) => settings.general.setDebugBar(checked)} />
+            </div>
+          </SettingsRow>
+        </Show>
+
         <SettingsRow
           title={language.t("settings.general.row.branchesTab.title")}
           description={language.t("settings.general.row.branchesTab.description")}

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -25,6 +25,7 @@ export interface Settings {
     followup: "queue" | "steer"
     reviewBatch: number
     branchesTab: boolean
+    debugBar: boolean
     branchGraphCompact: boolean
     branchGraphFontSize: "xs" | "sm" | "md" | "lg" | "xl"
     branchGraphRowDensity: "xcompact" | "compact" | "normal" | "relaxed" | "xrelaxed"
@@ -58,6 +59,7 @@ const defaultSettings: Settings = {
     followup: "steer",
     reviewBatch: 10,
     branchesTab: true,
+    debugBar: false,
     branchGraphCompact: false,
     branchGraphFontSize: "lg",
     branchGraphRowDensity: "xcompact",
@@ -170,6 +172,10 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
         branchesTab: withFallback(() => store.general?.branchesTab, defaultSettings.general.branchesTab),
         setBranchesTab(value: boolean) {
           setStore("general", "branchesTab", value)
+        },
+        debugBar: withFallback(() => store.general?.debugBar, defaultSettings.general.debugBar),
+        setDebugBar(value: boolean) {
+          setStore("general", "debugBar", value)
         },
         branchGraphCompact: withFallback(
           () => store.general?.branchGraphCompact,

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -1192,6 +1192,9 @@ export const dict = {
     "How many file changes the review panel loads at a time. The same count is used by Load more.",
   "settings.general.row.reasoningSummaries.title": "Show reasoning summaries",
   "settings.general.row.reasoningSummaries.description": "Display model reasoning summaries in the timeline",
+  "settings.general.row.debugBar.title": "Show debug bar",
+  "settings.general.row.debugBar.description":
+    "Display the development performance debug bar in the bottom-right corner",
   "settings.general.row.shellToolPartsExpanded.title": "Expand shell tool parts",
   "settings.general.row.shellToolPartsExpanded.description":
     "Show shell tool parts expanded by default in the timeline",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -1020,6 +1020,8 @@ export const dict = {
     "设置审查栏每次加载多少个文件变更，“加载更多”也会按这个数量继续加载。",
   "settings.general.row.reasoningSummaries.title": "显示推理摘要",
   "settings.general.row.reasoningSummaries.description": "在时间线中显示模型推理摘要",
+  "settings.general.row.debugBar.title": "显示调试栏",
+  "settings.general.row.debugBar.description": "在右下角显示开发性能调试栏",
   "settings.general.row.shellToolPartsExpanded.title": "展开 shell 工具部分",
   "settings.general.row.shellToolPartsExpanded.description": "默认在时间线中展开 shell 工具部分",
   "settings.general.row.editToolPartsExpanded.title": "展开编辑工具部分",

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -2834,7 +2834,7 @@ export default function Layout(props: ParentProps) {
             </div>
           </div>
         </div>
-        {import.meta.env.DEV && <DebugBar />}
+        {import.meta.env.DEV && settings.general.debugBar() && <DebugBar />}
       </div>
       <Toast.Region regionId="bottom-right" data-placement="bottom-right" />
       <Toast.Region regionId="top-center" data-placement="top-center" swipeDirection="right" swipeThreshold={100000} />


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This restores the persisted switch for the development debug bar in the app settings and defaults it to off. The debug bar only renders in development when that setting is enabled, and the toggle itself is only shown in development so non-dev users never see a setting that cannot do anything.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/app`
- The push hook also ran `bun turbo typecheck` successfully
- Confirmed the debug bar is disabled by default and can be toggled on in development

### Screenshots / recordings

默认关闭右下角的“debugbar”：
<img width="2560" height="1237" alt="image" src="https://github.com/user-attachments/assets/1faf51a8-e139-4a37-97c1-9a3fec57bd14" />

开启后重新显示“debugbar”：
<img width="2577" height="1281" alt="image" src="https://github.com/user-attachments/assets/224a6a30-31a2-48db-b304-e01957e7b054" />

用户版本是没有这个按钮的，只用用源代码运行的时候会有（开发者模式）
就这些了，没了

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
