### PR TITLE
fix: validate feishu credentials before marking connected

### DIFF
--- a/packages/opencode/src/mobile/feishu.ts
+++ b/packages/opencode/src/mobile/feishu.ts
@@ -284,6 +284,10 @@ class FeishuManagerImpl extends MobileManagerBase {
       await this.wsClient.start({ eventDispatcher })
       console.log("[feishu] wsClient.start() resolved")
 
+      console.log("[feishu] verifying credentials...")
+      await this.feishuAdapter.getTenantAccessToken()
+      console.log("[feishu] credentials verified")
+
       this._connectedModel = model
       this._reconnectCount = 0
 


### PR DESCRIPTION
### Issue for this PR

Closes #932

### Type of change

- [x] Bug fix

### What does this PR do?

飞书 `_doStart` 中 `wsClient.start()` 仅建立 WebSocket 物理连接，不校验 appId/appSecret 是否正确。错误凭证时飞书服务器不推送事件，但状态已标记为 `connected`，导致移动端发消息无响应。

修复：在 `wsClient.start()` 之后新增 `getTenantAccessToken()` 校验步骤。该 API 用 appId/appSecret 请求 tenant_access_token，凭证错误时会抛异常，进入 catch 块设 `status = "error"` 而非误报 `connected`。

### How did you verify your code works?

- `getTenantAccessToken()` 已是飞书心跳检测（`checkHeartbeat`）中使用的成熟 API，凭证错误时返回不含 `tenant_access_token` 的 JSON，方法会抛 `Error`
- 校验在 `wsClient.start()` 之后执行，不影响 WebSocket 建连；失败则自然进入已有的 catch/reconnect 流程
- typecheck 通过

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR