### PR TITLE
fix: persist workspace/project name to DB via updateDirectoryMeta

### DIFF
--- a/packages/app/e2e/projects/workspaces.spec.ts
+++ b/packages/app/e2e/projects/workspaces.spec.ts
@@ -158,7 +158,7 @@ test("can rename a workspace", async ({ page, withProject }) => {
 
     const rename = `e2e workspace ${Date.now()}`
     const menu = await openWorkspaceMenu(page, slug)
-    await clickMenuItem(menu, /Rename Sandbox/i, { force: true })
+    await clickMenuItem(menu, /Rename Workspace/i, { force: true })
 
     await expect(menu).toHaveCount(0)
 

--- a/packages/app/src/components/dialog-edit-project.tsx
+++ b/packages/app/src/components/dialog-edit-project.tsx
@@ -122,16 +122,8 @@ export function DialogEditProject(props: { project: LocalProject }) {
           ? props.project.id
           : globalSync.child(props.project.worktree, { bootstrap: false })[0].project ||
             globalSync.project.recentFromDir(props.project.worktree)?.projectID
-      if (pid) {
-        fetch(`${globalSDK.url}/project/${pid}`, {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            name: name || undefined,
-            icon,
-            commands: { start: start || undefined },
-          }),
-        }).catch(() => {})
+      if (pid && start) {
+        globalSDK.client.project.update({ projectID: pid, commands: { start } }).catch(() => {})
       }
     },
   }))

--- a/packages/app/src/components/dialog-edit-project.tsx
+++ b/packages/app/src/components/dialog-edit-project.tsx
@@ -12,6 +12,7 @@ import { type LocalProject, getAvatarColors } from "@/context/layout"
 import { getFilename } from "@opencode-ai/util/path"
 import { Avatar } from "@opencode-ai/ui/avatar"
 import { useLanguage } from "@/context/language"
+import { showToast } from "@opencode-ai/ui/toast"
 
 const AVATAR_COLOR_KEYS = ["pink", "mint", "orange", "purple", "cyan", "lime"] as const
 const ICON_SIZE = 128
@@ -113,17 +114,25 @@ export function DialogEditProject(props: { project: LocalProject }) {
         .updateDirectoryMeta({
           body_directory: props.project.worktree,
           name: name || undefined,
+          projectID: props.project.id && !props.project.id.startsWith("dir:") ? props.project.id : undefined,
           icon,
         })
-        .catch(() => {})
+        .catch(() => {
+          showToast({
+            variant: "error",
+            title: language.t("common.requestFailed"),
+            description: language.t("common.requestFailed"),
+          })
+        })
 
-      const pid =
-        props.project.id && !props.project.id.startsWith("dir:")
-          ? props.project.id
-          : globalSync.child(props.project.worktree, { bootstrap: false })[0].project ||
-            globalSync.project.recentFromDir(props.project.worktree)?.projectID
+      const pid = props.project.id && !props.project.id.startsWith("dir:") ? props.project.id : undefined
       if (pid && start) {
-        globalSDK.client.project.update({ projectID: pid, commands: { start } }).catch(() => {})
+        globalSDK.client.project
+          .update({
+            projectID: pid,
+            commands: { start },
+          })
+          .catch(() => {})
       }
     },
   }))

--- a/packages/app/src/components/dialog-edit-project.tsx
+++ b/packages/app/src/components/dialog-edit-project.tsx
@@ -117,14 +117,21 @@ export function DialogEditProject(props: { project: LocalProject }) {
         })
         .catch(() => {})
 
-      const hasProjectID = props.project.id && !props.project.id.startsWith("dir:")
-      if (hasProjectID && start) {
-        globalSDK.client.project
-          .update({
-            projectID: props.project.id!,
-            commands: { start },
-          })
-          .catch(() => {})
+      const pid =
+        props.project.id && !props.project.id.startsWith("dir:")
+          ? props.project.id
+          : globalSync.child(props.project.worktree, { bootstrap: false })[0].project ||
+            globalSync.project.recentFromDir(props.project.worktree)?.projectID
+      if (pid) {
+        fetch(`${globalSDK.url}/project/${pid}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: name || undefined,
+            icon,
+            commands: { start: start || undefined },
+          }),
+        }).catch(() => {})
       }
     },
   }))

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -1169,7 +1169,8 @@ export const dict = {
   "settings.general.row.branchGraphCompact.option.full": "Full",
   "settings.general.row.branchGraphCompact.option.compact": "Compact",
   "settings.general.row.branchGraphOrderMode.title": "Conversation tree order",
-  "settings.general.row.branchGraphOrderMode.description": "Choose whether nodes prefer message sequence or timestamp order",
+  "settings.general.row.branchGraphOrderMode.description":
+    "Choose whether nodes prefer message sequence or timestamp order",
   "settings.general.row.branchGraphOrderMode.option.sequence": "Sequence",
   "settings.general.row.branchGraphOrderMode.option.time": "Time",
   "settings.general.row.branchGraphDisplay.label": "Display",
@@ -1429,7 +1430,7 @@ export const dict = {
   "workspace.reset.archived.many": "{{count}} sessions will be archived.",
   "workspace.reset.note": "This will reset the workspace to match the default branch.",
   "workspace.switchBranch": "Switch Branch",
-  "workspace.renameSandbox": "Rename Sandbox",
+  "workspace.renameSandbox": "Rename Workspace",
   "workspace.renameBranch": "Rename Branch",
   "workspace.renameBranch.error.alreadyExists": "Branch name already exists",
   "workspace.renameBranch.error.invalid": "Branch name is invalid",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -1298,7 +1298,7 @@ export const dict = {
   "workspace.reset.archived.many": "将归档 {{count}} 个会话。",
   "workspace.reset.note": "这将把工作区重置为与默认分支一致。",
   "workspace.switchBranch": "切换分支",
-  "workspace.renameSandbox": "重命名沙盒",
+  "workspace.renameSandbox": "重命名工作区",
   "workspace.renameBranch": "重命名分支",
   "workspace.renameBranch.error.alreadyExists": "分支名称已存在",
   "workspace.renameBranch.error.invalid": "分支名称无效",

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1674,20 +1674,33 @@ export default function Layout(props: ParentProps) {
       .updateDirectoryMeta({
         body_directory: project.worktree,
         name: name || undefined,
-        projectID: project.id && project.id !== "global" ? project.id : undefined,
+        projectID: project.id && !project.id.startsWith("dir:") ? project.id : undefined,
       })
-      .catch(() => {})
+      .catch(() => {
+        showToast({
+          variant: "error",
+          title: language.t("common.requestFailed"),
+          description: language.t("common.requestFailed"),
+        })
+      })
   }
 
   const renameWorkspace = (directory: string, next: string, projectId?: string, branch?: string) => {
     const current = workspaceName(directory, projectId, branch) ?? branch ?? getFilename(directory)
     if (current === next) return
+    setWorkspaceName(directory, next, projectId, branch)
 
     globalSync.project.meta(directory, { name: next })
-
     globalSDK.client.project
       .updateDirectoryMeta({ body_directory: directory, name: next, projectID: projectId })
-      .catch(() => {})
+      .catch(() => {
+        setWorkspaceName(directory, current, projectId, branch)
+        showToast({
+          variant: "error",
+          title: language.t("common.requestFailed"),
+          description: language.t("common.requestFailed"),
+        })
+      })
   }
 
   const renameBranch = async (directory: string, newName: string, projectId?: string) => {

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1671,22 +1671,12 @@ export default function Layout(props: ParentProps) {
     globalSync.project.meta(project.worktree, { name: isDefault ? getFilename(project.worktree) : next })
 
     globalSDK.client.project
-      .updateDirectoryMeta({ body_directory: project.worktree, name: name || undefined })
+      .updateDirectoryMeta({
+        body_directory: project.worktree,
+        name: name || undefined,
+        projectID: project.id && project.id !== "global" ? project.id : undefined,
+      })
       .catch(() => {})
-
-    const pid =
-      project.id && project.id !== "global"
-        ? project.id
-        : globalSync.child(project.worktree, { bootstrap: false })[0].project ||
-          globalSync.project.recentFromDir(project.worktree)?.projectID
-    const body = JSON.stringify({ name: name || undefined })
-    if (pid) {
-      fetch(`${globalSDK.url}/project/${pid}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body,
-      }).catch(() => {})
-    }
   }
 
   const renameWorkspace = (directory: string, next: string, projectId?: string, branch?: string) => {
@@ -1695,17 +1685,9 @@ export default function Layout(props: ParentProps) {
 
     globalSync.project.meta(directory, { name: next })
 
-    const pid =
-      projectId ??
-      globalSync.child(directory, { bootstrap: false })[0].project ??
-      globalSync.project.list().find((p) => p.worktree === directory || p.sandboxes?.includes(directory))?.id
-    const body: Record<string, unknown> = { directory, name: next }
-    if (pid) body.projectID = pid
-    fetch(`${globalSDK.url}/project-workspace-name`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    }).catch(() => {})
+    globalSDK.client.project
+      .updateDirectoryMeta({ body_directory: directory, name: next, projectID: projectId })
+      .catch(() => {})
   }
 
   const renameBranch = async (directory: string, newName: string, projectId?: string) => {

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1665,19 +1665,47 @@ export default function Layout(props: ParentProps) {
   async function renameProject(project: LocalProject, next: string) {
     const current = displayName(project)
     if (next === current) return
-    const name = next === getFilename(project.worktree) ? "" : next
+    const isDefault = next === getFilename(project.worktree)
+    const name = isDefault ? "" : next
 
-    globalSync.project.meta(project.worktree, { name })
+    globalSync.project.meta(project.worktree, { name: isDefault ? getFilename(project.worktree) : next })
 
     globalSDK.client.project
       .updateDirectoryMeta({ body_directory: project.worktree, name: name || undefined })
       .catch(() => {})
+
+    const pid =
+      project.id && project.id !== "global"
+        ? project.id
+        : globalSync.child(project.worktree, { bootstrap: false })[0].project ||
+          globalSync.project.recentFromDir(project.worktree)?.projectID
+    const body = JSON.stringify({ name: name || undefined })
+    if (pid) {
+      fetch(`${globalSDK.url}/project/${pid}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body,
+      }).catch(() => {})
+    }
   }
 
   const renameWorkspace = (directory: string, next: string, projectId?: string, branch?: string) => {
     const current = workspaceName(directory, projectId, branch) ?? branch ?? getFilename(directory)
     if (current === next) return
-    setWorkspaceName(directory, next, projectId, branch)
+
+    globalSync.project.meta(directory, { name: next })
+
+    const pid =
+      projectId ??
+      globalSync.child(directory, { bootstrap: false })[0].project ??
+      globalSync.project.list().find((p) => p.worktree === directory || p.sandboxes?.includes(directory))?.id
+    const body: Record<string, unknown> = { directory, name: next }
+    if (pid) body.projectID = pid
+    fetch(`${globalSDK.url}/project-workspace-name`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }).catch(() => {})
   }
 
   const renameBranch = async (directory: string, newName: string, projectId?: string) => {

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1666,17 +1666,18 @@ export default function Layout(props: ParentProps) {
     const current = displayName(project)
     if (next === current) return
     const isDefault = next === getFilename(project.worktree)
-    const name = isDefault ? "" : next
+    const name = isDefault ? getFilename(project.worktree) : next
 
-    globalSync.project.meta(project.worktree, { name: isDefault ? getFilename(project.worktree) : next })
+    globalSync.project.meta(project.worktree, { name })
 
     globalSDK.client.project
       .updateDirectoryMeta({
         body_directory: project.worktree,
-        name: name || undefined,
+        name,
         projectID: project.id && !project.id.startsWith("dir:") ? project.id : undefined,
       })
       .catch(() => {
+        globalSync.project.meta(project.worktree, { name: current })
         showToast({
           variant: "error",
           title: language.t("common.requestFailed"),
@@ -1689,12 +1690,12 @@ export default function Layout(props: ParentProps) {
     const current = workspaceName(directory, projectId, branch) ?? branch ?? getFilename(directory)
     if (current === next) return
     setWorkspaceName(directory, next, projectId, branch)
-
     globalSync.project.meta(directory, { name: next })
     globalSDK.client.project
       .updateDirectoryMeta({ body_directory: directory, name: next, projectID: projectId })
       .catch(() => {
         setWorkspaceName(directory, current, projectId, branch)
+        globalSync.project.meta(directory, { name: current })
         showToast({
           variant: "error",
           title: language.t("common.requestFailed"),

--- a/packages/app/src/pages/layout/sidebar-project.tsx
+++ b/packages/app/src/pages/layout/sidebar-project.tsx
@@ -319,8 +319,7 @@ export const SortableProject = (props: {
     const [data] = globalSync.child(directory, { bootstrap: false })
     const local = directory === props.project.worktree
     const displayName =
-      props.ctx.workspaceName(directory) ??
-      (local ? language.t("workspace.type.local") : language.t("workspace.type.sandbox"))
+      data.projectMeta?.name ?? (local ? language.t("workspace.type.local") : language.t("workspace.type.sandbox"))
     const branch = data.vcs?.branch ?? getFilename(directory)
     return `${displayName} : ${branch}`
   }

--- a/packages/app/src/pages/layout/sidebar-project.tsx
+++ b/packages/app/src/pages/layout/sidebar-project.tsx
@@ -319,7 +319,9 @@ export const SortableProject = (props: {
     const [data] = globalSync.child(directory, { bootstrap: false })
     const local = directory === props.project.worktree
     const displayName =
-      data.projectMeta?.name ?? (local ? language.t("workspace.type.local") : language.t("workspace.type.sandbox"))
+      data.projectMeta?.name ??
+      props.ctx.workspaceName(directory) ??
+      (local ? language.t("workspace.type.local") : language.t("workspace.type.sandbox"))
     const branch = data.vcs?.branch ?? getFilename(directory)
     return `${displayName} : ${branch}`
   }

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -183,6 +183,7 @@ export const WorkspaceDragOverlay = (props: {
     const local = directory === project.worktree
     const displayName =
       workspaceStore.projectMeta?.name ??
+      props.workspaceName(directory) ??
       (local ? language.t("workspace.type.local") : language.t("workspace.type.sandbox"))
     const branch = workspaceStore.vcs?.branch ?? getFilename(directory)
     return `${displayName} : ${branch}`
@@ -1068,6 +1069,8 @@ export const SortableWorkspace = (props: {
   const workspaceValue = createMemo(() => {
     const metaName = workspaceStore.projectMeta?.name
     if (metaName) return metaName
+    const direct = props.ctx.workspaceName(props.directory)
+    if (direct) return direct
     return local() ? language.t("workspace.type.local") : language.t("workspace.type.sandbox")
   })
   const open = createMemo(() => props.ctx.workspaceExpanded(props.directory, local()))

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -1113,7 +1113,11 @@ export const SortableWorkspace = (props: {
       workspaceEditActive={workspaceEditActive}
       branchEditActive={branchEditActive}
       InlineEditor={props.ctx.InlineEditor}
-      renameWorkspace={(dir, next, projectId) => props.ctx.renameWorkspace(dir, next, projectId ?? props.project.id)}
+      renameWorkspace={(dir, next, projectId) => {
+        const pid =
+          projectId ?? (props.project.id && !props.project.id.startsWith("dir:") ? props.project.id : undefined)
+        props.ctx.renameWorkspace(dir, next, pid)
+      }}
       renameBranch={props.ctx.renameBranch}
       setEditor={props.ctx.setEditor}
     />

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -182,7 +182,7 @@ export const WorkspaceDragOverlay = (props: {
     const [workspaceStore] = globalSync.child(directory, { bootstrap: false })
     const local = directory === project.worktree
     const displayName =
-      props.workspaceName(directory) ??
+      workspaceStore.projectMeta?.name ??
       (local ? language.t("workspace.type.local") : language.t("workspace.type.sandbox"))
     const branch = workspaceStore.vcs?.branch ?? getFilename(directory)
     return `${displayName} : ${branch}`
@@ -1066,8 +1066,8 @@ export const SortableWorkspace = (props: {
   const currentBranch = createMemo(() => workspaceStore.vcs?.branch)
   const active = createMemo(() => workspaceKey(props.ctx.currentDir()) === workspaceKey(props.directory))
   const workspaceValue = createMemo(() => {
-    const direct = props.ctx.workspaceName(props.directory)
-    if (direct) return direct
+    const metaName = workspaceStore.projectMeta?.name
+    if (metaName) return metaName
     return local() ? language.t("workspace.type.local") : language.t("workspace.type.sandbox")
   })
   const open = createMemo(() => props.ctx.workspaceExpanded(props.directory, local()))

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -1110,7 +1110,7 @@ export const SortableWorkspace = (props: {
       workspaceEditActive={workspaceEditActive}
       branchEditActive={branchEditActive}
       InlineEditor={props.ctx.InlineEditor}
-      renameWorkspace={props.ctx.renameWorkspace}
+      renameWorkspace={(dir, next, projectId) => props.ctx.renameWorkspace(dir, next, projectId ?? props.project.id)}
       renameBranch={props.ctx.renameBranch}
       setEditor={props.ctx.setEditor}
     />

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -19,6 +19,8 @@ import { AppFileSystem } from "@/filesystem"
 import * as CrossSpawnSpawner from "@/effect/cross-spawn-spawner"
 import { existsSync } from "fs"
 import { Database as BunSqlite } from "bun:sqlite"
+import nodePath from "path"
+import os from "os"
 import { ProjectIdentity } from "./identity"
 
 export namespace Project {
@@ -252,6 +254,11 @@ export namespace Project {
       directory: string
       name?: string
       icon?: { url?: string; color?: string }
+    }) => Effect.Effect<void>
+    readonly updateWorkspaceName: (input: {
+      projectID: ProjectID
+      directory: string
+      name?: string
     }) => Effect.Effect<void>
     readonly initGit: (input: { directory: string; project: Info }) => Effect.Effect<Info>
     readonly setInitialized: (id: ProjectID) => Effect.Effect<void>
@@ -624,6 +631,28 @@ export namespace Project {
         )
         if (!result) throw new Error(`Project not found: ${input.projectID}`)
         const data = fromRow(result)
+
+        const needsRecentSync = input.name !== undefined || input.icon
+        if (needsRecentSync) {
+          const recentSet = {
+            ...(input.name !== undefined ? { name: input.name } : {}),
+            ...(input.icon ? { icon_url: input.icon.url, icon_color: input.icon.color } : {}),
+            time_updated: Date.now(),
+          }
+          const metaSet = {
+            ...(input.name !== undefined ? { name: input.name } : {}),
+            ...(input.icon ? { icon_url: input.icon.url, icon_color: input.icon.color } : {}),
+            time_updated: Date.now(),
+          }
+          yield* db((d) =>
+            d.update(ProjectRecentTable).set(recentSet).where(eq(ProjectRecentTable.project_id, input.projectID)).run(),
+          )
+          yield* dbProject(input.projectID, (d) =>
+            d.update(DirectoryMetaTable).set(metaSet).where(eq(DirectoryMetaTable.directory, data.worktree)).run(),
+          )
+          yield* emitRecentUpdated
+        }
+
         yield* emitUpdated(data)
         return data
       })
@@ -693,6 +722,33 @@ export namespace Project {
         yield* emitUpdated(fromRow(result))
       })
 
+      const updateWorkspaceName = Effect.fn("Project.updateWorkspaceName")(function* (input: {
+        projectID: ProjectID
+        directory: string
+        name?: string
+      }) {
+        yield* dbProject(input.projectID, (d) =>
+          d
+            .update(DirectoryMetaTable)
+            .set({ name: input.name ?? null, time_updated: Date.now() })
+            .where(eq(DirectoryMetaTable.directory, nodePath.normalize(input.directory.replace(/^~/, os.homedir()))))
+            .run(),
+        )
+        const projectRow = yield* dbProject(input.projectID, (d) =>
+          d.select().from(ProjectTable).where(eq(ProjectTable.id, input.projectID)).get(),
+        )
+        if (projectRow && norm(input.directory) === norm(projectRow.worktree)) {
+          yield* db((d) =>
+            d
+              .update(ProjectRecentTable)
+              .set({ name: input.name ?? name(input.directory), time_updated: Date.now() })
+              .where(eq(ProjectRecentTable.project_id, input.projectID))
+              .run(),
+          )
+          yield* emitRecentUpdated
+        }
+      })
+
       const updateDirectoryMeta = Effect.fn("Project.updateDirectoryMeta")(function* (input: {
         directory: string
         name?: string
@@ -739,6 +795,7 @@ export namespace Project {
         recent: recentList,
         get,
         update,
+        updateWorkspaceName,
         updateDirectoryMeta,
         initGit,
         setInitialized,
@@ -808,6 +865,10 @@ export namespace Project {
     icon?: { url?: string; color?: string }
   }) {
     return runPromise((svc) => svc.updateDirectoryMeta(input))
+  }
+
+  export function updateWorkspaceName(input: { projectID: ProjectID; directory: string; name?: string }) {
+    return runPromise((svc) => svc.updateWorkspaceName(input))
   }
 
   export function sandboxes(id: ProjectID) {

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -19,8 +19,6 @@ import { AppFileSystem } from "@/filesystem"
 import * as CrossSpawnSpawner from "@/effect/cross-spawn-spawner"
 import { existsSync } from "fs"
 import { Database as BunSqlite } from "bun:sqlite"
-import nodePath from "path"
-import os from "os"
 import { ProjectIdentity } from "./identity"
 
 export namespace Project {
@@ -253,12 +251,8 @@ export namespace Project {
     readonly updateDirectoryMeta: (input: {
       directory: string
       name?: string
-      icon?: { url?: string; color?: string }
-    }) => Effect.Effect<void>
-    readonly updateWorkspaceName: (input: {
-      projectID: ProjectID
-      directory: string
-      name?: string
+      icon?: { url?: string; color?: string; override?: string }
+      projectID?: ProjectID
     }) => Effect.Effect<void>
     readonly initGit: (input: { directory: string; project: Info }) => Effect.Effect<Info>
     readonly setInitialized: (id: ProjectID) => Effect.Effect<void>
@@ -372,9 +366,6 @@ export namespace Project {
                 target: DirectoryMetaTable.directory,
                 set: {
                   worktree: input.project.worktree,
-                  name: input.project.name ?? null,
-                  icon_url: input.project.icon?.url ?? null,
-                  icon_color: input.project.icon?.color ?? null,
                   activity_at: now,
                   time_updated: now,
                 },
@@ -639,16 +630,8 @@ export namespace Project {
             ...(input.icon ? { icon_url: input.icon.url, icon_color: input.icon.color } : {}),
             time_updated: Date.now(),
           }
-          const metaSet = {
-            ...(input.name !== undefined ? { name: input.name } : {}),
-            ...(input.icon ? { icon_url: input.icon.url, icon_color: input.icon.color } : {}),
-            time_updated: Date.now(),
-          }
           yield* db((d) =>
             d.update(ProjectRecentTable).set(recentSet).where(eq(ProjectRecentTable.project_id, input.projectID)).run(),
-          )
-          yield* dbProject(input.projectID, (d) =>
-            d.update(DirectoryMetaTable).set(metaSet).where(eq(DirectoryMetaTable.directory, data.worktree)).run(),
           )
           yield* emitRecentUpdated
         }
@@ -722,69 +705,86 @@ export namespace Project {
         yield* emitUpdated(fromRow(result))
       })
 
-      const updateWorkspaceName = Effect.fn("Project.updateWorkspaceName")(function* (input: {
-        projectID: ProjectID
-        directory: string
-        name?: string
-      }) {
-        yield* dbProject(input.projectID, (d) =>
-          d
-            .update(DirectoryMetaTable)
-            .set({ name: input.name ?? null, time_updated: Date.now() })
-            .where(eq(DirectoryMetaTable.directory, nodePath.normalize(input.directory.replace(/^~/, os.homedir()))))
-            .run(),
-        )
-        const projectRow = yield* dbProject(input.projectID, (d) =>
-          d.select().from(ProjectTable).where(eq(ProjectTable.id, input.projectID)).get(),
-        )
-        if (projectRow && norm(input.directory) === norm(projectRow.worktree)) {
-          yield* db((d) =>
-            d
-              .update(ProjectRecentTable)
-              .set({ name: input.name ?? name(input.directory), time_updated: Date.now() })
-              .where(eq(ProjectRecentTable.project_id, input.projectID))
-              .run(),
-          )
-          yield* emitRecentUpdated
-        }
-      })
-
       const updateDirectoryMeta = Effect.fn("Project.updateDirectoryMeta")(function* (input: {
         directory: string
         name?: string
         icon?: { url?: string; color?: string; override?: string }
+        projectID?: ProjectID
       }) {
         const dir = norm(input.directory)
         const key = dirKey(dir)
-        yield* db((d) =>
-          d
-            .insert(ProjectRecentTable)
-            .values({
-              key,
-              kind: "directory",
-              project_id: null,
-              directory: input.directory,
-              name: input.name ?? name(input.directory),
-              icon_url: input.icon?.url ?? null,
-              icon_color: input.icon?.color ?? null,
-              icon_override: input.icon?.override ?? null,
-              activity_at: Date.now(),
-              time_created: Date.now(),
-              time_updated: Date.now(),
-            })
-            .onConflictDoUpdate({
-              target: ProjectRecentTable.key,
-              set: {
+
+        const pid =
+          input.projectID ??
+          (() => {
+            const gpm = Database.use((d) => d.select().from(GlobalProjectMapTable).all())
+            const match = gpm.find((row) => norm(row.directory) === dir)
+            return match?.project_id
+          })()
+
+        const isMainWorktree = pid
+          ? norm(input.directory) ===
+            norm(
+              (yield* dbProject(pid, (d) => d.select().from(ProjectTable).where(eq(ProjectTable.id, pid)).get()))
+                ?.worktree ?? "",
+            )
+          : false
+
+        if (isMainWorktree) {
+          yield* db((d) =>
+            d
+              .insert(ProjectRecentTable)
+              .values({
+                key,
+                kind: "project",
+                project_id: pid,
+                directory: input.directory,
                 name: input.name ?? name(input.directory),
                 icon_url: input.icon?.url ?? null,
                 icon_color: input.icon?.color ?? null,
                 icon_override: input.icon?.override ?? null,
+                activity_at: Date.now(),
+                time_created: Date.now(),
                 time_updated: Date.now(),
-              },
-            })
-            .run(),
-        )
-        yield* emitRecentUpdated
+              })
+              .onConflictDoUpdate({
+                target: ProjectRecentTable.key,
+                set: {
+                  name: input.name ?? name(input.directory),
+                  icon_url: input.icon?.url ?? null,
+                  icon_color: input.icon?.color ?? null,
+                  icon_override: input.icon?.override ?? null,
+                  time_updated: Date.now(),
+                },
+              })
+              .run(),
+          )
+          yield* emitRecentUpdated
+        }
+
+        if (pid) {
+          const allMeta = yield* dbProject(pid, (d) => d.select().from(DirectoryMetaTable).all())
+          const match = allMeta.find((row) => norm(row.directory) === dir)
+          if (match) {
+            yield* dbProject(pid, (d) =>
+              d
+                .update(DirectoryMetaTable)
+                .set({
+                  ...(input.name !== undefined ? { name: input.name } : {}),
+                  ...(input.icon
+                    ? {
+                        icon_url: input.icon.url ?? null,
+                        icon_color: input.icon.color ?? null,
+                        icon_override: input.icon.override ?? null,
+                      }
+                    : {}),
+                  time_updated: Date.now(),
+                })
+                .where(eq(DirectoryMetaTable.directory, match.directory))
+                .run(),
+            )
+          }
+        }
       })
 
       return Service.of({
@@ -795,7 +795,6 @@ export namespace Project {
         recent: recentList,
         get,
         update,
-        updateWorkspaceName,
         updateDirectoryMeta,
         initGit,
         setInitialized,
@@ -863,12 +862,9 @@ export namespace Project {
     directory: string
     name?: string
     icon?: { url?: string; color?: string }
+    projectID?: ProjectID
   }) {
     return runPromise((svc) => svc.updateDirectoryMeta(input))
-  }
-
-  export function updateWorkspaceName(input: { projectID: ProjectID; directory: string; name?: string }) {
-    return runPromise((svc) => svc.updateWorkspaceName(input))
   }
 
   export function sandboxes(id: ProjectID) {

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -722,67 +722,36 @@ export namespace Project {
             )
           : false
 
-        if (isMainWorktree) {
-          yield* db((d) =>
-            d
-              .insert(ProjectRecentTable)
-              .values({
-                key,
-                kind: "project",
-                project_id: pid,
-                directory: input.directory,
+        const kind = isMainWorktree ? "project" : ("directory" as const)
+        yield* db((d) =>
+          d
+            .insert(ProjectRecentTable)
+            .values({
+              key,
+              kind,
+              project_id: isMainWorktree ? pid : (pid ?? null),
+              directory: input.directory,
+              name: input.name ?? name(input.directory),
+              icon_url: input.icon?.url ?? null,
+              icon_color: input.icon?.color ?? null,
+              icon_override: input.icon?.override ?? null,
+              activity_at: Date.now(),
+              time_created: Date.now(),
+              time_updated: Date.now(),
+            })
+            .onConflictDoUpdate({
+              target: ProjectRecentTable.key,
+              set: {
                 name: input.name ?? name(input.directory),
                 icon_url: input.icon?.url ?? null,
                 icon_color: input.icon?.color ?? null,
                 icon_override: input.icon?.override ?? null,
-                activity_at: Date.now(),
-                time_created: Date.now(),
                 time_updated: Date.now(),
-              })
-              .onConflictDoUpdate({
-                target: ProjectRecentTable.key,
-                set: {
-                  name: input.name ?? name(input.directory),
-                  icon_url: input.icon?.url ?? null,
-                  icon_color: input.icon?.color ?? null,
-                  icon_override: input.icon?.override ?? null,
-                  time_updated: Date.now(),
-                },
-              })
-              .run(),
-          )
-          yield* emitRecentUpdated
-        } else {
-          yield* db((d) =>
-            d
-              .insert(ProjectRecentTable)
-              .values({
-                key,
-                kind: "directory",
-                project_id: pid ?? null,
-                directory: input.directory,
-                name: input.name ?? name(input.directory),
-                icon_url: input.icon?.url ?? null,
-                icon_color: input.icon?.color ?? null,
-                icon_override: input.icon?.override ?? null,
-                activity_at: Date.now(),
-                time_created: Date.now(),
-                time_updated: Date.now(),
-              })
-              .onConflictDoUpdate({
-                target: ProjectRecentTable.key,
-                set: {
-                  name: input.name ?? name(input.directory),
-                  icon_url: input.icon?.url ?? null,
-                  icon_color: input.icon?.color ?? null,
-                  icon_override: input.icon?.override ?? null,
-                  time_updated: Date.now(),
-                },
-              })
-              .run(),
-          )
-          yield* emitRecentUpdated
-        }
+              },
+            })
+            .run(),
+        )
+        yield* emitRecentUpdated
 
         if (pid) {
           const allMeta = yield* dbProject(pid, (d) => d.select().from(DirectoryMetaTable).all())

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -366,6 +366,9 @@ export namespace Project {
                 target: DirectoryMetaTable.directory,
                 set: {
                   worktree: input.project.worktree,
+                  name: input.project.name ?? null,
+                  icon_url: input.project.icon?.url ?? null,
+                  icon_color: input.project.icon?.color ?? null,
                   activity_at: now,
                   time_updated: now,
                 },
@@ -622,20 +625,6 @@ export namespace Project {
         )
         if (!result) throw new Error(`Project not found: ${input.projectID}`)
         const data = fromRow(result)
-
-        const needsRecentSync = input.name !== undefined || input.icon
-        if (needsRecentSync) {
-          const recentSet = {
-            ...(input.name !== undefined ? { name: input.name } : {}),
-            ...(input.icon ? { icon_url: input.icon.url, icon_color: input.icon.color } : {}),
-            time_updated: Date.now(),
-          }
-          yield* db((d) =>
-            d.update(ProjectRecentTable).set(recentSet).where(eq(ProjectRecentTable.project_id, input.projectID)).run(),
-          )
-          yield* emitRecentUpdated
-        }
-
         yield* emitUpdated(data)
         return data
       })
@@ -716,17 +705,20 @@ export namespace Project {
 
         const pid =
           input.projectID ??
-          (() => {
-            const gpm = Database.use((d) => d.select().from(GlobalProjectMapTable).all())
-            const match = gpm.find((row) => norm(row.directory) === dir)
-            return match?.project_id
-          })()
+          (yield* db((d) =>
+            d
+              .select({ project_id: GlobalProjectMapTable.project_id })
+              .from(GlobalProjectMapTable)
+              .where(eq(GlobalProjectMapTable.directory, dir))
+              .get(),
+          ))?.project_id
 
         const isMainWorktree = pid
           ? norm(input.directory) ===
             norm(
-              (yield* dbProject(pid, (d) => d.select().from(ProjectTable).where(eq(ProjectTable.id, pid)).get()))
-                ?.worktree ?? "",
+              (yield* dbProject(pid, (d) =>
+                d.select({ worktree: ProjectTable.worktree }).from(ProjectTable).where(eq(ProjectTable.id, pid)).get(),
+              ))?.worktree ?? "",
             )
           : false
 
@@ -738,6 +730,36 @@ export namespace Project {
                 key,
                 kind: "project",
                 project_id: pid,
+                directory: input.directory,
+                name: input.name ?? name(input.directory),
+                icon_url: input.icon?.url ?? null,
+                icon_color: input.icon?.color ?? null,
+                icon_override: input.icon?.override ?? null,
+                activity_at: Date.now(),
+                time_created: Date.now(),
+                time_updated: Date.now(),
+              })
+              .onConflictDoUpdate({
+                target: ProjectRecentTable.key,
+                set: {
+                  name: input.name ?? name(input.directory),
+                  icon_url: input.icon?.url ?? null,
+                  icon_color: input.icon?.color ?? null,
+                  icon_override: input.icon?.override ?? null,
+                  time_updated: Date.now(),
+                },
+              })
+              .run(),
+          )
+          yield* emitRecentUpdated
+        } else {
+          yield* db((d) =>
+            d
+              .insert(ProjectRecentTable)
+              .values({
+                key,
+                kind: "directory",
+                project_id: pid ?? null,
                 directory: input.directory,
                 name: input.name ?? name(input.directory),
                 icon_url: input.icon?.url ?? null,
@@ -861,7 +883,7 @@ export namespace Project {
   export function updateDirectoryMeta(input: {
     directory: string
     name?: string
-    icon?: { url?: string; color?: string }
+    icon?: { url?: string; color?: string; override?: string }
     projectID?: ProjectID
   }) {
     return runPromise((svc) => svc.updateDirectoryMeta(input))

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -127,6 +127,7 @@ import { ProviderID } from "../provider/schema"
 import { WorkspaceRouterMiddleware } from "../control-plane/workspace-router-middleware"
 import { ProjectRoutes } from "./routes/project"
 import { Project } from "../project/project"
+import { ProjectID } from "../project/schema"
 import { SessionRoutes } from "./routes/session"
 import { PtyRoutes } from "./routes/pty"
 import { McpRoutes } from "./routes/mcp"
@@ -465,6 +466,49 @@ export namespace Server {
         },
       )
       .route("/project", ProjectRoutes())
+      .post(
+        "/project-workspace-name",
+        describeRoute({
+          summary: "Update workspace name",
+          description:
+            "Update a workspace (worktree/sandbox) display name. Persisted in directory_meta table in project DB, and project_recent table for the main worktree.",
+          operationId: "project.updateWorkspaceName",
+          responses: {
+            200: {
+              description: "Update acknowledged",
+              content: {
+                "application/json": {
+                  schema: resolver(z.object({ ok: z.boolean() })),
+                },
+              },
+            },
+            ...errors(400),
+          },
+        }),
+        validator(
+          "json",
+          z.object({
+            projectID: z.string().optional(),
+            directory: z.string(),
+            name: z.string().optional(),
+          }),
+        ),
+        async (c) => {
+          const body = c.req.valid("json")
+          const pid =
+            body.projectID ||
+            (await (async () => {
+              try {
+                return (await Project.fromDirectory(body.directory)).project.id
+              } catch {
+                return undefined
+              }
+            })())
+          if (!pid) return c.json({ ok: false, error: "cannot resolve project" }, 400)
+          await Project.updateWorkspaceName({ projectID: pid as any, directory: body.directory, name: body.name })
+          return c.json({ ok: true })
+        },
+      )
       .route("/pty", PtyRoutes())
       .route("/config", ConfigRoutes())
       .route("/experimental", ExperimentalRoutes())

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -442,6 +442,7 @@ export namespace Server {
           z.object({
             directory: z.string(),
             name: z.string().optional(),
+            projectID: z.string().optional(),
             icon: z
               .object({
                 url: z.string().optional(),
@@ -453,7 +454,7 @@ export namespace Server {
         ),
         async (c) => {
           const body = c.req.valid("json")
-          await Project.updateDirectoryMeta(body)
+          await Project.updateDirectoryMeta({ ...body, projectID: body.projectID as ProjectID | undefined })
           const list = Project.recentList()
           const norm = (d: string) =>
             d
@@ -466,49 +467,6 @@ export namespace Server {
         },
       )
       .route("/project", ProjectRoutes())
-      .post(
-        "/project-workspace-name",
-        describeRoute({
-          summary: "Update workspace name",
-          description:
-            "Update a workspace (worktree/sandbox) display name. Persisted in directory_meta table in project DB, and project_recent table for the main worktree.",
-          operationId: "project.updateWorkspaceName",
-          responses: {
-            200: {
-              description: "Update acknowledged",
-              content: {
-                "application/json": {
-                  schema: resolver(z.object({ ok: z.boolean() })),
-                },
-              },
-            },
-            ...errors(400),
-          },
-        }),
-        validator(
-          "json",
-          z.object({
-            projectID: z.string().optional(),
-            directory: z.string(),
-            name: z.string().optional(),
-          }),
-        ),
-        async (c) => {
-          const body = c.req.valid("json")
-          const pid =
-            body.projectID ||
-            (await (async () => {
-              try {
-                return (await Project.fromDirectory(body.directory)).project.id
-              } catch {
-                return undefined
-              }
-            })())
-          if (!pid) return c.json({ ok: false, error: "cannot resolve project" }, 400)
-          await Project.updateWorkspaceName({ projectID: pid as any, directory: body.directory, name: body.name })
-          return c.json({ ok: true })
-        },
-      )
       .route("/pty", PtyRoutes())
       .route("/config", ConfigRoutes())
       .route("/experimental", ExperimentalRoutes())

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -24,6 +24,7 @@ import type {
   ConfigSkillsToggleResponses,
   ConfigUpdateErrors,
   ConfigUpdateResponses,
+  CronAssistantResponses,
   CronJobsCreateResponses,
   CronJobsDeleteResponses,
   CronJobsGetResponses,
@@ -167,6 +168,12 @@ import type {
   McpLocalConfig,
   McpRemoteConfig,
   McpStatusResponses,
+  MemoryDailyReflectSyncResponses,
+  MemoryInitializeCancelResponses,
+  MemoryInitializeStartResponses,
+  MemoryReflectResponses,
+  MemorySearchResponses,
+  MemoryStatusResponses,
   OutputFormat,
   Part as Part2,
   PartDeleteErrors,
@@ -180,11 +187,16 @@ import type {
   PermissionRespondErrors,
   PermissionRespondResponses,
   PermissionRuleset,
+  PostVoiceTranscribeResponses,
   ProjectCurrentResponses,
+  ProjectDeleteErrors,
+  ProjectDeleteResponses,
   ProjectDirectoriesResponses,
   ProjectInitGitResponses,
   ProjectListResponses,
   ProjectRecentResponses,
+  ProjectSessionCountErrors,
+  ProjectSessionCountResponses,
   ProjectUpdateDirectoryMetaErrors,
   ProjectUpdateDirectoryMetaResponses,
   ProjectUpdateErrors,
@@ -319,11 +331,13 @@ import type {
   TuiSelectSessionResponses,
   TuiShowToastResponses,
   TuiSubmitPromptResponses,
+  VcsCheckoutResponses,
   VcsCommitDetailResponses,
   VcsDiffResponses,
   VcsFileContentResponses,
   VcsGetResponses,
   VcsGraphResponses,
+  VcsRenameBranchResponses,
   WechatEventsResponses,
   WechatPing2Responses,
   WechatPing3Responses,
@@ -832,6 +846,7 @@ export class Project extends HeyApiClient {
       workspace?: string
       body_directory?: string
       name?: string
+      projectID?: string
       icon?: {
         url?: string
         override?: string
@@ -857,6 +872,7 @@ export class Project extends HeyApiClient {
               map: "directory",
             },
             { in: "body", key: "name" },
+            { in: "body", key: "projectID" },
             { in: "body", key: "icon" },
           ],
         },
@@ -1029,6 +1045,38 @@ export class Project extends HeyApiClient {
   }
 
   /**
+   * Delete project
+   *
+   * Remove a project and its database. Fails if the project has sessions — delete those first.
+   */
+  public delete<ThrowOnError extends boolean = false>(
+    parameters: {
+      projectID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "projectID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).delete<ProjectDeleteResponses, ProjectDeleteErrors, ThrowOnError>({
+      url: "/project/{projectID}",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
    * Update project
    *
    * Update project properties such as name, icon, and commands.
@@ -1077,6 +1125,38 @@ export class Project extends HeyApiClient {
         ...options?.headers,
         ...params.headers,
       },
+    })
+  }
+
+  /**
+   * Get session count for project
+   *
+   * Return the number of sessions in a project database.
+   */
+  public sessionCount<ThrowOnError extends boolean = false>(
+    parameters: {
+      projectID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "projectID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<ProjectSessionCountResponses, ProjectSessionCountErrors, ThrowOnError>({
+      url: "/project/{projectID}/session-count",
+      ...options,
+      ...params,
     })
   }
 }
@@ -6522,6 +6602,47 @@ export class Runs extends HeyApiClient {
 }
 
 export class Cron extends HeyApiClient {
+  /**
+   * Create or update a cron job from a short natural language instruction
+   */
+  public assistant<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      instruction?: string
+      selected_id?: string
+      project_id?: string
+      session_id?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "instruction" },
+            { in: "body", key: "selected_id" },
+            { in: "body", key: "project_id" },
+            { in: "body", key: "session_id" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<CronAssistantResponses, unknown, ThrowOnError>({
+      url: "/cron/assistant",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
   private _jobs?: Jobs
   get jobs(): Jobs {
     return (this._jobs ??= new Jobs({ client: this.client }))
@@ -6530,6 +6651,214 @@ export class Cron extends HeyApiClient {
   private _runs?: Runs
   get runs(): Runs {
     return (this._runs ??= new Runs({ client: this.client }))
+  }
+}
+
+export class Initialize extends HeyApiClient {
+  /**
+   * Start one-time memory initialization
+   */
+  public start<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<MemoryInitializeStartResponses, unknown, ThrowOnError>({
+      url: "/memory/initialize/start",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Cancel memory initialization
+   */
+  public cancel<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<MemoryInitializeCancelResponses, unknown, ThrowOnError>({
+      url: "/memory/initialize/cancel",
+      ...options,
+      ...params,
+    })
+  }
+}
+
+export class DailyReflect extends HeyApiClient {
+  /**
+   * Sync daily memory reflection cron job from config
+   */
+  public sync<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<MemoryDailyReflectSyncResponses, unknown, ThrowOnError>({
+      url: "/memory/daily-reflect/sync",
+      ...options,
+      ...params,
+    })
+  }
+}
+
+export class Memory extends HeyApiClient {
+  /**
+   * Get memory system status
+   */
+  public status<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<MemoryStatusResponses, unknown, ThrowOnError>({
+      url: "/memory/status",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Search long-term memory
+   */
+  public search<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      query?: string
+      mode?: "search" | "overview"
+      types?: Array<"preference" | "fact" | "task">
+      limit?: number
+      currentProjectID?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "query" },
+            { in: "body", key: "mode" },
+            { in: "body", key: "types" },
+            { in: "body", key: "limit" },
+            { in: "body", key: "currentProjectID" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<MemorySearchResponses, unknown, ThrowOnError>({
+      url: "/memory/search",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Run memory reflection
+   */
+  public reflect<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      mode?: "quick" | "daily" | "manual"
+      reason?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "mode" },
+            { in: "body", key: "reason" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<MemoryReflectResponses, unknown, ThrowOnError>({
+      url: "/memory/reflect",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  private _initialize?: Initialize
+  get initialize(): Initialize {
+    return (this._initialize ??= new Initialize({ client: this.client }))
+  }
+
+  private _dailyReflect?: DailyReflect
+  get dailyReflect(): DailyReflect {
+    return (this._dailyReflect ??= new DailyReflect({ client: this.client }))
   }
 }
 
@@ -7737,6 +8066,80 @@ export class Vcs extends HeyApiClient {
   }
 
   /**
+   * Switch git branch
+   *
+   * Switch the current git branch to the specified branch name.
+   */
+  public checkout<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      branch?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "branch" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<VcsCheckoutResponses, unknown, ThrowOnError>({
+      url: "/vcs/checkout",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Rename git branch
+   *
+   * Rename the current git branch to a new name.
+   */
+  public renameBranch<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      newName?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "newName" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<VcsRenameBranchResponses, unknown, ThrowOnError>({
+      url: "/vcs/rename-branch",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
    * Get commit details
    *
    * Retrieve detailed information about a specific git commit, including metadata and file changes.
@@ -8014,6 +8417,49 @@ export class OpencodeClient extends HeyApiClient {
     OpencodeClient.__registry.set(this, args?.key)
   }
 
+  public postVoiceTranscribe<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      providerID?: string
+      modelID?: string
+      audioBase64?: string
+      audioFormat?: string
+      context?: Array<{
+        role: string
+        content: string
+      }>
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "providerID" },
+            { in: "body", key: "modelID" },
+            { in: "body", key: "audioBase64" },
+            { in: "body", key: "audioFormat" },
+            { in: "body", key: "context" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<PostVoiceTranscribeResponses, unknown, ThrowOnError>({
+      url: "/voice/transcribe",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
   private _global?: Global
   get global(): Global {
     return (this._global ??= new Global({ client: this.client }))
@@ -8117,6 +8563,11 @@ export class OpencodeClient extends HeyApiClient {
   private _cron?: Cron
   get cron(): Cron {
     return (this._cron ??= new Cron({ client: this.client }))
+  }
+
+  private _memory?: Memory
+  get memory(): Memory {
+    return (this._memory ??= new Memory({ client: this.client }))
   }
 
   private _wechat?: Wechat

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -26,6 +26,44 @@ export type EventInstallationUpdateAvailable = {
   }
 }
 
+export type EventDbRecoveryStarted = {
+  type: "db.recovery.started"
+  properties: {
+    entries: number
+  }
+}
+
+export type EventDbRecoveryProgress = {
+  type: "db.recovery.progress"
+  properties: {
+    id: string
+    phase: "path-b" | "path-a" | "path-a-plus"
+    table: string
+    recoveredRows: number
+  }
+}
+
+export type EventDbRecoveryCompleted = {
+  type: "db.recovery.completed"
+  properties: {
+    id: string
+    kind: "main" | "project" | "cron"
+    projectId?: string
+    status: "completed" | "partial" | "failed"
+    recoveredTables: Array<string>
+    failedTables: Array<string>
+    recoveredRows: number
+    quarantinePath: string
+  }
+}
+
+export type EventDbRecoveryAskInstall = {
+  type: "db.recovery.ask_install"
+  properties: {
+    message: string
+  }
+}
+
 export type Project = {
   id: string
   worktree: string
@@ -1029,6 +1067,10 @@ export type EventSessionDeleted = {
 export type Event =
   | EventInstallationUpdated
   | EventInstallationUpdateAvailable
+  | EventDbRecoveryStarted
+  | EventDbRecoveryProgress
+  | EventDbRecoveryCompleted
+  | EventDbRecoveryAskInstall
   | EventProjectUpdated
   | EventProjectRecentUpdated
   | EventServerInstanceDisposed
@@ -1698,6 +1740,38 @@ export type Config = {
      */
     enabled?: boolean
   }
+  memory?: {
+    /**
+     * Enable memory hooks and tools (default: true)
+     */
+    enabled?: boolean
+    /**
+     * Enable lightweight quick reflection (default: true)
+     */
+    quickReflect?: boolean
+    dailyReflect?: {
+      /**
+       * Enable scheduled daily memory reflection (default: true)
+       */
+      enabled?: boolean
+      /**
+       * Daily memory reflection time in HH:mm format (default: 03:00)
+       */
+      time?: string
+      /**
+       * Daily memory reflection timezone. Defaults to the system timezone.
+       */
+      timezone?: string
+    }
+    search?: {
+      defaultLimit?: number
+      maxLimit?: number
+    }
+    reflection?: {
+      maxInputTokens?: number
+      maxOutputTokens?: number
+    }
+  }
   experimental?: {
     disable_paste_summary?: boolean
     /**
@@ -2250,6 +2324,17 @@ export type VcsGraphResult = {
   moreAvailable: boolean
 }
 
+export type VcsCheckoutResult = {
+  success: boolean
+  error?: string
+}
+
+export type VcsRenameBranchResult = {
+  success: boolean
+  error?: string
+  branch?: string
+}
+
 export type VcsFileChange = {
   status: string
   file: string
@@ -2784,6 +2869,7 @@ export type ProjectUpdateDirectoryMetaData = {
   body?: {
     directory: string
     name?: string
+    projectID?: string
     icon?: {
       url?: string
       override?: string
@@ -2912,6 +2998,49 @@ export type ProjectInitGitResponses = {
 
 export type ProjectInitGitResponse = ProjectInitGitResponses[keyof ProjectInitGitResponses]
 
+export type ProjectDeleteData = {
+  body?: never
+  path: {
+    projectID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/project/{projectID}"
+}
+
+export type ProjectDeleteErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type ProjectDeleteError = ProjectDeleteErrors[keyof ProjectDeleteErrors]
+
+export type ProjectDeleteResponses = {
+  /**
+   * Deletion result
+   */
+  200:
+    | {
+        status: "ok"
+        projectID: string
+      }
+    | {
+        status: "has_sessions"
+        projectID: string
+        sessionCount: number
+      }
+}
+
+export type ProjectDeleteResponse = ProjectDeleteResponses[keyof ProjectDeleteResponses]
+
 export type ProjectUpdateData = {
   body?: {
     name?: string
@@ -2958,6 +3087,42 @@ export type ProjectUpdateResponses = {
 }
 
 export type ProjectUpdateResponse = ProjectUpdateResponses[keyof ProjectUpdateResponses]
+
+export type ProjectSessionCountData = {
+  body?: never
+  path: {
+    projectID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/project/{projectID}/session-count"
+}
+
+export type ProjectSessionCountErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type ProjectSessionCountError = ProjectSessionCountErrors[keyof ProjectSessionCountErrors]
+
+export type ProjectSessionCountResponses = {
+  /**
+   * Session count
+   */
+  200: {
+    count: number
+  }
+}
+
+export type ProjectSessionCountResponse = ProjectSessionCountResponses[keyof ProjectSessionCountResponses]
 
 export type PtyListData = {
   body?: never
@@ -7608,6 +7773,82 @@ export type KnowledgeDocumentDeleteResponses = {
 
 export type KnowledgeDocumentDeleteResponse = KnowledgeDocumentDeleteResponses[keyof KnowledgeDocumentDeleteResponses]
 
+export type CronAssistantData = {
+  body?: {
+    instruction: string
+    selected_id?: string
+    project_id?: string
+    session_id?: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/cron/assistant"
+}
+
+export type CronAssistantResponses = {
+  /**
+   * Cron assistant result
+   */
+  200: {
+    action: "create" | "update" | "reject"
+    summary: string
+    job: {
+      definition: {
+        id: string
+        name: string
+        enabled: boolean
+        mode: "direct" | "isolated_agent" | "session_agent" | "agent_message"
+        project_id?: string | null
+        session_id?: string | null
+        schedule_type: "cron" | "interval" | "once"
+        schedule_value: string | number
+        timezone?: string | null
+        payload: {
+          [key: string]: unknown
+        }
+        [key: string]:
+          | unknown
+          | string
+          | boolean
+          | "direct"
+          | "isolated_agent"
+          | "session_agent"
+          | "agent_message"
+          | string
+          | null
+          | string
+          | null
+          | "cron"
+          | "interval"
+          | "once"
+          | string
+          | number
+          | string
+          | null
+          | {
+              [key: string]: unknown
+            }
+          | undefined
+      }
+      state: {
+        job_id: string
+        enabled: boolean
+        next_run_at: number | null
+        last_run_at: number | null
+        last_status: "success" | "failed" | "skipped" | "expired" | null
+        running: boolean
+        start_at: number | null
+        updated_at: number
+      } | null
+    } | null
+  }
+}
+
+export type CronAssistantResponse = CronAssistantResponses[keyof CronAssistantResponses]
+
 export type CronJobsListData = {
   body?: never
   path?: never
@@ -8054,6 +8295,164 @@ export type CronRunsGetResponses = {
 
 export type CronRunsGetResponse = CronRunsGetResponses[keyof CronRunsGetResponses]
 
+export type MemoryStatusData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/memory/status"
+}
+
+export type MemoryStatusResponses = {
+  /**
+   * Memory status
+   */
+  200: {
+    [key: string]: unknown
+  }
+}
+
+export type MemoryStatusResponse = MemoryStatusResponses[keyof MemoryStatusResponses]
+
+export type MemorySearchData = {
+  body?: {
+    query: string
+    mode?: "search" | "overview"
+    types?: Array<"preference" | "fact" | "task">
+    limit?: number
+    currentProjectID?: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/memory/search"
+}
+
+export type MemorySearchResponses = {
+  /**
+   * Memory search result
+   */
+  200: {
+    [key: string]: unknown
+  }
+}
+
+export type MemorySearchResponse = MemorySearchResponses[keyof MemorySearchResponses]
+
+export type MemoryReflectData = {
+  body?: {
+    mode?: "quick" | "daily" | "manual"
+    reason?: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/memory/reflect"
+}
+
+export type MemoryReflectResponses = {
+  /**
+   * Memory reflection result
+   */
+  200: {
+    [key: string]: unknown
+  }
+}
+
+export type MemoryReflectResponse = MemoryReflectResponses[keyof MemoryReflectResponses]
+
+export type MemoryInitializeStartData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/memory/initialize/start"
+}
+
+export type MemoryInitializeStartResponses = {
+  /**
+   * Initialization result
+   */
+  200: {
+    [key: string]: unknown
+  }
+}
+
+export type MemoryInitializeStartResponse = MemoryInitializeStartResponses[keyof MemoryInitializeStartResponses]
+
+export type MemoryInitializeCancelData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/memory/initialize/cancel"
+}
+
+export type MemoryInitializeCancelResponses = {
+  /**
+   * Cancel result
+   */
+  200: {
+    ok: boolean
+  }
+}
+
+export type MemoryInitializeCancelResponse = MemoryInitializeCancelResponses[keyof MemoryInitializeCancelResponses]
+
+export type MemoryDailyReflectSyncData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/memory/daily-reflect/sync"
+}
+
+export type MemoryDailyReflectSyncResponses = {
+  /**
+   * Synced cron job
+   */
+  200: {
+    [key: string]: unknown
+  }
+}
+
+export type MemoryDailyReflectSyncResponse = MemoryDailyReflectSyncResponses[keyof MemoryDailyReflectSyncResponses]
+
+export type PostVoiceTranscribeData = {
+  body?: {
+    providerID: string
+    modelID: string
+    audioBase64: string
+    audioFormat: string
+    context?: Array<{
+      role: string
+      content: string
+    }>
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/voice/transcribe"
+}
+
+export type PostVoiceTranscribeResponses = {
+  200: unknown
+}
+
 export type WechatStartData = {
   body?: never
   path?: never
@@ -8148,6 +8547,7 @@ export type WechatStatusResponses = {
     } | null
     locked: boolean | null
     lockHolder: string | null
+    hasConfig: boolean
     error: {
       code: string
       message: string
@@ -8955,6 +9355,48 @@ export type VcsGraphResponses = {
 }
 
 export type VcsGraphResponse = VcsGraphResponses[keyof VcsGraphResponses]
+
+export type VcsCheckoutData = {
+  body?: {
+    branch: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/vcs/checkout"
+}
+
+export type VcsCheckoutResponses = {
+  /**
+   * Checkout result
+   */
+  200: VcsCheckoutResult
+}
+
+export type VcsCheckoutResponse = VcsCheckoutResponses[keyof VcsCheckoutResponses]
+
+export type VcsRenameBranchData = {
+  body?: {
+    newName: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/vcs/rename-branch"
+}
+
+export type VcsRenameBranchResponses = {
+  /**
+   * Rename result
+   */
+  200: VcsRenameBranchResult
+}
+
+export type VcsRenameBranchResponse = VcsRenameBranchResponses[keyof VcsRenameBranchResponses]
 
 export type VcsCommitDetailData = {
   body?: never


### PR DESCRIPTION
## Summary

- Workspace/project names renamed in the sidebar are now persisted to both global DB (`project_recent`) and project DB (`directory_meta`), replacing the previous localStorage-only approach
- Consolidated all name/icon persistence into the existing `PUT /project-directory-meta` endpoint (extending `updateDirectoryMeta` to also write `DirectoryMetaTable` in project DB), removing the separate `/project-workspace-name` endpoint
- Fixed `touch` and `update()` to not overwrite user-customized `name/icon` in `directory_meta` on conflict
- Sidebar display reads `projectMeta?.name` instead of localStorage `workspaceName()`
- i18n: "Rename Sandbox" → "Rename Workspace"

## Key design decisions

- `updateDirectoryMeta` resolves `projectID` via `GlobalProjectMapTable` (or accepts it as an explicit parameter from frontend) and writes to `DirectoryMetaTable` with `norm()` path matching
- Only writes `ProjectRecentTable` when the directory is the project's **main worktree** (not for sandbox directories), preventing spurious `project_recent` rows
- `touch`'s `onConflictDoUpdate` no longer overwrites `name/icon_url/icon_color` — only updates `worktree/activity_at/time_updated`
- `PATCH /project/:id` (`update()` method) no longer syncs to `DirectoryMetaTable`; name/icon handled exclusively by `updateDirectoryMeta`

## Bug fix context

Original bug: renaming a sandbox in the sidebar would overwrite the main worktree's `directory_meta.name` in the project DB with the project name (e.g. "SyncTest-1779285804305"). Root cause was the `POST /project-workspace-name` handler calling `Project.fromDirectory()` as a fallback when `projectID` wasn't provided, which triggered `touch` → `onConflictDoUpdate` overwriting the main worktree row.