### PR TITLE
fix(app): remove session sidebar hover preview

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -2349,10 +2349,7 @@ export default function Layout(props: ParentProps) {
   const workspaceSidebarCtx: WorkspaceSidebarContext = {
     currentDir,
     navList: currentSessions,
-    sidebarExpanded,
     sidebarHovering,
-    nav: () => state.nav,
-    hoverSession: () => state.hoverSession,
     setHoverSession,
     clearHoverProjectSoon,
     prefetchSession,
@@ -2393,7 +2390,6 @@ export default function Layout(props: ParentProps) {
     sidebarOpened: () => layout.sidebar.opened(),
     sidebarHovering,
     hoverProject: () => state.hoverProject,
-    nav: () => state.nav,
     onProjectMouseEnter: (worktree, event) => aim.enter(worktree, event),
     onProjectMouseLeave: (worktree) => aim.leave(worktree),
     onProjectFocus: (worktree) => aim.activate(worktree),
@@ -2413,10 +2409,7 @@ export default function Layout(props: ParentProps) {
     workspaceName,
     sessionProps: {
       navList: currentSessions,
-      sidebarExpanded,
       sidebarHovering,
-      nav: () => state.nav,
-      hoverSession: () => state.hoverSession,
       setHoverSession,
       clearHoverProjectSoon,
       prefetchSession,
@@ -2638,7 +2631,6 @@ export default function Layout(props: ParentProps) {
                           project={item()}
                           sortNow={sortNow}
                           mobile={panelProps.mobile}
-                          popover={popover()}
                         />
                       </div>
                     </>
@@ -2670,7 +2662,6 @@ export default function Layout(props: ParentProps) {
                                     project={item()}
                                     sortNow={sortNow}
                                     mobile={panelProps.mobile}
-                                    popover={popover()}
                                   />
                                 </div>
                               )}

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -1,18 +1,15 @@
-import type { Message, Session, TextPart, UserMessage } from "@opencode-ai/sdk/v2/client"
+import type { Session } from "@opencode-ai/sdk/v2/client"
 import { ContextMenu } from "@opencode-ai/ui/context-menu"
 import { Avatar } from "@opencode-ai/ui/avatar"
 import { Button } from "@opencode-ai/ui/button"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { Dialog } from "@opencode-ai/ui/dialog"
-import { HoverCard } from "@opencode-ai/ui/hover-card"
 import { Icon } from "@opencode-ai/ui/icon"
 import { IconButton } from "@opencode-ai/ui/icon-button"
-import { MessageNav } from "@opencode-ai/ui/message-nav"
 import { Spinner } from "@opencode-ai/ui/spinner"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
-import { base64Encode } from "@opencode-ai/util/encode"
 import { getFilename } from "@opencode-ai/util/path"
-import { A, useNavigate, useParams } from "@solidjs/router"
+import { A, useParams } from "@solidjs/router"
 import { type Accessor, createMemo, createSignal, For, type JSX, Match, onCleanup, Show, Switch } from "solid-js"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
@@ -82,12 +79,8 @@ export type SessionItemProps = {
   slug: string
   mobile?: boolean
   dense?: boolean
-  popover?: boolean
   children: Map<string, string[]>
-  sidebarExpanded: Accessor<boolean>
   sidebarHovering: Accessor<boolean>
-  nav: Accessor<HTMLElement | undefined>
-  hoverSession: Accessor<string | undefined>
   setHoverSession: (id: string | undefined) => void
   clearHoverProjectSoon: () => void
   prefetchSession: (session: Session, priority?: "high" | "low") => void
@@ -255,68 +248,8 @@ const SessionRow = (props: {
   </A>
 )
 
-const SessionHoverPreview = (props: {
-  mobile?: boolean
-  nav: Accessor<HTMLElement | undefined>
-  hoverSession: Accessor<string | undefined>
-  session: Session
-  sidebarHovering: Accessor<boolean>
-  hoverReady: Accessor<boolean>
-  hoverMessages: Accessor<UserMessage[] | undefined>
-  language: ReturnType<typeof useLanguage>
-  isActive: Accessor<boolean>
-  slug: string
-  setHoverSession: (id: string | undefined) => void
-  messageLabel: (message: Message) => string | undefined
-  onMessageSelect: (message: Message) => void
-  trigger: JSX.Element
-}): JSX.Element => {
-  let ref: HTMLDivElement | undefined
-
-  return (
-    <HoverCard
-      openDelay={1000}
-      closeDelay={props.sidebarHovering() ? 600 : 0}
-      placement="right-start"
-      gutter={16}
-      shift={-2}
-      trigger={
-        <div ref={ref} class="min-w-0 w-full">
-          {props.trigger}
-        </div>
-      }
-      open={props.hoverSession() === props.session.id}
-      onOpenChange={(open) => {
-        if (!open) {
-          props.setHoverSession(undefined)
-          return
-        }
-        if (!ref?.matches(":hover")) return
-        props.setHoverSession(props.session.id)
-      }}
-    >
-      <Show
-        when={props.hoverReady()}
-        fallback={<div class="text-12-regular text-text-weak">{props.language.t("session.messages.loading")}</div>}
-      >
-        <div class="overflow-y-auto overflow-x-hidden max-h-72 h-full">
-          <MessageNav
-            messages={props.hoverMessages() ?? []}
-            current={undefined}
-            getLabel={props.messageLabel}
-            onMessageSelect={props.onMessageSelect}
-            size="normal"
-            class="w-60"
-          />
-        </div>
-      </Show>
-    </HoverCard>
-  )
-}
-
 export const SessionItem = (props: SessionItemProps): JSX.Element => {
   const params = useParams()
-  const navigate = useNavigate()
   const layout = useLayout()
   const language = useLanguage()
   const dialog = useDialog()
@@ -356,12 +289,6 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
     return messageAgentColor(sessionStore.message[props.session.id], sessionStore.agent)
   })
 
-  const hoverMessages = createMemo(() =>
-    sessionStore.message[props.session.id]?.filter((message): message is UserMessage => message.role === "user"),
-  )
-  const hoverReady = createMemo(() => hoverMessages() !== undefined)
-  const hoverAllowed = createMemo(() => !props.mobile && props.sidebarExpanded())
-  const hoverEnabled = createMemo(() => (props.popover ?? true) && hoverAllowed())
   const isActive = createMemo(() => props.session.id === params.id)
 
   const warm = (span: number, priority: "high" | "low") => {
@@ -430,12 +357,6 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
     if (renameFrame !== undefined) cancelAnimationFrame(renameFrame)
   })
 
-  const messageLabel = (message: Message) => {
-    const parts = sessionStore.part[message.id] ?? []
-    const text = parts.find((part): part is TextPart => part?.type === "text" && !part.synthetic && !part.ignored)
-    return text?.text
-  }
-
   const hasChildren = createMemo(() => props.hasChildren ?? (props.children.get(props.session.id)?.length ?? 0) > 0)
   const expanded = createMemo(() => props.expanded ?? true)
 
@@ -481,44 +402,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
             <Show
               when={renaming()}
               fallback={
-                <Show
-                  when={hoverEnabled()}
-                  fallback={
-                    <Tooltip
-                      placement={props.mobile ? "bottom" : "right"}
-                      value={props.session.title}
-                      gutter={10}
-                      class="min-w-0 w-full"
-                    >
-                      {item}
-                    </Tooltip>
-                  }
-                >
-                  <SessionHoverPreview
-                    mobile={props.mobile}
-                    nav={props.nav}
-                    hoverSession={props.hoverSession}
-                    session={props.session}
-                    sidebarHovering={props.sidebarHovering}
-                    hoverReady={hoverReady}
-                    hoverMessages={hoverMessages}
-                    language={language}
-                    isActive={isActive}
-                    slug={props.slug}
-                    setHoverSession={props.setHoverSession}
-                    messageLabel={messageLabel}
-                    onMessageSelect={(message) => {
-                      if (!isActive())
-                        layout.pendingMessage.set(
-                          `${base64Encode(props.session.directory)}/${props.session.id}`,
-                          message.id,
-                        )
-
-                      navigate(sessionHref(props.slug, props.session, `#message-${message.id}`))
-                    }}
-                    trigger={item}
-                  />
-                </Show>
+                item
               }
             >
               <div class={`flex items-center gap-3 min-w-0 ${props.dense ? "py-0.5" : "py-1"}`}>
@@ -736,14 +620,12 @@ export const NewSessionItem = (props: {
   slug: string
   mobile?: boolean
   dense?: boolean
-  sidebarExpanded: Accessor<boolean>
   clearHoverProjectSoon: () => void
   setHoverSession: (id: string | undefined) => void
 }): JSX.Element => {
   const layout = useLayout()
   const language = useLanguage()
   const label = language.t("command.session.new")
-  const tooltip = () => props.mobile || !props.sidebarExpanded()
   const item = (
     <A
       href={`/${props.slug}/session`}
@@ -764,16 +646,7 @@ export const NewSessionItem = (props: {
 
   return (
     <div class="group/session relative shrink-0 min-w-0 rounded-md cursor-default transition-colors pl-2 pr-3 hover:bg-surface-raised-base-hover [&:has(:focus-visible)]:bg-surface-raised-base-hover has-[.active]:bg-surface-base-active">
-      <Show
-        when={!tooltip()}
-        fallback={
-          <Tooltip placement={props.mobile ? "bottom" : "right"} value={label} gutter={10} class="min-w-0 w-full">
-            {item}
-          </Tooltip>
-        }
-      >
-        {item}
-      </Show>
+      {item}
     </div>
   )
 }

--- a/packages/app/src/pages/layout/sidebar-project.tsx
+++ b/packages/app/src/pages/layout/sidebar-project.tsx
@@ -20,7 +20,6 @@ export type ProjectSidebarContext = {
   sidebarOpened: Accessor<boolean>
   sidebarHovering: Accessor<boolean>
   hoverProject: Accessor<string | undefined>
-  nav: Accessor<HTMLElement | undefined>
   onProjectMouseEnter: (worktree: string, event: MouseEvent) => void
   onProjectMouseLeave: (worktree: string) => void
   onProjectFocus: (worktree: string) => void
@@ -35,7 +34,7 @@ export type ProjectSidebarContext = {
   workspaceIds: (project: LocalProject) => string[]
   workspaceLabel: (directory: string, branch?: string, projectId?: string) => string
   workspaceName: (directory: string, projectId?: string, branch?: string) => string | undefined
-  sessionProps: Omit<SessionItemProps, "session" | "list" | "slug" | "children" | "mobile" | "dense" | "popover">
+  sessionProps: Omit<SessionItemProps, "session" | "list" | "slug" | "children" | "mobile" | "dense">
   setHoverSession: (id: string | undefined) => void
 }
 
@@ -58,7 +57,6 @@ export const ProjectDragOverlay = (props: {
 const ProjectTile = (props: {
   project: LocalProject
   mobile?: boolean
-  nav: Accessor<HTMLElement | undefined>
   sidebarHovering: Accessor<boolean>
   selected: Accessor<boolean>
   active: Accessor<boolean>
@@ -230,7 +228,6 @@ const ProjectPreviewPanel = (props: {
                 slug={base64Encode(props.project.worktree)}
                 dense
                 mobile={props.mobile}
-                popover={false}
                 children={props.projectChildren()}
               />
             )}
@@ -258,7 +255,6 @@ const ProjectPreviewPanel = (props: {
                       slug={base64Encode(directory)}
                       dense
                       mobile={props.mobile}
-                      popover={false}
                       children={children()}
                     />
                   )}
@@ -342,7 +338,6 @@ export const SortableProject = (props: {
     <ProjectTile
       project={props.project}
       mobile={props.mobile}
-      nav={props.ctx.nav}
       sidebarHovering={props.ctx.sidebarHovering}
       selected={selected}
       active={active}

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -132,10 +132,7 @@ type InlineEditorComponent = (props: {
 export type WorkspaceSidebarContext = {
   currentDir: Accessor<string>
   navList: Accessor<Session[]>
-  sidebarExpanded: Accessor<boolean>
   sidebarHovering: Accessor<boolean>
-  nav: Accessor<HTMLElement | undefined>
-  hoverSession: Accessor<string | undefined>
   setHoverSession: (id: string | undefined) => void
   clearHoverProjectSoon: () => void
   prefetchSession: (session: Session, priority?: "high" | "low") => void
@@ -552,7 +549,6 @@ const SessionTreeNodes = (props: {
   slug: Accessor<string>
   currentSessionID: Accessor<string | undefined>
   mobile?: boolean
-  popover?: boolean
   ctx: WorkspaceSidebarContext
   rootSessions: Accessor<Session[]>
   allSessions: Accessor<Session[]>
@@ -685,12 +681,8 @@ const SessionTreeNodes = (props: {
             navList={props.ctx.navList}
             slug={props.slug()}
             mobile={props.mobile}
-            popover={props.popover}
             children={props.children()}
-            sidebarExpanded={props.ctx.sidebarExpanded}
             sidebarHovering={props.ctx.sidebarHovering}
-            nav={props.ctx.nav}
-            hoverSession={props.ctx.hoverSession}
             setHoverSession={props.ctx.setHoverSession}
             clearHoverProjectSoon={props.ctx.clearHoverProjectSoon}
             prefetchSession={props.ctx.prefetchSession}
@@ -736,7 +728,6 @@ const ArchivedSessionList = (props: {
   slug: Accessor<string>
   ctx: WorkspaceSidebarContext
   mobile?: boolean
-  popover?: boolean
   language: ReturnType<typeof useLanguage>
 }): JSX.Element => {
   const globalSDK = useGlobalSDK()
@@ -866,7 +857,6 @@ const ArchivedSessionList = (props: {
             slug={props.slug}
             currentSessionID={() => params.id}
             mobile={props.mobile}
-            popover={props.popover}
             ctx={archivedTreeCtx}
             rootSessions={rootSessions}
             allSessions={sessions}
@@ -888,7 +878,6 @@ const WorkspaceSessionList = (props: {
   slug: Accessor<string>
   currentSessionID: Accessor<string | undefined>
   mobile?: boolean
-  popover?: boolean
   ctx: WorkspaceSidebarContext
   showNew: Accessor<boolean>
   loading: Accessor<boolean>
@@ -964,7 +953,6 @@ const WorkspaceSessionList = (props: {
             <NewSessionItem
               slug={props.slug()}
               mobile={props.mobile}
-              sidebarExpanded={props.ctx.sidebarExpanded}
               clearHoverProjectSoon={props.ctx.clearHoverProjectSoon}
               setHoverSession={props.ctx.setHoverSession}
             />
@@ -991,12 +979,8 @@ const WorkspaceSessionList = (props: {
                   navList={props.ctx.navList}
                   slug={props.slug()}
                   mobile={props.mobile}
-                  popover={props.popover}
                   children={props.children()}
-                  sidebarExpanded={props.ctx.sidebarExpanded}
                   sidebarHovering={props.ctx.sidebarHovering}
-                  nav={props.ctx.nav}
-                  hoverSession={props.ctx.hoverSession}
                   setHoverSession={props.ctx.setHoverSession}
                   clearHoverProjectSoon={props.ctx.clearHoverProjectSoon}
                   prefetchSession={props.ctx.prefetchSession}
@@ -1015,7 +999,6 @@ const WorkspaceSessionList = (props: {
             slug={props.slug}
             currentSessionID={props.currentSessionID}
             mobile={props.mobile}
-            popover={props.popover}
             ctx={props.ctx}
             rootSessions={props.rootSessions}
             allSessions={props.allSessions}
@@ -1048,7 +1031,6 @@ export const SortableWorkspace = (props: {
   project: LocalProject
   sortNow: Accessor<number>
   mobile?: boolean
-  popover?: boolean
 }): JSX.Element => {
   const params = useParams()
   const globalSync = useGlobalSync()
@@ -1212,7 +1194,6 @@ export const SortableWorkspace = (props: {
             slug={slug}
             currentSessionID={() => params.id}
             mobile={props.mobile}
-            popover={props.popover}
             ctx={props.ctx}
             showNew={showNew}
             loading={loading}
@@ -1238,7 +1219,6 @@ export const SortableWorkspace = (props: {
             slug={slug}
             ctx={props.ctx}
             mobile={props.mobile}
-            popover={props.popover}
             language={language}
           />
         </Collapsible.Content>
@@ -1252,7 +1232,6 @@ export const LocalWorkspace = (props: {
   project: LocalProject
   sortNow: Accessor<number>
   mobile?: boolean
-  popover?: boolean
 }): JSX.Element => {
   const params = useParams()
   const globalSync = useGlobalSync()
@@ -1286,7 +1265,6 @@ export const LocalWorkspace = (props: {
         slug={slug}
         currentSessionID={() => params.id}
         mobile={props.mobile}
-        popover={props.popover}
         ctx={props.ctx}
         showNew={() => false}
         loading={loading}
@@ -1312,7 +1290,6 @@ export const LocalWorkspace = (props: {
         slug={slug}
         ctx={props.ctx}
         mobile={props.mobile}
-        popover={props.popover}
         language={language}
       />
     </div>


### PR DESCRIPTION
### Issue for this PR

Closes #887

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Removes the hover-only UI from the conversation navigation session rows. Session titles no longer open the message hover preview or the duplicate title tooltip, and the now-unused hover-related props were removed from the sidebar session components.

### How did you verify your code works?

- Ran `bun run typecheck` in `packages/app`
- Ran `bun turbo typecheck` during push
- Confirmed the session row code path still keeps existing click, rename, archive, delete, tree expand/collapse, and hover prefetch behavior

### Screenshots / recordings

N/A. This change removes the existing hover overlay from the session navigation UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR