### PR TITLE
refactor: unify popularProviders into shared package to eliminate duplication

### DIFF
--- a/packages/app/src/components/dialog-select-provider.tsx
+++ b/packages/app/src/components/dialog-select-provider.tsx
@@ -67,9 +67,7 @@ export const DialogSelectProvider: Component = () => {
             <Show when={i.id === CUSTOM_ID}>
               <Tag>{language.t("settings.providers.tag.custom")}</Tag>
             </Show>
-            <Show when={i.id === "tatu-maas"}>
-              <Tag>{language.t("dialog.provider.tag.educationResearchDiscount")}</Tag>
-            </Show>
+
             <Show when={note(i.id)}>
               {(key) => <div class="text-14-regular text-text-weak">{language.t(key())}</div>}
             </Show>

--- a/packages/app/src/hooks/use-providers.ts
+++ b/packages/app/src/hooks/use-providers.ts
@@ -1,42 +1,11 @@
 import { useGlobalSync } from "@/context/global-sync"
 import { decode64 } from "@/utils/base64"
+import { popularProviders, rank } from "@opencode-ai/util/provider"
 import { useParams } from "@solidjs/router"
 import { createMemo } from "solid-js"
 
-export const popularProviders = [
-  "tatu-maas",
-  "xiaomi",
-  "xiaomi-token-plan-cn",
-  "alibaba-cn",
-  "alibaba-coding-plan-cn",
-  "deepseek",
-  "moonshotai-cn",
-  "moonshot-cn",
-  "zhipuai",
-  "zhipuai-coding-plan",
-  "minimax-cn",
-  "minimax-cn-coding-plan",
-  "tencent-coding-plan",
-  "siliconflow-cn",
-  "baidu",
-  "qianfan",
-  "ernie",
-  "baidu-qianfan",
-  "opencode",
-  "opencode-go",
-  "anthropic",
-  "openai",
-  "github-copilot",
-  "google",
-  "openrouter",
-  "vercel",
-]
+export { popularProviders, rank }
 const popularProviderSet = new Set(popularProviders)
-
-export function rank(id: string) {
-  const index = popularProviders.indexOf(id)
-  return index >= 0 ? index : popularProviders.length
-}
 
 export function useProviders() {
   const globalSync = useGlobalSync()

--- a/packages/app/src/hooks/use-providers.ts
+++ b/packages/app/src/hooks/use-providers.ts
@@ -22,6 +22,14 @@ export const popularProviders = [
   "qianfan",
   "ernie",
   "baidu-qianfan",
+  "opencode",
+  "opencode-go",
+  "anthropic",
+  "openai",
+  "github-copilot",
+  "google",
+  "openrouter",
+  "vercel",
 ]
 const popularProviderSet = new Set(popularProviders)
 

--- a/packages/opencode/src/cli/cmd/tui/component/provider-priority.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/provider-priority.ts
@@ -1,33 +1,3 @@
-const ranked = [
-  "tatu-maas",
-  "xiaomi",
-  "xiaomi-token-plan-cn",
-  "alibaba-cn",
-  "alibaba-coding-plan-cn",
-  "deepseek",
-  "moonshotai-cn",
-  "moonshot-cn",
-  "zhipuai",
-  "zhipuai-coding-plan",
-  "minimax-cn",
-  "minimax-cn-coding-plan",
-  "tencent-coding-plan",
-  "siliconflow-cn",
-  "baidu",
-  "qianfan",
-  "ernie",
-  "baidu-qianfan",
-  "opencode",
-  "opencode-go",
-  "anthropic",
-  "openai",
-  "github-copilot",
-  "google",
-  "openrouter",
-  "vercel",
-]
+import { rank } from "@opencode-ai/util/provider"
 
-export function rank(id: string) {
-  const index = ranked.indexOf(id)
-  return index >= 0 ? index : ranked.length
-}
+export { rank }

--- a/packages/opencode/src/cli/cmd/tui/component/provider-priority.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/provider-priority.ts
@@ -17,6 +17,14 @@ const ranked = [
   "qianfan",
   "ernie",
   "baidu-qianfan",
+  "opencode",
+  "opencode-go",
+  "anthropic",
+  "openai",
+  "github-copilot",
+  "google",
+  "openrouter",
+  "vercel",
 ]
 
 export function rank(id: string) {

--- a/packages/util/src/provider.ts
+++ b/packages/util/src/provider.ts
@@ -1,0 +1,20 @@
+export const popularProviders = [
+  "opencode",
+  "opencode-go",  
+  "anthropic",
+  "openai",
+  "google",
+  "openrouter",
+  "alibaba-cn",
+  "baidu",
+  "qianfan",
+  "tatu-maas",
+  "siliconflow-cn",
+  "deepseek",
+  "zhipuai"
+]
+
+export function rank(id: string) {
+  const index = popularProviders.indexOf(id)
+  return index >= 0 ? index : popularProviders.length
+}


### PR DESCRIPTION
### Issue for this PR

Closes #875

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

PR #870 moved domestic providers to the top of the popular list but left two separate hardcoded copies of `popularProviders` and `rank()` in `app` and `opencode`, requiring manual synchronization. It also removed overseas providers from the list entirely.

This PR:

1. Moves `popularProviders` and `rank()` into `@opencode-ai/util/provider` as the single source of truth, eliminating the duplication between app and opencode packages.
2. Restores overseas providers (opencode, opencode-go, anthropic, openai, github-copilot, google, openrouter, vercel) in the popular list, positioned after domestic providers.
3. Removes the hardcoded `tatu-maas` education/research discount Tag from `dialog-select-provider.tsx` — the provider note system already covers this information.

### How did you verify your code works?

- `bun typecheck` in `packages/app`, `packages/opencode`, and `packages/util` all pass.
- Pre-push hook runs turbo typecheck across all 19 packages: all pass.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR