### PR TITLE
fix(app): 提升会话树非当前分支文字可读性

### DIFF
--- a/packages/app/src/pages/session/branch/conversation-graph-list.tsx
+++ b/packages/app/src/pages/session/branch/conversation-graph-list.tsx
@@ -155,7 +155,7 @@ export function ConversationGraphList(props: {
                       "text-text-strong": node.isCurrentPath,
                       "text-text-weaker": !node.isCurrentPath,
                       "font-semibold": node.isCurrentPath,
-                      "opacity-30": !node.isCurrentPath,
+                      "opacity-100": !node.isCurrentPath,
                       italic: node.kind === "bud",
                     }}
                   >

--- a/packages/app/src/pages/session/branch/conversation-graph-list.vitest.tsx
+++ b/packages/app/src/pages/session/branch/conversation-graph-list.vitest.tsx
@@ -184,7 +184,7 @@ describe("ConversationGraphList path text highlighting", () => {
     expect(rowLabel(host, "1+1")?.className).toContain("text-text-strong")
     expect(rowLabel(host, "2+2")?.className).toContain("text-text-strong")
     expect(rowLabel(host, "3+3")?.className).toContain("text-text-weaker")
-    expect(rowLabel(host, "3+3")?.className).toContain("opacity-30")
+    expect(rowLabel(host, "3+3")?.className).toContain("opacity-100")
 
     off()
   })
@@ -222,9 +222,9 @@ describe("ConversationGraphList path text highlighting", () => {
 
     expect(rowLabel(host, "1+1")?.className).toContain("font-semibold")
     expect(rowLabel(host, "2+2")?.className).toContain("font-semibold")
-    expect(rowLabel(host, "1+1")?.className).not.toContain("opacity-30")
-    expect(rowLabel(host, "2+2")?.className).not.toContain("opacity-30")
-    expect(rowLabel(host, "3+3")?.className).toContain("opacity-30")
+    expect(rowLabel(host, "1+1")?.className).not.toContain("opacity-100")
+    expect(rowLabel(host, "2+2")?.className).not.toContain("opacity-100")
+    expect(rowLabel(host, "3+3")?.className).toContain("opacity-100")
 
     expect(edgePath(host, "root-1->child-current")?.getAttribute("opacity")).toBe("1")
     expect(edgePath(host, "root-1->child-sibling")?.getAttribute("opacity")).toBe("0.4")


### PR DESCRIPTION
### Issue for this PR

Closes #921

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

本次 PR 调整会话树中非当前分支右侧用户消息的可读性。此前非当前分支文字同时使用 `text-text-weaker` 和 `opacity-30`，在默认主题下会显得过暗。

这次改动将非当前分支文字的 opacity 提升到 `opacity-100`，保留 `text-text-weaker` 作为当前分支与非当前分支的层级区分。当前分支仍然使用 `text-text-strong` 和 `font-semibold` 强调，因此当前路径和其他分支仍有明确视觉差异。

同时更新了会话树组件测试中的样式断言，确保非当前分支文字保持新的可读性设置。

### How did you verify your code works?

- 本地运行会话树组件测试：`bun run ./script/vitest.ts run --config ./vitest.config.ts ./src/pages/session/branch/conversation-graph-list.vitest.tsx`
- 推送前通过 pre-push typecheck：`bun turbo typecheck`

### Screenshots / recordings

- 本次是会话树文字可读性微调，已结合本地界面检查默认主题下的显示效果。

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR