### PR TITLE
fix(mobile): flatten project/session list entries to single line

### DIFF
--- a/packages/opencode/src/mobile/base.ts
+++ b/packages/opencode/src/mobile/base.ts
@@ -1275,8 +1275,7 @@ export abstract class MobileManagerBase {
         const tag = directory === currentDir ? " ◀" : ""
         const mark = directory in this._hiddenDirs ? " [已隐藏]" : ""
         const sandboxTag = entry.sandbox ? " [sandbox]" : ""
-        lines.push(`${i + 1}. ${sandboxTag}${this.projectName(entry)}${tag}${mark}`)
-        lines.push(`   ${directory}`)
+        lines.push(`${i + 1}. ${sandboxTag}${this.projectName(entry)}${tag}${mark} (${directory})`)
       }
       await this.replyCmd(targetId, scope, lines.join("\n"))
       return
@@ -1310,8 +1309,7 @@ export abstract class MobileManagerBase {
       if (directory in this._hiddenDirs) continue
       const tag = directory === currentDir ? " ◀" : ""
       const sandboxTag = entry.sandbox ? " [sandbox]" : ""
-      lines.push(`${i + 1}. ${sandboxTag}${this.projectName(entry)}${tag}`)
-      lines.push(`   ${directory}`)
+      lines.push(`${i + 1}. ${sandboxTag}${this.projectName(entry)}${tag} (${directory})`)
       count++
     }
     lines.push("")
@@ -1505,8 +1503,7 @@ export abstract class MobileManagerBase {
         const s = entry.session
         const tag = s.id === currentId ? " ◀" : ""
         const forkTag = entry.fork ? " ↗" : ""
-        lines.push(`${i + 1}. ${forkTag}${s.title}${tag}`)
-        lines.push(`   ${this.formatSessionTime(s.time.updated)}`)
+        lines.push(`${i + 1}. ${forkTag}${s.title}${tag} (${this.formatSessionTime(s.time.updated)})`)
       }
       if (!items.length) lines.push("（当前项目下还没有任何会话）")
       await this.replyCmd(targetId, scope, lines.join("\n"))
@@ -1555,8 +1552,7 @@ export abstract class MobileManagerBase {
       const s = entry.session
       const tag = s.id === currentId ? " ◀" : ""
       const forkTag = entry.fork ? " ↗" : ""
-      lines.push(`${i + 1}. ${forkTag}${s.title}${tag}`)
-      lines.push(`   ${this.formatSessionTime(s.time.updated)}`)
+      lines.push(`${i + 1}. ${forkTag}${s.title}${tag} (${this.formatSessionTime(s.time.updated)})`)
     }
     lines.push("")
     lines.push("💡 /s n 切换会话 | /s l 查看全部（↗ = fork分支）")


### PR DESCRIPTION
### Issue for this PR

Closes #936

### Type of change

- [x] Bug fix

### What does this PR do?

WeChat and similar IM platforms lose indentation on secondary lines of multi-line list entries, causing the path/time line to merge with the next entry's number. This PR flattens each project/session list entry into a single line format:

**Before:**
```
1. aether-test ◀
   E:\aether-test
2. [sandbox]sandbox-35
   C:\Users\...
```

**After:**
```
1. aether-test ◀ (E:\aether-test)
2. [sandbox]sandbox-35 (C:\Users\...)
```

Same change applied to session list (`/s`): time is now parenthesized inline instead of on a second indented line.

### How did you verify your code works?

Typecheck passed (`bun turbo typecheck`). Logic is a simple string format change — no new code paths introduced.

### Screenshots / recordings

Not applicable — text output format change only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR