### PR TITLE
fix: exclude sandbox worktree entries from recent projects list

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -150,6 +150,10 @@ export namespace Project {
     const gpm = Database.use((d) => d.select().from(GlobalProjectMapTable).all())
     const canonicalPID = new Map<string, string>()
     for (const row of gpm) canonicalPID.set(norm(row.directory), row.project_id)
+    const pidCounts = new Map<string, number>()
+    for (const row of recentRows) {
+      if (row.project_id) pidCounts.set(row.project_id, (pidCounts.get(row.project_id) ?? 0) + 1)
+    }
     const seen = new Map<string, (typeof recentRows)[number]>()
     for (const row of recentRows) {
       const key = norm(row.directory)
@@ -196,6 +200,7 @@ export namespace Project {
             },
           }
         }
+        if (row.kind === "directory" && row.project_id && (pidCounts.get(row.project_id) ?? 0) > 1) return undefined
         const baseIcon =
           row.icon_url || row.icon_color
             ? rowIcon({ icon_url: row.icon_url ?? null, icon_color: row.icon_color ?? null })


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [x] Bug fix

### What does this PR do?

Exclude sandbox/worktree branch entries from the "Existing projects" (已有项目) list in the sidebar project picker.

Sandbox entries in `project_recent` are characterized by `kind="directory"` with a `project_id` value, where the same `project_id` appears more than once (meaning a main worktree entry also exists). By counting `project_id` occurrences in `project_recent`, when `kind="directory"` and the `project_id` count > 1, the entry is filtered out.

Entries with `kind="directory"` and `project_id` appearing only once (no corresponding main worktree, e.g. non-git project directories) are still shown normally.

### How did you verify your code works?

`bun typecheck` passes, full turbo typecheck passes.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR