### PR TITLE
fix: use recentFromDir in updateDirectoryMeta to avoid UI filter logic causing 404

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -455,7 +455,7 @@ export namespace Server {
         async (c) => {
           const body = c.req.valid("json")
           await Project.updateDirectoryMeta({ ...body, projectID: body.projectID as ProjectID | undefined })
-          const item = Project.recentList().find((r) => r.directory === body.directory)
+          const item = Project.recentFromDir(body.directory)
           if (!item) return c.json(null, 404)
           return c.json(item)
         },


### PR DESCRIPTION
## Summary

`POST /project-directory-meta` used `Project.recentList().find()` to look up the updated record for the response. `recentList()` is a UI-facing function that filters out sandbox entries (when `pidCounts > 1`) and project entries with missing DB files. This caused the API to return 404 for sandbox names and certain project names, making rename operations fail from the workspace context menu.

Fixed by replacing `recentList().find()` with `Project.recentFromDir()`, which queries `ProjectRecentTable` directly by key without UI filter logic.