### PR TITLE
fix: handle stale git worktree with prune, interactive fallback, and orphaned DB cleanup

### DIFF
--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -1425,6 +1425,12 @@ export const dict = {
   "workspace.delete.title": "Delete workspace",
   "workspace.delete.confirm": 'Delete workspace "{{name}}"?',
   "workspace.delete.button": "Delete workspace",
+  "workspace.delete.stale.title": "Stale workspace",
+  "workspace.delete.stale.confirm":
+    'Workspace "{{name}}" has lost its git worktree relationship. Force delete the directory?',
+  "workspace.delete.stale.description":
+    "The .git file is missing — this directory is no longer a valid git worktree. Force deletion will remove the directory and clean up git metadata.",
+  "workspace.delete.stale.button": "Force delete",
   "workspace.reset.title": "Reset workspace",
   "workspace.reset.confirm": 'Reset workspace "{{name}}"?',
   "workspace.reset.button": "Reset workspace",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -1292,6 +1292,11 @@ export const dict = {
   "workspace.delete.title": "删除工作区",
   "workspace.delete.confirm": '删除工作区 "{{name}}"？',
   "workspace.delete.button": "删除工作区",
+  "workspace.delete.stale.title": "失效工作区",
+  "workspace.delete.stale.confirm": '工作区 "{{name}}" 已失去 git worktree 关系。是否强制删除该目录？',
+  "workspace.delete.stale.description":
+    "目录中缺少 .git 文件，不再是有效的 git worktree。强制删除将移除该目录并清理 git 元数据。",
+  "workspace.delete.stale.button": "强制删除",
   "workspace.reset.title": "重置工作区",
   "workspace.reset.confirm": '重置工作区 "{{name}}"？',
   "workspace.reset.button": "重置工作区",

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1844,12 +1844,19 @@ export default function Layout(props: ParentProps) {
           title: language.t("workspace.delete.failed.title"),
           description: errorMessage(err, language.t("common.requestFailed")),
         })
-        return false
+        return undefined
       })
 
-    setBusy(directory, false)
+    if (!result) {
+      setBusy(directory, false)
+      return
+    }
 
-    if (!result) return
+    if (result && typeof result === "object" && result.status === "stale") {
+      setBusy(directory, false)
+      dialog.show(() => <DialogForceDeleteWorkspace root={root} directory={directory} gitStderr={result.gitStderr} />)
+      return
+    }
 
     if (workspaceKey(store.lastProjectSession[root]?.directory ?? "") === workspaceKey(directory)) {
       clearLastProjectSession(root)
@@ -2007,6 +2014,55 @@ export default function Layout(props: ParentProps) {
             </Button>
             <Button variant="primary" size="large" disabled={data.status === "loading"} onClick={handleDelete}>
               {language.t("workspace.delete.button")}
+            </Button>
+          </div>
+        </div>
+      </Dialog>
+    )
+  }
+
+  function DialogForceDeleteWorkspace(props: { root: string; directory: string; gitStderr: string }) {
+    const name = createMemo(() => getFilename(props.directory))
+
+    const handleForceDelete = async () => {
+      dialog.close()
+      setBusy(props.directory, true)
+      const result = await globalSDK.client.worktree
+        .remove({ directory: props.root, worktreeRemoveInput: { directory: props.directory, force: true } })
+        .then((x) => x.data)
+        .catch((err) => {
+          showToast({
+            title: language.t("workspace.delete.failed.title"),
+            description: errorMessage(err, language.t("common.requestFailed")),
+          })
+          return undefined
+        })
+      setBusy(props.directory, false)
+      if (!result) return
+      if (workspaceKey(store.lastProjectSession[props.root]?.directory ?? "") === workspaceKey(props.directory)) {
+        clearLastProjectSession(props.root)
+      }
+      globalSync.project.removeSandbox(props.root, props.directory)
+      setStore("workspaceOrder", props.root, (order) => (order ?? []).filter((w) => w !== props.directory))
+      layout.projects.close(props.directory)
+      layout.projects.open(props.root)
+    }
+
+    return (
+      <Dialog title={language.t("workspace.delete.stale.title")} fit>
+        <div class="flex flex-col gap-4 pl-6 pr-2.5 pb-3">
+          <div class="flex flex-col gap-1">
+            <span class="text-14-regular text-text-strong">
+              {language.t("workspace.delete.stale.confirm", { name: name() })}
+            </span>
+            <span class="text-12-regular text-text-weak">{language.t("workspace.delete.stale.description")}</span>
+          </div>
+          <div class="flex justify-end gap-2">
+            <Button variant="ghost" size="large" onClick={() => dialog.close()}>
+              {language.t("common.cancel")}
+            </Button>
+            <Button variant="primary" size="large" onClick={handleForceDelete}>
+              {language.t("workspace.delete.stale.button")}
             </Button>
           </div>
         </div>

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -535,6 +535,7 @@ export namespace Project {
       })
 
       const syncWorktrees = Effect.fn("Project.syncWorktrees")(function* (pid: ProjectID, worktree: string) {
+        yield* git(["worktree", "prune"], { cwd: worktree })
         const result = yield* git(["worktree", "list", "--porcelain"], { cwd: worktree })
         if (result.code !== 0) return
 

--- a/packages/opencode/src/server/routes/experimental.ts
+++ b/packages/opencode/src/server/routes/experimental.ts
@@ -148,7 +148,7 @@ export const ExperimentalRoutes = lazy(() =>
             description: "Worktree removed",
             content: {
               "application/json": {
-                schema: resolver(z.boolean()),
+                schema: resolver(Worktree.RemoveResult),
               },
             },
           },
@@ -158,9 +158,11 @@ export const ExperimentalRoutes = lazy(() =>
       validator("json", Worktree.RemoveInput),
       async (c) => {
         const body = c.req.valid("json")
-        await Worktree.remove(body)
-        await Project.removeSandbox(Instance.project.id, body.directory)
-        return c.json(true)
+        const result = await Worktree.remove(body)
+        if (result.status === "ok" || result.status === "forceOk") {
+          await Project.removeSandbox(Instance.project.id, body.directory)
+        }
+        return c.json(result)
       },
     )
     .post(

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -6,7 +6,8 @@ import { InstanceBootstrap } from "../project/bootstrap"
 import { Project } from "../project/project"
 import { Database, eq } from "../storage/db"
 import { ProjectTable } from "../project/project.sql"
-import type { ProjectID } from "../project/schema"
+import { ProjectIdentity } from "../project/identity"
+import { ProjectID } from "../project/schema"
 import { Log } from "../util/log"
 import { BusEvent } from "@/bus/bus-event"
 import { GlobalBus } from "@/bus/global"
@@ -65,12 +66,28 @@ export namespace Worktree {
   export const RemoveInput = z
     .object({
       directory: z.string(),
+      force: z.boolean().optional(),
     })
     .meta({
       ref: "WorktreeRemoveInput",
     })
 
   export type RemoveInput = z.infer<typeof RemoveInput>
+
+  export const RemoveResult = z.discriminatedUnion("status", [
+    z.object({ status: z.literal("ok") }),
+    z.object({
+      status: z.literal("stale"),
+      directory: z.string(),
+      gitStderr: z.string(),
+    }),
+    z.object({
+      status: z.literal("forceOk"),
+      hasOrphanedDb: z.boolean(),
+    }),
+  ])
+
+  export type RemoveResult = z.infer<typeof RemoveResult>
 
   export const ResetInput = z
     .object({
@@ -156,7 +173,7 @@ export namespace Worktree {
     readonly makeWorktreeInfo: (name?: string) => Effect.Effect<Info>
     readonly createFromInfo: (info: Info, startCommand?: string) => Effect.Effect<void>
     readonly create: (input?: CreateInput) => Effect.Effect<Info>
-    readonly remove: (input: RemoveInput) => Effect.Effect<boolean>
+    readonly remove: (input: RemoveInput) => Effect.Effect<RemoveResult>
     readonly reset: (input: ResetInput) => Effect.Effect<boolean>
   }
 
@@ -374,12 +391,45 @@ export namespace Worktree {
         )
       }
 
+      function pruneWorktree() {
+        return git(["worktree", "prune"], { cwd: Instance.worktree })
+      }
+
       const remove = Effect.fn("Worktree.remove")(function* (input: RemoveInput) {
         if (Instance.project.vcs !== "git") {
           throw new NotGitError({ message: "Worktrees are only supported for git projects" })
         }
 
         const directory = yield* canonical(input.directory)
+
+        if (input.force) {
+          yield* stopFsmonitor(directory)
+          const dirExists = yield* fsys.exists(directory).pipe(Effect.orDie)
+          if (dirExists) yield* cleanDirectory(directory)
+          yield* pruneWorktree()
+
+          const staleId = ProjectID.fromDirectory(ProjectIdentity.norm(directory))
+          const hasOrphanedDb = Database.hasProject(staleId)
+            ? (() => {
+                const row = Database.useProject(staleId, (d) =>
+                  d.select().from(ProjectTable).where(eq(ProjectTable.id, staleId)).get(),
+                )
+                return row?.worktree === directory
+              })()
+            : false
+
+          if (hasOrphanedDb) {
+            const dbPath = Database.projectPath(staleId)
+            for (const suffix of ["", "-wal", "-shm"]) {
+              const p = dbPath + suffix
+              if (yield* fsys.exists(p).pipe(Effect.orDie)) {
+                yield* cleanDirectory(p)
+              }
+            }
+          }
+
+          return { status: "forceOk" as const, hasOrphanedDb }
+        }
 
         const list = yield* git(["worktree", "list", "--porcelain"], { cwd: Instance.worktree })
         if (list.code !== 0) {
@@ -395,12 +445,18 @@ export namespace Worktree {
             yield* stopFsmonitor(directory)
             yield* cleanDirectory(directory)
           }
-          return true
+          yield* pruneWorktree()
+          return { status: "ok" as const }
         }
 
         yield* stopFsmonitor(entry.path)
         const removed = yield* git(["worktree", "remove", "--force", entry.path], { cwd: Instance.worktree })
         if (removed.code !== 0) {
+          const isStale = /does not exist|不存在|not a valid|验证失败/i.test(removed.stderr || removed.text || "")
+          if (isStale) {
+            return { status: "stale" as const, directory, gitStderr: removed.stderr || removed.text || "" }
+          }
+
           const next = yield* git(["worktree", "list", "--porcelain"], { cwd: Instance.worktree })
           if (next.code !== 0) {
             throw new RemoveFailedError({
@@ -415,6 +471,7 @@ export namespace Worktree {
         }
 
         yield* cleanDirectory(entry.path)
+        yield* pruneWorktree()
 
         const branch = entry.branch?.replace(/^refs\/heads\//, "")
         if (branch) {
@@ -426,7 +483,7 @@ export namespace Worktree {
           }
         }
 
-        return true
+        return { status: "ok" as const }
       })
 
       const gitExpect = Effect.fnUntraced(function* (

--- a/packages/opencode/test/project/worktree-remove.test.ts
+++ b/packages/opencode/test/project/worktree-remove.test.ts
@@ -55,7 +55,7 @@ describe("Worktree.remove", () => {
       }
     })()
 
-    expect(ok).toBe(true)
+    expect(ok).toEqual({ status: "ok" })
     expect(await Filesystem.exists(dir)).toBe(false)
 
     const list = await $`git worktree list --porcelain`.cwd(root).quiet().text()
@@ -87,7 +87,7 @@ describe("Worktree.remove", () => {
       fn: () => Worktree.remove({ directory: dir }),
     })
 
-    expect(ok).toBe(true)
+    expect(ok).toEqual({ status: "ok" })
     expect(await Filesystem.exists(dir)).toBe(false)
 
     const ref = await $`git show-ref --verify --quiet refs/heads/${branch}`.cwd(root).quiet().nothrow()

--- a/packages/opencode/test/project/worktree.test.ts
+++ b/packages/opencode/test/project/worktree.test.ts
@@ -89,7 +89,7 @@ describe("Worktree", () => {
       await Bun.sleep(1000)
 
       const ok = await withInstance(tmp.path, () => Worktree.remove({ directory: info.directory }))
-      expect(ok).toBe(true)
+      expect(ok).toEqual({ status: "ok" })
     })
 
     test("create returns after setup and fires Event.Ready after bootstrap", async () => {
@@ -159,7 +159,7 @@ describe("Worktree", () => {
       const ok = await withInstance(tmp.path, () =>
         Worktree.remove({ directory: path.join(tmp.path, "does-not-exist") }),
       )
-      expect(ok).toBe(true)
+      expect(ok).toEqual({ status: "ok" })
     })
 
     test("throws NotGitError for non-git directories", async () => {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1974,6 +1974,7 @@ export type WorktreeCreateInput = {
 
 export type WorktreeRemoveInput = {
   directory: string
+  force?: boolean
 }
 
 export type WorktreeResetInput = {
@@ -3662,7 +3663,19 @@ export type WorktreeRemoveResponses = {
   /**
    * Worktree removed
    */
-  200: boolean
+  200:
+    | {
+        status: "ok"
+      }
+    | {
+        status: "stale"
+        directory: string
+        gitStderr: string
+      }
+    | {
+        status: "forceOk"
+        hasOrphanedDb: boolean
+      }
 }
 
 export type WorktreeRemoveResponse = WorktreeRemoveResponses[keyof WorktreeRemoveResponses]


### PR DESCRIPTION
### Issue for this PR

Closes #855

### Type of change

- [x] Bug fix

### What does this PR do?

修复 stale git worktree 导致幽灵条目出现、空壳目录和独立 DB 被创建、以及删除失败的问题。三处核心修复：

1. **`git worktree prune` 集成**：在 `Worktree.remove` 的所有成功路径末尾以及 `Project.syncWorktrees` 调用 `git worktree list` 之前加入 `git worktree prune`，确保 stale 元数据被及时清理。这同时阻断了幽灵 worktree 的传播链：prune 后 list 不再返回 stale 记录 → `syncWorktrees` 不再注入幽灵路径 → 前端不再对幽灵路径发请求 → 不再创建空壳目录和独立 DB。

2. **stale worktree 删除的交互式 fallback**：当 `git worktree remove --force` 因 `.git` 缺失失败时，不再直接抛异常，而是返回 `{ status: "stale" }` 给前端。前端弹出确认弹窗，用户同意后以 `force: true` 再次调用删除接口，执行 `rm -rf` + `git worktree prune`。

3. **独立 DB 检测与删除**：`force` 删除时检查该 worktree 目录是否存在独立的 per-project DB（通过 `ProjectID.fromDirectory` 计算 ID 并验证 `project.worktree` 严格匹配），如存在则一并删除。

### How did you verify your code works?

- `bun typecheck` 在 `packages/opencode`、`packages/app`、`packages/sdk/js` 三个包均通过
- `bun test test/project/worktree-remove.test.ts` 通过
- SDK 重新生成（`./packages/sdk/js/script/build.ts`）后类型正确
- pre-push hook 中 turbo typecheck 全部通过（19 packages）

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR