### PR TITLE
fix(web-update): align web version management with Electron semver semantics

### DIFF
--- a/packages/app/src/utils/web-update.ts
+++ b/packages/app/src/utils/web-update.ts
@@ -44,20 +44,30 @@ export const viewOf = (data: Pick<UpdateStatus, "updateAvailable" | "status">): 
 }
 
 const cmp = (a: string, b: string) => {
-  const norm = (v: string) =>
-    v
-      .replace(/^v/i, "")
-      .split("-")[0]
-      .split(".")
-      .map((x) => Number.parseInt(x || "0", 10) || 0)
-  const x = norm(a)
-  const y = norm(b)
-  const len = Math.max(x.length, y.length, 3)
+  const parse = (v: string) => {
+    const stripped = v.replace(/^v/, "")
+    const dashIdx = stripped.indexOf("-")
+    const release = dashIdx >= 0 ? stripped.slice(0, dashIdx) : stripped
+    const prerelease = dashIdx >= 0 ? stripped.slice(dashIdx + 1) : null
+    const parts = release.split(".").map((x) => Number.parseInt(x, 10))
+    if (parts.some((x) => Number.isNaN(x))) return null
+    return { release: parts, prerelease }
+  }
+  const x = parse(a)
+  const y = parse(b)
+  if (!x || !y) return 0
+  const len = Math.max(x.release.length, y.release.length)
   for (let i = 0; i < len; i++) {
-    const p = x[i] ?? 0
-    const q = y[i] ?? 0
+    const p = x.release[i] ?? 0
+    const q = y.release[i] ?? 0
     if (p < q) return -1
     if (p > q) return 1
+  }
+  if (x.prerelease === null && y.prerelease !== null) return 1
+  if (x.prerelease !== null && y.prerelease === null) return -1
+  if (x.prerelease !== null && y.prerelease !== null) {
+    if (x.prerelease < y.prerelease) return -1
+    if (x.prerelease > y.prerelease) return 1
   }
   return 0
 }

--- a/packages/opencode/src/server/web-update.ts
+++ b/packages/opencode/src/server/web-update.ts
@@ -257,7 +257,10 @@ function vbs(val: string) {
 }
 
 function hide(args: string[], cwd: string) {
-  const file = path.join(tmpdir(), `aether-update-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.vbs`)
+  const file = path.join(
+    tmpdir(),
+    `aether-update-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.vbs`,
+  )
   const cmd = `cmd.exe /d /s /c "${args.map(quote).join(" ")}"`
   writeFileSync(
     file,
@@ -648,28 +651,32 @@ function versioned(name: string, ver: string) {
   return `${name.slice(0, idx)}-${ver}${name.slice(idx)}`
 }
 
-function normalizeVersion(v: string): string {
-  const parts = v
-    .replace(/^v/i, "")
-    .split("-")[0]
-    .split(".")
-    .map((x) => Number.parseInt(x || "0", 10) || 0)
-  return parts.join(".")
+function parseVersion(value: string) {
+  const stripped = value.replace(/^v/, "")
+  const dashIdx = stripped.indexOf("-")
+  const release = dashIdx >= 0 ? stripped.slice(0, dashIdx) : stripped
+  const prerelease = dashIdx >= 0 ? stripped.slice(dashIdx + 1) : null
+  const parts = release.split(".").map((x) => Number.parseInt(x, 10))
+  if (parts.some((x) => Number.isNaN(x))) return null
+  return { release: parts, prerelease }
 }
 
-function compareVer(a: string, b: string) {
-  const norm = (v: string) =>
-    normalizeVersion(v)
-      .split(".")
-      .map((x) => Number.parseInt(x || "0", 10) || 0)
-  const x = norm(a)
-  const y = norm(b)
-  const len = Math.max(x.length, y.length)
+function compareVer(a: string, b: string): number {
+  const x = parseVersion(a)
+  const y = parseVersion(b)
+  if (!x || !y) return 0
+  const len = Math.max(x.release.length, y.release.length)
   for (let i = 0; i < len; i++) {
-    const xi = x[i] ?? 0
-    const yi = y[i] ?? 0
+    const xi = x.release[i] ?? 0
+    const yi = y.release[i] ?? 0
     if (xi < yi) return -1
     if (xi > yi) return 1
+  }
+  if (x.prerelease === null && y.prerelease !== null) return 1
+  if (x.prerelease !== null && y.prerelease === null) return -1
+  if (x.prerelease !== null && y.prerelease !== null) {
+    if (x.prerelease < y.prerelease) return -1
+    if (x.prerelease > y.prerelease) return 1
   }
   return 0
 }
@@ -734,7 +741,7 @@ async function scanLocalVersions() {
   const entries = await fs.readdir(parent).catch(() => [])
   const versions: string[] = []
   for (const entry of entries) {
-    if (!/^aether[-_]/i.test(entry) || !/^aether[-_]\d+\.\d+\.\d+/.test(entry)) continue
+    if (!/^aether[-_]\d+\.\d+\.\d+([\-._][0-9A-Za-z]+)*$/.test(entry)) continue
     const full = path.join(parent, entry)
     const stat = await fs.stat(full).catch(() => null)
     if (!stat?.isDirectory()) continue
@@ -754,9 +761,9 @@ export async function readWebCurrentVersion() {
     .then((x) => x.trim())
     .catch(() => "")
 
-  if (marker) return normalizeVersion(marker)
+  if (marker) return marker
 
-  const fallback = normalizeVersion(Installation.VERSION)
+  const fallback = Installation.VERSION
   await fs.writeFile(file, `${fallback}\n`, "utf-8").catch(() => undefined)
   return fallback
 }
@@ -771,13 +778,13 @@ export async function readWebUpdateHighestVersion() {
   const local = await scanLocalVersions()
   let best = ""
   for (const v of local) {
-    if (compareVer(v, best) > 0) best = v
+    if (!best || compareVer(v, best) > 0) best = v
   }
 
-  if (marker && (!best || compareVer(marker, best) > 0)) return normalizeVersion(marker)
-  if (best) return normalizeVersion(best)
+  if (marker && (!best || compareVer(marker, best) > 0)) return marker
+  if (best) return best
 
-  const fallback = normalizeVersion(Installation.VERSION)
+  const fallback = Installation.VERSION
   await fs.writeFile(file, `${fallback}\n`, "utf-8").catch(() => undefined)
   return fallback
 }
@@ -1053,4 +1060,6 @@ export const WebUpdateTest = {
   verifyInstall,
   versioned,
   writeUpdateState,
+  parseVersion,
+  compareVer,
 }

--- a/packages/opencode/test/server/web-update.test.ts
+++ b/packages/opencode/test/server/web-update.test.ts
@@ -266,4 +266,82 @@ notes_url: notes.md
       if (desc) Object.defineProperty(process, "arch", desc)
     }
   })
+
+  describe("parseVersion", () => {
+    test("parses standard 3-segment version", () => {
+      const result = WebUpdateTest.parseVersion("1.3.2")
+      expect(result).toEqual({ release: [1, 3, 2], prerelease: null })
+    })
+
+    test("parses 4-segment version", () => {
+      const result = WebUpdateTest.parseVersion("0.6.2.68")
+      expect(result).toEqual({ release: [0, 6, 2, 68], prerelease: null })
+    })
+
+    test("parses pre-release version", () => {
+      const result = WebUpdateTest.parseVersion("0.6.3-beta.1")
+      expect(result).toEqual({ release: [0, 6, 3], prerelease: "beta.1" })
+    })
+
+    test("strips leading lowercase v", () => {
+      const result = WebUpdateTest.parseVersion("v1.3.2")
+      expect(result).toEqual({ release: [1, 3, 2], prerelease: null })
+    })
+
+    test("does not strip uppercase V", () => {
+      const result = WebUpdateTest.parseVersion("V1.3.2")
+      expect(result).toBeNull()
+    })
+
+    test("returns null for non-numeric segments", () => {
+      expect(WebUpdateTest.parseVersion("1.2.x")).toBeNull()
+    })
+
+    test("returns null for empty string", () => {
+      expect(WebUpdateTest.parseVersion("")).toBeNull()
+    })
+  })
+
+  describe("compareVer", () => {
+    test("4-segment version is lower than higher 3-segment", () => {
+      expect(WebUpdateTest.compareVer("0.6.2.68", "0.6.3")).toBe(-1)
+    })
+
+    test("pre-release is lower than release", () => {
+      expect(WebUpdateTest.compareVer("0.6.3-beta.1", "0.6.3")).toBe(-1)
+    })
+
+    test("release is higher than pre-release", () => {
+      expect(WebUpdateTest.compareVer("0.6.3", "0.6.3-beta.1")).toBe(1)
+    })
+
+    test("pre-release is lower than patch bump", () => {
+      expect(WebUpdateTest.compareVer("0.6.3-beta.1", "0.6.3.1")).toBe(-1)
+    })
+
+    test("equal versions", () => {
+      expect(WebUpdateTest.compareVer("1.3.2", "1.3.2")).toBe(0)
+    })
+
+    test("higher version", () => {
+      expect(WebUpdateTest.compareVer("1.3.2", "1.3.1")).toBe(1)
+    })
+
+    test("pre-release alphabetical ordering", () => {
+      expect(WebUpdateTest.compareVer("0.6.3-alpha.1", "0.6.3-beta.1")).toBe(-1)
+      expect(WebUpdateTest.compareVer("0.6.3-beta.1", "0.6.3-beta.2")).toBe(-1)
+    })
+
+    test("dev version is lower than release", () => {
+      expect(WebUpdateTest.compareVer("0.0.0-dev-20260529T1430", "1.3.2")).toBe(-1)
+    })
+
+    test("NaN safety returns 0", () => {
+      expect(WebUpdateTest.compareVer("1.2.x", "1.3.0")).toBe(0)
+    })
+
+    test("v prefix is stripped", () => {
+      expect(WebUpdateTest.compareVer("v1.3.2", "1.3.2")).toBe(0)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Replace `normalizeVersion` + `compareVer` with `parseVersion` + `compareVer` that correctly handle pre-release versions, 4-segment versions, and NaN safety
- Update frontend `cmp()` to mirror the new `compareVer` logic
- Preserve raw version strings in marker files and version reads instead of normalizing away pre-release info

## Problem

Web version management had several inconsistencies compared to Electron:

1. **`normalizeVersion` stripped pre-release suffixes** — `0.6.3-beta.1` was truncated to `0.6.3`, losing channel information and causing `verifyInstall` mismatches
2. **`compareVer` had redundant double-parsing** — normalized to string, then re-parsed to integers
3. **No NaN safety** — invalid segments silently became `0` via `||0`
4. **`v` prefix handling differed** — web used case-insensitive `/^v/i`, Electron uses `/^v/`
5. **`scanLocalVersions` regex was too strict** — didn't properly anchor or support pre-release directory names

## Changes

### `packages/opencode/src/server/web-update.ts`
- Delete `normalizeVersion()`
- Add `parseVersion()`: separates release segments (integer array) from pre-release suffix (string), returns `null` for unparseable inputs
- Replace `compareVer()`: per-segment integer comparison (aligned with Electron's `parseVersion` + `compareVersions`), plus correct pre-release ordering (pre-release < release)
- `readWebCurrentVersion` / `readWebUpdateHighestVersion`: preserve raw version strings, no normalization
- `scanLocalVersions` regex: `/^aether[-_]\d+\.\d+\.\d+([\-._][0-9A-Za-z]+)*$/`

### `packages/app/src/utils/web-update.ts`
- Replace `cmp()` with logic mirroring the server-side `parseVersion` + `compareVer`

### `packages/opencode/test/server/web-update.test.ts`
- Add `parseVersion` tests (7 cases) and `compareVer` tests (10 cases)

## Compatibility

| Version format | `parseVersion` result | `compareVer` behavior |
|---|---|---|
| `1.3.2` | `{release:[1,3,2], prerelease:null}` | Standard comparison ✅ |
| `0.6.2.68` | `{release:[0,6,2,68], prerelease:null}` | 4-segment comparison ✅ |
| `0.6.3-beta.1` | `{release:[0,6,3], prerelease:"beta.1"}` | pre-release < release ✅ |
| `0.0.0-dev-20260529T1430` | `{release:[0,0,0], prerelease:"dev-20260529T1430"}` | dev < release ✅ |
| `1.2.x` / `""` / `"local"` | `null` | Returns 0 (no update) ✅ |

## No impact on Electron

- Electron uses `electron-updater` + `app.getVersion()`, completely independent of `web-update.ts`
- `cmp()` is only called inside `createWebUpdate()` closure, which is never invoked in Electron's renderer
- Electron version display uses `pkg.version` from `package.json`, not the web-update API