### PR TITLE
refactor: 统一术语"沙盒"→"沙箱"

### DIFF
--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -1305,7 +1305,7 @@ export const dict = {
   "workspace.reset.archived.many": "将归档 {{count}} 个会话。",
   "workspace.reset.note": "这将把工作区重置为与默认分支一致。",
   "workspace.switchBranch": "切换分支",
-  "workspace.renameSandbox": "重命名沙箱",
+  "workspace.renameSandbox": "重命名工作区",
   "workspace.renameBranch": "重命名分支",
   "workspace.renameBranch.error.alreadyExists": "分支名称已存在",
   "workspace.renameBranch.error.invalid": "分支名称无效",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -1276,7 +1276,7 @@ export const dict = {
 
   "workspace.new": "新建工作区",
   "workspace.type.local": "本地",
-  "workspace.type.sandbox": "沙盒",
+  "workspace.type.sandbox": "沙箱",
   "workspace.create.failed.title": "创建工作区失败",
   "workspace.delete.failed.title": "删除工作区失败",
   "workspace.resetting.title": "正在重置工作区",
@@ -1305,7 +1305,7 @@ export const dict = {
   "workspace.reset.archived.many": "将归档 {{count}} 个会话。",
   "workspace.reset.note": "这将把工作区重置为与默认分支一致。",
   "workspace.switchBranch": "切换分支",
-  "workspace.renameSandbox": "重命名工作区",
+  "workspace.renameSandbox": "重命名沙箱",
   "workspace.renameBranch": "重命名分支",
   "workspace.renameBranch.error.alreadyExists": "分支名称已存在",
   "workspace.renameBranch.error.invalid": "分支名称无效",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -926,7 +926,7 @@ export const dict = {
 
   "workspace.new": "新增工作區",
   "workspace.type.local": "本地",
-  "workspace.type.sandbox": "沙盒",
+  "workspace.type.sandbox": "沙箱",
   "workspace.create.failed.title": "建立工作區失敗",
   "workspace.delete.failed.title": "刪除工作區失敗",
   "workspace.resetting.title": "正在重設工作區",

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -2320,7 +2320,7 @@ export default function Layout(props: ParentProps) {
 
     if (!created?.directory) return
 
-    const displayName = created.branch.replace(/^sandbox-(\d+)$/, (_, n) => `沙盒-${n}`)
+    const displayName = created.branch.replace(/^sandbox-(\d+)$/, (_, n) => `沙箱-${n}`)
     setWorkspaceName(created.directory, displayName, project.id, created.branch)
 
     const local = project.worktree


### PR DESCRIPTION
### Issue for this PR

N/A — 纯术语统一改动

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

将代码中所有"沙盒"统一替换为"沙箱"，涉及3个文件4处：
- `zh.ts` — `"workspace.type.sandbox"` 和 `"workspace.renameSandbox"`
- `zht.ts` — `"workspace.type.sandbox"`
- `layout.tsx` — sandbox 分支显示名模板字符串

### How did you verify your code works?

全局 grep 确认"沙盒"已无残留，所有替换均为纯字符串替换，不影响逻辑。

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR