### PR TITLE
fix: use directory_meta as single source of truth for project metadata

### DIFF
--- a/packages/app/e2e/projects/workspaces.spec.ts
+++ b/packages/app/e2e/projects/workspaces.spec.ts
@@ -25,13 +25,15 @@ import {
   workspaceMenuTriggerSelector,
 } from "../selectors"
 import { createSdk, dirSlug } from "../utils"
+import { base64Encode } from "@opencode-ai/util/encode"
 
 type Space = { directory: string; slug: string; raw?: string }
 
 function slugs(space: string | Space) {
   if (typeof space === "string") return [space]
+  const normSlug = dirSlug(space.directory.replace(/\\/g, "/"))
   if (process.platform !== "win32") return [space.slug]
-  return [...new Set([space.slug, space.raw].filter((item): item is string => !!item))]
+  return [...new Set([space.slug, space.raw, normSlug].filter((item): item is string => !!item))]
 }
 
 function itemSelector(space: string | Space) {
@@ -62,7 +64,10 @@ function key(dir: string) {
 }
 
 async function same(dir: string) {
-  return fs.realpath(dir).then(key).catch(() => key(dir))
+  return fs
+    .realpath(dir)
+    .then(key)
+    .catch(() => key(dir))
 }
 
 async function listed(list: string[], dir: string) {

--- a/packages/app/src/components/dialog-select-file.tsx
+++ b/packages/app/src/components/dialog-select-file.tsx
@@ -297,7 +297,7 @@ export function DialogSelectFile(props: { mode?: DialogSelectFileMode; onOpenFil
     const kind =
       current && directory === current.worktree
         ? language.t("workspace.type.local")
-        : language.t("workspace.type.sandbox")
+        : (globalSync.project.recentFromDir(directory)?.name ?? language.t("workspace.type.sandbox"))
     const [store] = globalSync.child(directory, { bootstrap: false })
     const home = homedir()
     const path = displayPath(directory, home)

--- a/packages/app/src/pages/layout/sidebar-project.tsx
+++ b/packages/app/src/pages/layout/sidebar-project.tsx
@@ -321,6 +321,7 @@ export const SortableProject = (props: {
     const displayName =
       data.projectMeta?.name ??
       props.ctx.workspaceName(directory) ??
+      globalSync.project.recentFromDir(directory)?.name ??
       (local ? language.t("workspace.type.local") : language.t("workspace.type.sandbox"))
     const branch = data.vcs?.branch ?? getFilename(directory)
     return `${displayName} : ${branch}`

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -184,6 +184,7 @@ export const WorkspaceDragOverlay = (props: {
     const displayName =
       workspaceStore.projectMeta?.name ??
       props.workspaceName(directory) ??
+      globalSync.project.recentFromDir(directory)?.name ??
       (local ? language.t("workspace.type.local") : language.t("workspace.type.sandbox"))
     const branch = workspaceStore.vcs?.branch ?? getFilename(directory)
     return `${displayName} : ${branch}`
@@ -1071,6 +1072,8 @@ export const SortableWorkspace = (props: {
     if (metaName) return metaName
     const direct = props.ctx.workspaceName(props.directory)
     if (direct) return direct
+    const recentName = globalSync.project.recentFromDir(props.directory)?.name
+    if (recentName) return recentName
     return local() ? language.t("workspace.type.local") : language.t("workspace.type.sandbox")
   })
   const open = createMemo(() => props.ctx.workspaceExpanded(props.directory, local()))

--- a/packages/opencode/src/project/identity.ts
+++ b/packages/opencode/src/project/identity.ts
@@ -12,8 +12,7 @@ export namespace ProjectIdentity {
 
   export function norm(input: string) {
     const next = path.resolve(input).replace(/\\/g, "/")
-    const trim = /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
-    return trim.toLowerCase()
+    return /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
   }
 
   function marker(dir: string): string | undefined {

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -1,4 +1,5 @@
 import z from "zod"
+import path from "path"
 import { Database, desc, eq } from "../storage/db"
 import { ProjectRecentTable } from "./project.sql"
 import { GlobalProjectMapTable } from "./global-project-map.sql"
@@ -84,9 +85,8 @@ export namespace Project {
   type Row = typeof ProjectTable.$inferSelect
 
   export function norm(input: string) {
-    const next = input.replace(/\\/g, "/")
-    const trim = /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
-    return trim.toLowerCase()
+    const next = path.resolve(input).replace(/\\/g, "/")
+    return /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
   }
 
   function name(input: string) {
@@ -131,10 +131,15 @@ export namespace Project {
       const projectRow = Database.useProject(row.project_id, (d) =>
         d.select().from(ProjectTable).where(eq(ProjectTable.id, row.project_id!)).get(),
       )
-      if (projectRow) {
-        seen.add(row.project_id)
-        result.push(fromRow(projectRow))
-      }
+      if (!projectRow) continue
+      seen.add(row.project_id)
+      const info = fromRow(projectRow)
+      const wt = norm(info.worktree)
+      const metaRows = Database.useProject(row.project_id, (d) =>
+        d.select({ directory: DirectoryMetaTable.directory }).from(DirectoryMetaTable).all(),
+      )
+      info.sandboxes = metaRows.map((r) => norm(r.directory)).filter((d) => d !== wt)
+      result.push(info)
     }
     return result.sort((a, b) => a.id.localeCompare(b.id))
   }
@@ -299,11 +304,20 @@ export namespace Project {
         Effect.sync(() => Database.useProject(pid, fn))
 
       const emitUpdated = (data: Info) =>
-        Effect.sync(() =>
+        Effect.sync(() => {
+          const pid = data.id
+          const projectRow = Database.useProject(pid, (d) =>
+            d.select({ worktree: ProjectTable.worktree }).from(ProjectTable).where(eq(ProjectTable.id, pid)).get(),
+          )
+          const wt = projectRow ? norm(projectRow.worktree) : ""
+          const metaRows = Database.useProject(pid, (d) =>
+            d.select({ directory: DirectoryMetaTable.directory }).from(DirectoryMetaTable).all(),
+          )
+          const dirs = metaRows.map((r) => norm(r.directory)).filter((d) => d !== wt)
           GlobalBus.emit("event", {
-            payload: { type: Event.Updated.type, properties: data },
-          }),
-        )
+            payload: { type: Event.Updated.type, properties: { ...data, sandboxes: dirs } },
+          })
+        })
 
       const emitRecentUpdated = Effect.sync(() =>
         GlobalBus.emit("event", {
@@ -320,7 +334,7 @@ export namespace Project {
         const isProject = input.project.worktree !== "/"
         const key = dirKey(norm(input.directory))
         const kind = isProject ? "project" : "directory"
-        const directory = input.directory
+        const directory = norm(input.directory)
 
         yield* db((d) =>
           d
@@ -353,7 +367,7 @@ export namespace Project {
               .insert(DirectoryMetaTable)
               .values({
                 directory,
-                worktree: input.project.worktree,
+                worktree: norm(input.project.worktree),
                 name: input.project.name ?? null,
                 icon_url: input.project.icon?.url ?? null,
                 icon_color: input.project.icon?.color ?? null,
@@ -501,8 +515,8 @@ export namespace Project {
           d
             .insert(DirectoryMetaTable)
             .values({
-              directory,
-              worktree: data.worktree,
+              directory: norm(directory),
+              worktree: norm(data.worktree),
               name: result.name ?? null,
               icon_url: result.icon?.url ?? null,
               icon_color: result.icon?.color ?? null,
@@ -514,7 +528,7 @@ export namespace Project {
             .onConflictDoUpdate({
               target: DirectoryMetaTable.directory,
               set: {
-                worktree: data.worktree,
+                worktree: norm(data.worktree),
                 activity_at: Date.now(),
                 time_updated: Date.now(),
               },
@@ -639,11 +653,17 @@ export namespace Project {
       })
 
       const sandboxes = Effect.fn("Project.sandboxes")(function* (id: ProjectID) {
-        const row = yield* dbProject(id, (d) => d.select().from(ProjectTable).where(eq(ProjectTable.id, id)).get())
-        if (!row) return []
-        const data = fromRow(row)
+        const projectRow = yield* dbProject(id, (d) =>
+          d.select({ worktree: ProjectTable.worktree }).from(ProjectTable).where(eq(ProjectTable.id, id)).get(),
+        )
+        if (!projectRow) return []
+        const worktree = norm(projectRow.worktree)
+        const metaRows = yield* dbProject(id, (d) =>
+          d.select({ directory: DirectoryMetaTable.directory }).from(DirectoryMetaTable).all(),
+        )
+        const dirs = metaRows.filter((r) => norm(r.directory) !== worktree).map((r) => r.directory)
         return yield* Effect.forEach(
-          data.sandboxes,
+          dirs,
           (dir) =>
             fsys.isDir(dir).pipe(
               Effect.orDie,
@@ -656,8 +676,9 @@ export namespace Project {
       const addSandbox = Effect.fn("Project.addSandbox")(function* (id: ProjectID, directory: string) {
         const row = yield* dbProject(id, (d) => d.select().from(ProjectTable).where(eq(ProjectTable.id, id)).get())
         if (!row) throw new Error(`Project not found: ${id}`)
+        const dirNorm = norm(directory)
         const sboxes = [...row.sandboxes]
-        if (!sboxes.some((s) => norm(s) === norm(directory))) sboxes.push(directory)
+        if (!sboxes.some((s) => norm(s) === dirNorm)) sboxes.push(dirNorm)
         const result = yield* dbProject(id, (d) =>
           d
             .update(ProjectTable)
@@ -667,13 +688,30 @@ export namespace Project {
             .get(),
         )
         if (!result) throw new Error(`Project not found: ${id}`)
+        yield* dbProject(id, (d) =>
+          d
+            .insert(DirectoryMetaTable)
+            .values({
+              directory: dirNorm,
+              worktree: norm(row.worktree),
+              activity_at: Date.now(),
+              time_created: Date.now(),
+              time_updated: Date.now(),
+            })
+            .onConflictDoUpdate({
+              target: DirectoryMetaTable.directory,
+              set: { activity_at: Date.now(), time_updated: Date.now() },
+            })
+            .run(),
+        )
         yield* emitUpdated(fromRow(result))
       })
 
       const removeSandbox = Effect.fn("Project.removeSandbox")(function* (id: ProjectID, directory: string) {
         const row = yield* dbProject(id, (d) => d.select().from(ProjectTable).where(eq(ProjectTable.id, id)).get())
         if (!row) throw new Error(`Project not found: ${id}`)
-        const sboxes = row.sandboxes.filter((s) => norm(s) !== norm(directory))
+        const dirNorm = norm(directory)
+        const sboxes = row.sandboxes.filter((s) => norm(s) !== dirNorm)
         const result = yield* dbProject(id, (d) =>
           d
             .update(ProjectTable)
@@ -683,6 +721,7 @@ export namespace Project {
             .get(),
         )
         if (!result) throw new Error(`Project not found: ${id}`)
+        yield* dbProject(id, (d) => d.delete(DirectoryMetaTable).where(eq(DirectoryMetaTable.directory, dirNorm)).run())
         yield* emitUpdated(fromRow(result))
       })
 

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -34,7 +34,8 @@ const log = Log.create({ service: "db" })
 
 export namespace Database {
   export function norm(input: string) {
-    return path.resolve(input).replace(/\\/g, "/").toLowerCase()
+    const next = path.resolve(input).replace(/\\/g, "/")
+    return /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
   }
 
   export type Source = {
@@ -603,20 +604,20 @@ export namespace Database {
 
     const directories = (
       pSqlite.prepare("SELECT DISTINCT directory FROM session").all() as { directory: string }[]
-    ).map((r) => r.directory)
+    ).map((r) => norm(r.directory))
 
-    if (!directories.includes(worktree)) directories.push(worktree)
+    const wtNorm = norm(worktree)
+    if (!directories.includes(wtNorm)) directories.push(wtNorm)
 
     const insert = pSqlite.prepare(
       "INSERT OR IGNORE INTO directory_meta (directory, worktree, name, icon_url, icon_color, icon_override, activity_at, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
 
     for (const dir of directories) {
-      const dirNorm = norm(dir)
-      const recentRow = recentLookup.get(dirNorm)
+      const recentRow = recentLookup.get(dir)
       insert.run(
         dir,
-        worktree,
+        wtNorm,
         recentRow?.name ?? null,
         recentRow?.icon_url ?? null,
         recentRow?.icon_color ?? null,
@@ -680,21 +681,58 @@ export namespace Database {
 
     const validDirs = new Set([...setA, ...setB])
 
-    const metaRows = pSqlite.prepare("SELECT directory FROM directory_meta").all() as { directory: string }[]
-    let deleted = 0
+    const metaRows = pSqlite.prepare("SELECT * FROM directory_meta").all() as {
+      directory: string
+      worktree: string
+      name: string | null
+      icon_url: string | null
+      icon_color: string | null
+      icon_override: string | null
+      activity_at: number
+      time_created: number
+      time_updated: number
+    }[]
+
+    // Group existing rows by normalized directory to detect duplicates
+    const byNorm = new Map<string, typeof metaRows>()
     for (const row of metaRows) {
-      if (!validDirs.has(norm(row.directory))) {
+      const key = norm(row.directory)
+      const group = byNorm.get(key) ?? []
+      group.push(row)
+      byNorm.set(key, group)
+    }
+
+    let deduped = 0
+    let stale = 0
+    const surviving = new Map<string, (typeof metaRows)[0]>() // norm → best surviving row
+
+    for (const [key, group] of byNorm) {
+      // Not in validDirs → delete all rows in this group
+      if (!validDirs.has(key)) {
+        for (const row of group) {
+          pSqlite.prepare("DELETE FROM directory_meta WHERE directory = ?").run(row.directory)
+        }
+        stale += group.length
+        continue
+      }
+      // Multiple rows for the same norm → keep highest activity_at, delete rest
+      const sorted = group.sort((a, b) => b.activity_at - a.activity_at)
+      const best = sorted[0]
+      surviving.set(key, best)
+      for (const row of sorted.slice(1)) {
         pSqlite.prepare("DELETE FROM directory_meta WHERE directory = ?").run(row.directory)
-        deleted++
+        deduped++
+      }
+      const wtNorm = norm(worktree)
+      // If best row's directory or worktree is not normalized, update them
+      if (best.directory !== key || best.worktree !== wtNorm) {
+        pSqlite
+          .prepare("UPDATE directory_meta SET directory = ?, worktree = ? WHERE directory = ?")
+          .run(key, wtNorm, best.directory)
       }
     }
-    if (deleted > 0) log.info("removed stale directory_meta entries", { pid, deleted })
-
-    const existingMetaDirs = new Set(
-      (pSqlite.prepare("SELECT directory FROM directory_meta").all() as { directory: string }[]).map((r) =>
-        norm(r.directory),
-      ),
-    )
+    if (stale > 0) log.info("removed stale directory_meta entries", { pid, stale })
+    if (deduped > 0) log.info("deduped directory_meta entries", { pid, deduped })
 
     const insert = pSqlite.prepare(
       "INSERT OR IGNORE INTO directory_meta (directory, worktree, name, icon_url, icon_color, icon_override, activity_at, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -702,11 +740,11 @@ export namespace Database {
 
     let added = 0
     for (const dir of validDirs) {
-      if (existingMetaDirs.has(dir)) continue
+      if (surviving.has(dir)) continue
       const recentRow = recentLookup.get(dir)
       insert.run(
         dir,
-        worktree,
+        norm(worktree),
         recentRow?.name ?? null,
         recentRow?.icon_url ?? null,
         recentRow?.icon_color ?? null,
@@ -718,6 +756,25 @@ export namespace Database {
       added++
     }
     if (added > 0) log.info("added missing directory_meta entries", { pid, added })
+  }
+
+  function syncProjectSandboxes(pSqlite: BunSqlite, pid: string) {
+    const hasTable = pSqlite
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='directory_meta'")
+      .get()
+    if (!hasTable) return
+
+    const projectRow = pSqlite.prepare("SELECT worktree FROM project WHERE id = ?").get(pid) as
+      | { worktree: string }
+      | undefined
+    if (!projectRow) return
+
+    const worktree = norm(projectRow.worktree)
+    const metaRows = pSqlite.prepare("SELECT directory FROM directory_meta").all() as { directory: string }[]
+    const sandboxes = metaRows.filter((r) => norm(r.directory) !== worktree).map((r) => r.directory)
+    pSqlite
+      .prepare("UPDATE project SET sandboxes = ?, time_updated = ? WHERE id = ?")
+      .run(JSON.stringify(sandboxes), Date.now(), pid)
   }
 
   function syncDirectoryMetaToGlobal(sqlite: BunSqlite, pSqlite: BunSqlite, pid: string) {
@@ -751,7 +808,7 @@ export namespace Database {
     const insertRecent = sqlite.prepare(
       `INSERT INTO project_recent (key, kind, project_id, directory, name, icon_url, icon_color, icon_override, activity_at, time_created, time_updated)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT(key) DO UPDATE SET project_id = excluded.project_id, activity_at = excluded.activity_at, time_updated = excluded.time_updated`,
+       ON CONFLICT(key) DO UPDATE SET project_id = excluded.project_id, name = excluded.name, icon_url = excluded.icon_url, icon_color = excluded.icon_color, icon_override = excluded.icon_override, activity_at = excluded.activity_at, time_updated = excluded.time_updated`,
     )
 
     for (const row of metaRows) {
@@ -759,11 +816,11 @@ export namespace Database {
       insertMap.run(dirNorm, pid, row.time_created, row.time_updated)
 
       const isWorktree = row.worktree !== "/" && norm(row.directory) === norm(canonicalWorktree)
-      if (!isWorktree) continue
+      const kind = isWorktree ? "project" : "directory"
 
       insertRecent.run(
         `dir:${dirNorm}`,
-        "project",
+        kind,
         pid,
         row.directory,
         row.name,
@@ -787,8 +844,8 @@ export namespace Database {
     for (const row of recentRows) {
       const dirNorm = norm(row.directory ?? "")
       recentLookup.set(dirNorm, row)
-      const keyNorm = row.key?.replace(/^dir:/, "").toLowerCase()
-      if (keyNorm && keyNorm !== dirNorm) recentLookup.set(keyNorm, row)
+      const keyNorm = row.key?.replace(/^dir:/, "")
+      if (keyNorm && norm(keyNorm) !== dirNorm) recentLookup.set(keyNorm, row)
     }
 
     const chDir = channelDir()
@@ -839,6 +896,7 @@ export namespace Database {
 
           ensureDirectoryMeta(pSqlite, pid, recentLookup)
           validateDirectoryMeta(pSqlite, pid, recentLookup)
+          syncProjectSandboxes(pSqlite, pid)
           syncDirectoryMetaToGlobal(sqlite, pSqlite, pid)
           if (projectRow?.worktree && projectRow.worktree !== "/")
             validWorktreeKeys.add(`dir:${norm(projectRow.worktree)}`)
@@ -857,7 +915,10 @@ export namespace Database {
 
           synced++
         } finally {
-          if (!closed) pSqlite.close()
+          if (!closed) {
+            pSqlite.exec("PRAGMA wal_checkpoint(TRUNCATE)")
+            pSqlite.close()
+          }
         }
       } catch (err) {
         log.error("failed to process project db, quarantining", { pid, error: String(err) })

--- a/packages/opencode/src/storage/split-migration.ts
+++ b/packages/opencode/src/storage/split-migration.ts
@@ -167,7 +167,8 @@ export namespace SplitMigration {
   }
 
   function norm(input: string) {
-    return path.resolve(input).replace(/\\/g, "/").toLowerCase()
+    const next = path.resolve(input).replace(/\\/g, "/")
+    return /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
   }
 
   function initDb(filePath: string) {
@@ -634,7 +635,7 @@ export namespace SplitMigration {
           seenDirs.add(dn)
           const recentRow = recentByDirNorm.get(dn)
           entries.push({
-            directory: d,
+            directory: dn,
             worktree,
             name: recentRow?.name ?? projRow?.name ?? null,
             icon_url: recentRow?.icon_url ?? projRow?.icon_url ?? null,
@@ -834,7 +835,7 @@ export namespace SplitMigration {
             for (const entry of metaEntries) {
               metaInsert.run(
                 entry.directory,
-                entry.worktree,
+                norm(entry.worktree),
                 entry.name,
                 entry.icon_url,
                 entry.icon_color,

--- a/packages/opencode/test/project/project-fromdirectory-order.test.ts
+++ b/packages/opencode/test/project/project-fromdirectory-order.test.ts
@@ -7,6 +7,12 @@ import { tmpdir } from "../fixture/fixture"
 import { existsSync } from "fs"
 import { ProjectTable } from "../../src/project/project.sql"
 import { eq } from "drizzle-orm"
+import path from "path"
+
+function norm(input: string) {
+  const next = path.resolve(input).replace(/\\/g, "/")
+  return /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
+}
 
 Log.init({ print: false })
 
@@ -45,11 +51,11 @@ describe("Project.fromDirectory ordering", () => {
       .all(project.id) as { directory: string }[]
 
     const dirs = gpm.map((r) => r.directory)
-    const wt = project.worktree.replace(/\\/g, "/").toLowerCase()
-    const raw = tmp.path.replace(/\\/g, "/").toLowerCase()
+    const wt = norm(project.worktree)
+    const raw = norm(tmp.path)
 
-    expect(dirs.some((d) => d === wt)).toBe(true)
-    expect(dirs.some((d) => d === raw)).toBe(true)
+    expect(dirs.some((d) => norm(d) === wt)).toBe(true)
+    expect(dirs.some((d) => norm(d) === raw)).toBe(true)
   })
 
   test("project_recent entry has matching directory", async () => {
@@ -61,7 +67,6 @@ describe("Project.fromDirectory ordering", () => {
       .get(project.id) as { directory: string } | undefined
 
     expect(recent).toBeDefined()
-    const expected = tmp.path.replace(/\\/g, "/").toLowerCase()
-    expect(recent!.directory.replace(/\\/g, "/").toLowerCase()).toBe(expected)
+    expect(norm(recent!.directory)).toBe(norm(tmp.path))
   })
 })

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -9,6 +9,11 @@ import { tmpdir } from "../fixture/fixture"
 import { GlobalBus } from "../../src/bus/global"
 import { ProjectID } from "../../src/project/schema"
 import { Effect, Layer, Stream } from "effect"
+
+function norm(input: string) {
+  const next = path.resolve(input).replace(/\\/g, "/")
+  return /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
+}
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { NodeFileSystem, NodePath } from "@effect/platform-node"
 import { AppFileSystem } from "../../src/filesystem"
@@ -149,7 +154,7 @@ describe("Project.fromDirectory with worktrees", () => {
 
     expect(project.worktree).toBe(tmp.path)
     expect(sandbox).toBe(tmp.path)
-    expect(project.sandboxes).not.toContain(tmp.path)
+    expect(project.sandboxes.every((s) => norm(s) !== norm(tmp.path))).toBe(true)
   })
 
   test("should set worktree to root when called from a worktree", async () => {
@@ -163,8 +168,8 @@ describe("Project.fromDirectory with worktrees", () => {
 
       expect(project.worktree).toBe(tmp.path)
       expect(sandbox).toBe(worktreePath)
-      expect(project.sandboxes).toContain(worktreePath)
-      expect(project.sandboxes).not.toContain(tmp.path)
+      expect(project.sandboxes.some((s) => norm(s) === norm(worktreePath))).toBe(true)
+      expect(project.sandboxes.every((s) => norm(s) !== norm(tmp.path))).toBe(true)
     } finally {
       await $`git worktree remove ${worktreePath}`
         .cwd(tmp.path)
@@ -229,9 +234,9 @@ describe("Project.fromDirectory with worktrees", () => {
       const { project } = await Project.fromDirectory(worktree2)
 
       expect(project.worktree).toBe(tmp.path)
-      expect(project.sandboxes).toContain(worktree1)
-      expect(project.sandboxes).toContain(worktree2)
-      expect(project.sandboxes).not.toContain(tmp.path)
+      expect(project.sandboxes.some((s) => norm(s) === norm(worktree1))).toBe(true)
+      expect(project.sandboxes.some((s) => norm(s) === norm(worktree2))).toBe(true)
+      expect(project.sandboxes.every((s) => norm(s) !== norm(tmp.path))).toBe(true)
     } finally {
       await $`git worktree remove ${worktree1}`
         .cwd(tmp.path)
@@ -427,8 +432,8 @@ describe("Project.recentList", () => {
 
     const before = Project.recentList()
       .filter((item) => item.kind === "project")
-      .map((item) => item.directory)
-    expect(before.slice(0, 2)).toEqual([b.path, a.path])
+      .map((item) => norm(item.directory))
+    expect(before.slice(0, 2)).toEqual([norm(b.path), norm(a.path)])
 
     const item = Project.list().find((project) => project.worktree === a.path)
     expect(item).toBeDefined()
@@ -439,8 +444,8 @@ describe("Project.recentList", () => {
 
     const after = Project.recentList()
       .filter((entry) => entry.kind === "project")
-      .map((entry) => entry.directory)
-    expect(after.slice(0, 2)).toEqual([b.path, a.path])
+      .map((entry) => norm(entry.directory))
+    expect(after.slice(0, 2)).toEqual([norm(b.path), norm(a.path)])
   })
 
   test("lists non-git project entries from fromDirectory", async () => {
@@ -448,7 +453,7 @@ describe("Project.recentList", () => {
 
     const { project } = await Project.fromDirectory(tmp.path)
 
-    const item = Project.recentList().find((entry) => entry.directory === project.worktree)
+    const item = Project.recentList().find((entry) => norm(entry.directory) === norm(project.worktree))
     expect(item).toBeDefined()
     expect(item!.kind).toBe("project")
   })
@@ -458,7 +463,7 @@ describe("Project.recentList", () => {
 
     await Project.fromDirectory(tmp.path)
 
-    const item = Project.recentList().find((entry) => entry.directory === tmp.path)
+    const item = Project.recentList().find((entry) => norm(entry.directory) === norm(tmp.path))
     expect(item).toBeDefined()
     expect(item!.kind).toBe("project")
   })
@@ -487,12 +492,12 @@ describe("Project.addSandbox and Project.removeSandbox", () => {
     await Project.addSandbox(project.id, sandboxDir)
 
     let found = Project.get(project.id)
-    expect(found?.sandboxes).toContain(sandboxDir)
+    expect(found?.sandboxes.some((s) => norm(s) === norm(sandboxDir))).toBe(true)
 
     await Project.removeSandbox(project.id, sandboxDir)
 
     found = Project.get(project.id)
-    expect(found?.sandboxes).not.toContain(sandboxDir)
+    expect(found?.sandboxes.every((s) => norm(s) !== norm(sandboxDir))).toBe(true)
   })
 
   test("addSandbox emits GlobalBus event", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #857

### Type of change

- [x] Bug fix
- [x] Refactor / code improvement

### What does this PR do?

Makes `directory_meta` the single source of truth for project workspace metadata, fixing multiple consistency issues between `directory_meta`, `project_recent`, `project.sandboxes`, and the frontend display.

Key changes:

1. **Normalize `directory_meta` paths at startup** — `validateDirectoryMeta()` now deduplicates rows by normalized `directory` and normalizes the `worktree` field too, eliminating `E:\path` vs `e:/path` inconsistencies
2. **Derive `sandboxes` from `directory_meta`** — `sandboxes()` service, `emitUpdated` events, and `canonical()` (GET /project API) all read sandbox list from `directory_meta` instead of `project.sandboxes` column
3. **Sync `project.sandboxes` column at startup** — `syncProjectSandboxes()` writes `directory_meta`-derived sandbox list back to the `project.sandboxes` column for backward compat
4. **Sync all `directory_meta` rows to `project_recent`** — `syncDirectoryMetaToGlobal` now syncs sandbox rows too (not just main worktree), and the `ON CONFLICT` clause updates `name`, `icon_url`, `icon_color`, `icon_override`
5. **Frontend reads `project_recent.name`** — sidebar workspace name display falls through to `globalSync.project.recentFromDir(directory)?.name` before the i18n "沙盒"/"sandbox" fallback
6. **`addSandbox()` writes to `directory_meta`** — new sandboxes are upserted into both `project.sandboxes` and `DirectoryMetaTable`
7. **WAL checkpoint before closing temp DB connections** — `PRAGMA wal_checkpoint(TRUNCATE)` on Windows to ensure startup writes persist

### How did you verify your code works?

- `bun typecheck` passes in both `packages/opencode` and `packages/app`
- Manually verified `directory_meta` dedup and normalization in project DBs after restart
- Checked that `project_recent` now contains sandbox rows with `name` from `directory_meta`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR