### PR TITLE
fix: make error toast, dialog and input-error text selectable

### DIFF
--- a/packages/ui/src/components/dialog.css
+++ b/packages/ui/src/components/dialog.css
@@ -61,6 +61,7 @@
         align-self: stretch;
 
         [data-slot="dialog-title"] {
+          user-select: text;
           color: var(--text-strong);
 
           /* text-16-medium */
@@ -85,6 +86,7 @@
         flex-shrink: 0;
         align-self: stretch;
 
+        user-select: text;
         color: var(--text-base);
 
         /* text-14-regular */

--- a/packages/ui/src/components/text-field.css
+++ b/packages/ui/src/components/text-field.css
@@ -121,6 +121,7 @@
 
     [data-slot="input-error"] {
       color: var(--text-on-critical-base);
+      user-select: text;
 
       /* text-12-medium */
       font-family: var(--font-family-sans);

--- a/packages/ui/src/components/toast.css
+++ b/packages/ui/src/components/toast.css
@@ -135,6 +135,7 @@
 
   [data-slot="toast-title"] {
     color: var(--text-invert-strong);
+    user-select: text;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -152,6 +153,7 @@
 
   [data-slot="toast-description"] {
     color: var(--text-invert-base);
+    user-select: text;
     text-wrap-style: pretty;
     overflow-wrap: anywhere;
     word-break: break-word;


### PR DESCRIPTION
## Summary
- Add `user-select: text` to toast title/description, dialog title/description, and input-error slots
- These slots were inheriting `user-select: none` from the layout container, making error text unselectable and uncopyable
- Fixes the issue where users could not copy error messages from toast notifications, dialogs, or input error fields