### PR TITLE
fix: prevent server crash when deleting workspace

### DIFF
--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -8,7 +8,6 @@ import { networkInterfaces } from "os"
 import { Global } from "../../global"
 import { Database } from "../../storage/db"
 import nodePath from "path"
-import { Log } from "../../util/log"
 import { Lease } from "../../server/lease"
 import { Instance } from "../../project/instance"
 import { FeishuManager } from "../../mobile/feishu"
@@ -118,15 +117,6 @@ export const WebCommand = cmd({
   builder: (yargs) => withNetworkOptions(yargs),
   describe: "start opencode server and open web interface",
   handler: async (args) => {
-    process.on("uncaughtException", (e) => {
-      Log.Default.error("uncaught exception in web server", { error: e instanceof Error ? e.stack : String(e) })
-    })
-    process.on("unhandledRejection", (e) => {
-      Log.Default.error("unhandled rejection in web server", { error: e instanceof Error ? e.stack : String(e) })
-    })
-    process.on("exit", (code) => {
-      Log.Default.error("process exiting", { code })
-    })
     async function gracefulShutdown(server: { stop: (close?: boolean) => Promise<void> }) {
       const FORCE_EXIT_MS = 10_000
       const timer = setTimeout(() => {

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -8,6 +8,7 @@ import { networkInterfaces } from "os"
 import { Global } from "../../global"
 import { Database } from "../../storage/db"
 import nodePath from "path"
+import { Log } from "../../util/log"
 import { Lease } from "../../server/lease"
 import { Instance } from "../../project/instance"
 import { FeishuManager } from "../../mobile/feishu"
@@ -117,6 +118,15 @@ export const WebCommand = cmd({
   builder: (yargs) => withNetworkOptions(yargs),
   describe: "start opencode server and open web interface",
   handler: async (args) => {
+    process.on("uncaughtException", (e) => {
+      Log.Default.error("uncaught exception in web server", { error: e instanceof Error ? e.stack : String(e) })
+    })
+    process.on("unhandledRejection", (e) => {
+      Log.Default.error("unhandled rejection in web server", { error: e instanceof Error ? e.stack : String(e) })
+    })
+    process.on("exit", (code) => {
+      Log.Default.error("process exiting", { code })
+    })
     async function gracefulShutdown(server: { stop: (close?: boolean) => Promise<void> }) {
       const FORCE_EXIT_MS = 10_000
       const timer = setTimeout(() => {

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -140,7 +140,7 @@ export namespace Workspace {
     if (row) {
       const info = fromRow(row)
       const adaptor = await getAdaptor(row.type)
-      adaptor.remove(info)
+      await adaptor.remove(info)
       Database.useProject(Instance.project.id, (db) => db.delete(WorkspaceTable).where(eq(WorkspaceTable.id, id)).run())
       return info
     }

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -22,15 +22,19 @@ const disposal = {
 }
 
 function emit(directory: string) {
-  GlobalBus.emit("event", {
-    directory,
-    payload: {
-      type: "server.instance.disposed",
-      properties: {
-        directory,
+  try {
+    GlobalBus.emit("event", {
+      directory,
+      payload: {
+        type: "server.instance.disposed",
+        properties: {
+          directory,
+        },
       },
-    },
-  })
+    })
+  } catch (e) {
+    Log.Default.error("emit instance disposed failed", { directory, error: e instanceof Error ? e.message : e })
+  }
 }
 
 function boot(input: { directory: string; init?: () => Promise<any>; project?: Project.Info; worktree?: string }) {
@@ -173,7 +177,11 @@ export const Instance = {
     const directory = Instance.directory
     const projectId = Instance.project.id
     Log.Default.info("disposing instance", { directory })
-    await Promise.all([State.dispose(directory), disposeInstance(directory)])
+    try {
+      await Promise.all([State.dispose(directory), disposeInstance(directory)])
+    } catch (e) {
+      Log.Default.error("instance dispose failed", { directory, error: e instanceof Error ? e.message : e })
+    }
     Database.detach(projectId)
     cache.delete(directory)
     emit(directory)
@@ -188,7 +196,11 @@ export const Instance = {
       return
     }
     Log.Default.info("disposing instance by directory", { directory: dir })
-    await Promise.all([State.dispose(dir), disposeInstance(dir)])
+    try {
+      await Promise.all([State.dispose(dir), disposeInstance(dir)])
+    } catch (e) {
+      Log.Default.error("instance dispose failed", { directory: dir, error: e instanceof Error ? e.message : e })
+    }
     Database.detach(ctx.project.id)
     if (cache.get(dir) === entry) cache.delete(dir)
     emit(dir)

--- a/packages/opencode/src/server/routes/event.ts
+++ b/packages/opencode/src/server/routes/event.ts
@@ -67,9 +67,6 @@ export function EventRoutes(onBrowserConnectionChange?: (count: number) => void)
 
         const unsub = Bus.subscribeAll((event) => {
           q.push(JSON.stringify(event))
-          if (event.type === Bus.InstanceDisposed.type) {
-            stop()
-          }
         })
 
         stream.onAbort(stop)

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -514,7 +514,11 @@ export namespace Database {
     const client = projectClients.get(projectId)
     if (!client) return
     log.info("closing project database", { projectId })
-    client.$client.close()
+    try {
+      client.$client.close()
+    } catch (e) {
+      log.warn("failed to close project database", { projectId, error: e instanceof Error ? e.message : e })
+    }
     projectClients.delete(projectId)
   }
 

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -516,7 +516,6 @@ export namespace Database {
     log.info("closing project database", { projectId })
     try {
       client.$client.close()
-      log.info("closed project database", { projectId })
     } catch (e) {
       log.warn("failed to close project database", { projectId, error: e instanceof Error ? e.message : e })
     }

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -516,6 +516,7 @@ export namespace Database {
     log.info("closing project database", { projectId })
     try {
       client.$client.close()
+      log.info("closed project database", { projectId })
     } catch (e) {
       log.warn("failed to close project database", { projectId, error: e instanceof Error ? e.message : e })
     }

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -394,6 +394,10 @@ export namespace Worktree {
       function disposeAndClean(target: string) {
         return Effect.promise(() => Instance.disposeDirectory(target)).pipe(
           Effect.flatMap(() => cleanDirectory(target)),
+          Effect.catchCause((cause) => {
+            log.error("disposeAndClean failed", { target, cause: String(cause) })
+            return Effect.void
+          }),
         )
       }
 
@@ -425,6 +429,7 @@ export namespace Worktree {
             : false
 
           if (hasOrphanedDb) {
+            Database.detach(staleId)
             const dbPath = Database.projectPath(staleId)
             for (const suffix of ["", "-wal", "-shm"]) {
               const p = dbPath + suffix


### PR DESCRIPTION
### Issue for this PR

Closes #925

### Type of change

- [x] Bug fix

### What does this PR do?

Adds error resilience across the workspace deletion pipeline to prevent the backend process from crashing. Key changes:

1. **`event.ts`**: Removed `InstanceDisposed → stop()` logic so SSE connections stay alive when a workspace is disposed
2. **`workspace.ts`**: Added `await` to `adaptor.remove(info)` to prevent unhandled promise rejections
3. **`instance.ts`**: Added try-catch in `dispose()` and `disposeDirectory()` so disposal failures only log errors instead of crashing; wrapped `emit()` (GlobalBus.emit) in try-catch to prevent listener exceptions from propagating
4. **`db.ts`**: Added try-catch in `Database.detach` around `client.$client.close()` to handle DB close failures gracefully
5. **`worktree/index.ts`**: Added `Effect.catchCause` to `disposeAndClean` so any Effect-level failure is logged and swallowed instead of crashing; added `Database.detach(staleId)` before deleting orphaned DB files in force mode to prevent SQLite WAL conflicts

### How did you verify your code works?

- `bun typecheck` passes from `packages/opencode`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR