### PR TITLE
fix: make question answers selectable/copyable in message part

### DIFF
--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -708,6 +708,7 @@
 [data-component="write-content"],
 [data-component="todos"],
 [data-component="diagnostics"],
+[data-component="question-answers"],
 .error-card {
   -webkit-user-select: text;
   user-select: text;


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [x] Bug fix

### What does this PR do?

After a question tool is replied, both the question text and the answer text inside `[data-component="question-answers"]` were not selectable/copyable. This PR adds `[data-component="question-answers"]` to the `user-select: text` CSS rule so that the content becomes selectable and copyable.

### How did you verify your code works?

Verified the CSS selector list now includes `[data-component="question-answers"]` alongside other already-selectable components.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR