### PR TITLE
fix: prevent steer popup Enter from sending during IME composition

### DIFF
--- a/packages/app/src/components/steer-button.tsx
+++ b/packages/app/src/components/steer-button.tsx
@@ -71,7 +71,7 @@ export const SteerButton: Component = () => {
   }
 
   const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key === "Enter" && !e.shiftKey && !e.isComposing) {
       e.preventDefault()
       handleSend()
     }


### PR DESCRIPTION
### Issue for this PR

Closes #891

### Type of change

- [x] Bug fix

### What does this PR do?

Steer 弹窗的 `<textarea>` 在 `onKeyDown` 中处理 Enter 时未检查 IME 组合输入状态，导致中文输入法下按回车确认原始输入时消息被提前发送。添加 `!e.isComposing` 条件，使 IME composing 期间的回车不被拦截为发送操作。主输入框 `prompt-input.tsx` 已有相同的 IME 防护逻辑，此处补齐。

### How did you verify your code works?

- `bun typecheck` 通过
- 手动测试：macOS 中文输入法下在 steer 弹窗中输入字母 + 回车，IME 正常确认输入，不再触发发送

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR