### PR TITLE
fix: norm worktree/sandbox paths in split-migration and sync directory in project_recent upsert

### DIFF
--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -808,7 +808,7 @@ export namespace Database {
     const insertRecent = sqlite.prepare(
       `INSERT INTO project_recent (key, kind, project_id, directory, name, icon_url, icon_color, icon_override, activity_at, time_created, time_updated)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT(key) DO UPDATE SET project_id = excluded.project_id, name = excluded.name, icon_url = excluded.icon_url, icon_color = excluded.icon_color, icon_override = excluded.icon_override, activity_at = excluded.activity_at, time_updated = excluded.time_updated`,
+       ON CONFLICT(key) DO UPDATE SET project_id = excluded.project_id, directory = excluded.directory, name = excluded.name, icon_url = excluded.icon_url, icon_color = excluded.icon_color, icon_override = excluded.icon_override, activity_at = excluded.activity_at, time_updated = excluded.time_updated`,
     )
 
     for (const row of metaRows) {

--- a/packages/opencode/src/storage/split-migration.ts
+++ b/packages/opencode/src/storage/split-migration.ts
@@ -550,10 +550,10 @@ export namespace SplitMigration {
       const mergeProject = (pid: string, info: ProjectIdentity.Info, row?: any) => {
         const prev = projectById.get(pid)
         const sandboxes = new Set<string>(json(prev?.sandboxes))
-        if (info.sandbox !== info.root) sandboxes.add(info.sandbox)
+        if (info.sandbox !== info.root) sandboxes.add(norm(info.sandbox))
         projectById.set(pid, {
           id: pid,
-          worktree: info.root,
+          worktree: norm(info.root),
           vcs: info.vcs ?? row?.vcs ?? prev?.vcs ?? null,
           name: prev?.name ?? row?.name ?? null,
           icon_url: prev?.icon_url ?? row?.icon_url ?? null,


### PR DESCRIPTION
## Summary
- On Windows, `ProjectIdentity.resolve()` returns backslash paths via `path.resolve()`/`path.dirname()`, but `mergeProject` stored these raw values as `worktree` without `norm()`, causing `project.worktree` and `project_recent.directory` to use backslashes while `directory_meta` used forward slashes.
- Fix by `norm()`'ing `info.root` and `info.sandbox` in `mergeProject` so all stored paths use forward slash consistently.
- Also add `directory = excluded.directory` to the `ON CONFLICT DO UPDATE SET` in `syncDirectoryMetaToGlobal`, so existing rows with backslash directories get corrected on next sync.