### PR TITLE
fix: use result.worktree in fromDirectory directory_meta upsert

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -521,7 +521,7 @@ export namespace Project {
             .insert(DirectoryMetaTable)
             .values({
               directory: norm(directory),
-              worktree: norm(data.worktree),
+              worktree: norm(result.worktree),
               name: result.name ?? null,
               icon_url: result.icon?.url ?? null,
               icon_color: result.icon?.color ?? null,
@@ -533,7 +533,7 @@ export namespace Project {
             .onConflictDoUpdate({
               target: DirectoryMetaTable.directory,
               set: {
-                worktree: norm(data.worktree),
+                worktree: norm(result.worktree),
                 activity_at: Date.now(),
                 time_updated: Date.now(),
               },


### PR DESCRIPTION
## Summary

When `fromDirectory` adopts an existing project ID from `global_project_map` (`adopted=true`), the code was using `data.worktree` to write `directory_meta.worktree`. `data.worktree` reflects the current opened directory (often a sandbox), not the project's canonical worktree. This corrupts `directory_meta` by setting `worktree` to the sandbox path instead of the project's canonical worktree.

- Changed two occurrences of `norm(data.worktree)` → `norm(result.worktree)` in the `fromDirectory` `DirectoryMetaTable` upsert (`project.ts:521,533`)
- `result.worktree` correctly resolves to `existing.worktree` when `adopted=true`, and `data.worktree` when `adopted=false`, matching the behavior already used for `ProjectTable` upsert and `touch` at the same call site

## Root cause

Opening a sandbox directory (e.g. `silent-pixel`) triggers `fromDirectory`. `ProjectIdentity.resolve` sets `data.worktree` to the sandbox path itself (no git repo → root = sandbox). The `global_project_map` maps this sandbox to the parent project, so `adopted=true` and `data.id` is changed to the parent project ID. But `data.worktree` is still the sandbox path. The `DirectoryMetaTable` upsert then writes the sandbox path as `worktree`, overwriting the correct value.

## Impact

Every time a sandbox directory is opened, all `directory_meta` rows for the sandbox's directory get their `worktree` corrupted from the project's canonical worktree to the sandbox directory path.