### PR TITLE
fix: exclude sandbox from recent projects & normalize worktree on write

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -384,7 +384,7 @@ export namespace Project {
               .onConflictDoUpdate({
                 target: DirectoryMetaTable.directory,
                 set: {
-                  worktree: input.project.worktree,
+                  worktree: norm(input.project.worktree),
                   activity_at: now,
                   time_updated: now,
                 },
@@ -467,7 +467,7 @@ export namespace Project {
             .insert(ProjectTable)
             .values({
               id: result.id,
-              worktree: result.worktree,
+              worktree: norm(result.worktree),
               vcs: result.vcs ?? null,
               name: result.name,
               icon_url: result.icon?.url,
@@ -481,7 +481,7 @@ export namespace Project {
             .onConflictDoUpdate({
               target: ProjectTable.id,
               set: {
-                worktree: result.worktree,
+                worktree: norm(result.worktree),
                 vcs: result.vcs ?? null,
                 time_updated: result.time.updated,
                 time_initialized: result.time.initialized,


### PR DESCRIPTION
## Summary

- Exclude sandbox/worktree entries from the recent projects list so they don't appear as duplicate sidebar entries when a project has both a main worktree and linked worktrees.
- Normalize worktree paths before writing to `ProjectTable` and `DirectoryMetaTable` (insert and upsert). On Windows, `ProjectIdentity.resolve` returns `root` with backslashes (`E:\work\...`), which was stored un-normalized in the project DB, causing path mismatches.

## Changes

- `packages/opencode/src/project/project.ts`:
  - Added `pidCounts` to track how many `project_recent` rows each project has; when a `directory`-kind row belongs to a project with multiple entries, it is filtered out (it's a sandbox alias, not a standalone project).
  - Applied `norm()` to `worktree` in 3 DB write locations: `ProjectTable` insert, `ProjectTable` onConflictDoUpdate, and `DirectoryMetaTable` onConflictDoUpdate.