### PR TITLE
revert: remove debug CI logging for Windows worktree dirty detection

### DIFF
--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -729,42 +729,11 @@ export namespace File {
       const status = Effect.fn("File.status")(function* () {
         if (Instance.project.vcs !== "git") return []
 
-        Log.Default.warn("[DEBUG-FILE] File.status called", {
-          directory: Instance.directory,
-          worktree: Instance.worktree,
-          platform: process.platform,
-        })
-
         const items = yield* Effect.promise(() => Git.status(Instance.directory))
-        Log.Default.warn("[DEBUG-FILE] Git.status returned", { directory: Instance.directory, itemCount: items.length, items })
-
         if (!items.length) return []
 
         const modified = items.filter((i) => i.status === "modified")
         const stats = modified.length ? yield* Effect.promise(() => Git.stats(Instance.directory, "HEAD")) : []
-
-        Log.Default.warn("[DEBUG-FILE] Git.stats returned", { directory: Instance.directory, statCount: stats.length, stats })
-
-        // Also check: does the sandbox directory actually have files?
-        const dirExists = yield* Effect.promise(() => Filesystem.exists(Instance.directory).catch(() => false))
-        const readmeExists = yield* Effect.promise(() =>
-          Filesystem.exists(path.join(Instance.directory, "README.md")).catch(() => false),
-        )
-        Log.Default.warn("[DEBUG-FILE] Sandbox directory state", { directory: Instance.directory, dirExists, readmeExists })
-
-        // Also run git status with cfg (autocrlf=false) for comparison
-        const cfgStatusResult = yield* Effect.promise(() =>
-          Git.run(["status", "--porcelain=v1", "--untracked-files=all", "--no-renames", "-z", "--", "."], {
-            cwd: Instance.directory,
-          })
-            .then((r) => r.text())
-            .catch(() => "ERROR"),
-        )
-        Log.Default.warn("[DEBUG-FILE] Comparison: git status with cfg (autocrlf=false)", {
-          directory: Instance.directory,
-          cfgResultLen: cfgStatusResult.length,
-          cfgResultPreview: cfgStatusResult.slice(0, 200),
-        })
 
         const statMap = new Map(stats.map((s) => [s.file, s]))
         const changed: File.Info[] = []

--- a/packages/opencode/src/git/index.ts
+++ b/packages/opencode/src/git/index.ts
@@ -4,7 +4,6 @@ import { Effect, Layer, ServiceMap, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { makeRuntime } from "@/effect/run-service"
 import * as Graph from "./git-graph"
-import { Log } from "@/util/log"
 
 export namespace Git {
   const cfg = [
@@ -146,13 +145,9 @@ export namespace Git {
     Effect.gen(function* () {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
 
-      const dbg = Log.Default
-
       const run = Effect.fn("Git.run")(
         function* (args: string[], opts: Options) {
           const gitArgs = [...(opts.config ?? cfg), ...args]
-          const configUsed = opts.config === statusCfg ? "statusCfg" : opts.config ? "custom" : "cfg"
-          dbg.warn("[DEBUG-GIT] Git.run", { configUsed, args, cwd: opts.cwd, platform: process.platform })
           const proc = ChildProcess.make("git", gitArgs, {
             cwd: opts.cwd,
             env: opts.env,
@@ -261,22 +256,17 @@ export namespace Git {
       })
 
       const status = Effect.fn("Git.status")(function* (cwd: string) {
-        const rawText = yield* text(
-          ["status", "--porcelain=v1", "--untracked-files=all", "--no-renames", "-z", "--", "."],
-          {
+        return nuls(
+          yield* text(["status", "--porcelain=v1", "--untracked-files=all", "--no-renames", "-z", "--", "."], {
             cwd,
             config: statusCfg,
-          },
-        )
-        dbg.warn("[DEBUG-GIT] Git.status raw", { cwd, rawLen: rawText.length, rawPreview: rawText.slice(0, 200) })
-        const items = nuls(rawText).flatMap((item) => {
+          }),
+        ).flatMap((item) => {
           const file = item.slice(3)
           if (!file) return []
           const code = item.slice(0, 2)
           return [{ file, code, status: kind(code) } satisfies Item]
         })
-        dbg.warn("[DEBUG-GIT] Git.status parsed", { cwd, itemCount: items.length, items })
-        return items
       })
 
       const diff = Effect.fn("Git.diff")(function* (cwd: string, ref: string) {
@@ -292,11 +282,9 @@ export namespace Git {
       })
 
       const stats = Effect.fn("Git.stats")(function* (cwd: string, ref: string) {
-        const rawText = yield* text(["diff", "--no-ext-diff", "--no-renames", "--numstat", "-z", ref, "--", "."], {
-          cwd,
-        })
-        dbg.warn("[DEBUG-GIT] Git.stats raw", { cwd, ref, rawLen: rawText.length, rawPreview: rawText.slice(0, 200) })
-        const result = nuls(rawText).flatMap((item) => {
+        return nuls(
+          yield* text(["diff", "--no-ext-diff", "--no-renames", "--numstat", "-z", ref, "--", "."], { cwd }),
+        ).flatMap((item) => {
           const a = item.indexOf("\t")
           const b = item.indexOf("\t", a + 1)
           if (a === -1 || b === -1) return []
@@ -314,8 +302,6 @@ export namespace Git {
             } satisfies Stat,
           ]
         })
-        dbg.warn("[DEBUG-GIT] Git.stats parsed", { cwd, ref, statCount: result.length, result })
-        return result
       })
 
       const log = Effect.fn("Git.log")(function* (


### PR DESCRIPTION
Closes #950

## Type of change

Revert / cleanup

## What does this PR do?

Reverts commit `f6c27731d` ("debug: add extensive CI debug logging for Windows worktree dirty detection") which was accidentally included in PR #949. That commit added diagnostic `Log.Default.warn` calls in `file/index.ts`, `git/index.ts`, and `worktree/index.ts` that were meant only for CI debugging and should not be in production code. The subsequent commits in #949 removed the worktree debug logs but the file/git ones remain.

This revert removes all remaining `[DEBUG-FILE]`, `[DEBUG-GIT]`, and `[DEBUG-WT]` diagnostic logging without affecting the actual segfault fix (dispose-before-delete logic, watcher finalizer improvements, etc.).

## How did you verify your code works?

- `bun typecheck` passes
- Verified the revert diff only touches debug log lines, not the fix logic
- Checked that `dispose()`, `disposeAndClean()`, `disposeOnly()`, watcher finalizer, and all fix-related code remain intact

## Screenshots / recordings

Not applicable.

## Checklist

- [x] Code follows project style guide
- [x] Typecheck passes
- [x] No functional code changed — only debug logging removed