### PR TITLE
fix: skip core.symlinks=true on Windows to avoid false type-change di…

### DIFF
--- a/packages/opencode/src/git/index.ts
+++ b/packages/opencode/src/git/index.ts
@@ -14,11 +14,10 @@ export namespace Git {
     "core.fsmonitor=false",
     "-c",
     "core.longpaths=true",
-    "-c",
-    "core.symlinks=true",
+    ...(process.platform !== "win32" ? ["-c", "core.symlinks=true"] : []),
     "-c",
     "core.quotepath=false",
-  ] as const
+  ]
 
   const out = (result: { text(): string }) => result.text().trim()
   const nuls = (text: string) => text.split("\0").filter(Boolean)


### PR DESCRIPTION
### Issue for this PR

Closes None

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Fixes false uncommitted changes shown in VCS panel on Windows git worktrees
- The `core.symlinks=true` config caused `git status` to report symlink files as type-changed on Windows
- Solution: conditionally set `core.symlinks=true` only on non-Windows platforms

### How did you verify your code works?

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR