### PR TITLE
[DEBUG] Add extensive CI debug logging for Windows worktree dirty detection

### DIFF
--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -729,11 +729,42 @@ export namespace File {
       const status = Effect.fn("File.status")(function* () {
         if (Instance.project.vcs !== "git") return []
 
+        Log.Default.warn("[DEBUG-FILE] File.status called", {
+          directory: Instance.directory,
+          worktree: Instance.worktree,
+          platform: process.platform,
+        })
+
         const items = yield* Effect.promise(() => Git.status(Instance.directory))
+        Log.Default.warn("[DEBUG-FILE] Git.status returned", { directory: Instance.directory, itemCount: items.length, items })
+
         if (!items.length) return []
 
         const modified = items.filter((i) => i.status === "modified")
         const stats = modified.length ? yield* Effect.promise(() => Git.stats(Instance.directory, "HEAD")) : []
+
+        Log.Default.warn("[DEBUG-FILE] Git.stats returned", { directory: Instance.directory, statCount: stats.length, stats })
+
+        // Also check: does the sandbox directory actually have files?
+        const dirExists = yield* Effect.promise(() => Filesystem.exists(Instance.directory).catch(() => false))
+        const readmeExists = yield* Effect.promise(() =>
+          Filesystem.exists(path.join(Instance.directory, "README.md")).catch(() => false),
+        )
+        Log.Default.warn("[DEBUG-FILE] Sandbox directory state", { directory: Instance.directory, dirExists, readmeExists })
+
+        // Also run git status with cfg (autocrlf=false) for comparison
+        const cfgStatusResult = yield* Effect.promise(() =>
+          Git.run(["status", "--porcelain=v1", "--untracked-files=all", "--no-renames", "-z", "--", "."], {
+            cwd: Instance.directory,
+          })
+            .then((r) => r.text())
+            .catch(() => "ERROR"),
+        )
+        Log.Default.warn("[DEBUG-FILE] Comparison: git status with cfg (autocrlf=false)", {
+          directory: Instance.directory,
+          cfgResultLen: cfgStatusResult.length,
+          cfgResultPreview: cfgStatusResult.slice(0, 200),
+        })
 
         const statMap = new Map(stats.map((s) => [s.file, s]))
         const changed: File.Info[] = []

--- a/packages/opencode/src/git/index.ts
+++ b/packages/opencode/src/git/index.ts
@@ -4,6 +4,7 @@ import { Effect, Layer, ServiceMap, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { makeRuntime } from "@/effect/run-service"
 import * as Graph from "./git-graph"
+import { Log } from "@/util/log"
 
 export namespace Git {
   const cfg = [
@@ -145,9 +146,13 @@ export namespace Git {
     Effect.gen(function* () {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
 
+      const dbg = Log.Default
+
       const run = Effect.fn("Git.run")(
         function* (args: string[], opts: Options) {
           const gitArgs = [...(opts.config ?? cfg), ...args]
+          const configUsed = opts.config === statusCfg ? "statusCfg" : opts.config ? "custom" : "cfg"
+          dbg.warn("[DEBUG-GIT] Git.run", { configUsed, args, cwd: opts.cwd, platform: process.platform })
           const proc = ChildProcess.make("git", gitArgs, {
             cwd: opts.cwd,
             env: opts.env,
@@ -256,17 +261,22 @@ export namespace Git {
       })
 
       const status = Effect.fn("Git.status")(function* (cwd: string) {
-        return nuls(
-          yield* text(["status", "--porcelain=v1", "--untracked-files=all", "--no-renames", "-z", "--", "."], {
+        const rawText = yield* text(
+          ["status", "--porcelain=v1", "--untracked-files=all", "--no-renames", "-z", "--", "."],
+          {
             cwd,
             config: statusCfg,
-          }),
-        ).flatMap((item) => {
+          },
+        )
+        dbg.warn("[DEBUG-GIT] Git.status raw", { cwd, rawLen: rawText.length, rawPreview: rawText.slice(0, 200) })
+        const items = nuls(rawText).flatMap((item) => {
           const file = item.slice(3)
           if (!file) return []
           const code = item.slice(0, 2)
           return [{ file, code, status: kind(code) } satisfies Item]
         })
+        dbg.warn("[DEBUG-GIT] Git.status parsed", { cwd, itemCount: items.length, items })
+        return items
       })
 
       const diff = Effect.fn("Git.diff")(function* (cwd: string, ref: string) {
@@ -282,9 +292,11 @@ export namespace Git {
       })
 
       const stats = Effect.fn("Git.stats")(function* (cwd: string, ref: string) {
-        return nuls(
-          yield* text(["diff", "--no-ext-diff", "--no-renames", "--numstat", "-z", ref, "--", "."], { cwd }),
-        ).flatMap((item) => {
+        const rawText = yield* text(["diff", "--no-ext-diff", "--no-renames", "--numstat", "-z", ref, "--", "."], {
+          cwd,
+        })
+        dbg.warn("[DEBUG-GIT] Git.stats raw", { cwd, ref, rawLen: rawText.length, rawPreview: rawText.slice(0, 200) })
+        const result = nuls(rawText).flatMap((item) => {
           const a = item.indexOf("\t")
           const b = item.indexOf("\t", a + 1)
           if (a === -1 || b === -1) return []
@@ -302,6 +314,8 @@ export namespace Git {
             } satisfies Stat,
           ]
         })
+        dbg.warn("[DEBUG-GIT] Git.stats parsed", { cwd, ref, statCount: result.length, result })
+        return result
       })
 
       const log = Effect.fn("Git.log")(function* (

--- a/packages/opencode/src/server/routes/file.ts
+++ b/packages/opencode/src/server/routes/file.ts
@@ -7,6 +7,7 @@ import { Ripgrep } from "../../file/ripgrep"
 import { LSP } from "../../lsp"
 import { Instance } from "../../project/instance"
 import { lazy } from "../../util/lazy"
+import { Log } from "../../util/log"
 import { errors } from "../error"
 import { $ } from "bun"
 import { spawn } from "bun"
@@ -933,7 +934,16 @@ export const FileRoutes = lazy(() =>
         },
       }),
       async (c) => {
+        console.warn("[DEBUG-FILE-HTTP] file.status called", {
+          directory: Instance.directory,
+          platform: process.platform,
+        })
         const content = await File.status()
+        console.warn("[DEBUG-FILE-HTTP] file.status returned", {
+          directory: Instance.directory,
+          itemCount: content.length,
+          items: content.map((f) => ({ path: f.path, status: f.status })),
+        })
         return c.json(content)
       },
     )

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -389,6 +389,12 @@ export namespace Server {
               create,
               init: create ? InstanceBootstrap : undefined,
               async fn() {
+                Log.Default.warn("[DEBUG-SERVER] request handling", {
+                  path: c.req.path,
+                  directory,
+                  create,
+                  platform: process.platform,
+                })
                 return next()
               },
             })

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -282,6 +282,11 @@ export namespace Worktree {
         const projectID = Instance.project.id
         const extra = startCommand?.trim()
 
+        Log.Default.warn("[DEBUG-WT] Worktree.boot: git reset --hard starting", {
+          directory: info.directory,
+          platform: process.platform,
+        })
+
         const populated = yield* git(["reset", "--hard"], { cwd: info.directory })
         if (populated.code !== 0) {
           const message = populated.stderr || populated.text || "Failed to populate worktree"
@@ -292,6 +297,46 @@ export namespace Worktree {
           })
           return
         }
+
+        Log.Default.warn("[DEBUG-WT] Worktree.boot: git reset --hard done", { directory: info.directory })
+
+        // Check status right after reset --hard
+        const bootStatus = yield* git(["-c", "core.fsmonitor=false", "status", "--porcelain=v1"], {
+          cwd: info.directory,
+        })
+        Log.Default.warn("[DEBUG-WT] Worktree.boot: status after reset --hard", {
+          directory: info.directory,
+          statusCode: bootStatus.code,
+          statusText: bootStatus.text.slice(0, 500),
+          statusStderr: bootStatus.stderr.slice(0, 200),
+        })
+
+        // Also check with statusCfg
+        const bootStatusCfg = yield* git(
+          [
+            "--no-optional-locks",
+            "-c",
+            "core.fsmonitor=false",
+            "-c",
+            "core.longpaths=true",
+            ...(process.platform !== "win32" ? ["-c", "core.symlinks=true"] : []),
+            "-c",
+            "core.quotepath=false",
+            "status",
+            "--porcelain=v1",
+          ],
+          { cwd: info.directory },
+        )
+        Log.Default.warn("[DEBUG-WT] Worktree.boot: statusCfg after reset --hard", {
+          directory: info.directory,
+          statusCode: bootStatusCfg.code,
+          statusText: bootStatusCfg.text.slice(0, 500),
+        })
+
+        // Also check README.md existence
+        const readmePath = pathSvc.join(info.directory, "README.md")
+        const readmeExists = yield* fsys.exists(readmePath).pipe(Effect.orDie)
+        Log.Default.warn("[DEBUG-WT] Worktree.boot: README.md exists?", { readmePath, readmeExists })
 
         const booted = yield* Effect.promise(() =>
           Instance.provide({
@@ -330,11 +375,18 @@ export namespace Worktree {
 
       const create = Effect.fn("Worktree.create")(function* (input?: CreateInput) {
         const info = yield* makeWorktreeInfo(input?.name)
+        Log.Default.warn("[DEBUG-WT] Worktree.create: setup starting", {
+          directory: info.directory,
+          branch: info.branch,
+          platform: process.platform,
+        })
         yield* setup(info)
+        Log.Default.warn("[DEBUG-WT] Worktree.create: setup done, boot starting (forked)", { directory: info.directory })
         yield* boot(info, input?.startCommand).pipe(
           Effect.catchCause((cause) => Effect.sync(() => log.error("worktree bootstrap failed", { cause }))),
           Effect.forkIn(scope),
         )
+        Log.Default.warn("[DEBUG-WT] Worktree.create: returning info (boot is async)", { directory: info.directory })
         return info
       })
 
@@ -573,6 +625,8 @@ export namespace Worktree {
         }
 
         const directory = yield* canonical(input.directory)
+        Log.Default.warn("[DEBUG-WT] Worktree.reset starting", { directory, platform: process.platform })
+
         const primary = yield* canonical(Instance.worktree)
         if (directory === primary) {
           throw new ResetFailedError({ message: "Cannot reset the primary workspace" })
@@ -611,8 +665,10 @@ export namespace Worktree {
           { cwd: worktreePath },
           (r) => new ResetFailedError({ message: r.stderr || r.text || "Failed to reset worktree to target" }),
         )
+        Log.Default.warn("[DEBUG-WT] Worktree.reset: git reset --hard done", { worktreePath, baseRef: base.ref })
 
         const cleanResult = yield* sweep(worktreePath)
+        Log.Default.warn("[DEBUG-WT] Worktree.reset: git clean -ffdx done", { worktreePath, cleanCode: cleanResult.code })
         if (cleanResult.code !== 0) {
           throw new ResetFailedError({ message: cleanResult.stderr || cleanResult.text || "Failed to clean worktree" })
         }
@@ -636,6 +692,60 @@ export namespace Worktree {
         )
 
         const status = yield* git(["-c", "core.fsmonitor=false", "status", "--porcelain=v1"], { cwd: worktreePath })
+        Log.Default.warn("[DEBUG-WT] Worktree.reset: status check result", {
+          worktreePath,
+          statusCode: status.code,
+          statusTextLen: status.text.length,
+          statusTextPreview: status.text.slice(0, 500),
+          statusStderr: status.stderr.slice(0, 200),
+        })
+
+        // Also run statusCfg comparison
+        const statusCfgResult = yield* git(
+          [
+            "--no-optional-locks",
+            "-c",
+            "core.fsmonitor=false",
+            "-c",
+            "core.longpaths=true",
+            ...(process.platform !== "win32" ? ["-c", "core.symlinks=true"] : []),
+            "-c",
+            "core.quotepath=false",
+            "status",
+            "--porcelain=v1",
+          ],
+          { cwd: worktreePath },
+        )
+        Log.Default.warn("[DEBUG-WT] Worktree.reset: statusCfg result", {
+          worktreePath,
+          statusCode: statusCfgResult.code,
+          statusTextPreview: statusCfgResult.text.slice(0, 500),
+        })
+
+        // Also run cfg comparison (with autocrlf=false)
+        const cfgStatusResult = yield* git(
+          [
+            "--no-optional-locks",
+            "-c",
+            "core.autocrlf=false",
+            "-c",
+            "core.fsmonitor=false",
+            "-c",
+            "core.longpaths=true",
+            ...(process.platform !== "win32" ? ["-c", "core.symlinks=true"] : []),
+            "-c",
+            "core.quotepath=false",
+            "status",
+            "--porcelain=v1",
+          ],
+          { cwd: worktreePath },
+        )
+        Log.Default.warn("[DEBUG-WT] Worktree.reset: cfg (autocrlf=false) result", {
+          worktreePath,
+          statusCode: cfgStatusResult.code,
+          statusTextPreview: cfgStatusResult.text.slice(0, 500),
+        })
+
         if (status.code !== 0) {
           throw new ResetFailedError({ message: status.stderr || status.text || "Failed to read git status" })
         }


### PR DESCRIPTION
## Purpose

Debug-only PR. Adds extensive logging to diagnose why `app e2e (windows)` CI fails on "can delete a workspace" and "can reset a workspace" tests.

## Debug Logs Added

### `Git.run()` — logs every git command with config type (cfg/statusCfg/custom), args, and cwd
### `Git.status()` — logs raw output and parsed items
### `Git.stats()` — logs raw output and parsed stats
### `File.status()` — logs:
  - When called (directory, worktree, platform)
  - Git.status results (item count and items)
  - Git.stats results  
  - Sandbox directory state (does dir exist? does README.md exist?)
  - Comparison: git status with cfg (autocrlf=false)
### `Worktree.create()` — logs setup start/end vs boot start
### `Worktree.boot()` — logs:
  - git reset --hard start/end
  - Status after reset (with local git function)
  - StatusCfg after reset
  - README.md existence check
### `Worktree.reset()` — logs:
  - reset start
  - git reset --hard done
  - git clean done
  - Status check result (local git + statusCfg + cfg comparison)

## NOT FOR MERGE
This is a diagnostic PR. After CI results are analyzed, this branch will be deleted.