### PR TITLE
fix: sync .gitignore into snapshot gitdir exclude file

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -138,9 +138,11 @@ export namespace Snapshot {
 
             const sync = Effect.fnUntraced(function* (list: string[] = []) {
               const file = yield* excludes()
+              const ignore = path.join(state.worktree, ".gitignore")
               const target = path.join(state.gitdir, "info", "exclude")
               const text = [
                 file ? (yield* read(file)).trimEnd() : "",
+                (yield* read(ignore)).trimEnd(),
                 ...list.map((item) => `/${item.replaceAll("\\", "/")}`),
               ]
                 .filter(Boolean)


### PR DESCRIPTION
### Issue for this PR

Closes #879

### Type of change

- [x] Bug fix

### What does this PR do?

`Snapshot.sync()` only reads the main repo's `.git/info/exclude` (a default git template without `node_modules`) and writes it to the snapshot gitdir's `info/exclude`. It **does not read the worktree's `.gitignore`** where exclude patterns like `node_modules` are defined.

This causes `git add --sparse .` in `Snapshot.add()` to track everything, including `node_modules` (646K files / 480MB pack in the Aether monorepo case). Every `Snapshot.track()` call — required at session creation — becomes extremely slow on large projects (minutes vs seconds on smaller ones).

The fix adds a single line: read the worktree's `.gitignore` content and merge it into the snapshot gitdir's `info/exclude`. The existing `read()` helper already returns empty string for nonexistent files, so projects without `.gitignore` are unaffected.

### How did you verify your code works?

- `bun typecheck` passes
- Pre-push turbo typecheck passes across all 19 packages
- Manually verified on the find-projects project: rebuilt the snapshot gitdir with the exclude fix, tracked files dropped from 745K to 5K, `Snapshot.track()` time dropped from minutes to 0.7s, new sessions open instantly

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR