### PR TITLE
fix(app): route prompts to owning session

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -76,6 +76,7 @@ import {
   sortedRootSessions,
   workspaceKey,
 } from "./layout/helpers"
+import { dismissKeys, shouldNotify } from "./layout/request-alert"
 import {
   collectNewSessionDeepLinks,
   collectOpenProjectDeepLinks,
@@ -637,6 +638,17 @@ export default function Layout(props: ParentProps) {
             ? language.t("notification.permission.description", { sessionTitle, projectName })
             : language.t("notification.question.description", { sessionTitle, projectName })
         const href = `/${base64Encode(directory)}/session/${props.sessionID}`
+        const notify = shouldNotify({
+          current_dir: currentDir(),
+          current_session: params.id,
+          dir: directory,
+          session_id: props.sessionID,
+        })
+
+        if (!notify) {
+          dismissSessionAlert(sessionKey)
+          return
+        }
 
         const now = Date.now()
         const lastAlerted = alertedAtBySession.get(sessionKey) ?? 0
@@ -657,10 +669,6 @@ export default function Layout(props: ParentProps) {
             void platform.notify(title, description, href)
           }
         }
-
-        const currentSession = params.id
-        if (directory === currentDir() && props.sessionID === currentSession) return
-        if (directory === currentDir() && session?.parentID === currentSession) return
 
         dismissSessionAlert(sessionKey)
 
@@ -687,14 +695,8 @@ export default function Layout(props: ParentProps) {
       onCleanup(unsub)
 
       createEffect(() => {
-        const currentSession = params.id
-        if (!currentDir() || !currentSession) return
-        const sessionKey = `${currentDir()}:${currentSession}`
-        dismissSessionAlert(sessionKey)
-        const [store] = globalSync.child(currentDir(), { bootstrap: false })
-        const childSessions = store.session.filter((s) => s.parentID === currentSession)
-        for (const child of childSessions) {
-          dismissSessionAlert(`${currentDir()}:${child.id}`)
+        for (const key of dismissKeys({ current_dir: currentDir(), current_session: params.id })) {
+          dismissSessionAlert(key)
         }
       })
     })

--- a/packages/app/src/pages/layout/request-alert.test.ts
+++ b/packages/app/src/pages/layout/request-alert.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test"
+import { dismissKeys, shouldNotify } from "./request-alert"
+
+describe("shouldNotify", () => {
+  test("skips the current session request", () => {
+    expect(
+      shouldNotify({
+        current_dir: "/tmp/project",
+        current_session: "root",
+        dir: "/tmp/project",
+        session_id: "root",
+      }),
+    ).toBe(false)
+  })
+
+  test("notifies for a child session request", () => {
+    expect(
+      shouldNotify({
+        current_dir: "/tmp/project",
+        current_session: "root",
+        dir: "/tmp/project",
+        session_id: "child",
+      }),
+    ).toBe(true)
+  })
+
+  test("notifies for a parent session request", () => {
+    expect(
+      shouldNotify({
+        current_dir: "/tmp/project",
+        current_session: "child",
+        dir: "/tmp/project",
+        session_id: "root",
+      }),
+    ).toBe(true)
+  })
+})
+
+describe("dismissKeys", () => {
+  test("only clears the current session alert", () => {
+    expect(
+      dismissKeys({
+        current_dir: "/tmp/project",
+        current_session: "root",
+      }),
+    ).toEqual(["/tmp/project:root"])
+  })
+
+  test("returns no keys without a current session", () => {
+    expect(
+      dismissKeys({
+        current_dir: "/tmp/project",
+      }),
+    ).toEqual([])
+  })
+})

--- a/packages/app/src/pages/layout/request-alert.ts
+++ b/packages/app/src/pages/layout/request-alert.ts
@@ -1,0 +1,16 @@
+export function shouldNotify(input: {
+  current_dir?: string
+  current_session?: string
+  dir: string
+  session_id: string
+}) {
+  return input.dir !== input.current_dir || input.session_id !== input.current_session
+}
+
+export function dismissKeys(input: {
+  current_dir?: string
+  current_session?: string
+}) {
+  if (!input.current_dir || !input.current_session) return []
+  return [`${input.current_dir}:${input.current_session}`]
+}

--- a/packages/app/src/pages/session/composer/session-composer-state.test.ts
+++ b/packages/app/src/pages/session/composer/session-composer-state.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test"
 import type { PermissionRequest, QuestionRequest, Session } from "@opencode-ai/sdk/v2/client"
 import { todoState } from "./session-composer-state"
-import { sessionPermissionRequest, sessionQuestionRequest } from "./session-request-tree"
+import {
+  sessionCurrentPermissionRequest,
+  sessionCurrentQuestionRequest,
+  sessionPermissionRequest,
+  sessionQuestionRequest,
+} from "./session-request-tree"
 
 const session = (input: { id: string; parentID?: string }) =>
   ({
@@ -102,6 +107,46 @@ describe("sessionQuestionRequest", () => {
     }
 
     expect(sessionQuestionRequest(sessions, questions, "root")?.id).toBe("q-grand")
+  })
+})
+
+describe("sessionCurrentPermissionRequest", () => {
+  test("returns the current session permission", () => {
+    const permissions = {
+      root: [permission("perm-root", "root")],
+      child: [permission("perm-child", "child")],
+    }
+
+    expect(sessionCurrentPermissionRequest(permissions, "root")?.id).toBe("perm-root")
+  })
+
+  test("ignores nested child permissions", () => {
+    const permissions = {
+      child: [permission("perm-child", "child")],
+      grand: [permission("perm-grand", "grand")],
+    }
+
+    expect(sessionCurrentPermissionRequest(permissions, "root")).toBeUndefined()
+  })
+})
+
+describe("sessionCurrentQuestionRequest", () => {
+  test("returns the current session question", () => {
+    const questions = {
+      root: [question("q-root", "root")],
+      child: [question("q-child", "child")],
+    }
+
+    expect(sessionCurrentQuestionRequest(questions, "root")?.id).toBe("q-root")
+  })
+
+  test("ignores nested child questions", () => {
+    const questions = {
+      child: [question("q-child", "child")],
+      grand: [question("q-grand", "grand")],
+    }
+
+    expect(sessionCurrentQuestionRequest(questions, "root")).toBeUndefined()
   })
 })
 

--- a/packages/app/src/pages/session/composer/session-composer-state.ts
+++ b/packages/app/src/pages/session/composer/session-composer-state.ts
@@ -11,7 +11,7 @@ import { useSync } from "@/context/sync"
 import { createWorkingState } from "@/utils/working-state"
 import { childMapByParent } from "@/pages/layout/helpers"
 import { composerDriver, composerEnabled, composerEvent } from "@/testing/session-composer"
-import { sessionPermissionRequest, sessionQuestionRequest } from "./session-request-tree"
+import { sessionCurrentPermissionRequest, sessionCurrentQuestionRequest } from "./session-request-tree"
 
 export const todoState = (input: {
   count: number
@@ -35,11 +35,11 @@ export function createSessionComposerState(options?: { closeMs?: number | (() =>
   const permission = usePermission()
 
   const questionRequest = createMemo((): QuestionRequest | undefined => {
-    return sessionQuestionRequest(sync.data.session, sync.data.question, params.id)
+    return sessionCurrentQuestionRequest(sync.data.question, params.id)
   })
 
   const permissionRequest = createMemo((): PermissionRequest | undefined => {
-    return sessionPermissionRequest(sync.data.session, sync.data.permission, params.id, (item) => {
+    return sessionCurrentPermissionRequest(sync.data.permission, params.id, (item) => {
       return !permission.autoResponds(item, sdk.directory)
     })
   })

--- a/packages/app/src/pages/session/composer/session-request-tree.ts
+++ b/packages/app/src/pages/session/composer/session-request-tree.ts
@@ -33,6 +33,15 @@ function sessionTreeRequest<T>(
   return request[id]?.find(include)
 }
 
+function sessionCurrentRequest<T>(
+  request: Record<string, T[] | undefined>,
+  sessionID?: string,
+  include: (item: T) => boolean = () => true,
+) {
+  if (!sessionID) return
+  return request[sessionID]?.find(include)
+}
+
 export function sessionPermissionRequest(
   session: Session[],
   request: Record<string, PermissionRequest[] | undefined>,
@@ -42,6 +51,14 @@ export function sessionPermissionRequest(
   return sessionTreeRequest(session, request, sessionID, include)
 }
 
+export function sessionCurrentPermissionRequest(
+  request: Record<string, PermissionRequest[] | undefined>,
+  sessionID?: string,
+  include?: (item: PermissionRequest) => boolean,
+) {
+  return sessionCurrentRequest(request, sessionID, include)
+}
+
 export function sessionQuestionRequest(
   session: Session[],
   request: Record<string, QuestionRequest[] | undefined>,
@@ -49,4 +66,12 @@ export function sessionQuestionRequest(
   include?: (item: QuestionRequest) => boolean,
 ) {
   return sessionTreeRequest(session, request, sessionID, include)
+}
+
+export function sessionCurrentQuestionRequest(
+  request: Record<string, QuestionRequest[] | undefined>,
+  sessionID?: string,
+  include?: (item: QuestionRequest) => boolean,
+) {
+  return sessionCurrentRequest(request, sessionID, include)
 }


### PR DESCRIPTION
### Issue for this PR

Closes #903

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

修正 App 端 `question` / `permission` 在父子会话之间的展示与处理逻辑。

这次修改把 composer 区域里的待处理请求来源从“当前会话树”收紧为“仅当前会话本身”，避免父会话直接接管子会话的 prompt。现在只有 prompt 所属的会话才会在对话栏里显示对应的 question / permission dock，并阻塞该会话。

同时调整了通知逻辑：只有当前会话本身的 prompt 会抑制通知，来自其他会话的 prompt 会先弹通知，用户跳转到目标会话后再处理。也同步修正了提醒清理逻辑，避免父会话页面提前把子会话的提醒清掉。

另外补了针对 current-only selector 和通知判定的单测，保留现有树状聚合 helper 给侧边栏等其他场景继续使用。

### How did you verify your code works?

- 运行 `bun typecheck`（`packages/app`）
- 推送前触发并通过 `bun turbo typecheck`
- 手动验证 App 端父/子会话下的 `question` / `permission` 场景，确认非当前会话先通知，跳转后才在所属会话内显示 dock

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR