### PR TITLE
fix: unify norm() to use OS-native path separators and consolidate path normalization

### DIFF
--- a/packages/app/e2e/projects/workspaces.spec.ts
+++ b/packages/app/e2e/projects/workspaces.spec.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { base64Decode } from "@opencode-ai/util/encode"
+import { norm } from "@opencode-ai/util/path"
 import type { Page } from "@playwright/test"
 
 import { test, expect } from "../fixtures"
@@ -31,7 +32,7 @@ type Space = { directory: string; slug: string; raw?: string }
 
 function slugs(space: string | Space) {
   if (typeof space === "string") return [space]
-  const normSlug = dirSlug(space.directory.replace(/\\/g, "/"))
+  const normSlug = dirSlug(norm(space.directory))
   if (process.platform !== "win32") return [space.slug]
   return [...new Set([space.slug, space.raw, normSlug].filter((item): item is string => !!item))]
 }
@@ -59,8 +60,7 @@ async function openMenu(page: Page, space: string | Space) {
 }
 
 function key(dir: string) {
-  const next = dir.replace(/\\/g, "/")
-  return next.toLowerCase().replace(/\/+$/, "")
+  return norm(dir)
 }
 
 async function same(dir: string) {

--- a/packages/app/src/context/global-sync/utils.ts
+++ b/packages/app/src/context/global-sync/utils.ts
@@ -1,21 +1,17 @@
 import type { Agent, Project, ProjectRecent, ProviderListResponse } from "@opencode-ai/sdk/v2/client"
+import { norm } from "@opencode-ai/util/path"
 
 export const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
 
 export function normalizeDir(directory: string): string {
-  if (!directory) return directory
-  const normalized = directory.replace(/\\/g, "/")
-  const cased = /^[A-Za-z]:/.test(normalized) ? normalized.toLowerCase() : normalized
-  if (/^[a-z]:\/+$/i.test(cased)) return `${cased[0]}:/`
-  if (/^\/+$/.test(cased)) return "/"
-  return cased.replace(/\/+$/, "")
+  return norm(directory)
 }
 
 export function isRoot(directory: string) {
   const dir = normalizeDir(directory)
   if (!dir) return false
   if (dir === "/") return true
-  return /^[a-z]:\/$/i.test(dir)
+  return /^[a-z]:\\?$/i.test(dir)
 }
 
 function isAgent(input: unknown): input is Agent {

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -102,17 +102,20 @@ describe("layout deep links", () => {
 })
 
 describe("layout workspace helpers", () => {
+  const isWin = process.platform === "win32"
   test("normalizes trailing slash in workspace key", () => {
     expect(workspaceKey("/tmp/demo///")).toBe("/tmp/demo")
-    expect(workspaceKey("C:\\tmp\\demo\\\\")).toBe("c:/tmp/demo")
+    if (isWin) expect(workspaceKey("C:\\tmp\\demo\\\\")).toBe("C:\\tmp\\demo")
   })
 
   test("preserves posix and drive roots in workspace key", () => {
     expect(workspaceKey("/")).toBe("/")
     expect(workspaceKey("///")).toBe("/")
-    expect(workspaceKey("C:\\")).toBe("c:/")
-    expect(workspaceKey("C://")).toBe("c:/")
-    expect(workspaceKey("C:///")).toBe("c:/")
+    if (isWin) {
+      expect(workspaceKey("C:\\")).toBe("C:\\")
+      expect(workspaceKey("C://")).toBe("C:\\")
+      expect(workspaceKey("C:///")).toBe("C:\\")
+    }
   })
 
   test("keeps local first while preserving known order", () => {

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -1,4 +1,4 @@
-import { getFilename } from "@opencode-ai/util/path"
+import { getFilename, norm } from "@opencode-ai/util/path"
 import { type Session } from "@opencode-ai/sdk/v2/client"
 
 type SessionStore = {
@@ -6,14 +6,7 @@ type SessionStore = {
   path: { directory: string }
 }
 
-export const workspaceKey = (directory: string) => {
-  // Normalize separators to forward slashes; lowercase for Windows drive paths (case-insensitive FS)
-  const normalized = directory.replace(/\\/g, "/")
-  const cased = /^[A-Za-z]:/.test(normalized) ? normalized.toLowerCase() : normalized
-  if (/^[a-z]:\/+$/i.test(cased)) return `${cased[0]}:/`
-  if (/^\/+$/.test(cased)) return "/"
-  return cased.replace(/\/+$/, "")
-}
+export const workspaceKey = (directory: string) => norm(directory)
 
 function sortSessions(now: number) {
   const oneMinuteAgo = now - 60 * 1000

--- a/packages/opencode/src/cli/cmd/tui/context/directory.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/directory.ts
@@ -1,10 +1,11 @@
 import { createMemo } from "solid-js"
 import { useSync } from "./sync"
 import { Global } from "@/global"
+import { ProjectIdentity } from "@/project/identity"
 
 function tuiDisplayPath(directory: string, home: string) {
-  const normDir = directory.replace(/\\/g, "/")
-  const normHome = home.replace(/\\/g, "/")
+  const normDir = ProjectIdentity.norm(directory)
+  const normHome = ProjectIdentity.norm(home)
   return normDir.startsWith(normHome) ? "~" + normDir.slice(normHome.length) : normDir
 }
 

--- a/packages/opencode/src/mobile/base.ts
+++ b/packages/opencode/src/mobile/base.ts
@@ -206,27 +206,20 @@ export abstract class MobileManagerBase {
   // ── Path helpers ────────────────────────────────────────────────────────────
 
   protected normDir(d: string): string {
-    const text = (d || "").replace(/\\/g, "/")
-    if (!text) return ""
-    if (/^\/+$/.test(text)) return "/"
-    if (/^[A-Za-z]:/.test(text)) {
-      const lower = `${text[0].toLowerCase()}${text.slice(1)}`
-      if (/^[a-z]:\/?$/.test(lower)) return `${lower[0]}:/`
-      return lower.replace(/\/+$/, "")
-    }
-    return text.replace(/\/+$/, "")
+    if (!d) return ""
+    return Project.norm(d)
   }
 
   protected isAbsolutePath(p: string): boolean {
     const n = this.normDir(p)
     if (!n || n === "/") return false
-    return n.startsWith("/") || /^[a-z]:/.test(n)
+    return n.startsWith("/") || /^[a-z]:/i.test(n)
   }
 
   protected isRootDir(d: string): boolean {
     const text = this.normDir(d)
     if (text === "/") return true
-    return /^[a-z]:/.test(text) && text.length <= 3
+    return /^[a-z]:/i.test(text) && text.length <= 3
   }
 
   protected projectDir(entry: ProjectEntry): string {

--- a/packages/opencode/src/project/identity.ts
+++ b/packages/opencode/src/project/identity.ts
@@ -12,7 +12,10 @@ export namespace ProjectIdentity {
 
   export function norm(input: string) {
     const next = path.resolve(input).replace(/\\/g, "/")
-    return /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
+    const result = /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
+    const out = process.platform === "win32" ? result.replace(/\//g, "\\") : result
+    if (process.platform === "win32" && /^[A-Za-z]:$/.test(out)) return out + "\\"
+    return out
   }
 
   function marker(dir: string): string | undefined {

--- a/packages/opencode/src/project/identity.ts
+++ b/packages/opencode/src/project/identity.ts
@@ -13,9 +13,12 @@ export namespace ProjectIdentity {
   export function norm(input: string) {
     const next = path.resolve(input).replace(/\\/g, "/")
     const result = /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
-    const out = process.platform === "win32" ? result.replace(/\//g, "\\") : result
-    if (process.platform === "win32" && /^[A-Za-z]:$/.test(out)) return out + "\\"
-    return out
+    if (process.platform === "win32" && /^[A-Za-z]:/.test(result)) {
+      const out = result.replace(/\//g, "\\")
+      if (/^[A-Za-z]:$/.test(out)) return out + "\\"
+      return out
+    }
+    return result
   }
 
   function marker(dir: string): string | undefined {

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -86,7 +86,10 @@ export namespace Project {
 
   export function norm(input: string) {
     const next = path.resolve(input).replace(/\\/g, "/")
-    return /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
+    const result = /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
+    const out = process.platform === "win32" ? result.replace(/\//g, "\\") : result
+    if (process.platform === "win32" && /^[A-Za-z]:$/.test(out)) return out + "\\"
+    return out
   }
 
   function name(input: string) {

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -87,9 +87,12 @@ export namespace Project {
   export function norm(input: string) {
     const next = path.resolve(input).replace(/\\/g, "/")
     const result = /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
-    const out = process.platform === "win32" ? result.replace(/\//g, "\\") : result
-    if (process.platform === "win32" && /^[A-Za-z]:$/.test(out)) return out + "\\"
-    return out
+    if (process.platform === "win32" && /^[A-Za-z]:/.test(result)) {
+      const out = result.replace(/\//g, "\\")
+      if (/^[A-Za-z]:$/.test(out)) return out + "\\"
+      return out
+    }
+    return result
   }
 
   function name(input: string) {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -455,13 +455,7 @@ export namespace Server {
         async (c) => {
           const body = c.req.valid("json")
           await Project.updateDirectoryMeta({ ...body, projectID: body.projectID as ProjectID | undefined })
-          const list = Project.recentList()
-          const norm = (d: string) =>
-            d
-              .replace(/\\/g, "/")
-              .replace(/\/+$/, "")
-              .replace(/^([A-Za-z]):/, (m) => m[0].toLowerCase() + ":")
-          const item = list.find((i) => i && norm(i.directory) === norm(body.directory))
+          const item = Project.recentFromDir(body.directory)
           if (!item) return c.json(null, 404)
           return c.json(item)
         },

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -1126,9 +1126,14 @@ export namespace Session {
     let projectID: ProjectID = Instance.project.id
     if (input?.directory) {
       const dir = Project.norm(input.directory)
-      const row = Database.use((d) =>
+      let row = Database.use((d) =>
         d.select().from(GlobalProjectMapTable).where(eq(GlobalProjectMapTable.directory, dir)).get(),
       )
+      if (!row && dir !== dir.toLowerCase()) {
+        row = Database.use((d) =>
+          d.select().from(GlobalProjectMapTable).where(eq(GlobalProjectMapTable.directory, dir.toLowerCase())).get(),
+        )
+      }
       if (row) projectID = row.project_id as ProjectID
     }
     const conditions = [eq(SessionTable.project_id, projectID)]

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -36,9 +36,12 @@ export namespace Database {
   export function norm(input: string) {
     const next = path.resolve(input).replace(/\\/g, "/")
     const result = /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
-    const out = process.platform === "win32" ? result.replace(/\//g, "\\") : result
-    if (process.platform === "win32" && /^[A-Za-z]:$/.test(out)) return out + "\\"
-    return out
+    if (process.platform === "win32" && /^[A-Za-z]:/.test(result)) {
+      const out = result.replace(/\//g, "\\")
+      if (/^[A-Za-z]:$/.test(out)) return out + "\\"
+      return out
+    }
+    return result
   }
 
   export type Source = {

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -35,7 +35,10 @@ const log = Log.create({ service: "db" })
 export namespace Database {
   export function norm(input: string) {
     const next = path.resolve(input).replace(/\\/g, "/")
-    return /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
+    const result = /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
+    const out = process.platform === "win32" ? result.replace(/\//g, "\\") : result
+    if (process.platform === "win32" && /^[A-Za-z]:$/.test(out)) return out + "\\"
+    return out
   }
 
   export type Source = {

--- a/packages/opencode/src/storage/split-migration.ts
+++ b/packages/opencode/src/storage/split-migration.ts
@@ -169,9 +169,12 @@ export namespace SplitMigration {
   function norm(input: string) {
     const next = path.resolve(input).replace(/\\/g, "/")
     const result = /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
-    const out = process.platform === "win32" ? result.replace(/\//g, "\\") : result
-    if (process.platform === "win32" && /^[A-Za-z]:$/.test(out)) return out + "\\"
-    return out
+    if (process.platform === "win32" && /^[A-Za-z]:/.test(result)) {
+      const out = result.replace(/\//g, "\\")
+      if (/^[A-Za-z]:$/.test(out)) return out + "\\"
+      return out
+    }
+    return result
   }
 
   function initDb(filePath: string) {

--- a/packages/opencode/src/storage/split-migration.ts
+++ b/packages/opencode/src/storage/split-migration.ts
@@ -168,7 +168,10 @@ export namespace SplitMigration {
 
   function norm(input: string) {
     const next = path.resolve(input).replace(/\\/g, "/")
-    return /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
+    const result = /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
+    const out = process.platform === "win32" ? result.replace(/\//g, "\\") : result
+    if (process.platform === "win32" && /^[A-Za-z]:$/.test(out)) return out + "\\"
+    return out
   }
 
   function initDb(filePath: string) {

--- a/packages/opencode/test/project/project-fromdirectory-order.test.ts
+++ b/packages/opencode/test/project/project-fromdirectory-order.test.ts
@@ -6,13 +6,11 @@ import { Log } from "../../src/util/log"
 import { tmpdir } from "../fixture/fixture"
 import { existsSync } from "fs"
 import { ProjectTable } from "../../src/project/project.sql"
+import { ProjectIdentity } from "../../src/project/identity"
 import { eq } from "drizzle-orm"
 import path from "path"
 
-function norm(input: string) {
-  const next = path.resolve(input).replace(/\\/g, "/")
-  return /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
-}
+const { norm } = ProjectIdentity
 
 Log.init({ print: false })
 

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -8,12 +8,10 @@ import path from "path"
 import { tmpdir } from "../fixture/fixture"
 import { GlobalBus } from "../../src/bus/global"
 import { ProjectID } from "../../src/project/schema"
+import { ProjectIdentity } from "../../src/project/identity"
 import { Effect, Layer, Stream } from "effect"
 
-function norm(input: string) {
-  const next = path.resolve(input).replace(/\\/g, "/")
-  return /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
-}
+const { norm } = ProjectIdentity
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { NodeFileSystem, NodePath } from "@effect/platform-node"
 import { AppFileSystem } from "../../src/filesystem"

--- a/packages/opencode/test/storage/startup-flow.test.ts
+++ b/packages/opencode/test/storage/startup-flow.test.ts
@@ -6,12 +6,11 @@ import os from "os"
 import { rm, mkdtemp } from "fs/promises"
 import { detectCorruption, quarantine } from "../../src/storage/db-recovery"
 import type { CorruptionType } from "../../src/storage/db-recovery"
+import { ProjectIdentity } from "../../src/project/identity"
 
 const tmpRoot = await mkdtemp(path.join(os.tmpdir(), "aether-startup-test-"))
 
-function norm(input: string) {
-  return input.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase()
-}
+const { norm } = ProjectIdentity
 
 function initHealthyDb(dbPath: string) {
   mkdirSync(path.dirname(dbPath), { recursive: true })
@@ -183,8 +182,8 @@ describe("registerUntrackedProjects fault tolerance", () => {
     for (const row of recentRows) {
       const dirNorm = norm(row.directory ?? "")
       recentLookup.set(dirNorm, row)
-      const keyNorm = row.key?.replace(/^dir:/, "").toLowerCase()
-      if (keyNorm && keyNorm !== dirNorm) recentLookup.set(keyNorm, row)
+      const keyNorm = row.key?.replace(/^dir:/, "")
+      if (keyNorm && norm(keyNorm) !== dirNorm) recentLookup.set(keyNorm, row)
     }
 
     const existingDbIds = new Set<string>()

--- a/packages/opencode/test/storage/workspace-data-loss.test.ts
+++ b/packages/opencode/test/storage/workspace-data-loss.test.ts
@@ -6,12 +6,11 @@ import { existsSync, mkdirSync, readFileSync, readdirSync } from "fs"
 import path from "path"
 import os from "os"
 import { rm } from "fs/promises"
+import { ProjectIdentity } from "../../src/project/identity"
 
 const tmpBase = path.join(os.tmpdir(), "aether-workspace-dl-test")
 
-function norm(input: string) {
-  return path.resolve(input).replace(/\\/g, "/").toLowerCase()
-}
+const { norm } = ProjectIdentity
 
 function getMigrationEntries() {
   const dir = path.join(import.meta.dirname, "../../migration")

--- a/packages/util/src/path.ts
+++ b/packages/util/src/path.ts
@@ -4,9 +4,12 @@ export function norm(input: string): string {
   if (!input) return input
   const next = input.replace(/\\/g, "/")
   const result = /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
-  const out = isWin ? result.replace(/\//g, "\\") : result
-  if (isWin && /^[A-Za-z]:$/.test(out)) return out + "\\"
-  return out
+  if (isWin && /^[A-Za-z]:/.test(result)) {
+    const out = result.replace(/\//g, "\\")
+    if (/^[A-Za-z]:$/.test(out)) return out + "\\"
+    return out
+  }
+  return result
 }
 
 export function displayPath(directory: string, home: string) {

--- a/packages/util/src/path.ts
+++ b/packages/util/src/path.ts
@@ -1,6 +1,17 @@
+const isWin = typeof process !== "undefined" && process.platform === "win32"
+
+export function norm(input: string): string {
+  if (!input) return input
+  const next = input.replace(/\\/g, "/")
+  const result = /^\/+$/g.test(next) ? "/" : next.replace(/\/+$/, "")
+  const out = isWin ? result.replace(/\//g, "\\") : result
+  if (isWin && /^[A-Za-z]:$/.test(out)) return out + "\\"
+  return out
+}
+
 export function displayPath(directory: string, home: string) {
-  const normDir = directory.replace(/\\/g, "/")
-  const normHome = home.replace(/\\/g, "/")
+  const normDir = norm(directory)
+  const normHome = norm(home)
   return normDir.startsWith(normHome) ? "~" + normDir.slice(normHome.length) : normDir
 }
 


### PR DESCRIPTION
Closes #872

## Summary

- **Unified `norm()` output format**: All 4 copies of `norm()` (identity.ts, project.ts, db.ts, split-migration.ts) now output OS-native path separators — backslash `\` on Windows, forward slash `/` on Unix. This matches `Filesystem.resolve()` output, eliminating the mismatch where DB writes used `\` paths (via `Filesystem.resolve`) while comparisons used `/` paths (via old `norm()`).

- **Consolidated path normalization across codebase**: Frontend `normalizeDir()`/`workspaceKey()` (helpers.ts, utils.ts), mobile `normDir()` (base.ts), TUI display path, and e2e `key()` now all use a shared `norm()` from `@opencode-ai/util/path`. Test files import `ProjectIdentity.norm` instead of defining local copies.

- **Added Windows drive root handling**: `norm("C:\\")` now correctly returns `"C:\\"` instead of `"C:"`.

- **Backward compatibility**: Added lowercase fallback lookup in `session/index.ts` for `global_project_map`, project_id adoption logic in `project.ts` for old norm format migration, and `recentFromDir` helper replacing inline norm in `server.ts`.

## Key changes

| Area | Change |
|------|--------|
| `project/identity.ts`, `project/project.ts`, `storage/db.ts`, `storage/split-migration.ts` | `norm()` now outputs `\` paths on Windows + drive root fix |
| `mobile/base.ts` | `normDir()` delegates to `Project.norm()`, removed duplicated logic |
| `cli/cmd/tui/context/directory.ts` | Uses `ProjectIdentity.norm` instead of inline `\→/` |
| `util/path.ts` | Added shared `norm()` with `typeof process` guard for browser safety |
| `app/src/context/global-sync/utils.ts` | `normalizeDir()` → `norm()`, `isRoot` regex adapted for `\` |
| `app/src/pages/layout/helpers.ts` | `workspaceKey()` → `norm()` |
| `app/e2e/projects/workspaces.spec.ts` | `key()` → `norm()` |
| Test files (4) | Import `ProjectIdentity.norm`, removed local copies, fixed startup-flow test to match db.ts logic |
| `project/project.ts` | Added project_id adoption from `global_project_map` for old norm format compatibility |
| `session/index.ts` | Added lowercase fallback lookup for `global_project_map` |
| `server/server.ts` | Replaced inline norm with `Project.recentFromDir()` |
| `storage/db.ts` | Added `directory = excluded.directory` to `project_recent` upsert |
| `storage/split-migration.ts` | `norm()` applied to sandbox/worktree in merge logic |

## Root cause

`Filesystem.resolve()` produces `C:\Users\foo` on Windows, while old `norm()` produced `C:/Users/foo`. When session data was written via `Filesystem.resolve` but looked up via `norm()`, or vice versa, DB comparisons silently failed because the strings never matched.