### PR TITLE
fix: prevent ghost worktrees from reappearing after deletion

### DIFF
--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -513,9 +513,10 @@ function createGlobalSync() {
     },
     removeSandbox(root: string, directory: string) {
       setProjects((draft) => {
-        const item = draft.find((project) => project.worktree === root)
+        const item = draft.find((project) => normalizeDir(project.worktree) === normalizeDir(root))
         if (!item) return
-        item.sandboxes = (item.sandboxes ?? []).filter((sandbox) => sandbox !== directory)
+        const nd = normalizeDir(directory)
+        item.sandboxes = (item.sandboxes ?? []).filter((sandbox) => normalizeDir(sandbox) !== nd)
       })
     },
     refreshRecent,

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -758,6 +758,22 @@ export namespace Project {
         )
         if (!result) throw new Error(`Project not found: ${id}`)
         yield* dbProject(id, (d) => d.delete(DirectoryMetaTable).where(eq(DirectoryMetaTable.directory, dirNorm)).run())
+        yield* db((d) => d.delete(GlobalProjectMapTable).where(eq(GlobalProjectMapTable.directory, dirNorm)).run())
+        yield* db((d) =>
+          d
+            .delete(ProjectRecentTable)
+            .where(eq(ProjectRecentTable.key, dirKey(dirNorm)))
+            .run(),
+        )
+        const staleId = ProjectID.fromDirectory(dirNorm)
+        if (Database.hasProject(staleId)) {
+          const staleRow = Database.useProject(staleId, (d) =>
+            d.select().from(ProjectTable).where(eq(ProjectTable.id, staleId)).get(),
+          )
+          if (staleRow?.worktree === dirNorm) {
+            Database.deleteProject(staleId)
+          }
+        }
         yield* emitUpdated(fromRow(result))
       })
 

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -685,7 +685,11 @@ export namespace Database {
       }
     }
 
-    const validDirs = new Set([...setA, ...setB])
+    const validDirs = new Set<string>()
+    for (const dir of setB) validDirs.add(dir)
+    for (const dir of setA) {
+      if (validDirs.has(dir) || existsSync(dir)) validDirs.add(dir)
+    }
 
     const metaRows = pSqlite.prepare("SELECT * FROM directory_meta").all() as {
       directory: string


### PR DESCRIPTION
### Issue for this PR

Closes #881

### Type of change

- [x] Bug fix

### What does this PR do?

**幽灵 worktree 定义**：同时满足以下三个条件的目录——(1) 项目数据库中记录为 sandbox（存在于 `project.sandboxes` 或 `directory_meta`）；(2) `git worktree list` 不识别；(3) 磁盘上不存在。

**问题**：对幽灵 worktree 点击"删除工作区"后，当前会话内确实消失，但重启程序后再次出现。同样，通过 UI 正常删除一个真实 worktree 后重启，也会因残留数据而复活为幽灵。

**根因**：`Project.removeSandbox()` 仅清理 `project.sandboxes` 和 `directory_meta`，未清理 `session` 表中对应 directory 的历史记录、`global_project_map` 映射、`project_recent` 条目、以及该目录对应的独立项目 DB 文件。下次启动时，`validateDirectoryMeta()` 将 session 残留目录视为有效（`setA`），导致幽灵目录被重建回 `directory_meta`，进而通过 `syncProjectSandboxes()` 写回 `project.sandboxes`、通过 `syncDirectoryMetaToGlobal()` 写回全局表，完成复活。

**三层修复**：

1. **`removeSandbox()` 完整清理**（第一层防线）：删除 sandbox 时同步清理 `global_project_map`、`project_recent`、以及该目录对应的独立项目 DB 文件，不留复活种子。

2. **`validateDirectoryMeta()` 磁盘存在性校验**（第二层防线）：对来自 session 残留的目录（`setA`），若不在 `git worktree list` 中且磁盘不存在，不视为有效目录，阻断 `session 残留 → directory_meta 重建 → sandboxes 写回` 的复活链路。

3. **前端 `removeSandbox()` 规范化路径比较**：改用 `normalizeDir()` 比较路径，避免因尾部斜杠差异导致前端删除静默失败。

**数据安全说明**：被删除的子 worktree 的会话数据仍然保存在主项目的 DB 中，不会因本次修改而丢失。

### How did you verify your code works?

- `bun typecheck` 通过（packages/opencode + packages/app）
- 对照实际数据库数据（`~/.local/share/aether/`）验证了幽灵 worktree 的残留路径与修复覆盖范围一致

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR