### PR TITLE
refactor: make skill evolution silent like memory system

### DIFF
--- a/packages/opencode/src/skill-evolution/db.ts
+++ b/packages/opencode/src/skill-evolution/db.ts
@@ -1,0 +1,82 @@
+import { mkdirSync } from "fs"
+import path from "path"
+import { Database as BunSqlite } from "bun:sqlite"
+import { ulid } from "ulid"
+import { Global } from "@/global"
+
+let db: BunSqlite | null = null
+
+function dbPath() {
+  return path.join(Global.Path.data, "latest", "aether-skill-evolution.db")
+}
+
+function initDb(sqlite: BunSqlite) {
+  sqlite.exec("PRAGMA journal_mode = WAL")
+  sqlite.exec("PRAGMA synchronous = NORMAL")
+  sqlite.exec("PRAGMA busy_timeout = 5000")
+  sqlite.exec(`CREATE TABLE IF NOT EXISTS evolution_run (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL,
+    folder_name TEXT NOT NULL,
+    source_session_id TEXT NOT NULL,
+    started_at INTEGER NOT NULL,
+    completed_at INTEGER,
+    model TEXT,
+    tool_calls_json TEXT,
+    result_summary TEXT,
+    error TEXT
+  )`)
+  sqlite.exec("CREATE INDEX IF NOT EXISTS evolution_run_project_idx ON evolution_run(project_id)")
+  sqlite.exec("CREATE INDEX IF NOT EXISTS evolution_run_started_idx ON evolution_run(started_at)")
+  sqlite.exec("CREATE TABLE IF NOT EXISTS evolution_setting (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+  return sqlite
+}
+
+function openDb() {
+  if (db) return db
+  mkdirSync(path.dirname(dbPath()), { recursive: true })
+  const sqlite = initDb(new BunSqlite(dbPath(), { create: true }))
+  db = sqlite
+  return sqlite
+}
+
+export namespace EvolutionDb {
+  export function insertRun(input: {
+    projectId: string
+    folderName: string
+    sourceSessionId: string
+    model?: string
+  }): string {
+    const id = `evo_${ulid()}`
+    const sqlite = openDb()
+    sqlite
+      .prepare(
+        "INSERT INTO evolution_run (id, project_id, folder_name, source_session_id, started_at, model) VALUES (?, ?, ?, ?, ?, ?)",
+      )
+      .run(id, input.projectId, input.folderName, input.sourceSessionId, Date.now(), input.model ?? null)
+    return id
+  }
+
+  export function completeRun(
+    id: string,
+    result: {
+      toolCallsJson?: string
+      resultSummary?: string
+      error?: string
+    },
+  ) {
+    const sqlite = openDb()
+    sqlite
+      .prepare(
+        "UPDATE evolution_run SET completed_at = ?, tool_calls_json = ?, result_summary = ?, error = ? WHERE id = ?",
+      )
+      .run(Date.now(), result.toolCallsJson ?? null, result.resultSummary ?? null, result.error ?? null, id)
+  }
+
+  export function close() {
+    if (db) {
+      db.close()
+      db = null
+    }
+  }
+}

--- a/packages/opencode/src/skill-evolution/review-agent.ts
+++ b/packages/opencode/src/skill-evolution/review-agent.ts
@@ -1,80 +1,27 @@
 import fs from "fs/promises"
 import path from "path"
+import z from "zod"
+import { generateText, tool, jsonSchema, stepCountIs } from "ai"
 import { Global } from "@/global"
-import { Instance } from "@/project/instance"
 import { Spawner } from "./spawner"
 import { SKILL_REVIEW_PROMPT_BASE } from "./constants"
-import { Filesystem } from "@/util/filesystem"
 import { Log } from "@/util/log"
-import { Database } from "@/storage/db"
-import { ProjectIdentity } from "@/project/identity"
-import { Project } from "@/project/project"
-import { ProjectID } from "@/project/schema"
 import { SessionID } from "@/session/schema"
+import { Provider } from "@/provider/provider"
+import { ProviderTransform } from "@/provider/transform"
+import { Auth } from "@/auth"
+import { EvolutionDb } from "./db"
+import { SkillManageTool, SkillManageInput, SKILL_MANAGE_DESCRIPTION } from "./skill-manage-tool"
 
 const log = Log.create({ service: "skill-evolution.review-agent" })
-
-/** Directory treated as the skill-sessions project root. */
-const SKILL_SESSIONS_ROOT = path.join(Global.Path.home, ".aether", "skill-sessions")
 
 /** Projects with a review currently running, keyed by folderName. */
 const runningReviews = new Set<string>()
 /** Latest pending input per project, keyed by folderName. Overwritten on each new trigger. */
 const pendingReviews = new Map<string, { sessionID: SessionID; projectId: string; projectDirectory?: string }>()
 
-/** Maximum number of review rounds (user messages) per evolution session before rolling over. */
-const MAX_REVIEW_ROUNDS = 20
-
-/** Stable project ID for the skill-sessions project, derived from its directory path. */
-function skillSessionsProjectId(): ProjectID {
-  return ProjectID.fromDirectory(ProjectIdentity.norm(SKILL_SESSIONS_ROOT))
-}
-
-/**
- * Find the evolution session for this title in the skill-sessions DB.
- * If the session has reached MAX_REVIEW_ROUNDS user messages, deletes the oldest half to make room.
- * Returns undefined only when no session exists yet.
- */
-function findEvolutionSession(projectId: ProjectID, sessionTitle: string): SessionID | undefined {
-  const db = Database.projectClient(projectId)
-  const row = db.$client
-    .prepare(
-      "SELECT id FROM session WHERE project_id = ? AND title = ? ORDER BY time_created DESC LIMIT 1",
-    )
-    .get(projectId, sessionTitle) as { id: string } | undefined
-
-  if (!row) return undefined
-
-  const { cnt } = db.$client
-    .prepare(
-      "SELECT count(*) as cnt FROM message WHERE session_id = ? AND json_extract(data, '$.role') = 'assistant' AND json_extract(data, '$.finish') = 'stop'",
-    )
-    .get(row.id) as { cnt: number }
-
-  if (cnt >= MAX_REVIEW_ROUNDS) {
-    // Delete the oldest half of completed rounds to keep the session fresh.
-    // A round ends at an assistant message with finish='stop'; deleting up to
-    // the Nth such message's timestamp removes whole rounds, never partial ones.
-    // Part rows cascade-delete automatically via FK.
-    const deleteCount = Math.floor(MAX_REVIEW_ROUNDS / 2)
-    const boundary = db.$client
-      .prepare(
-        `SELECT time_created FROM message
-         WHERE session_id = ? AND json_extract(data, '$.role') = 'assistant' AND json_extract(data, '$.finish') = 'stop'
-         ORDER BY time_created ASC
-         LIMIT 1 OFFSET ?`,
-      )
-      .get(row.id, deleteCount - 1) as { time_created: number } | undefined
-
-    if (boundary) {
-      db.$client
-        .prepare("DELETE FROM message WHERE session_id = ? AND time_created <= ?")
-        .run(row.id, boundary.time_created)
-    }
-  }
-
-  return row.id as SessionID
-}
+/** Maximum number of tool-call steps the LLM may take in a single review. */
+const MAX_STEPS = 15
 
 /** Minimal snapshot of a message part used when serializing conversation history. */
 interface PartSnapshot {
@@ -120,10 +67,7 @@ function escapeXml(s: string): string {
  */
 async function collectCategories(folderName: string): Promise<string[]> {
   const categories = new Set<string>()
-  const dirsToScan = [
-    path.join(Global.Path.home, ".aether", "skills"),
-    Spawner.skillSessionsDir(folderName),
-  ]
+  const dirsToScan = [path.join(Global.Path.home, ".aether", "skills"), Spawner.skillSessionsDir(folderName)]
   for (const dir of dirsToScan) {
     const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => [])
     for (const entry of entries) {
@@ -144,24 +88,17 @@ async function collectCategories(folderName: string): Promise<string[]> {
 /**
  * Build the full review prompt for the background agent.
  */
-export async function buildReviewPrompt(
-  messages: ReadonlyArray<MessageSnapshot>,
-  folderName: string,
-): Promise<string> {
+export async function buildReviewPrompt(messages: ReadonlyArray<MessageSnapshot>, folderName: string): Promise<string> {
   const categories = await collectCategories(folderName)
   const categoryHint =
-    categories.length > 0
-      ? categories.map((c) => `  - ${c}`).join("\n") + "\n"
-      : "  (no existing categories yet)\n"
+    categories.length > 0 ? categories.map((c) => `  - ${c}`).join("\n") + "\n" : "  (no existing categories yet)\n"
   return [serializeHistory(messages), "", SKILL_REVIEW_PROMPT_BASE + categoryHint].join("\n")
 }
 
 /**
- * Spawn a background review session for the given conversation.
+ * Spawn a background skill evolution review using a direct LLM call (no Session/Instance).
  *
- * All review sessions for a project share a single evolution session in the skill-sessions
- * project (title: "<projectName> / skill-evolution"). When a session reaches MAX_REVIEW_ROUNDS
- * user messages it rolls over to a fresh one. Runs fire-and-forget; errors are logged only.
+ * Runs fire-and-forget; errors are logged only.
  */
 export async function spawnReview(input: {
   sessionID: SessionID
@@ -179,7 +116,6 @@ export async function spawnReview(input: {
   runningReviews.add(folderName)
 
   try {
-    // Read messages here (deferred) so callers don't pay the DB cost on every session end
     const { MessageV2 } = await import("@/session/message-v2")
     const rawMessages = await MessageV2.filterCompacted(MessageV2.stream(input.sessionID))
     const messages: MessageSnapshot[] = rawMessages.map((m) => ({
@@ -194,17 +130,7 @@ export async function spawnReview(input: {
 
     const prompt = await buildReviewPrompt(messages, folderName)
 
-    await fs.mkdir(SKILL_SESSIONS_ROOT, { recursive: true })
-    const skillProjectId = skillSessionsProjectId()
-    await Project.fromDirectory(SKILL_SESSIONS_ROOT)
-
-    // Dynamically import to avoid circular deps and keep startup cost low
-    const { Instance } = await import("@/project/instance")
-    const { SessionPrompt } = await import("@/session/prompt")
-    const { ToolRegistry } = await import("@/tool/registry")
-    const { createBoundSkillManageTool } = await import("./skill-manage-tool")
     const { Skill } = await import("@/skill")
-
     const allSkills = await Skill.all()
     const skillLocationMap: Record<string, string> = {}
     const skillSessionMap: Record<string, string> = {}
@@ -220,61 +146,103 @@ export async function spawnReview(input: {
       }
     }
 
-    const sessionTitle = folderName
-
     log.info("spawning skill evolution review", {
       parentSessionID: input.sessionID,
       projectId: input.projectId,
       folderName,
-      skillProjectId,
-      sessionTitle,
     })
 
-    // Run the review agent fire-and-forget inside the skill-sessions Instance context so that
-    // Session.get / MessageV2 reads+writes all target the skill-sessions DB.
-    let reviewSessionId: SessionID | undefined
-    Instance.provide({
-      directory: SKILL_SESSIONS_ROOT,
-      create: true,
-      fn: async () => {
-        const { Session } = await import("@/session")
-        const existing = findEvolutionSession(skillProjectId, sessionTitle)
-        reviewSessionId =
-          existing ??
-          (await Session.createNext({ title: sessionTitle, directory: SKILL_SESSIONS_ROOT })).id
+    void (async () => {
+      const runId = EvolutionDb.insertRun({
+        projectId: input.projectId,
+        folderName,
+        sourceSessionId: input.sessionID,
+      })
+      try {
+        const model = await Provider.defaultModel()
+        const resolved = await Provider.getModel(model.providerID, model.modelID)
+        const language = await Provider.getLanguage(resolved)
 
-        log.info(existing ? "reusing evolution session" : "created evolution session", {
-          reviewSessionId,
-          sessionTitle,
+        const skillManageSchema = ProviderTransform.schema(resolved, z.toJSONSchema(SkillManageInput as any))
+
+        const skillManageTool = tool({
+          description: SKILL_MANAGE_DESCRIPTION,
+          parameters: jsonSchema(skillManageSchema as any),
+          execute: async (params: any) => {
+            const resolvedLocation = params.skillLocation ?? skillLocationMap?.[params.name]
+            const resolvedSessionId =
+              params.sessionProjectId ?? skillSessionMap?.[params.name] ?? (!resolvedLocation ? folderName : undefined)
+            const result = await SkillManageTool.execute({
+              ...params,
+              skillLocation: resolvedLocation,
+              sessionProjectId: resolvedSessionId,
+            })
+            return JSON.stringify(result)
+          },
+        } as any)
+
+        const readTool = tool({
+          description: "Read the contents of a file at the given absolute path.",
+          parameters: jsonSchema({
+            type: "object" as const,
+            properties: {
+              filePath: { type: "string", description: "The absolute path to the file to read." },
+            },
+            required: ["filePath"],
+          }),
+          execute: async (params: any) => {
+            try {
+              const content = await fs.readFile(params.filePath, "utf-8")
+              return content
+            } catch (e) {
+              return `Error reading file: ${e instanceof Error ? e.message : String(e)}`
+            }
+          },
+        } as any)
+
+        const authInfo = await Auth.get(model.providerID)
+        const providerOptions =
+          authInfo?.type === "oauth" ? ProviderTransform.providerOptions(resolved, { store: false }) : undefined
+
+        const result = await generateText({
+          model: language,
+          system: SKILL_REVIEW_PROMPT_BASE,
+          messages: [{ role: "user" as const, content: prompt }],
+          tools: { skill_manage: skillManageTool, read: readTool },
+          stopWhen: stepCountIs(MAX_STEPS),
+          providerOptions,
         })
 
-        // Register skill_manage scoped to this review session only, so concurrent
-        // reviews for different projects don't overwrite each other's bound tool.
-        ToolRegistry.registerForSession(reviewSessionId, createBoundSkillManageTool(folderName, skillLocationMap, skillSessionMap))
-        try {
-          return await SessionPrompt.prompt({
-            sessionID: reviewSessionId,
-            parts: [{ type: "text", text: prompt }],
-            tools: {
-              "*": false,
-              skill_manage: true,
-              read: true,
-            },
-          })
-        } finally {
-          ToolRegistry.unregisterSession(reviewSessionId)
+        const toolCalls = result.steps
+          .flatMap((s) => s.toolCalls ?? [])
+          .map((tc) => ({ tool: tc.toolName, input: "input" in tc ? tc.input : undefined }))
+
+        const summary = result.text?.slice(0, 500) || "(no text output)"
+
+        EvolutionDb.completeRun(runId, {
+          toolCallsJson: JSON.stringify(toolCalls),
+          resultSummary: summary,
+        })
+
+        log.info("skill evolution review completed", {
+          runId,
+          folderName,
+          toolCallCount: toolCalls.length,
+        })
+      } catch (err) {
+        EvolutionDb.completeRun(runId, {
+          error: err instanceof Error ? err.message : String(err),
+        })
+        log.error("skill evolution review failed", { error: err, runId })
+      } finally {
+        runningReviews.delete(folderName)
+        const pending = pendingReviews.get(folderName)
+        if (pending) {
+          pendingReviews.delete(folderName)
+          spawnReview(pending)
         }
-      },
-    }).catch((err) => {
-      log.error("review session failed", { error: err, reviewSessionId })
-    }).finally(() => {
-      runningReviews.delete(folderName)
-      const pending = pendingReviews.get(folderName)
-      if (pending) {
-        pendingReviews.delete(folderName)
-        spawnReview(pending)
       }
-    })
+    })()
   } catch (err) {
     runningReviews.delete(folderName)
     log.error("failed to spawn review session", { error: err, sessionID: input.sessionID })
@@ -282,9 +250,7 @@ export async function spawnReview(input: {
 }
 
 export function isReviewSession(): boolean {
-  try {
-    return Instance.directory === Filesystem.resolve(SKILL_SESSIONS_ROOT)
-  } catch {
-    return false
-  }
+  // With the direct LLM approach there is no Instance context for review sessions,
+  // so this always returns false. Kept for API compatibility with the hook.
+  return false
 }

--- a/packages/opencode/src/skill-evolution/skill-manage-tool.ts
+++ b/packages/opencode/src/skill-evolution/skill-manage-tool.ts
@@ -35,7 +35,10 @@ function parseFrontmatter(content: string): { meta: Record<string, string>; body
     const colon = line.indexOf(":")
     if (colon === -1) continue
     const key = line.slice(0, colon).trim()
-    const val = line.slice(colon + 1).trim().replace(/^['"]|['"]$/g, "")
+    const val = line
+      .slice(colon + 1)
+      .trim()
+      .replace(/^['"]|['"]$/g, "")
     if (key) meta[key] = val
   }
   return { meta, body }
@@ -76,10 +79,11 @@ export const SkillManageInput = z.preprocess(
     return out
   },
   z.object({
-    action: z.enum(["create", "edit", "patch", "write_file", "delete", "history", "rollback"]).describe(
-      "Action to perform on a skill",
-    ),
-    name: z.string()
+    action: z
+      .enum(["create", "edit", "patch", "write_file", "delete", "history", "rollback"])
+      .describe("Action to perform on a skill"),
+    name: z
+      .string()
       .regex(/^[a-zA-Z0-9_-]+$/, "Skill name must only contain letters, numbers, hyphens, or underscores")
       .describe("Skill name (directory name under the skills folder). Required for all actions."),
     description: z
@@ -92,8 +96,16 @@ export const SkillManageInput = z.preprocess(
       .describe(
         "Short category label for grouping skills (e.g. 'Git', 'Testing', 'Refactoring'). Required for create and edit — always infer one from the skill content if not obvious.",
       ),
-    content: z.string().optional().describe("Full skill body (markdown, without frontmatter) for create/edit; file content for write_file."),
-    old_str: z.string().optional().describe("Exact text to replace (patch action). Read SKILL.md first if content is not already in context — never guess."),
+    content: z
+      .string()
+      .optional()
+      .describe("Full skill body (markdown, without frontmatter) for create/edit; file content for write_file."),
+    old_str: z
+      .string()
+      .optional()
+      .describe(
+        "Exact text to replace (patch action). Read SKILL.md first if content is not already in context — never guess.",
+      ),
     new_str: z.string().optional().describe("Replacement text (patch action)"),
     /** For write_file: name of the auxiliary file to write */
     filename: z.string().optional().describe("Auxiliary file name within the skill directory (for write_file)"),
@@ -120,7 +132,9 @@ const skillLocks = new Map<string, Promise<void>>()
 async function withSkillLock<T>(skillDir: string, fn: () => Promise<T>): Promise<T> {
   const prev = skillLocks.get(skillDir) ?? Promise.resolve()
   let resolve!: () => void
-  const current = new Promise<void>(r => { resolve = r })
+  const current = new Promise<void>((r) => {
+    resolve = r
+  })
   skillLocks.set(skillDir, current)
   await prev
   try {
@@ -166,11 +180,14 @@ export namespace SkillManageTool {
       if (!ShadowWriter.validateSkillLocation(input.skillLocation)) {
         throw new Error(
           `Unsafe skillLocation rejected: "${input.skillLocation}". ` +
-          `Must point to a file inside a <config-marker>/skills/ directory (e.g. .claude/skills/foo/SKILL.md).`,
+            `Must point to a file inside a <config-marker>/skills/ directory (e.g. .claude/skills/foo/SKILL.md).`,
         )
       }
       const originalDir = path.dirname(input.skillLocation)
-      const shadowExists = await fs.access(skillDir).then(() => true).catch(() => false)
+      const shadowExists = await fs
+        .access(skillDir)
+        .then(() => true)
+        .catch(() => false)
       if (!shadowExists) {
         await ShadowWriter.copyToShadowIfNeeded(originalDir, skillDir)
         await Versions.create(skillDir, "original")
@@ -231,7 +248,12 @@ export namespace SkillManageTool {
     const skillMd = path.join(skillDir, "SKILL.md")
     const oldContent = await fs.readFile(skillMd, "utf-8").catch(() => null)
     const existingCategory = oldContent ? parseFrontmatter(oldContent).meta.category : undefined
-    const fileContent = buildContent(input.name, input.description.trim(), input.content, input.category ?? existingCategory)
+    const fileContent = buildContent(
+      input.name,
+      input.description.trim(),
+      input.content,
+      input.category ?? existingCategory,
+    )
     await atomicWrite(skillMd, fileContent)
 
     return guardAndPublish(skillDir, "edit")
@@ -262,7 +284,8 @@ export namespace SkillManageTool {
 
   async function handleWriteFile(input: SkillManageInput): Promise<SkillManageResult> {
     if (!input.filename) return { ok: false, message: "filename is required for action=write_file" }
-    if (input.file_content === undefined) return { ok: false, message: "file_content is required for action=write_file" }
+    if (input.file_content === undefined)
+      return { ok: false, message: "file_content is required for action=write_file" }
     const skillDir = await resolveAndPrepare(input)
     const target = path.resolve(skillDir, input.filename)
     if (!target.startsWith(skillDir + path.sep)) {
@@ -275,7 +298,10 @@ export namespace SkillManageTool {
 
   async function handleDelete(input: SkillManageInput): Promise<SkillManageResult> {
     const skillDir = ShadowWriter.resolveSkillDir(input.name, input.skillLocation, input.sessionProjectId)
-    const exists = await fs.access(skillDir).then(() => true).catch(() => false)
+    const exists = await fs
+      .access(skillDir)
+      .then(() => true)
+      .catch(() => false)
     if (!exists) return { ok: false, message: `Skill directory not found: ${skillDir}` }
 
     await fs.rm(skillDir, { recursive: true, force: true })
@@ -289,9 +315,7 @@ export namespace SkillManageTool {
     const entries = await Versions.list(skillDir)
     if (entries.length === 0) return { ok: true, message: "No version history found", skillDir }
 
-    const lines = entries.map(
-      (e) => `  ${e.filename.replace(".bundle.json", "")}  (${e.action}, ${e.timestamp})`,
-    )
+    const lines = entries.map((e) => `  ${e.filename.replace(".bundle.json", "")}  (${e.action}, ${e.timestamp})`)
     return { ok: true, message: `Version history:\n${lines.join("\n")}`, skillDir }
   }
 
@@ -306,7 +330,7 @@ export namespace SkillManageTool {
   }
 }
 
-const SKILL_MANAGE_DESCRIPTION = [
+export const SKILL_MANAGE_DESCRIPTION = [
   "The sole tool for modifying skill files. Use instead of edit/write for any file under a skills/ directory.",
   "Create, edit, patch, delete, or version-manage skills (reusable procedural memories saved as SKILL.md files).",
   "",


### PR DESCRIPTION
## Summary

- Replace Session-based skill evolution review with direct LLM call via `generateText()`, bypassing Instance/Session/SessionPrompt so the UI no longer shows review sessions
- Add `aether-skill-evolution.db` for evolution run audit logging (evolution_run + evolution_setting tables)
- Export `SKILL_MANAGE_DESCRIPTION` from skill-manage-tool.ts to avoid duplication

## Before (problem)

`spawnReview()` created a real Session via `Instance.provide()` → `Session.createNext()` → `SessionPrompt.prompt()`, which broadcast `Session.Event.Created` to the UI — users saw a "skill-sessions" project pop up with review sessions, which was disruptive.

## After (fix)

Follow the same pattern as the memory system's `llmReflector()`: call `generateText()` directly with `Provider.defaultModel()` / `Provider.getModel()` / `Provider.getLanguage()`, with `skill_manage` and `read` as AI SDK tools. No Session/Instance is created, so the UI stays undisturbed. Results are recorded in `aether-skill-evolution.db` instead.

**Unchanged**: trigger mechanism (hook counter → `spawnReview`), prompt construction (`buildReviewPrompt` + `serializeHistory` + `collectCategories`), concurrency control, `skill_manage` tool logic.