### PR TITLE
fix: use statusCfg without autocrlf=false to avoid false dirty detection on Windows

### DIFF
--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -635,7 +635,20 @@ export namespace Worktree {
           (r) => new ResetFailedError({ message: r.stderr || r.text || "Failed to clean submodules" }),
         )
 
-        const status = yield* git(["-c", "core.fsmonitor=false", "status", "--porcelain=v1"], { cwd: worktreePath })
+        const status = yield* git(
+          [
+            ...(process.platform !== "win32" ? ["-c", "core.symlinks=true"] : []),
+            "-c",
+            "core.fsmonitor=false",
+            "-c",
+            "core.longpaths=true",
+            "-c",
+            "core.quotepath=false",
+            "status",
+            "--porcelain=v1",
+          ],
+          { cwd: worktreePath },
+        )
         if (status.code !== 0) {
           throw new ResetFailedError({ message: status.stderr || status.text || "Failed to read git status" })
         }

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -635,26 +635,10 @@ export namespace Worktree {
           (r) => new ResetFailedError({ message: r.stderr || r.text || "Failed to clean submodules" }),
         )
 
-        const status = yield* git(
-          [
-            ...(process.platform !== "win32" ? ["-c", "core.symlinks=true"] : []),
-            "-c",
-            "core.fsmonitor=false",
-            "-c",
-            "core.longpaths=true",
-            "-c",
-            "core.quotepath=false",
-            "status",
-            "--porcelain=v1",
-          ],
-          { cwd: worktreePath },
-        )
-        if (status.code !== 0) {
-          throw new ResetFailedError({ message: status.stderr || status.text || "Failed to read git status" })
-        }
-
-        if (status.text.trim()) {
-          throw new ResetFailedError({ message: `Worktree reset left local changes:\n${status.text.trim()}` })
+        const items = yield* Effect.promise(() => Git.status(worktreePath))
+        if (items.length) {
+          const detail = items.map((i) => `${i.code} ${i.file}`).join("\n")
+          throw new ResetFailedError({ message: `Worktree reset left local changes:\n${detail}` })
         }
 
         yield* runStartScripts(worktreePath, { projectID: Instance.project.id }).pipe(


### PR DESCRIPTION
## Summary

Fixes false dirty detection for git worktrees (sandboxes) on Windows, which prevented users from deleting sandbox workspaces.

## Root Cause

`Git.run()` unconditionally injects `-c core.autocrlf=false` on every git command. On Windows where `core.autocrlf=true` (the default for Git for Windows), when the index has zeroed stat cache entries (from `git worktree add --no-checkout`), git must re-hash working directory files for comparison. With `autocrlf=false`, git compares raw CRLF bytes against LF blobs in HEAD → mismatch → false "modified" status.

## Changes

### `packages/opencode/src/git/index.ts`

- Added `statusCfg` array: same config as `cfg` but **without** `-c core.autocrlf=false`. This allows `git status` to respect the user's real `core.autocrlf` setting so line-ending normalization works correctly.
- Added optional `config?: string[]` to the `Options` interface to allow callers to override the default config array.
- Modified `Git.run()` to select the config via `opts.config ?? cfg`.
- Modified `Git.status()` to pass `config: statusCfg` so that status checks use the correct autocrlf setting.

### `packages/opencode/src/file/index.ts`

- Rewritten `File.status()` to use `Git.status()` (which now respects `statusCfg`) and `Git.stats(HEAD)` for line counts on modified files.
- Removed old 3-command approach that duplicated config override logic.

### `packages/opencode/src/worktree/index.ts`

- Aligned `Worktree.reset()` status check to use the same config as `statusCfg` (no `core.autocrlf=false`, no `core.symlinks=true` on Windows). Previously it used a minimal `-c core.fsmonitor=false` override only.

## Verification

- All CI checks pass on Linux/macOS  
- Local testing on Windows with `core.autocrlf=true` shows clean worktrees correctly detected as clean
- Local testing with `core.autocrlf=input` and `core.autocrlf=false` also works correctly