### PR TITLE
feat(app): 优化会话树布局与当前路径高亮

### DIFF
--- a/packages/app/src/pages/session/branch/conversation-graph-list.tsx
+++ b/packages/app/src/pages/session/branch/conversation-graph-list.tsx
@@ -70,6 +70,7 @@ export function ConversationGraphList(props: {
           <For each={props.edges}>
             {(edge) => (
               <path
+                data-graph-edge-id={edge.id}
                 d={edgePath(edge)}
                 fill="none"
                 stroke={edge.isCurrentPath ? colorForIndex(nodeByID().get(edge.to)?.colorIndex ?? 0) : "#6b7280"}
@@ -91,15 +92,18 @@ export function ConversationGraphList(props: {
               return (
                 <>
                   <circle
+                    data-graph-node-circle={node.id}
                     cx={x()}
                     cy={y()}
                     r={radius()}
                     fill={node.kind === "bud" ? "transparent" : color()}
                     stroke={color()}
                     stroke-width={node.isCurrentPath ? "2.5" : "2"}
+                    opacity={node.isCurrentPath ? "1" : "0.5"}
                   />
                   <Show when={node.isCurrentTarget && node.kind === "turn"}>
                     <circle
+                      data-graph-node-target-ring={node.id}
                       cx={x()}
                       cy={y()}
                       r="8"
@@ -142,13 +146,16 @@ export function ConversationGraphList(props: {
               >
                 <div class="min-w-0 flex-1">
                   <div
+                    data-graph-node-label={node.id}
                     class={`truncate ${props.labelClass}`}
                     style={{
                       ...props.labelStyle,
                     }}
                     classList={{
-                      "text-text-strong": node.sessionID === props.currentSessionID,
-                      "text-text-weaker": node.sessionID !== props.currentSessionID,
+                      "text-text-strong": node.isCurrentPath,
+                      "text-text-weaker": !node.isCurrentPath,
+                      "font-semibold": node.isCurrentPath,
+                      "opacity-30": !node.isCurrentPath,
                       italic: node.kind === "bud",
                     }}
                   >

--- a/packages/app/src/pages/session/branch/conversation-graph-list.vitest.tsx
+++ b/packages/app/src/pages/session/branch/conversation-graph-list.vitest.tsx
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import { render } from "solid-js/web"
+import { ConversationGraphList } from "./conversation-graph-list"
+import type { ConversationGraphEdge, ConversationGraphNode } from "./conversation-graph-model"
+
+vi.mock("@/context/language", () => ({
+  useLanguage: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock("@opencode-ai/ui/icon-button", () => ({
+  IconButton: (props: { children?: unknown; onClick?: () => void }) => (
+    <button type="button" onClick={props.onClick}>
+      {props.children}
+    </button>
+  ),
+}))
+
+vi.mock("@opencode-ai/ui/dropdown-menu", () => ({
+  DropdownMenu: Object.assign((props: { children?: unknown }) => props.children, {
+    Trigger: (props: { children?: unknown }) => props.children,
+    Portal: (props: { children?: unknown }) => props.children,
+    Content: (props: { children?: unknown }) => props.children,
+    Item: (props: { children?: unknown }) => props.children,
+    ItemLabel: (props: { children?: unknown }) => props.children,
+  }),
+}))
+
+const node = (input: {
+  id: string
+  sessionID: string
+  label: string
+  displayRow: number
+  displayLane: number
+  colorIndex?: number
+  isCurrentPath?: boolean
+  isCurrentTarget?: boolean
+  kind?: ConversationGraphNode["kind"]
+  userMessageID?: string
+}): ConversationGraphNode => ({
+  id: input.id,
+  sessionID: input.sessionID,
+  label: input.label,
+  displayRow: input.displayRow,
+  displayLane: input.displayLane,
+  colorIndex: input.colorIndex ?? 0,
+  isCurrentPath: input.isCurrentPath ?? false,
+  isCurrentTarget: input.isCurrentTarget ?? false,
+  kind: input.kind ?? "turn",
+  userMessageID: input.userMessageID ?? `${input.id}-user`,
+  lane: input.displayLane,
+  row: input.displayRow,
+  time: input.displayRow + 1,
+  origin: "tree",
+})
+
+const edge = (input: {
+  from: string
+  to: string
+  isCurrentPath?: boolean
+  kind?: ConversationGraphEdge["kind"]
+  style?: ConversationGraphEdge["style"]
+}): ConversationGraphEdge => ({
+  id: `${input.from}->${input.to}`,
+  from: input.from,
+  to: input.to,
+  isCurrentPath: input.isCurrentPath ?? false,
+  kind: input.kind ?? "continuation",
+  style: input.style ?? "solid",
+})
+
+function mount(props: {
+  currentSessionID?: string
+  nodes: ConversationGraphNode[]
+  edges?: ConversationGraphEdge[]
+}) {
+  const host = document.createElement("div")
+  document.body.append(host)
+  const off = render(
+    () => (
+      <ConversationGraphList
+        currentSessionID={props.currentSessionID ?? "session-child"}
+        nodes={props.nodes}
+        edges={props.edges ?? []}
+        laneCount={2}
+        rowHeight={24}
+        labelClass="text-12-medium"
+        onSelect={() => undefined}
+        onFork={() => undefined}
+        onRename={() => undefined}
+        showRowActions={false}
+      />
+    ),
+    host,
+  )
+  return { host, off }
+}
+
+function rowLabel(host: HTMLElement, text: string) {
+  return [...host.querySelectorAll("[data-graph-node-label]")].find(
+    (element) => element.textContent?.trim() === text,
+  ) as HTMLDivElement | undefined
+}
+
+function nodeCircle(host: HTMLElement, id: string) {
+  return host.querySelector(`[data-graph-node-circle="${id}"]`) as SVGCircleElement | null
+}
+
+function edgePath(host: HTMLElement, id: string) {
+  return host.querySelector(`[data-graph-edge-id="${id}"]`) as SVGPathElement | null
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ""
+})
+
+afterEach(() => {
+  document.body.innerHTML = ""
+  vi.restoreAllMocks()
+})
+
+describe("ConversationGraphList path text highlighting", () => {
+  test("highlights inherited prefix labels that belong to the current path", () => {
+    const { host, off } = mount({
+      nodes: [
+        node({ id: "root-1", sessionID: "session-root", label: "1+1", displayRow: 0, displayLane: 0, isCurrentPath: true }),
+        node({ id: "root-2", sessionID: "session-root", label: "1+2", displayRow: 1, displayLane: 0, isCurrentPath: true }),
+        node({
+          id: "child-1",
+          sessionID: "session-child",
+          label: "2+2",
+          displayRow: 2,
+          displayLane: 1,
+          isCurrentPath: true,
+          isCurrentTarget: true,
+        }),
+      ],
+      edges: [
+        edge({ from: "root-1", to: "root-2", isCurrentPath: true }),
+        edge({ from: "root-2", to: "child-1", isCurrentPath: true, kind: "branch" }),
+      ],
+    })
+
+    expect(rowLabel(host, "1+1")?.className).toContain("text-text-strong")
+    expect(rowLabel(host, "1+2")?.className).toContain("text-text-strong")
+    expect(rowLabel(host, "2+2")?.className).toContain("text-text-strong")
+    expect(rowLabel(host, "1+1")?.className).toContain("font-semibold")
+    expect(rowLabel(host, "2+2")?.className).toContain("font-semibold")
+
+    off()
+  })
+
+  test("keeps sibling branch labels weak when they are not on the current path", () => {
+    const { host, off } = mount({
+      nodes: [
+        node({ id: "root-1", sessionID: "session-root", label: "1+1", displayRow: 0, displayLane: 0, isCurrentPath: true }),
+        node({ id: "root-2", sessionID: "session-root", label: "1+2", displayRow: 1, displayLane: 0, isCurrentPath: true }),
+        node({
+          id: "child-current",
+          sessionID: "session-child",
+          label: "2+2",
+          displayRow: 2,
+          displayLane: 1,
+          isCurrentPath: true,
+          isCurrentTarget: true,
+        }),
+        node({
+          id: "child-sibling",
+          sessionID: "session-sibling",
+          label: "3+3",
+          displayRow: 3,
+          displayLane: 0,
+          isCurrentPath: false,
+        }),
+      ],
+      edges: [
+        edge({ from: "root-1", to: "root-2", isCurrentPath: true }),
+        edge({ from: "root-2", to: "child-current", isCurrentPath: true, kind: "branch" }),
+        edge({ from: "root-2", to: "child-sibling", isCurrentPath: false, kind: "branch" }),
+      ],
+    })
+
+    expect(rowLabel(host, "1+1")?.className).toContain("text-text-strong")
+    expect(rowLabel(host, "2+2")?.className).toContain("text-text-strong")
+    expect(rowLabel(host, "3+3")?.className).toContain("text-text-weaker")
+    expect(rowLabel(host, "3+3")?.className).toContain("opacity-30")
+
+    off()
+  })
+
+  test("dims non-current nodes and labels while keeping current edges unchanged", () => {
+    const { host, off } = mount({
+      nodes: [
+        node({ id: "root-1", sessionID: "session-root", label: "1+1", displayRow: 0, displayLane: 0, isCurrentPath: true }),
+        node({
+          id: "child-current",
+          sessionID: "session-child",
+          label: "2+2",
+          displayRow: 1,
+          displayLane: 1,
+          isCurrentPath: true,
+        }),
+        node({
+          id: "child-sibling",
+          sessionID: "session-sibling",
+          label: "3+3",
+          displayRow: 2,
+          displayLane: 0,
+          isCurrentPath: false,
+        }),
+      ],
+      edges: [
+        edge({ from: "root-1", to: "child-current", isCurrentPath: true, kind: "branch" }),
+        edge({ from: "root-1", to: "child-sibling", isCurrentPath: false, kind: "branch" }),
+      ],
+    })
+
+    expect(nodeCircle(host, "root-1")?.getAttribute("opacity")).toBe("1")
+    expect(nodeCircle(host, "child-current")?.getAttribute("opacity")).toBe("1")
+    expect(nodeCircle(host, "child-sibling")?.getAttribute("opacity")).toBe("0.5")
+
+    expect(rowLabel(host, "1+1")?.className).toContain("font-semibold")
+    expect(rowLabel(host, "2+2")?.className).toContain("font-semibold")
+    expect(rowLabel(host, "1+1")?.className).not.toContain("opacity-30")
+    expect(rowLabel(host, "2+2")?.className).not.toContain("opacity-30")
+    expect(rowLabel(host, "3+3")?.className).toContain("opacity-30")
+
+    expect(edgePath(host, "root-1->child-current")?.getAttribute("opacity")).toBe("1")
+    expect(edgePath(host, "root-1->child-sibling")?.getAttribute("opacity")).toBe("0.4")
+
+    off()
+  })
+})

--- a/packages/app/src/pages/session/branch/conversation-graph-model.test.ts
+++ b/packages/app/src/pages/session/branch/conversation-graph-model.test.ts
@@ -1,0 +1,239 @@
+import type { SessionGraphResult } from "@opencode-ai/sdk/v2"
+import { describe, expect, test } from "bun:test"
+import { buildConversationGraphView } from "./conversation-graph-model"
+
+type GraphPayload = Extract<SessionGraphResult, { kind: "graph" }>
+type GraphNode = GraphPayload["nodes"][number]
+type GraphEdge = GraphPayload["edges"][number]
+
+const node = (input: {
+  id: string
+  sessionID: string
+  time: number
+  lane?: number
+  row?: number
+  kind?: GraphNode["kind"]
+  label?: string
+  userMessageID?: string
+  origin?: GraphNode["origin"]
+}): GraphNode => ({
+  id: input.id,
+  kind: input.kind ?? "turn",
+  sessionID: input.sessionID,
+  lane: input.lane ?? 0,
+  row: input.row ?? 0,
+  time: input.time,
+  label: input.label ?? input.id,
+  origin: input.origin ?? "tree",
+  ...(input.kind === "turn" ? { userMessageID: input.userMessageID ?? `${input.id}-user` } : {}),
+})
+
+const edge = (input: {
+  from: string
+  to: string
+  kind?: GraphEdge["kind"]
+  style?: GraphEdge["style"]
+}): GraphEdge => ({
+  id: `${input.from}->${input.to}`,
+  from: input.from,
+  to: input.to,
+  kind: input.kind ?? "continuation",
+  style: input.style ?? "solid",
+})
+
+const graph = (input: {
+  nodes: GraphNode[]
+  edges?: GraphEdge[]
+  pathNodeIDs?: string[]
+  targetNodeID?: string
+  sessionID?: string
+}): GraphPayload => ({
+  kind: "graph",
+  treeID: "tree-1",
+  current: {
+    sessionID: input.sessionID ?? input.nodes.at(-1)?.sessionID ?? "session-root",
+    pathNodeIDs: input.pathNodeIDs ?? [],
+    latestNodeID: undefined,
+    targetNodeID: input.targetNodeID,
+  },
+  nodes: input.nodes,
+  edges: input.edges ?? [],
+})
+
+describe("buildConversationGraphView time mode lane compaction", () => {
+  test("keeps a linear session on one lane", () => {
+    const view = buildConversationGraphView({
+      graph: graph({
+        nodes: [
+          node({ id: "a1", sessionID: "session-a", time: 1 }),
+          node({ id: "a2", sessionID: "session-a", time: 2 }),
+          node({ id: "a3", sessionID: "session-a", time: 3 }),
+        ],
+        edges: [edge({ from: "a1", to: "a2" }), edge({ from: "a2", to: "a3" })],
+        pathNodeIDs: ["a1", "a2", "a3"],
+        targetNodeID: "a3",
+      }),
+      compact: false,
+      orderMode: "time",
+    })
+
+    expect(view.nodes.map((item) => item.displayLane)).toEqual([0, 0, 0])
+    expect(view.laneCount).toBe(1)
+  })
+
+  test("reuses the leftmost released lane for later sessions", () => {
+    const view = buildConversationGraphView({
+      graph: graph({
+        nodes: [
+          node({ id: "root-1", sessionID: "root", time: 1, lane: 0 }),
+          node({ id: "root-2", sessionID: "root", time: 2, lane: 0 }),
+          node({ id: "child-1", sessionID: "child-1", time: 3, lane: 1 }),
+          node({ id: "child-2", sessionID: "child-1", time: 4, lane: 1 }),
+          node({ id: "child-3", sessionID: "child-2", time: 5, lane: 2 }),
+          node({ id: "child-4", sessionID: "child-2", time: 6, lane: 2 }),
+        ],
+        edges: [
+          edge({ from: "root-1", to: "root-2" }),
+          edge({ from: "root-2", to: "child-1", kind: "branch" }),
+          edge({ from: "child-1", to: "child-2" }),
+          edge({ from: "root-2", to: "child-3", kind: "branch" }),
+          edge({ from: "child-3", to: "child-4" }),
+        ],
+      }),
+      compact: false,
+      orderMode: "time",
+    })
+
+    expect(view.nodes.map((item) => [item.id, item.displayLane])).toEqual([
+      ["root-1", 0],
+      ["root-2", 0],
+      ["child-1", 0],
+      ["child-2", 0],
+      ["child-3", 0],
+      ["child-4", 0],
+    ])
+    expect(view.laneCount).toBe(1)
+  })
+
+  test("keeps a session on a stable lane while it is still active", () => {
+    const view = buildConversationGraphView({
+      graph: graph({
+        nodes: [
+          node({ id: "a1", sessionID: "session-a", time: 1, lane: 0 }),
+          node({ id: "b1", sessionID: "session-b", time: 2, lane: 1 }),
+          node({ id: "a2", sessionID: "session-a", time: 3, lane: 0 }),
+        ],
+        edges: [edge({ from: "a1", to: "a2" }), edge({ from: "a1", to: "b1", kind: "branch" })],
+      }),
+      compact: false,
+      orderMode: "time",
+    })
+
+    expect(view.nodes.map((item) => [item.id, item.displayLane])).toEqual([
+      ["a1", 0],
+      ["b1", 1],
+      ["a2", 0],
+    ])
+    expect(view.laneCount).toBe(2)
+  })
+
+  test("preserves time-mode row order while compacting lanes", () => {
+    const view = buildConversationGraphView({
+      graph: graph({
+        nodes: [
+          node({ id: "b", sessionID: "session-b", time: 10, lane: 1 }),
+          node({ id: "a", sessionID: "session-a", time: 10, lane: 2 }),
+          node({ id: "c", sessionID: "session-c", time: 11, lane: 0 }),
+        ],
+      }),
+      compact: false,
+      orderMode: "time",
+    })
+
+    expect(view.nodes.map((item) => item.id)).toEqual(["b", "a", "c"])
+  })
+
+  test("uses the same display lanes in full and compact views", () => {
+    const payload = graph({
+      nodes: [
+        node({ id: "n1", sessionID: "session-a", time: 1, lane: 0 }),
+        node({ id: "n2", sessionID: "session-a", time: 2, lane: 0 }),
+        node({ id: "n3", sessionID: "session-a", time: 3, lane: 0 }),
+      ],
+      edges: [edge({ from: "n1", to: "n2" }), edge({ from: "n2", to: "n3" })],
+      pathNodeIDs: ["n1", "n2", "n3"],
+      targetNodeID: "n3",
+    })
+
+    const full = buildConversationGraphView({
+      graph: payload,
+      compact: false,
+      orderMode: "time",
+    })
+    const compact = buildConversationGraphView({
+      graph: payload,
+      compact: true,
+      orderMode: "time",
+    })
+
+    const fullLaneByID = new Map(full.nodes.map((item) => [item.id, item.displayLane] as const))
+    expect(compact.nodes.map((item) => [item.id, item.displayLane])).toEqual([
+      ["n1", fullLaneByID.get("n1")!],
+      ["n3", fullLaneByID.get("n3")!],
+    ])
+  })
+
+  test("treats bud nodes as part of their session for lane assignment", () => {
+    const view = buildConversationGraphView({
+      graph: graph({
+        nodes: [
+          node({ id: "root-1", sessionID: "root", time: 1, lane: 0 }),
+          node({ id: "root-2", sessionID: "root", time: 2, lane: 0 }),
+          node({ id: "bud-1", sessionID: "branch", time: 3, lane: 1, kind: "bud", label: "", origin: "tree" }),
+        ],
+        edges: [edge({ from: "root-1", to: "root-2" }), edge({ from: "root-2", to: "bud-1", kind: "bud" })],
+        pathNodeIDs: ["root-1", "root-2", "bud-1"],
+        targetNodeID: "bud-1",
+        sessionID: "branch",
+      }),
+      compact: false,
+      orderMode: "time",
+    })
+
+    expect(view.nodes.map((item) => [item.id, item.displayLane])).toEqual([
+      ["root-1", 0],
+      ["root-2", 0],
+      ["bud-1", 0],
+    ])
+  })
+})
+
+describe("buildConversationGraphView sequence mode", () => {
+  test("keeps the existing sequence-first layout behavior", () => {
+    const view = buildConversationGraphView({
+      graph: graph({
+        nodes: [
+          node({ id: "root-1", sessionID: "root", time: 1, lane: 0 }),
+          node({ id: "root-2", sessionID: "root", time: 2, lane: 0 }),
+          node({ id: "child-a", sessionID: "child-a", time: 3, lane: 1 }),
+          node({ id: "child-b", sessionID: "child-b", time: 4, lane: 2 }),
+        ],
+        edges: [
+          edge({ from: "root-1", to: "root-2" }),
+          edge({ from: "root-2", to: "child-a", kind: "branch" }),
+          edge({ from: "root-2", to: "child-b", kind: "branch" }),
+        ],
+      }),
+      compact: false,
+      orderMode: "sequence",
+    })
+
+    expect(view.nodes.map((item) => item.id)).toEqual(["root-1", "root-2", "child-a", "child-b"])
+    expect(view.nodes.map((item) => [item.id, item.displayLane])).toEqual([
+      ["root-1", 0],
+      ["root-2", 0],
+      ["child-a", 0],
+      ["child-b", 1],
+    ])
+  })
+})

--- a/packages/app/src/pages/session/branch/conversation-graph-model.ts
+++ b/packages/app/src/pages/session/branch/conversation-graph-model.ts
@@ -134,6 +134,48 @@ const createSessionColorIndexMap = (nodes: SessionGraphNode[]) => {
   return new Map(orderedSessionIDs.map((sessionID, index) => [sessionID, index] as const))
 }
 
+const createTimeDisplayLaneMap = (nodes: SessionGraphNode[]) => {
+  const lastRowBySessionID = new Map<string, number>()
+  const sessionIDsEndingAtRow = new Map<number, string[]>()
+
+  nodes.forEach((node, row) => {
+    lastRowBySessionID.set(node.sessionID, row)
+  })
+
+  for (const [sessionID, row] of lastRowBySessionID) {
+    const sessions = sessionIDsEndingAtRow.get(row)
+    if (sessions) sessions.push(sessionID)
+    else sessionIDsEndingAtRow.set(row, [sessionID])
+  }
+
+  const sessionLaneBySessionID = new Map<string, number>()
+  const displayLaneByNodeID = new Map<string, number>()
+  const reusableLanes: number[] = []
+  let nextLane = 0
+
+  const releaseEndedSessions = (row: number) => {
+    for (const sessionID of sessionIDsEndingAtRow.get(row - 1) ?? []) {
+      const lane = sessionLaneBySessionID.get(sessionID)
+      if (typeof lane !== "number") continue
+      reusableLanes.push(lane)
+      reusableLanes.sort((a, b) => a - b)
+    }
+  }
+
+  nodes.forEach((node, row) => {
+    if (row > 0) releaseEndedSessions(row)
+
+    let lane = sessionLaneBySessionID.get(node.sessionID)
+    if (typeof lane !== "number") {
+      lane = reusableLanes.shift() ?? nextLane++
+      sessionLaneBySessionID.set(node.sessionID, lane)
+    }
+    displayLaneByNodeID.set(node.id, lane)
+  })
+
+  return displayLaneByNodeID
+}
+
 const createDisplayLaneMap = (input: {
   nodes: SessionGraphNode[]
   sortedNodeIDs: string[]
@@ -141,7 +183,7 @@ const createDisplayLaneMap = (input: {
   orderMode: ConversationGraphOrderMode
 }) => {
   if (input.orderMode === "time") {
-    return new Map(input.nodes.map((node) => [node.id, node.lane] as const))
+    return createTimeDisplayLaneMap(input.nodes)
   }
 
   const rowByID = new Map(input.sortedNodeIDs.map((nodeID, row) => [nodeID, row] as const))


### PR DESCRIPTION
### Issue for this PR

Closes #894

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

本次 PR 主要优化会话树（conversation tree）的展示效果，聚焦三个方面：

1. 调整 `时间优先`排序模式下的横向 lane 分配逻辑，复用已释放的左侧空闲 lane，避免每次 fork 新分支都持续向右漂移。
2. 修正当前选中分支的文字高亮逻辑，让 fork 之前继承来的前缀节点也会随整条当前路径一起高亮。
3. 提高当前路径与其他分支的视觉对比度：当前路径右侧文字加粗，非当前分支的节点与文字进一步弱化。

这些改动都只发生在会话树前端视图层，没有改动后端接口或持久化结构。

### How did you verify your code works?

- 本地运行 `packages/app` 单元测试：`bun run test:unit`
- 定向验证会话树组件测试：`bun run ./script/vitest.ts run --config ./vitest.config.ts ./src/pages/session/branch/conversation-graph-list.vitest.tsx`
- 结合本地 UI 交互检查了以下场景：
  - `time` 模式下连续 fork 后横向布局更紧凑
  - 当前路径的前缀节点文字会一起高亮
  - 非当前分支的节点与文字会变得更加不明显

### Screenshots / recordings

- 本次是会话树 UI 细节优化，已在本地界面中验证。

下面是按时间优先排序的当前效果，可以看到更加紧凑了，右边的空间尽量利用起来了：

<img width="399" height="674" alt="image" src="https://github.com/user-attachments/assets/829ec1de-5363-4b04-bd31-0b05ab49ed0b" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR