### PR TITLE
fix: reduce browser SSE connection slot usage to resolve persistent red-dot status

### DIFF
--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -15,6 +15,7 @@ import {
 import { useLanguage } from "./language"
 import { usePlatform } from "./platform"
 import { useServer } from "./server"
+import { connectShared } from "./shared-connection"
 
 const abortError = z.object({
   name: z.literal("AbortError"),
@@ -57,11 +58,6 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       }
     }
 
-    const eventSdk = createSdkForServer({
-      signal: abort.signal,
-      fetch: eventFetch,
-      server: currentServer.http,
-    })
     const emitter = createGlobalEmitter<{
       [key: string]: Event
     }>()
@@ -123,7 +119,6 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       timer = setTimeout(flush, Math.max(0, FLUSH_FRAME_MS - elapsed))
     }
 
-    let streamErrorLogged = false
     const wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
     const aborted = (error: unknown) => abortError.safeParse(error).success
 
@@ -152,25 +147,24 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
           attempt?.abort()
         }
         abort.signal.addEventListener("abort", onAbort)
+        const conn = connectShared({
+          server: currentServer.http,
+          fetch: eventFetch,
+          signal: attempt.signal,
+          onSseError: (error) => {
+            if (aborted(error)) return
+            console.error("[global-sdk] event stream error", {
+              url: currentServer.http.url,
+              fetch: eventFetch ? "platform" : "webview",
+              error,
+            })
+          },
+        })
         try {
-          const events = await eventSdk.global.event({
-            signal: attempt.signal,
-            onSseError: (error) => {
-              if (aborted(error)) return
-              if (streamErrorLogged) return
-              streamErrorLogged = true
-              console.error("[global-sdk] event stream error", {
-                url: currentServer.http.url,
-                fetch: eventFetch ? "platform" : "webview",
-                error,
-              })
-            },
-          })
           let yielded = Date.now()
           resetHeartbeat()
-          for await (const event of events.stream) {
+          for await (const event of conn.stream) {
             resetHeartbeat()
-            streamErrorLogged = false
             const directory = event.directory ?? "global"
             const payload = event.payload
             const k = key(directory, payload)
@@ -194,8 +188,7 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
             await wait(0)
           }
         } catch (error) {
-          if (!aborted(error) && !streamErrorLogged) {
-            streamErrorLogged = true
+          if (!aborted(error)) {
             console.error("[global-sdk] event stream failed", {
               url: currentServer.http.url,
               fetch: eventFetch ? "platform" : "webview",
@@ -203,6 +196,7 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
             })
           }
         } finally {
+          conn.destroy()
           abort.signal.removeEventListener("abort", onAbort)
           attempt = undefined
           clearHeartbeat()

--- a/packages/app/src/context/mobile.ts
+++ b/packages/app/src/context/mobile.ts
@@ -81,13 +81,6 @@ interface MobileEvent {
   }
 }
 
-const sseControllers: Record<MobilePlatform, AbortController | null> = { feishu: null, qq: null, wechat: null }
-const sseRetryTimers: Record<MobilePlatform, ReturnType<typeof setTimeout> | undefined> = {
-  feishu: undefined,
-  qq: undefined,
-  wechat: undefined,
-}
-const pingTimer: ReturnType<typeof setInterval> | undefined = undefined
 let clientId: string | null = null
 let pingInterval: ReturnType<typeof setInterval> | undefined
 let pingFails = 0
@@ -104,138 +97,64 @@ const api = () => {
   return resolve()
 }
 
-function connectSSE(p: MobilePlatform) {
-  const abort = sseControllers[p]
-  if (abort) abort.abort()
-  const retry = sseRetryTimers[p]
-  if (retry !== undefined) {
-    clearTimeout(retry)
-    sseRetryTimers[p] = undefined
-  }
-  sseControllers[p] = new AbortController()
+type Emitter = {
+  listen: (cb: (e: { name: string; details: { type: string; properties: any } }) => void) => () => void
+}
+let emitter: Emitter | null = null
 
-  void (async () => {
-    try {
-      const { url, headers } = api()
-      const prefix = `/mobile/${p}`
-      const sseUrl =
-        p === "wechat" && clientId
-          ? `${url}${prefix}/events?clientId=${encodeURIComponent(clientId)}`
-          : `${url}${prefix}/events`
-      const response = await fetch(sseUrl, {
-        headers: { ...headers, Accept: "text/event-stream" },
-        signal: sseControllers[p]!.signal,
-      })
-      if (!response.ok || !response.body) {
-        const s = prev(p).status
-        if (s !== "idle" && s !== "error" && s !== "stolen") updateStatus(p, "reconnecting")
-        scheduleSseRetry(p)
+export function bindEmitter(e: Emitter) {
+  if (emitter) return
+  emitter = e
+  emitter.listen((ev) => {
+    const type = ev.details.type as string
+    const props = ev.details.properties
+    for (const p of ["wechat", "feishu", "qq"] as const) {
+      if (type.startsWith(`${p}.`)) {
+        handleMobileEvent(p, type, props)
         return
       }
-
-      if (prev(p).status === "reconnecting") updateStatus(p, "connected")
-
-      const reader = response.body.getReader()
-      const decoder = new TextDecoder()
-      let buf = ""
-
-      while (true) {
-        const { done, value } = await reader.read()
-        if (done) break
-        buf += decoder.decode(value, { stream: true })
-
-        const lines = buf.split("\n")
-        buf = lines.pop() ?? ""
-        for (const line of lines) {
-          if (!line.startsWith("data:")) continue
-          const raw = line.slice(5).trim()
-          if (!raw) continue
-          try {
-            const event: MobileEvent = JSON.parse(raw)
-            const type = event.type
-            const props = event.properties
-
-            if (type.endsWith(".qrcode") && props.image) {
-              patch(p, { qrcode: props.image, status: "qrcode" })
-            } else if (type.endsWith(".connected")) {
-              const u: Partial<PlatformState> = { status: "connected", error: null }
-              if (props.appId) u.appId = props.appId
-              if (props.user) u.user = props.user
-              patch(p, u)
-              setAutoConnect(p, true)
-              clearSseRetry(p)
-            } else if (type.endsWith(".reconnecting")) {
-              updateStatus(p, "reconnecting")
-              patch(p, {
-                loadingMsg:
-                  p === "feishu"
-                    ? "飞书连接中断，正在自动重连..."
-                    : p === "qq"
-                      ? "QQ连接中断，正在自动重连..."
-                      : "正在重新连接微信...",
-              })
-            } else if (type.endsWith(".error")) {
-              patch(p, {
-                error: { code: props.code || "unknown", message: props.message || "未知错误" },
-                status: "error",
-              })
-            } else if (type.endsWith(".status") && props.status) {
-              const s = props.status === "starting" ? "loading" : (props.status as MobileStatus)
-              const cur = prev(p).status
-              if (
-                s === "idle" &&
-                (cur === "loading" ||
-                  cur === "reconnecting" ||
-                  cur === "qrcode" ||
-                  cur === "connected" ||
-                  cur === "config")
-              )
-                continue
-              const u: Partial<PlatformState> = { status: s }
-              if (props.message) u.loadingMsg = props.message
-              if (props.appId) u.appId = props.appId
-              if (props.user) u.user = props.user
-              if (s === "connected") clearSseRetry(p)
-              patch(p, u)
-            }
-          } catch {}
-        }
-      }
-
-      const s = prev(p).status
-      if (p === "wechat") {
-        if (s !== "idle" && s !== "error" && s !== "stolen") scheduleSseRetry(p)
-      } else if (s !== "idle" && s !== "error" && s !== "stolen") {
-        updateStatus(p, "reconnecting")
-        scheduleSseRetry(p)
-      }
-    } catch {
-      const s = prev(p).status
-      if (p === "wechat") {
-        if (s !== "idle" && s !== "error" && s !== "stolen") scheduleSseRetry(p)
-      } else if (s !== "idle" && s !== "error" && s !== "stolen") {
-        updateStatus(p, "reconnecting")
-        scheduleSseRetry(p)
-      }
     }
-  })()
+  })
 }
 
-function clearSseRetry(p: MobilePlatform) {
-  const t = sseRetryTimers[p]
-  if (t !== undefined) {
-    clearTimeout(t)
-    sseRetryTimers[p] = undefined
+function handleMobileEvent(p: MobilePlatform, type: string, props: any) {
+  if (type.endsWith(".qrcode") && props.image) {
+    patch(p, { qrcode: props.image, status: "qrcode" })
+  } else if (type.endsWith(".connected")) {
+    const u: Partial<PlatformState> = { status: "connected", error: null }
+    if (props.appId) u.appId = props.appId
+    if (props.user) u.user = props.user
+    patch(p, u)
+    setAutoConnect(p, true)
+  } else if (type.endsWith(".reconnecting")) {
+    updateStatus(p, "reconnecting")
+    patch(p, {
+      loadingMsg:
+        p === "feishu"
+          ? "飞书连接中断，正在自动重连..."
+          : p === "qq"
+            ? "QQ连接中断，正在自动重连..."
+            : "正在重新连接微信...",
+    })
+  } else if (type.endsWith(".error")) {
+    patch(p, {
+      error: { code: props.code || "unknown", message: props.message || "未知错误" },
+      status: "error",
+    })
+  } else if (type.endsWith(".status") && props.status) {
+    const s = props.status === "starting" ? "loading" : (props.status as MobileStatus)
+    const cur = prev(p).status
+    if (
+      s === "idle" &&
+      (cur === "loading" || cur === "reconnecting" || cur === "qrcode" || cur === "connected" || cur === "config")
+    )
+      return
+    const u: Partial<PlatformState> = { status: s }
+    if (props.message) u.loadingMsg = props.message
+    if (props.appId) u.appId = props.appId
+    if (props.user) u.user = props.user
+    patch(p, u)
   }
-}
-
-function scheduleSseRetry(p: MobilePlatform) {
-  if (sseRetryTimers[p] !== undefined) return
-  sseRetryTimers[p] = setTimeout(() => {
-    sseRetryTimers[p] = undefined
-    const s = prev(p).status
-    if (s !== "idle" && s !== "error" && s !== "stolen") connectSSE(p)
-  }, 3000)
 }
 
 function startPing(p: MobilePlatform) {
@@ -254,11 +173,6 @@ function startPing(p: MobilePlatform) {
       pingFails = 0
       if (data.stolen) {
         stopPing()
-        if (sseControllers.wechat) {
-          sseControllers.wechat.abort()
-          sseControllers.wechat = null
-        }
-        clearSseRetry("wechat")
         patch("wechat", { status: "stolen" })
       }
     } catch {
@@ -316,14 +230,11 @@ export async function fetchStatus(p: MobilePlatform) {
       patch(p, u)
       setAutoConnect(p, true)
       startPing(p)
-      connectSSE(p)
     } else if (data.status === "qrcode" && data.qrcode) {
       patch(p, { qrcode: data.qrcode, status: "qrcode" })
       startPing(p)
-      connectSSE(p)
     } else if (data.status === "reconnecting") {
       patch(p, { status: "reconnecting" })
-      connectSSE(p)
     } else if (data.error) {
       patch(p, { error: data.error, status: "error" })
     } else if (p === "feishu" && data.hasConfig) {
@@ -353,8 +264,6 @@ export async function startBridge(
   })
 
   if (p === "wechat") clientId = clientId || crypto.randomUUID()
-
-  connectSSE(p)
 
   try {
     const { url, headers } = api()
@@ -414,12 +323,6 @@ export async function startBridge(
 
 export async function stopBridge(p: MobilePlatform) {
   setAutoConnect(p, false)
-  const abort = sseControllers[p]
-  if (abort) {
-    abort.abort()
-    sseControllers[p] = null
-  }
-  clearSseRetry(p)
   if (p === "wechat") stopPing()
   try {
     const { url, headers } = api()
@@ -437,12 +340,6 @@ export async function stopBridge(p: MobilePlatform) {
 }
 
 export async function logout(p: MobilePlatform) {
-  const abort = sseControllers[p]
-  if (abort) {
-    abort.abort()
-    sseControllers[p] = null
-  }
-  clearSseRetry(p)
   if (p === "wechat") stopPing()
   const { url, headers } = api()
   const prefix = `/mobile/${p}`
@@ -463,7 +360,6 @@ export async function retryBridge(p: MobilePlatform) {
   if (p === "qq") return startBridge(p)
   patch(p, { status: "reconnecting", loadingMsg: "正在重新连接飞书...", error: null })
   patch(p, { status: "reconnecting", loadingMsg: "正在重新连接微信...", error: null })
-  connectSSE(p)
   try {
     const { url, headers } = api()
     const res = await fetch(`${url}/mobile/wechat/retry`, {

--- a/packages/app/src/context/shared-connection.ts
+++ b/packages/app/src/context/shared-connection.ts
@@ -1,0 +1,137 @@
+import type { Event } from "@opencode-ai/sdk/v2/client"
+import { createSdkForServer } from "@/utils/server"
+import type { ServerConnection } from "@/context/server"
+
+type SSEvent = { directory?: string; payload: Event }
+
+type Msg = { kind: "event"; data: SSEvent } | { kind: "heartbeat"; id: string } | { kind: "claim"; id: string }
+
+type Opts = {
+  server: ServerConnection.HttpBase
+  fetch?: typeof globalThis.fetch
+  signal: AbortSignal
+  onSseError?: (error: unknown) => void
+}
+
+type Conn = {
+  stream: AsyncIterable<SSEvent>
+  destroy: () => void
+}
+
+const CHANNEL = "aether:sse"
+const HB_MS = 2000
+const TIMEOUT_MS = 5000
+
+function uid() {
+  return Math.random().toString(36).slice(2) + Date.now().toString(36)
+}
+
+function sleep(ms: number) {
+  return new Promise<void>((r) => setTimeout(r, ms))
+}
+
+export function connectShared(opts: Opts): Conn {
+  if (typeof BroadcastChannel === "undefined") return connectDirect(opts)
+
+  const ch = new BroadcastChannel(CHANNEL)
+  const id = uid()
+  let dead = false
+  let wake: (() => void) | undefined
+
+  const destroy = () => {
+    dead = true
+    ch.close()
+    wake?.()
+  }
+
+  opts.signal.addEventListener("abort", destroy, { once: true })
+
+  const notify = () => wake?.()
+
+  async function* run(): AsyncGenerator<SSEvent> {
+    if (dead || opts.signal.aborted) return
+
+    ch.postMessage({ kind: "claim", id } satisfies Msg)
+    await sleep(500)
+    if (dead) return
+
+    let isLeader = true
+    const detect = (e: MessageEvent<Msg>) => {
+      if (e.data.kind === "heartbeat" && e.data.id !== id) isLeader = false
+    }
+    ch.addEventListener("message", detect)
+    await sleep(500)
+    ch.removeEventListener("message", detect)
+    if (dead) return
+
+    if (isLeader) {
+      const hb = setInterval(() => ch.postMessage({ kind: "heartbeat", id } satisfies Msg), HB_MS)
+      try {
+        const sdk = createSdkForServer({ server: opts.server, fetch: opts.fetch, signal: opts.signal })
+        const result = await sdk.global.event({ signal: opts.signal, onSseError: opts.onSseError })
+        for await (const ev of result.stream) {
+          if (dead) return
+          ch.postMessage({ kind: "event", data: ev as SSEvent } satisfies Msg)
+          yield ev as SSEvent
+        }
+      } finally {
+        clearInterval(hb)
+      }
+    } else {
+      const q: SSEvent[] = []
+      let timer: ReturnType<typeof setTimeout> | undefined
+
+      const resetTimer = () => {
+        if (timer) clearTimeout(timer)
+        timer = setTimeout(notify, TIMEOUT_MS)
+      }
+
+      const onMsg = (e: MessageEvent<Msg>) => {
+        const msg = e.data
+        if (msg.kind === "event") {
+          q.push(msg.data)
+          notify()
+        } else if (msg.kind === "heartbeat") {
+          resetTimer()
+        }
+      }
+      ch.addEventListener("message", onMsg)
+      resetTimer()
+
+      try {
+        while (!dead) {
+          if (q.length > 0) {
+            yield q.shift()!
+            continue
+          }
+          await new Promise<void>((r) => (wake = r))
+          wake = undefined
+        }
+      } finally {
+        if (timer) clearTimeout(timer)
+        ch.removeEventListener("message", onMsg)
+      }
+    }
+  }
+
+  return { stream: { [Symbol.asyncIterator]: run }, destroy }
+}
+
+function connectDirect(opts: Opts): Conn {
+  let ctrl: AbortController | undefined
+  return {
+    stream: {
+      async *[Symbol.asyncIterator]() {
+        ctrl = new AbortController()
+        const link = new AbortController()
+        opts.signal.addEventListener("abort", () => link.abort(), { once: true })
+        const sdk = createSdkForServer({ server: opts.server, fetch: opts.fetch, signal: link.signal })
+        const result = await sdk.global.event({ signal: link.signal, onSseError: opts.onSseError })
+        for await (const ev of result.stream) yield ev as SSEvent
+      },
+    },
+    destroy() {
+      ctrl?.abort()
+    },
+  }
+}

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -65,7 +65,7 @@ import { DialogEditProject } from "@/components/dialog-edit-project"
 import { DebugBar } from "@/components/debug-bar"
 import { Titlebar } from "@/components/titlebar"
 import { useServer } from "@/context/server"
-import { bindResolver, initMobile } from "@/context/mobile"
+import { bindResolver, bindEmitter, initMobile } from "@/context/mobile"
 import { useLanguage, type Locale } from "@/context/language"
 import { actionOf, messageOf } from "@/utils/web-update"
 import {
@@ -132,6 +132,7 @@ export default function Layout(props: ParentProps) {
       : { Authorization: `Basic ${btoa(`${s.username ?? "opencode"}:${s.password}`)}` }
     return { url: globalSDK.url, headers }
   })
+  bindEmitter(globalSDK.event)
   initMobile("wechat")
   initMobile("feishu")
   initMobile("qq")


### PR DESCRIPTION
### Issue for this PR

Closes #918

### Type of change

- [x] Bug fix

### What does this PR do?

Two changes to reduce browser HTTP/1.1 connection slot consumption:

**1. Merge mobile SSE into global event stream** (`mobile.ts`, `layout.tsx`)

Mobile platforms (wechat/feishu/qq) each opened independent SSE connections to `/mobile/*/events`. These events are already published via `Bus.publish` → `GlobalBus` → `/global/event`. Removed per-platform SSE connections and instead listen on the existing global event emitter for `wechat.*`/`feishu.*`/`qq.*` events. Reduces persistent connections from 4 to 1.

**2. Share SSE across browser tabs via BroadcastChannel** (`shared-connection.ts`, `global-sdk.tsx`)

Multiple browser tabs each opened their own SSE to `/global/event`. Added a BroadcastChannel-based leader election: only one tab (leader) holds the actual SSE connection and broadcasts events to follower tabs. Leader sends heartbeats every 2s; followers detect leader death within 5s and elect a new leader. Falls back to per-tab SSE if BroadcastChannel is unsupported.

| Scenario | Before | After |
|----------|--------|-------|
| 1 tab + 3 mobile | 4 SSE connections | 1 SSE |
| 3 tabs + 3 mobile | 7 SSE connections | 1 SSE |

### How did you verify your code works?

- `bun typecheck` passes in `packages/app`
- Code review of event flow: mobile events confirmed to flow through `Bus.publish` → `GlobalBus` → `/global/event` SSE

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR