### PR TITLE
fix: discard reasoning_content re-injection for DashScope providers

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -198,16 +198,15 @@ export namespace ProviderTransform {
 
     if (typeof model.capabilities.interleaved === "object" && model.capabilities.interleaved.field) {
       const field = model.capabilities.interleaved.field
+      const discard = ["alibaba-cn", "siliconflow-cn"].includes(model.providerID)
       return msgs.map((msg) => {
         if (msg.role === "assistant" && Array.isArray(msg.content)) {
           const reasoningParts = msg.content.filter((part: any) => part.type === "reasoning")
           const reasoningText = reasoningParts.map((part: any) => part.text).join("")
 
-          // Filter out reasoning parts from content
           const filteredContent = msg.content.filter((part: any) => part.type !== "reasoning")
 
-          // Include reasoning_content | reasoning_details directly on the message for all assistant messages
-          if (reasoningText) {
+          if (reasoningText && !discard) {
             return {
               ...msg,
               content: filteredContent,
@@ -413,8 +412,8 @@ export namespace ProviderTransform {
     const id = model.id.toLowerCase()
     const api = `${id} ${model.api.id.toLowerCase()}`
     const opus47 = ["opus-4-7", "opus-4.7"].some((v) => api.includes(v))
-    const isAnthropicAdaptive = ["opus-4-6", "opus-4.6", "opus-4-7", "opus-4.7", "sonnet-4-6", "sonnet-4.6"].some(
-      (v) => api.includes(v),
+    const isAnthropicAdaptive = ["opus-4-6", "opus-4.6", "opus-4-7", "opus-4.7", "sonnet-4-6", "sonnet-4.6"].some((v) =>
+      api.includes(v),
     )
     const adaptiveEfforts = opus47 ? ["low", "medium", "high", "xhigh", "max"] : ["low", "medium", "high", "max"]
     if (

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3034,7 +3034,51 @@ describe("ProviderTransform.message - consecutive assistant message merging", ()
       { type: "text", text: "text_before" },
       { type: "tool-call", toolCallId: "c1", toolName: "bash", input: { cmd: "ls" } },
     ])
-    expect((result[0] as any).providerOptions?.openaiCompatible?.reasoning_content).toBe("thinking1thinking2")
+    expect((result[0] as any).providerOptions?.openaiCompatible?.reasoning_content).toBeUndefined()
+  })
+
+  test("interleaved reasoning re-injection for non-DashScope providers", () => {
+    const otherModel = {
+      ...alibabaModel,
+      providerID: "aihubmix",
+    } as any
+
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "thinking1" },
+          { type: "text", text: "response_text" },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, otherModel, {})
+
+    expect(result[0].content).toEqual([{ type: "text", text: "response_text" }])
+    expect((result[0] as any).providerOptions?.openaiCompatible?.reasoning_content).toBe("thinking1")
+  })
+
+  test("siliconflow-cn also discards interleaved reasoning_content", () => {
+    const sfModel = {
+      ...alibabaModel,
+      providerID: "siliconflow-cn",
+    } as any
+
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "thinking1" },
+          { type: "text", text: "response_text" },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, sfModel, {})
+
+    expect(result[0].content).toEqual([{ type: "text", text: "response_text" }])
+    expect((result[0] as any).providerOptions?.openaiCompatible?.reasoning_content).toBeUndefined()
   })
 
   test("skips merge for Anthropic provider", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #909

### Type of change

- [x] Bug fix

### What does this PR do?

DashScope (alibaba-cn, siliconflow-cn) treats `reasoning_content` as a response-only field that cannot be used as input on assistant messages. The Aether `interleaved` logic currently re-injects historical reasoning into `providerOptions.openaiCompatible.reasoning_content`, which the SDK then spreads onto the message object. This illegal re-injection causes unpredictable model behavior (hallucination, ignoring user messages) for GLM and other models on DashScope.

The fix adds a `discard` flag for alibaba-cn/siliconflow-cn providers: reasoning parts are still removed from the content array, but they are **not** re-injected into `providerOptions`. This matches DashScope's default `preserve_thinking=false` behavior.

### How did you verify your code works?

- `bun typecheck` passes
- All 136 transform tests pass
- Updated existing test for alibaba-cn to expect discarded reasoning_content
- Added tests for aihubmix (still re-injects) and siliconflow-cn (discards)

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR