### PR TITLE
fix: replace fixed 2s wait with event-driven wait in oauth-browser test

### DIFF
--- a/packages/opencode/test/mcp/oauth-browser.test.ts
+++ b/packages/opencode/test/mcp/oauth-browser.test.ts
@@ -128,9 +128,14 @@ test("BrowserOpenFailed event is published when open() throws", async () => {
     fn: async () => {
       openShouldFail = true
 
+      let resolveEvent!: () => void
+      const eventReceived = new Promise<void>((r) => {
+        resolveEvent = r
+      })
       const events: Array<{ mcpName: string; url: string }> = []
       const unsubscribe = Bus.subscribe(MCP.BrowserOpenFailed, (evt) => {
         events.push(evt.properties)
+        resolveEvent()
       })
 
       // Run authenticate with a timeout to avoid waiting forever for the callback
@@ -138,8 +143,10 @@ test("BrowserOpenFailed event is published when open() throws", async () => {
       // don't show up as unhandled between tests.
       const authPromise = MCP.authenticate("test-oauth-server").catch(() => undefined)
 
-      // Config.get() can be slow in tests, so give it plenty of time.
-      await new Promise((resolve) => setTimeout(resolve, 2_000))
+      // Wait for the BrowserOpenFailed event to arrive before calling stop().
+      // This guarantees waitForCallback() has already registered the pending auth,
+      // so stop() will find and reject it — no race condition.
+      await Promise.race([eventReceived, new Promise<void>((resolve) => setTimeout(resolve, 10_000))])
 
       // Stop the callback server and cancel any pending auth
       await McpOAuthCallback.stop()


### PR DESCRIPTION
### Issue for this PR

Closes #895

### Type of change

- [x] Bug fix

### What does this PR do?

Fix flaky test "BrowserOpenFailed event is published when open() throws" by replacing the fixed 2-second `setTimeout` wait with an event-driven wait. The test now awaits the `BrowserOpenFailed` event (with a 10s safety timeout) before calling `McpOAuthCallback.stop()`, which guarantees `waitForCallback()` has already registered the pending auth entry so `stop()` can properly reject it. This eliminates the race condition that caused the test to hang on macOS CI where Config loading + Effect Layer construction could exceed 2 seconds.

### How did you verify your code works?

- Ran `bun test test/mcp/oauth-browser.test.ts --timeout 30000` locally — test passes.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR