### PR TITLE
fix: red-dot false impression, slow recovery, and connection slot exhaustion

### DIFF
--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -211,6 +211,7 @@ beforeAll(async () => {
   mock.module("@/context/server", () => ({
     useServer: () => ({
       current: undefined,
+      healthy: () => true,
     }),
   }))
 

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -78,11 +78,14 @@ function buildAuthHeaders(input: { username?: string; password?: string; json?: 
   return headers
 }
 
-function fillReadingQuestionPrompt(template: string, input: {
-  selectedContent: string
-  userQuestion: string
-  contextPages: string
-}) {
+function fillReadingQuestionPrompt(
+  template: string,
+  input: {
+    selectedContent: string
+    userQuestion: string
+    contextPages: string
+  },
+) {
   return template
     .replaceAll("{selected_content}", input.selectedContent)
     .replaceAll("{user_question}", input.userQuestion)
@@ -440,6 +443,14 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       return
     }
 
+    if (server.healthy() === false) {
+      showToast({
+        title: language.t("prompt.toast.serverUnavailable.title"),
+        description: language.t("prompt.toast.serverUnavailable.description"),
+      })
+      return
+    }
+
     const currentPrompt = prompt.current()
     const text = currentPrompt.map((part) => ("content" in part ? part.content : "")).join("")
     const images = input.imageAttachments().slice()
@@ -550,7 +561,8 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     const selText = fileCtx.selectedText()
     const readingQuestion = readingMode?.store.pendingQuestion
     const quickReadingPendingQuestion = quickReadingMode?.store.pendingQuestion ?? null
-    const quickReadingQuestion = quickReadingPendingQuestion?.sessionID === params.id ? quickReadingPendingQuestion : null
+    const quickReadingQuestion =
+      quickReadingPendingQuestion?.sessionID === params.id ? quickReadingPendingQuestion : null
     const draft: FollowupDraft = {
       sessionID: session.id,
       sessionDirectory,
@@ -751,11 +763,11 @@ export function createPromptSubmit(input: PromptSubmitInput) {
             ignored: true,
           },
           {
-              text: fillReadingQuestionPrompt(settings.questionPrompt, {
-                selectedContent:
-                  quickReadingQuestion.kind === "image-question"
-                    ? `The user selected a screenshot region from page ${quickReadingQuestion.page} of ${quickReadingQuestion.pdfFileName}.`
-                    : `The user selected text from pages ${formatReadingPageRange({ startPage: quickReadingQuestion.startPage, endPage: quickReadingQuestion.endPage })} of ${quickReadingQuestion.pdfFileName}.\n\n${quickReadingQuestion.text}`,
+            text: fillReadingQuestionPrompt(settings.questionPrompt, {
+              selectedContent:
+                quickReadingQuestion.kind === "image-question"
+                  ? `The user selected a screenshot region from page ${quickReadingQuestion.page} of ${quickReadingQuestion.pdfFileName}.`
+                  : `The user selected text from pages ${formatReadingPageRange({ startPage: quickReadingQuestion.startPage, endPage: quickReadingQuestion.endPage })} of ${quickReadingQuestion.pdfFileName}.\n\n${quickReadingQuestion.text}`,
               userQuestion: typedQuestion,
               contextPages: "",
             }),
@@ -888,7 +900,8 @@ export function createPromptSubmit(input: PromptSubmitInput) {
             {
               text: fillReadingQuestionPrompt(sessionMeta.settings.questionPrompt, {
                 selectedContent: describeReadingSelection({
-                  startPage: readingQuestion.kind === "text-question" ? readingQuestion.startPage : readingQuestion.page,
+                  startPage:
+                    readingQuestion.kind === "text-question" ? readingQuestion.startPage : readingQuestion.page,
                   endPage: readingQuestion.kind === "text-question" ? readingQuestion.endPage : readingQuestion.page,
                   kind: readingQuestion.kind,
                   text: readingQuestion.kind === "text-question" ? readingQuestion.text : undefined,
@@ -981,7 +994,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       knowledgeBase:
         knowledge.enabled() && knowledge.activeKnowledgeBases().length > 0
           ? {
-              paths: knowledge.activeKnowledgeBases().map(kb => kb.path),
+              paths: knowledge.activeKnowledgeBases().map((kb) => kb.path),
               apiKey: knowledge.activeKnowledgeBases()[0]!.apiKey,
               baseURL: knowledge.activeKnowledgeBases()[0]!.baseURL,
             }

--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -496,7 +496,7 @@ export const Terminal = (props: TerminalProps) => {
         if (disposed) return
         if (reconn !== undefined) return
 
-        const ms = Math.min(250 * 2 ** Math.min(tries, 4), 4_000)
+        const ms = server.healthy() === false ? 10_000 : Math.min(250 * 2 ** Math.min(tries, 4), 4_000)
         reconn = setTimeout(async () => {
           reconn = undefined
           if (disposed) return
@@ -506,6 +506,10 @@ export const Terminal = (props: TerminalProps) => {
             return
           }
           if (disposed) return
+          if (server.healthy() === false) {
+            retry(err)
+            return
+          }
           tries += 1
           open()
         }, ms)

--- a/packages/app/src/context/connection-slots.test.ts
+++ b/packages/app/src/context/connection-slots.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync, readdirSync, statSync } from "fs"
+import { join } from "path"
+
+const root = join(import.meta.dir, "..", "..")
+
+function read(rel: string) {
+  return readFileSync(join(root, rel), "utf-8")
+}
+
+describe("mobile.ts must not open independent SSE connections", () => {
+  const src = read("src/context/mobile.ts")
+
+  test("does not fetch /mobile/*/events endpoint", () => {
+    expect(src).not.toMatch(/\/events/)
+  })
+
+  test("does not use EventSource", () => {
+    expect(src).not.toMatch(/EventSource/)
+  })
+
+  test("does not set Accept: text/event-stream", () => {
+    expect(src).not.toMatch(/text\/event-stream/)
+  })
+
+  test("does not contain SSE retry or reconnect logic", () => {
+    expect(src).not.toMatch(/connectSSE/)
+    expect(src).not.toMatch(/scheduleSseRetry/)
+    expect(src).not.toMatch(/clearSseRetry/)
+    expect(src).not.toMatch(/sseControllers/)
+  })
+
+  test("exports bindEmitter for global event integration", () => {
+    expect(src).toMatch(/export function bindEmitter/)
+  })
+
+  test("exports bindResolver for API access", () => {
+    expect(src).toMatch(/export function bindResolver/)
+  })
+})
+
+describe("layout.tsx must bind global emitter to mobile module", () => {
+  const src = read("src/pages/layout.tsx")
+
+  test("imports bindEmitter from mobile context", () => {
+    expect(src).toMatch(/bindEmitter/)
+  })
+
+  test("calls bindEmitter with globalSDK.event", () => {
+    expect(src).toMatch(/bindEmitter\(globalSDK\.event\)/)
+  })
+})
+
+describe("global-sdk.tsx must use shared connection", () => {
+  const src = read("src/context/global-sdk.tsx")
+
+  test("imports connectShared", () => {
+    expect(src).toMatch(/connectShared/)
+  })
+
+  test("does not directly call eventSdk.global.event", () => {
+    expect(src).not.toMatch(/eventSdk\.global\.event/)
+  })
+
+  test("does not create a dedicated eventSdk for SSE", () => {
+    const lines = src.split("\n")
+    const hasEventSdk = lines.some((l) => l.includes("eventSdk") && l.includes("createSdkForServer"))
+    expect(hasEventSdk).toBe(false)
+  })
+})
+
+describe("shared-connection.ts must implement BroadcastChannel sharing", () => {
+  const src = read("src/context/shared-connection.ts")
+
+  test("uses BroadcastChannel", () => {
+    expect(src).toMatch(/BroadcastChannel/)
+  })
+
+  test("falls back to direct connection when BroadcastChannel unavailable", () => {
+    expect(src).toMatch(/typeof BroadcastChannel === "undefined"/)
+    expect(src).toMatch(/connectDirect/)
+  })
+
+  test("implements heartbeat mechanism", () => {
+    expect(src).toMatch(/heartbeat/)
+    expect(src).toMatch(/HB_MS/)
+  })
+
+  test("implements leader claim mechanism", () => {
+    expect(src).toMatch(/kind: "claim"/)
+    expect(src).toMatch(/kind: "heartbeat"/)
+    expect(src).toMatch(/kind: "event"/)
+  })
+
+  test("has timeout for leader death detection", () => {
+    expect(src).toMatch(/TIMEOUT_MS/)
+  })
+})
+
+describe("no frontend module creates independent mobile SSE connections", () => {
+  const ctx = join(root, "src", "context")
+  const pages = join(root, "src", "pages")
+
+  function scanDir(dir: string): string[] {
+    const results: string[] = []
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry)
+      if (statSync(full).isDirectory()) {
+        results.push(...scanDir(full))
+      } else if (/\.(ts|tsx)$/.test(entry) && !entry.includes(".test.") && !entry.includes(".spec.")) {
+        results.push(full)
+      }
+    }
+    return results
+  }
+
+  test("no file fetches /mobile/*/events", () => {
+    const violations: string[] = []
+    for (const file of [...scanDir(ctx), ...scanDir(pages)]) {
+      const content = readFileSync(file, "utf-8")
+      if (/\/mobile\/\w+\/events/.test(content)) {
+        violations.push(file)
+      }
+    }
+    expect(violations).toEqual([])
+  })
+
+  test("no file opens EventSource to mobile endpoints", () => {
+    const violations: string[] = []
+    for (const file of [...scanDir(ctx), ...scanDir(pages)]) {
+      const content = readFileSync(file, "utf-8")
+      if (/new EventSource\(.*mobile/.test(content)) {
+        violations.push(file)
+      }
+    }
+    expect(violations).toEqual([])
+  })
+})

--- a/packages/app/src/context/mobile.ts
+++ b/packages/app/src/context/mobile.ts
@@ -158,31 +158,7 @@ function handleMobileEvent(p: MobilePlatform, type: string, props: any) {
 }
 
 function startPing(p: MobilePlatform) {
-  if (p !== "wechat") return
-  stopPing()
-  pingInterval = setInterval(async () => {
-    if (!clientId) return
-    try {
-      const { url, headers } = api()
-      const res = await fetch(`${url}/mobile/wechat/ping`, {
-        method: "POST",
-        headers: { ...headers, "Content-Type": "application/json" },
-        body: JSON.stringify({ clientId }),
-      })
-      const data = await res.json()
-      pingFails = 0
-      if (data.stolen) {
-        stopPing()
-        patch("wechat", { status: "stolen" })
-      }
-    } catch {
-      pingFails += 1
-      if (pingFails < 3) return
-      pingFails = 0
-      const s = prev("wechat").status
-      if (s !== "idle" && s !== "stolen") patch("wechat", { status: "reconnecting" })
-    }
-  }, 10_000)
+  return
 }
 
 function stopPing() {

--- a/packages/app/src/context/server.tsx
+++ b/packages/app/src/context/server.tsx
@@ -10,6 +10,9 @@ type StoredServer = string | ServerConnection.HttpBase | ServerConnection.Http
 const HEALTH_POLL_INTERVAL_MS = 10_000
 const HEALTH_CHECK_TIMEOUT_MS = 8_000
 
+let _pingPaused = false
+export const pingPaused = () => _pingPaused
+
 export function normalizeServerUrl(input: string) {
   const trimmed = input.trim()
   if (!trimmed) return
@@ -154,10 +157,12 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
           .then((result) => {
             if (!alive) return
             setState("healthy", result.healthy)
+            _pingPaused = !result.healthy
           })
           .catch(() => {
             if (!alive) return
             setState("healthy", false)
+            _pingPaused = true
           })
           .finally(() => {
             clearTimeout(timeout)

--- a/packages/app/src/context/server.tsx
+++ b/packages/app/src/context/server.tsx
@@ -2,11 +2,13 @@ import { createSimpleContext } from "@opencode-ai/ui/context"
 import { type Accessor, batch, createEffect, createMemo, onCleanup } from "solid-js"
 import { createStore } from "solid-js/store"
 import { Persist, persisted } from "@/utils/persist"
-import { useCheckServerHealth } from "@/utils/server-health"
+import { checkServerHealth, useCheckServerHealth } from "@/utils/server-health"
+import { usePlatform } from "@/context/platform"
 
 type StoredProject = { worktree: string; expanded: boolean }
 type StoredServer = string | ServerConnection.HttpBase | ServerConnection.Http
 const HEALTH_POLL_INTERVAL_MS = 10_000
+const HEALTH_CHECK_TIMEOUT_MS = 8_000
 
 export function normalizeServerUrl(input: string) {
   const trimmed = input.trim()
@@ -95,7 +97,8 @@ export namespace ServerConnection {
 export const { use: useServer, provider: ServerProvider } = createSimpleContext({
   name: "Server",
   init: (props: { defaultServer: ServerConnection.Key; servers?: Array<ServerConnection.Any> }) => {
-    const checkServerHealth = useCheckServerHealth()
+    const checkServerHealthFn = useCheckServerHealth()
+    const platform = usePlatform()
 
     const [store, setStore, _, ready] = persisted(
       Persist.global("server", ["server.v3"]),
@@ -140,18 +143,24 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
 
     function startHealthPolling(conn: ServerConnection.Any) {
       let alive = true
-      let busy = false
+      let abort: AbortController | undefined
 
       const run = () => {
-        if (busy) return
-        busy = true
-        void check(conn)
-          .then((next) => {
+        if (!alive) return
+        abort?.abort()
+        abort = new AbortController()
+        const timeout = setTimeout(() => abort?.abort(), HEALTH_CHECK_TIMEOUT_MS)
+        void checkServerHealth(conn.http, platform.fetch ?? globalThis.fetch, { signal: abort.signal })
+          .then((result) => {
             if (!alive) return
-            setState("healthy", next)
+            setState("healthy", result.healthy)
+          })
+          .catch(() => {
+            if (!alive) return
+            setState("healthy", false)
           })
           .finally(() => {
-            busy = false
+            clearTimeout(timeout)
           })
       }
 
@@ -160,6 +169,7 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
       return () => {
         alive = false
         clearInterval(interval)
+        abort?.abort()
       }
     }
 
@@ -196,7 +206,7 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
 
     const isReady = createMemo(() => ready() && !!state.active)
 
-    const check = (conn: ServerConnection.Any) => checkServerHealth(conn.http).then((x) => x.healthy)
+    const check = (conn: ServerConnection.Any) => checkServerHealthFn(conn.http).then((x) => x.healthy)
 
     createEffect(() => {
       const current_ = current()

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -9,6 +9,7 @@ import { dict as zh } from "@/i18n/zh"
 import { createWebUpdate } from "@/utils/web-update"
 import { handleNotificationClick } from "@/utils/notification-click"
 import { ServerConnection } from "./context/server"
+import { pingPaused } from "./context/server"
 
 const DEFAULT_SERVER_URL_KEY = "opencode.settings.dat:defaultServerUrl"
 const PROXY_KEY = "opencode.settings.dat:proxy"
@@ -210,12 +211,24 @@ const lease = (() => {
   }
 })()
 
+const PING_TIMEOUT_MS = 5_000
+
 const ping = async (alive = true) => {
-  await req("/global/ping", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ id: lease, alive }),
-  }).catch(() => undefined)
+  if (pingPaused()) return
+  const ac = new AbortController()
+  const timer = setTimeout(() => ac.abort(), PING_TIMEOUT_MS)
+  try {
+    await req("/global/ping", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: lease, alive }),
+      signal: ac.signal,
+    })
+  } catch {
+    return undefined
+  } finally {
+    clearTimeout(timer)
+  }
 }
 
 const release = () => {

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -341,6 +341,8 @@ export const dict = {
   "prompt.toast.commandSendFailed.title": "Failed to send command",
   "prompt.toast.promptSendFailed.title": "Failed to send prompt",
   "prompt.toast.promptSendFailed.description": "Unable to retrieve session",
+  "prompt.toast.serverUnavailable.title": "Server temporarily unavailable",
+  "prompt.toast.serverUnavailable.description": "Please wait for the server to recover before sending",
 
   "dialog.mcp.title": "MCPs",
   "dialog.mcp.description": "{{enabled}} of {{total}} enabled",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -356,6 +356,8 @@ export const dict = {
   "prompt.toast.commandSendFailed.title": "发送命令失败",
   "prompt.toast.promptSendFailed.title": "发送提示失败",
   "prompt.toast.promptSendFailed.description": "无法获取会话",
+  "prompt.toast.serverUnavailable.title": "服务器暂时不可用",
+  "prompt.toast.serverUnavailable.description": "请等待服务器恢复后再发送消息",
 
   "dialog.mcp.title": "MCPs",
   "dialog.mcp.description": "已启用 {{enabled}} / {{total}}",

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -455,7 +455,7 @@ export namespace Server {
         async (c) => {
           const body = c.req.valid("json")
           await Project.updateDirectoryMeta({ ...body, projectID: body.projectID as ProjectID | undefined })
-          const item = Project.recentFromDir(body.directory)
+          const item = Project.recentList().find((r) => r.directory === body.directory)
           if (!item) return c.json(null, 404)
           return c.json(item)
         },


### PR DESCRIPTION
### Issue for this PR

Closes #927

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes three related problems around the server red-dot (unhealthy) indicator:

1. **Block message sending when server is unhealthy** (`submit.ts`): When `server.healthy() === false`, `handleSubmit` shows a toast instead of optimistically adding the message and setting AI busy state. This prevents the false impression that a message was sent when the HTTP request would actually be queued/blocked.

2. **Fix health polling stuck at `healthy=false`** (`server.tsx`): Removed the `busy` lock that prevented new health polls when a previous check was stuck. Instead, each poll aborts the previous request and starts fresh with an 8-second timeout via `AbortController`. The server now auto-recovers from red-dot without needing a page refresh.

3. **Prevent connection slot exhaustion from ping/PTY backlog**:
   - Global ping (`entry.tsx`): Added 5s `AbortController` timeout and skips ping when `pingPaused()` returns true (server unhealthy).
   - Removed wechat ping entirely (`mobile.ts`) — other mobile platforms don't use ping, and it doubled the ping connection slot usage.
   - PTY WebSocket retry (`terminal.tsx`): When `server.healthy() === false`, waits 10s and re-checks before retrying, preventing WebSocket upgrade requests from piling up and exhausting HTTP/1.1 connection slots.
   - Exported `pingPaused()` from `server.tsx` so ping and PTY can check server health state.

Root cause analysis from real network panel data: during server busy periods, PTY WebSocket exponential backoff creates ~9 pending upgrade requests per tab, wechat ping doubles the ping lines, and SSE holds 1 persistent slot. This exhausts localhost's ~10 HTTP/1.1 connection slots, causing health check to be cancelled at 3s timeout → red-dot.

### How did you verify your code works?

- `bun typecheck` passes for all packages (turbo typecheck)
- Analyzed real network panel data from user showing ping (8-60s each), health (3s cancelled), and PTY upgrade (6-9 pending) requests during server busy periods
- Verified logic: ping/PTY paused during unhealthy → no new connection slot occupation → health check can get a slot → auto-recovery

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR