### PR TITLE
fix: use result.worktree instead of data.worktree in fromDirectory touch/icon/syncWorktrees

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -490,7 +490,7 @@ export namespace Project {
           )
         }
 
-        const touchDir = data.worktree !== "/" ? data.worktree : directory
+        const touchDir = result.worktree !== "/" ? result.worktree : directory
         yield* touch({ project: result, directory: touchDir })
 
         yield* dbProject(data.id, (d) =>
@@ -522,8 +522,8 @@ export namespace Project {
             .run(),
         )
 
-        if (data.worktree !== "/") {
-          const recentKey = dirKey(data.worktree)
+        if (result.worktree !== "/") {
+          const recentKey = dirKey(result.worktree)
           const recentRow = yield* db((d) =>
             d.select().from(ProjectRecentTable).where(eq(ProjectRecentTable.key, recentKey)).get(),
           )
@@ -574,7 +574,7 @@ export namespace Project {
 
         yield* emitUpdated(result)
 
-        if (result.vcs === "git" && data.sandbox === data.worktree) {
+        if (result.vcs === "git" && data.sandbox === result.worktree) {
           yield* syncWorktrees(result.id, result.worktree).pipe(
             Effect.catch(() => Effect.void),
             Effect.forkIn(scope),


### PR DESCRIPTION
## Summary

- Fix `fromDirectory` using `data.worktree` (resolve result) instead of `result.worktree` (project's canonical worktree) in three places when `adopted=true`
- When a sandbox worktree directory has no `.git` file, `ProjectIdentity.resolve` returns `root = sandbox_path`, causing `data.worktree` to point to the sandbox instead of the project's real worktree
- This is the same class of bug as PR #883, which fixed `directory_meta.worktree` — the adoption logic means `data.worktree` is not authoritative and `result.worktree` must be used

## Bugs fixed

1. **`touchDir`** (line 493): `data.worktree` → `result.worktree` — sandbox's `kind` in `project_recent` was incorrectly overwritten from `directory` to `project`
2. **Icon migration lookup** (lines 525-526): `data.worktree` → `result.worktree` — icon migration looked up and cleared the wrong `project_recent` key
3. **`syncWorktrees` condition** (line 577): `data.sandbox === data.worktree` → `data.sandbox === result.worktree` — `syncWorktrees` was incorrectly triggered when sandbox had no `.git`