### PR TITLE
fix: disable web-style update check UI in Electron desktop

### DIFF
--- a/packages/desktop-electron/src/renderer/index.tsx
+++ b/packages/desktop-electron/src/renderer/index.tsx
@@ -158,16 +158,6 @@ const createPlatform = (): Platform => {
 
     storage,
 
-    checkUpdate: async () => {
-      if (!UPDATER_ENABLED()) return { updateAvailable: false }
-      return window.api.checkUpdate()
-    },
-
-    update: async () => {
-      if (!UPDATER_ENABLED()) return
-      await window.api.installUpdate()
-    },
-
     restart: async () => {
       await window.api.killSidecar().catch(() => undefined)
       window.api.relaunch()


### PR DESCRIPTION
### Issue for this PR

Closes #947

### Type of change

- [x] Bug fix

### What does this PR do?

从 Electron 渲染进程的 `platform` 对象中移除 `checkUpdate` 和 `update` 两个字段。这两个字段的存在导致设置页"检查更新"按钮和"启动时检查更新"开关始终可用，但它们走的是 Web 版更新流程，与 Electron 的 `electron-updater` 原生更新通道不兼容。

移除后，已有的 `!platform.checkUpdate` 守卫自动生效：
- 设置页"检查更新"按钮 → 禁用
- "启动时检查更新"开关 → 禁用
- 启动轮询 `useUpdatePolling` → 不启动
- 错误页更新按钮 → 不渲染

Electron 版更新仍通过菜单栏"Check for Updates..."和 `electron-updater` 原生对话框正常工作。Web 版完全不受影响。

### How did you verify your code works?

- `bun typecheck` 通过，无类型错误
- `platform.checkUpdate` 为 `undefined` 时，所有依赖它的 UI 守卫（`!platform.checkUpdate`、`<Show when={platform.checkUpdate}>`）均已验证正确

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR