### PR TITLE
fix: override core.symlinks in File.status to prevent false dirty on Windows

### DIFF
--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -411,13 +411,10 @@ export namespace File {
     opts: {
       expectedChecksum?: string
     } = {},
-  ): Promise<
-    | void
-    | {
-        currentChecksum: string
-        currentContent: string
-      }
-  > {
+  ): Promise<void | {
+    currentChecksum: string
+    currentContent: string
+  }> {
     const resolved = path.join(Instance.directory, filePath)
     if (!Instance.containsPath(resolved)) {
       throw new Error("Access denied: path escapes project directory")
@@ -734,9 +731,22 @@ export namespace File {
 
         return yield* Effect.promise(async () => {
           const diffOutput = (
-            await Git.run(["-c", "core.fsmonitor=false", "-c", "core.quotepath=false", "diff", "--numstat", "HEAD"], {
-              cwd: Instance.directory,
-            })
+            await Git.run(
+              [
+                "-c",
+                "core.symlinks=false",
+                "-c",
+                "core.fsmonitor=false",
+                "-c",
+                "core.quotepath=false",
+                "diff",
+                "--numstat",
+                "HEAD",
+              ],
+              {
+                cwd: Instance.directory,
+              },
+            )
           ).text()
 
           const changed: File.Info[] = []
@@ -756,6 +766,8 @@ export namespace File {
           const untrackedOutput = (
             await Git.run(
               [
+                "-c",
+                "core.symlinks=false",
                 "-c",
                 "core.fsmonitor=false",
                 "-c",
@@ -789,6 +801,8 @@ export namespace File {
           const deletedOutput = (
             await Git.run(
               [
+                "-c",
+                "core.symlinks=false",
                 "-c",
                 "core.fsmonitor=false",
                 "-c",


### PR DESCRIPTION
### Issue for this PR

Closes #913

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `-c core.symlinks=false` to all three git commands (`diff --numstat`, `ls-files --others`, `ls-files --deleted`) in `File.status`. On Windows, git's default symlink handling causes false positives in dirty detection — files appear modified even when no changes were made. Explicitly setting `core.symlinks=false` prevents git from treating symlink differences as file changes.

### How did you verify your code works?

Verified locally on Windows that files no longer show as dirty after the fix.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR