### PR TITLE
fix: prevent user-set workspace names from being overwritten on restart

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -464,9 +464,6 @@ export namespace Project {
               set: {
                 worktree: result.worktree,
                 vcs: result.vcs ?? null,
-                name: result.name,
-                icon_url: result.icon?.url,
-                icon_color: result.icon?.color,
                 time_updated: result.time.updated,
                 time_initialized: result.time.initialized,
                 commands: result.commands,

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -366,9 +366,6 @@ export namespace Project {
                 target: DirectoryMetaTable.directory,
                 set: {
                   worktree: input.project.worktree,
-                  name: input.project.name ?? null,
-                  icon_url: input.project.icon?.url ?? null,
-                  icon_color: input.project.icon?.color ?? null,
                   activity_at: now,
                   time_updated: now,
                 },
@@ -521,9 +518,6 @@ export namespace Project {
               target: DirectoryMetaTable.directory,
               set: {
                 worktree: data.worktree,
-                name: result.name ?? null,
-                icon_url: result.icon?.url ?? null,
-                icon_color: result.icon?.color ?? null,
                 activity_at: Date.now(),
                 time_updated: Date.now(),
               },
@@ -742,10 +736,14 @@ export namespace Project {
             .onConflictDoUpdate({
               target: ProjectRecentTable.key,
               set: {
-                name: input.name ?? name(input.directory),
-                icon_url: input.icon?.url ?? null,
-                icon_color: input.icon?.color ?? null,
-                icon_override: input.icon?.override ?? null,
+                ...(input.name !== undefined ? { name: input.name } : {}),
+                ...(input.icon
+                  ? {
+                      icon_url: input.icon.url ?? null,
+                      icon_color: input.icon.color ?? null,
+                      icon_override: input.icon.override ?? null,
+                    }
+                  : {}),
                 time_updated: Date.now(),
               },
             })

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -628,6 +628,98 @@ export namespace Database {
     }
   }
 
+  function gitWorktreeDirectories(worktree: string): string[] {
+    if (!existsSync(worktree)) return []
+    try {
+      const proc = Bun.spawnSync(["git", "worktree", "list", "--porcelain"], {
+        cwd: worktree,
+        stderr: "pipe",
+        stdout: "pipe",
+      })
+      if (proc.exitCode !== 0) return []
+      const text = proc.stdout?.toString() ?? ""
+      const dirs: string[] = []
+      for (const line of text.split("\n")) {
+        const trimmed = line.trim()
+        if (trimmed.startsWith("worktree ")) {
+          dirs.push(trimmed.slice("worktree ".length).trim())
+        }
+      }
+      return dirs
+    } catch {
+      return []
+    }
+  }
+
+  function validateDirectoryMeta(pSqlite: BunSqlite, pid: string, recentLookup: Map<string, any>) {
+    const hasTable = pSqlite
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='directory_meta'")
+      .get()
+    if (!hasTable) return
+
+    const projectRow = pSqlite.prepare("SELECT worktree, vcs FROM project WHERE id = ?").get(pid) as
+      | { worktree: string; vcs: string | null }
+      | undefined
+    if (!projectRow) return
+
+    const worktree = projectRow.worktree
+
+    const setA = new Set<string>()
+    const sessionDirs = (
+      pSqlite.prepare("SELECT DISTINCT directory FROM session").all() as { directory: string }[]
+    ).map((r) => r.directory)
+    for (const dir of sessionDirs) setA.add(norm(dir))
+    setA.add(norm(worktree))
+
+    const setB = new Set<string>()
+    if (projectRow.vcs === "git" && worktree !== "/") {
+      for (const dir of gitWorktreeDirectories(worktree)) {
+        setB.add(norm(dir))
+      }
+    }
+
+    const validDirs = new Set([...setA, ...setB])
+
+    const metaRows = pSqlite.prepare("SELECT directory FROM directory_meta").all() as { directory: string }[]
+    let deleted = 0
+    for (const row of metaRows) {
+      if (!validDirs.has(norm(row.directory))) {
+        pSqlite.prepare("DELETE FROM directory_meta WHERE directory = ?").run(row.directory)
+        deleted++
+      }
+    }
+    if (deleted > 0) log.info("removed stale directory_meta entries", { pid, deleted })
+
+    const existingMetaDirs = new Set(
+      (pSqlite.prepare("SELECT directory FROM directory_meta").all() as { directory: string }[]).map((r) =>
+        norm(r.directory),
+      ),
+    )
+
+    const insert = pSqlite.prepare(
+      "INSERT OR IGNORE INTO directory_meta (directory, worktree, name, icon_url, icon_color, icon_override, activity_at, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+
+    let added = 0
+    for (const dir of validDirs) {
+      if (existingMetaDirs.has(dir)) continue
+      const recentRow = recentLookup.get(dir)
+      insert.run(
+        dir,
+        worktree,
+        recentRow?.name ?? null,
+        recentRow?.icon_url ?? null,
+        recentRow?.icon_color ?? null,
+        recentRow?.icon_override ?? null,
+        recentRow?.activity_at ?? Date.now(),
+        Date.now(),
+        Date.now(),
+      )
+      added++
+    }
+    if (added > 0) log.info("added missing directory_meta entries", { pid, added })
+  }
+
   function syncDirectoryMetaToGlobal(sqlite: BunSqlite, pSqlite: BunSqlite, pid: string) {
     const hasTable = pSqlite
       .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='directory_meta'")
@@ -746,6 +838,7 @@ export namespace Database {
           }
 
           ensureDirectoryMeta(pSqlite, pid, recentLookup)
+          validateDirectoryMeta(pSqlite, pid, recentLookup)
           syncDirectoryMetaToGlobal(sqlite, pSqlite, pid)
           if (projectRow?.worktree && projectRow.worktree !== "/")
             validWorktreeKeys.add(`dir:${norm(projectRow.worktree)}`)

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -659,7 +659,7 @@ export namespace Database {
     const insertRecent = sqlite.prepare(
       `INSERT INTO project_recent (key, kind, project_id, directory, name, icon_url, icon_color, icon_override, activity_at, time_created, time_updated)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT(key) DO UPDATE SET project_id = excluded.project_id, name = excluded.name, icon_url = excluded.icon_url, icon_color = excluded.icon_color, icon_override = excluded.icon_override, activity_at = excluded.activity_at, time_updated = excluded.time_updated`,
+       ON CONFLICT(key) DO UPDATE SET project_id = excluded.project_id, activity_at = excluded.activity_at, time_updated = excluded.time_updated`,
     )
 
     for (const row of metaRows) {


### PR DESCRIPTION
### Issue for this PR

Closes #853

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes workspace/project names being overwritten in DB upon restart. PR #852 ensured that renamed names persisted to DB, but three `onConflictDoUpdate` code paths still unconditionally overwrote `name`/`icon` fields during startup, causing names to revert to the original directory name after each restart.

Changes:
1. `touch()` in project.ts — removed `name`/`icon_url`/`icon_color` from `DirectoryMetaTable.onConflictDoUpdate`, keeping only `worktree`/`activity_at`/`time_updated`
2. `fromDirectory()` in project.ts — same fix for its own `DirectoryMetaTable.onConflictDoUpdate`
3. `updateDirectoryMeta()` in project.ts — `ProjectRecentTable.onConflictDoUpdate` now conditionally sets `name` and `icon` only when explicitly provided, instead of using `name(input.directory)` as fallback which could overwrite user names on icon-only updates
4. `syncDirectoryMetaToGlobal()` in db.ts — removed `name`/`icon_url`/`icon_color`/`icon_override` from `ON CONFLICT DO UPDATE SET`, keeping only `project_id`/`activity_at`/`time_updated`. This function only processes main worktree entries (kind: "project"), explaining why sandbox names (kind: "directory") were preserved while main worktree names were overwritten.

### How did you verify your code works?

- `bun typecheck` passes on all packages
- Verified the data flow: `DirectoryMetaTable` and `ProjectRecentTable` no longer overwrite name/icon fields on conflict during startup sync and instance initialization

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR