### PR TITLE
fix: voice model dropdown and modalities field in API response

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1387,7 +1387,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             if (!(target instanceof HTMLElement)) return
             if (
               target.closest(
-                '[data-action="prompt-attach"], [data-action="prompt-submit"], [data-action="prompt-permissions"]',
+                '[data-action="prompt-attach"], [data-action="prompt-submit"], [data-action="prompt-permissions"], [data-action="prompt-voice-input"]',
               )
             ) {
               return
@@ -1477,27 +1477,6 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                   aria-label={working() ? language.t("prompt.action.stop") : language.t("prompt.action.send")}
                 />
               </Tooltip>
-              <VoiceInputButton
-                onStateChange={setVoiceState}
-                onTranscription={(text) => {
-                  const current = prompt.current()
-                  const textParts = current.filter((p) => p.type !== "image")
-                  const lastTextPart = textParts.findLast((p) => p.type === "text")
-                  if (lastTextPart && lastTextPart.type === "text") {
-                    const newContent = lastTextPart.content ? lastTextPart.content + " " + text : text
-                    const newParts = current.map((p) =>
-                      p === lastTextPart ? { ...p, content: newContent, end: p.start + newContent.length } : p,
-                    )
-                    prompt.set(newParts as Prompt, promptLength(newParts as Prompt))
-                  } else {
-                    prompt.set(
-                      [{ type: "text" as const, content: text, start: 0, end: text.length }, ...current],
-                      text.length,
-                    )
-                  }
-                  requestAnimationFrame(() => editorRef.focus())
-                }}
-              />
             </div>
           </div>
 
@@ -1528,6 +1507,29 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                   <Icon name="plus" class="size-4.5" />
                 </Button>
               </TooltipKeybind>
+              <div style={buttons()}>
+                <VoiceInputButton
+                  onStateChange={setVoiceState}
+                  onTranscription={(text) => {
+                    const current = prompt.current()
+                    const textParts = current.filter((p) => p.type !== "image")
+                    const lastTextPart = textParts.findLast((p) => p.type === "text")
+                    if (lastTextPart && lastTextPart.type === "text") {
+                      const newContent = lastTextPart.content ? lastTextPart.content + " " + text : text
+                      const newParts = current.map((p) =>
+                        p === lastTextPart ? { ...p, content: newContent, end: p.start + newContent.length } : p,
+                      )
+                      prompt.set(newParts as Prompt, promptLength(newParts as Prompt))
+                    } else {
+                      prompt.set(
+                        [{ type: "text" as const, content: text, start: 0, end: text.length }, ...current],
+                        text.length,
+                      )
+                    }
+                    requestAnimationFrame(() => editorRef.focus())
+                  }}
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -137,7 +137,6 @@ export const SettingsGeneral: Component = () => {
     const none = { value: "", label: language.t("settings.general.row.defaultModel.none"), providerID: "" }
     const items = models
       .list()
-      .filter((m) => models.visible({ providerID: m.provider.id, modelID: m.id }))
       .filter((m) => m.modalities?.input?.includes("audio"))
       .map((m) => ({
         value: `${m.provider.id}/${m.id}`,

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -138,26 +138,12 @@ export const SettingsGeneral: Component = () => {
     const items = models
       .list()
       .filter((m) => models.visible({ providerID: m.provider.id, modelID: m.id }))
-      .filter((m) => {
-        const id = m.id.toLowerCase()
-        return id.includes("omni") || id.includes("whisper") || id.includes("audio") || id.includes("speech")
-      })
+      .filter((m) => m.modalities?.input?.includes("audio"))
       .map((m) => ({
         value: `${m.provider.id}/${m.id}`,
         label: `${m.name} (${m.provider.name})`,
         providerID: m.provider.id,
       }))
-    if (items.length === 0) {
-      const allItems = models
-        .list()
-        .filter((m) => models.visible({ providerID: m.provider.id, modelID: m.id }))
-        .map((m) => ({
-          value: `${m.provider.id}/${m.id}`,
-          label: `${m.name} (${m.provider.name})`,
-          providerID: m.provider.id,
-        }))
-      return [none, ...allItems]
-    }
     return [none, ...items]
   })
 
@@ -441,7 +427,10 @@ export const SettingsGeneral: Component = () => {
             description={language.t("settings.general.row.debugBar.description")}
           >
             <div data-action="settings-debug-bar">
-              <Switch checked={settings.general.debugBar()} onChange={(checked) => settings.general.setDebugBar(checked)} />
+              <Switch
+                checked={settings.general.debugBar()}
+                onChange={(checked) => settings.general.setDebugBar(checked)}
+              />
             </div>
           </SettingsRow>
         </Show>
@@ -450,7 +439,10 @@ export const SettingsGeneral: Component = () => {
           title={language.t("settings.general.row.branchesTab.title")}
           description={language.t("settings.general.row.branchesTab.description")}
         >
-          <div class="flex w-full flex-wrap items-center justify-end gap-2 sm:w-auto sm:flex-nowrap" data-action="settings-feed-branches-tab">
+          <div
+            class="flex w-full flex-wrap items-center justify-end gap-2 sm:w-auto sm:flex-nowrap"
+            data-action="settings-feed-branches-tab"
+          >
             <Show when={settings.general.branchesTab()}>
               <div class="flex flex-wrap justify-end gap-2" data-action="settings-branch-graph-controls">
                 <button
@@ -464,7 +456,10 @@ export const SettingsGeneral: Component = () => {
                     : language.t("settings.general.row.branchGraphCompact.option.compact")}
                 </button>
 
-                <div class="flex overflow-hidden rounded-md border border-border-weak-base" data-action="settings-branch-graph-order-mode">
+                <div
+                  class="flex overflow-hidden rounded-md border border-border-weak-base"
+                  data-action="settings-branch-graph-order-mode"
+                >
                   <button
                     type="button"
                     class="px-2 py-px text-[11px] transition-colors"
@@ -499,11 +494,19 @@ export const SettingsGeneral: Component = () => {
                   <DropdownMenu.Portal>
                     <DropdownMenu.Content class="min-w-40">
                       <DropdownMenu.Group>
-                        <DropdownMenu.GroupLabel>{language.t("settings.general.row.branchGraphFontSize.title")}</DropdownMenu.GroupLabel>
+                        <DropdownMenu.GroupLabel>
+                          {language.t("settings.general.row.branchGraphFontSize.title")}
+                        </DropdownMenu.GroupLabel>
                         <DropdownMenu.RadioGroup
                           value={settings.general.branchGraphFontSize()}
                           onChange={(value) => {
-                            if (value === "xs" || value === "sm" || value === "md" || value === "lg" || value === "xl") {
+                            if (
+                              value === "xs" ||
+                              value === "sm" ||
+                              value === "md" ||
+                              value === "lg" ||
+                              value === "xl"
+                            ) {
                               settings.general.setBranchGraphFontSize(value)
                             }
                           }}
@@ -522,7 +525,9 @@ export const SettingsGeneral: Component = () => {
                       <DropdownMenu.Separator />
 
                       <DropdownMenu.Group>
-                        <DropdownMenu.GroupLabel>{language.t("settings.general.row.branchGraphRowDensity.title")}</DropdownMenu.GroupLabel>
+                        <DropdownMenu.GroupLabel>
+                          {language.t("settings.general.row.branchGraphRowDensity.title")}
+                        </DropdownMenu.GroupLabel>
                         <DropdownMenu.RadioGroup
                           value={settings.general.branchGraphRowDensity()}
                           onChange={(value) => {
@@ -553,7 +558,10 @@ export const SettingsGeneral: Component = () => {
               </div>
             </Show>
 
-            <Switch checked={settings.general.branchesTab()} onChange={(checked) => settings.general.setBranchesTab(checked)} />
+            <Switch
+              checked={settings.general.branchesTab()}
+              onChange={(checked) => settings.general.setBranchesTab(checked)}
+            />
           </div>
         </SettingsRow>
 

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -93,7 +93,7 @@ const defaultSettings: Settings = {
     errors: "nope-03",
   },
   voice: {
-    model: "qwen2.5-omni-7b",
+    model: "",
   },
 }
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -890,6 +890,12 @@ export namespace Provider {
       options: z.record(z.string(), z.any()),
       headers: z.record(z.string(), z.string()),
       release_date: z.string(),
+      modalities: z
+        .object({
+          input: z.array(z.enum(["text", "audio", "image", "video", "pdf"])),
+          output: z.array(z.enum(["text", "audio", "image", "video", "pdf"])),
+        })
+        .optional(),
       variants: z.record(z.string(), z.record(z.string(), z.any())).optional(),
     })
     .meta({
@@ -971,6 +977,7 @@ export namespace Provider {
         interleaved: model.interleaved ?? false,
       },
       release_date: model.release_date,
+      modalities: model.modalities,
       variants: {},
     }
 
@@ -1145,6 +1152,7 @@ export namespace Provider {
           headers: mergeDeep(existingModel?.headers ?? {}, model.headers ?? {}),
           family: model.family ?? existingModel?.family ?? "",
           release_date: model.release_date ?? existingModel?.release_date ?? "",
+          modalities: model.modalities ?? existingModel?.modalities,
           variants: {},
         }
         const merged = mergeDeep(ProviderTransform.variants(parsedModel), model.variants ?? {})


### PR DESCRIPTION
### Issue for this PR

Closes #884

### Type of change

- [x] Bug fix

### What does this PR do?

1. Frontend (`settings-general.tsx`): filters voice model dropdown by `modalities.input.includes("audio")` instead of keyword matching, removes `models.visible()` filter so disabled models still appear, and removes the fallback that showed all models when no audio models matched.
2. Frontend (`settings.tsx`): changes default voice model from `"qwen2.5-omni-7b"` (lacked provider prefix) to `""`.
3. Frontend (`prompt-input.tsx`): moves voice input button from send/stop area to after the attach-file button.
4. Backend (`provider.ts`): adds `modalities` field to the Zod schema and `fromModelsDevModel` output so the API response includes audio capability information.

### How did you verify your code works?

- `bun typecheck` passes in both `packages/opencode` and `packages/app`.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR