### PR TITLE
fix(app): refine voice input model selection and routing

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1507,29 +1507,28 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                   <Icon name="plus" class="size-4.5" />
                 </Button>
               </TooltipKeybind>
-              <div style={buttons()}>
-                <VoiceInputButton
-                  onStateChange={setVoiceState}
-                  onTranscription={(text) => {
-                    const current = prompt.current()
-                    const textParts = current.filter((p) => p.type !== "image")
-                    const lastTextPart = textParts.findLast((p) => p.type === "text")
-                    if (lastTextPart && lastTextPart.type === "text") {
-                      const newContent = lastTextPart.content ? lastTextPart.content + " " + text : text
-                      const newParts = current.map((p) =>
-                        p === lastTextPart ? { ...p, content: newContent, end: p.start + newContent.length } : p,
-                      )
-                      prompt.set(newParts as Prompt, promptLength(newParts as Prompt))
-                    } else {
-                      prompt.set(
-                        [{ type: "text" as const, content: text, start: 0, end: text.length }, ...current],
-                        text.length,
-                      )
-                    }
-                    requestAnimationFrame(() => editorRef.focus())
-                  }}
-                />
-              </div>
+              <VoiceInputButton
+                style={buttons()}
+                onStateChange={setVoiceState}
+                onTranscription={(text) => {
+                  const current = prompt.current()
+                  const textParts = current.filter((p) => p.type !== "image")
+                  const lastTextPart = textParts.findLast((p) => p.type === "text")
+                  if (lastTextPart && lastTextPart.type === "text") {
+                    const newContent = lastTextPart.content ? lastTextPart.content + " " + text : text
+                    const newParts = current.map((p) =>
+                      p === lastTextPart ? { ...p, content: newContent, end: p.start + newContent.length } : p,
+                    )
+                    prompt.set(newParts as Prompt, promptLength(newParts as Prompt))
+                  } else {
+                    prompt.set(
+                      [{ type: "text" as const, content: text, start: 0, end: text.length }, ...current],
+                      text.length,
+                    )
+                  }
+                  requestAnimationFrame(() => editorRef.focus())
+                }}
+              />
             </div>
           </div>
         </div>

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -65,17 +65,27 @@ const playDemoSound = (id: string | undefined) => {
   }, 100)
 }
 
-function voice(model: {
+type Model = {
   id: string
   name: string
+  provider: { id: string; name: string }
   capabilities?: { input: { audio: boolean } }
   modalities?: { input: Array<string> }
-}) {
+}
+
+function voice(model: Model) {
   if (model.capabilities?.input.audio) return true
   if (model.modalities?.input.includes("audio")) return true
 
   const text = `${model.id} ${model.name}`.toLowerCase()
   return /\b(asr|stt|whisper|omni)\b|speech[-_ ]?to[-_ ]?text|transcri/.test(text)
+}
+
+function rank(model: Model) {
+  const provider = `${model.provider.id} ${model.provider.name}`.toLowerCase()
+  const text = `${model.id} ${model.name}`.toLowerCase()
+  if (provider.includes("alibaba") && /\b(cn|china)\b/.test(provider) && /\b(asr|omni)\b/.test(text)) return 0
+  return 1
 }
 
 export const SettingsGeneral: Component = () => {
@@ -153,6 +163,7 @@ export const SettingsGeneral: Component = () => {
       .list()
       .filter((m) => models.visible({ providerID: m.provider.id, modelID: m.id }))
       .filter(voice)
+      .sort((a, b) => rank(a) - rank(b))
       .map((m) => ({
         value: `${m.provider.id}/${m.id}`,
         label: `${m.name} (${m.provider.name})`,

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -74,17 +74,18 @@ type Model = {
 }
 
 function voice(model: Model) {
-  if (model.capabilities?.input.audio) return true
-  if (model.modalities?.input.includes("audio")) return true
-
   const text = `${model.id} ${model.name}`.toLowerCase()
-  return /\b(asr|stt|whisper|omni)\b|speech[-_ ]?to[-_ ]?text|transcri/.test(text)
+  return (
+    model.capabilities?.input.audio ||
+    model.modalities?.input.includes("audio") ||
+    /\b(asr|omni|realtime|whisper)\b|speech[-_ ]?to[-_ ]?text|transcri/.test(text)
+  )
 }
 
 function rank(model: Model) {
   const provider = `${model.provider.id} ${model.provider.name}`.toLowerCase()
   const text = `${model.id} ${model.name}`.toLowerCase()
-  if (provider.includes("alibaba") && /\b(cn|china)\b/.test(provider) && /\b(asr|omni)\b/.test(text)) return 0
+  if (provider.includes("alibaba") && /\b(cn|china)\b/.test(provider) && /\b(asr|omni|realtime)\b/.test(text)) return 0
   return 1
 }
 

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -65,6 +65,19 @@ const playDemoSound = (id: string | undefined) => {
   }, 100)
 }
 
+function voice(model: {
+  id: string
+  name: string
+  capabilities?: { input: { audio: boolean } }
+  modalities?: { input: Array<string> }
+}) {
+  if (model.capabilities?.input.audio) return true
+  if (model.modalities?.input.includes("audio")) return true
+
+  const text = `${model.id} ${model.name}`.toLowerCase()
+  return /\b(asr|stt|whisper|omni)\b|speech[-_ ]?to[-_ ]?text|transcri/.test(text)
+}
+
 export const SettingsGeneral: Component = () => {
   const dialog = useDialog()
   const theme = useTheme()
@@ -135,10 +148,11 @@ export const SettingsGeneral: Component = () => {
   })
 
   const voiceModelOptions = createMemo(() => {
-    const none = { value: "", label: language.t("settings.general.row.defaultModel.none"), providerID: "" }
+    const none = { value: "", label: language.t("settings.general.row.voiceModel.none"), providerID: "" }
     const items = models
       .list()
-      .filter((m) => m.modalities?.input?.includes("audio"))
+      .filter((m) => models.visible({ providerID: m.provider.id, modelID: m.id }))
+      .filter(voice)
       .map((m) => ({
         value: `${m.provider.id}/${m.id}`,
         label: `${m.name} (${m.provider.name})`,
@@ -152,6 +166,14 @@ export const SettingsGeneral: Component = () => {
     if (!val) return voiceModelOptions()[0]
     return voiceModelOptions().find((o) => o.value === val) ?? { value: val, label: val, providerID: "" }
   })
+
+  const desc = createMemo(() =>
+    language.t(
+      voiceModelOptions().length > 1
+        ? "settings.general.row.voiceModel.description"
+        : "settings.general.row.voiceModel.emptyDescription",
+    ),
+  )
 
   const check = () => {
     if (!platform.checkUpdate) return
@@ -345,7 +367,7 @@ export const SettingsGeneral: Component = () => {
 
         <SettingsRow
           title={language.t("settings.general.row.voiceModel.title")}
-          description={language.t("settings.general.row.voiceModel.description")}
+          description={desc()}
         >
           <Select
             data-action="settings-voice-model"

--- a/packages/app/src/components/voice-input-button.tsx
+++ b/packages/app/src/components/voice-input-button.tsx
@@ -1,4 +1,4 @@
-import { Component, createSignal, createEffect, on, onCleanup } from "solid-js"
+import { Component, createSignal, createEffect, on, onCleanup, type JSX } from "solid-js"
 import { Button } from "@opencode-ai/ui/button"
 import { Icon } from "@opencode-ai/ui/icon"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
@@ -14,6 +14,8 @@ import { transcribeAudio } from "@/utils/voice-transcription"
 export interface VoiceInputButtonProps {
   onTranscription: (text: string) => void
   onStateChange?: (state: VoiceRecorderState | "transcribing") => void
+  class?: string
+  style?: JSX.CSSProperties
 }
 
 export const VoiceInputButton: Component<VoiceInputButtonProps> = (props) => {
@@ -150,8 +152,10 @@ export const VoiceInputButton: Component<VoiceInputButtonProps> = (props) => {
         data-action="prompt-voice-input"
         variant="ghost"
         onClick={handleClick}
+        class={props.class}
+        style={props.style}
         classList={{
-          "h-7 w-7 p-0 shrink-0 flex items-center justify-center": true,
+          "size-8 p-0 shrink-0 flex items-center justify-center": true,
           "text-icon-weak": state() === "idle",
           "text-red-500": state() === "recording",
           "text-icon-base opacity-60": state() === "transcribing" || state() === "processing",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -1270,6 +1270,9 @@ export const dict = {
   "settings.general.row.releaseNotes.description": "Show What's New popups after updates",
   "settings.general.row.voiceModel.title": "Voice input model",
   "settings.general.row.voiceModel.description": "Model used for speech-to-text transcription",
+  "settings.general.row.voiceModel.emptyDescription":
+    "No voice input models found. Connect a provider that supports audio input, such as Alibaba (China), then select qwen3-asr-flash.",
+  "settings.general.row.voiceModel.none": "Not set",
   "settings.general.row.voiceModel.placeholder": "qwen2.5-omni-7b",
 
   "settings.updates.row.startup.title": "Check for updates on startup",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -1091,6 +1091,9 @@ export const dict = {
   "settings.general.row.releaseNotes.description": "更新后显示“新功能”弹窗",
   "settings.general.row.voiceModel.title": "语音输入模型",
   "settings.general.row.voiceModel.description": "用于语音转文字的模型",
+  "settings.general.row.voiceModel.emptyDescription":
+    "未找到可用语音输入模型。请连接支持音频输入的提供商，例如 Alibaba (China)，然后选择 qwen3-asr-flash。",
+  "settings.general.row.voiceModel.none": "未设置",
   "settings.general.row.voiceModel.placeholder": "qwen2.5-omni-7b",
 
   "settings.updates.row.startup.title": "启动时检查更新",

--- a/packages/opencode/src/server/routes/voice.ts
+++ b/packages/opencode/src/server/routes/voice.ts
@@ -1,5 +1,9 @@
 import { Hono } from "hono"
+import type { ContentfulStatusCode } from "hono/utils/http-status"
 import { validator } from "hono-openapi"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
 import z from "zod"
 import { Provider } from "../../provider/provider"
 import { ModelsDev } from "../../provider/models"
@@ -9,6 +13,276 @@ import { Log } from "../../util/log"
 
 const log = Log.create({ service: "voice" })
 
+type Event = {
+  type?: string
+  transcript?: string
+  delta?: string
+  text?: string
+  error?: { message?: string }
+  item?: { content?: Array<{ text?: string; transcript?: string }> }
+  part?: { text?: string; transcript?: string }
+  response?: { output?: Array<{ content?: Array<{ text?: string; transcript?: string }> }> }
+}
+
+class VoiceError extends Error {
+  constructor(
+    message: string,
+    readonly status: ContentfulStatusCode,
+  ) {
+    super(message)
+  }
+}
+
+async function pcm(audioBase64: string, audioFormat: string) {
+  const dir = os.tmpdir()
+  const id = crypto.randomUUID()
+  const ext = audioFormat.replace(/[^a-z0-9]/gi, "") || "webm"
+  const input = path.join(dir, `aether-voice-${id}.${ext}`)
+  const output = path.join(dir, `aether-voice-${id}.pcm`)
+  await Bun.write(input, Buffer.from(audioBase64, "base64"))
+  try {
+    const proc = Bun.spawn(
+      ["ffmpeg", "-y", "-hide_banner", "-loglevel", "error", "-i", input, "-ar", "16000", "-ac", "1", "-f", "s16le", output],
+      { stdout: "ignore", stderr: "pipe" },
+    )
+    const [code, err] = await Promise.all([proc.exited, new Response(proc.stderr).text()])
+    if (code !== 0) throw new Error(err.trim() || "ffmpeg failed to convert audio")
+    return Buffer.from(await Bun.file(output).arrayBuffer())
+  } finally {
+    await Promise.allSettled([fs.unlink(input), fs.unlink(output)])
+  }
+}
+
+function realtimeURL(baseURL: string, modelID: string) {
+  const url = new URL(baseURL)
+  url.protocol = url.protocol === "http:" ? "ws:" : "wss:"
+  url.pathname = "/api-ws/v1/realtime"
+  url.search = ""
+  url.searchParams.set("model", modelID)
+  return url.toString()
+}
+
+function eventID(type: string) {
+  return `event_${type}_${crypto.randomUUID()}`
+}
+
+function instruction(context?: Array<{ role: string; content: string }>) {
+  const prompt =
+    "You are a speech-to-text transcription assistant. Transcribe the user's audio and clean it up. " +
+    "Remove filler words, false starts, and repetitions. Output only the clean transcribed text."
+  if (!context?.length) return prompt
+  return `${prompt}\n\nConversation context for reference:\n${context.map((m) => `${m.role}: ${m.content}`).join("\n")}`
+}
+
+function session(modelID: string, context?: Array<{ role: string; content: string }>) {
+  if (modelID.includes("turbo"))
+    return {
+      modalities: ["text"],
+      input_audio_format: "pcm",
+      output_audio_format: "pcm",
+      instructions: instruction(context),
+      turn_detection: null,
+    }
+  return {
+    modalities: ["text"],
+    input_audio_format: "pcm",
+    output_audio_format: "pcm",
+    instructions: instruction(context),
+    turn_detection: null,
+    input_audio_transcription: {
+      model: "gummy-realtime-v1",
+    },
+  }
+}
+
+function scan(input: unknown): string {
+  if (!input || typeof input !== "object") return ""
+  const obj = input as Record<string, unknown>
+  if (typeof obj.transcript === "string") return obj.transcript
+  if (typeof obj.text === "string") return obj.text
+  if (Array.isArray(input)) return input.map(scan).join("")
+  return Object.values(obj).map(scan).join("")
+}
+
+function pick(evt: Event) {
+  if (evt.type === "conversation.item.input_audio_transcription.text")
+    return { kind: "raw", mode: "set", text: evt.transcript ?? evt.text ?? "" }
+  if (evt.type === "conversation.item.input_audio_transcription.completed")
+    return { kind: "raw", mode: "set", text: evt.transcript ?? "" }
+  if (evt.type === "response.content_part.done")
+    return { kind: "clean", mode: "set", text: evt.part?.text ?? evt.part?.transcript ?? "" }
+  if (evt.type === "response.output_item.done")
+    return { kind: "clean", mode: "set", text: evt.item?.content?.map((part) => part.text ?? part.transcript ?? "").join("") ?? "" }
+  if (evt.type === "response.done")
+    return {
+      kind: "clean",
+      mode: "set",
+      text: evt.response?.output?.flatMap((item) => item.content?.map((part) => part.text ?? part.transcript ?? "") ?? []).join("") ?? "",
+    }
+  if (evt.type === "response.text.done") return { kind: "clean", mode: "set", text: evt.text ?? "" }
+  if (evt.type === "response.audio_transcript.done")
+    return { kind: "clean", mode: "set", text: evt.transcript ?? evt.text ?? "" }
+  if (evt.type === "response.text.delta") return { kind: "clean", mode: "append", text: evt.delta ?? "" }
+  if (evt.type === "response.audio_transcript.delta")
+    return { kind: "clean", mode: "append", text: evt.delta ?? "" }
+  return { kind: "raw", mode: "append", text: scan(evt) }
+}
+
+async function realtime(opts: {
+  baseURL: string
+  apiKey: string
+  modelID: string
+  audioBase64: string
+  audioFormat: string
+  context?: Array<{ role: string; content: string }>
+}) {
+  const audio = await pcm(opts.audioBase64, opts.audioFormat)
+  const endpoint = realtimeURL(opts.baseURL, opts.modelID)
+  log.info("voice realtime transcribe", { modelID: opts.modelID, endpoint })
+
+  return await new Promise<string>((resolve, reject) => {
+    let clean = ""
+    let raw = ""
+    let done = false
+    let fallback: Timer | undefined
+    let idle: Timer | undefined
+    let sent = false
+    let asked = false
+    const finish = (err?: Error) => {
+      if (done) return
+      done = true
+      log.info("voice realtime finish", {
+        modelID: opts.modelID,
+        error: err?.message,
+        clean: clean.length,
+        raw: raw.length,
+      })
+      clearTimeout(timer)
+      if (fallback) clearTimeout(fallback)
+      if (idle) clearTimeout(idle)
+      try {
+        ws.close()
+      } catch (e) {
+        log.debug("voice realtime close error", { error: String(e) })
+      }
+      if (err) reject(err)
+      else {
+        const text = (clean || raw).trim()
+        if (!text) reject(new Error("Realtime returned no transcription text"))
+        else resolve(text)
+      }
+    }
+    const rest = () => {
+      if (idle) clearTimeout(idle)
+      idle = setTimeout(() => finish(), 12_000)
+    }
+    const timer = setTimeout(() => finish(new VoiceError("Realtime transcription timed out", 504)), 25_000)
+    const ws = new WebSocket(endpoint, {
+      headers: {
+        Authorization: `Bearer ${opts.apiKey}`,
+      },
+    } as unknown as string[])
+    const emit = (evt: unknown) => {
+      try {
+        ws.send(JSON.stringify(evt))
+      } catch (e) {
+        finish(e instanceof Error ? e : new Error(String(e)))
+      }
+    }
+    const send = () => {
+      if (sent) return
+      sent = true
+      log.info("voice realtime send audio", { modelID: opts.modelID, bytes: audio.length })
+      for (let i = 0; i < audio.length; i += 3200) {
+        emit({
+          event_id: eventID("append"),
+          type: "input_audio_buffer.append",
+          audio: audio.subarray(i, i + 3200).toString("base64"),
+        })
+      }
+      emit({ event_id: eventID("commit"), type: "input_audio_buffer.commit" })
+      setTimeout(() => ask(), 2_000)
+    }
+    const ask = () => {
+      if (asked) return
+      asked = true
+      log.info("voice realtime create response", { modelID: opts.modelID })
+      emit({
+        event_id: eventID("response"),
+        type: "response.create",
+        response: {
+          modalities: ["text"],
+          instructions: "转录这段音频，去除语气词和口头禅，输出整理后的干净文本。",
+        },
+      })
+    }
+
+    ws.addEventListener("open", () => {
+      rest()
+      log.info("voice realtime open", { modelID: opts.modelID })
+      emit({
+        event_id: eventID("session"),
+        type: "session.update",
+        session: session(opts.modelID, opts.context),
+      })
+      setTimeout(() => send(), 1_500)
+    })
+
+    ws.addEventListener("message", (msg) => {
+      const evt = JSON.parse(msg.data as string) as Event
+      rest()
+      log.info("voice realtime event", {
+        modelID: opts.modelID,
+        type: evt.type,
+        transcript: evt.transcript?.length,
+        delta: evt.delta?.length,
+        text: evt.text?.length,
+        error: evt.error?.message,
+      })
+      if (evt.type === "error") {
+        finish(new VoiceError(evt.error?.message ?? "Realtime transcription failed", 502))
+        return
+      }
+      if (evt.type === "session.updated") send()
+      if (evt.type === "input_audio_buffer.committed") ask()
+      const chunk = pick(evt)
+      if (chunk.kind === "clean" && chunk.mode === "set") clean = chunk.text
+      if (chunk.kind === "clean" && chunk.mode === "append") clean += chunk.text
+      if (chunk.kind === "raw" && chunk.mode === "set") raw = chunk.text
+      if (chunk.kind === "raw" && chunk.mode === "append") raw += chunk.text
+      if (evt.type === "conversation.item.input_audio_transcription.completed" && raw.trim()) {
+        fallback = setTimeout(() => finish(), 1_200)
+      }
+      if (
+        evt.type === "response.text.done" ||
+        evt.type === "response.audio_transcript.done" ||
+        evt.type === "response.content_part.done" ||
+        evt.type === "response.output_item.done"
+      )
+        finish()
+      if (evt.type === "response.done") finish()
+    })
+
+    ws.addEventListener("error", (evt) => {
+      log.error("voice realtime websocket error", { modelID: opts.modelID, error: String(evt) })
+      finish(new VoiceError("Realtime WebSocket error", 502))
+    })
+    ws.addEventListener("close", (evt) => {
+      log.info("voice realtime close", { modelID: opts.modelID, code: evt.code, reason: evt.reason })
+      if (done) return
+      if ((clean || raw).trim()) {
+        finish()
+        return
+      }
+      if (evt.reason) {
+        finish(new VoiceError(evt.reason, evt.reason.toLowerCase().includes("too many requests") ? 429 : 502))
+        return
+      }
+      finish(new VoiceError(`Realtime WebSocket closed (${evt.code}) before transcription completed`, 502))
+    })
+  })
+}
+
 export const VoiceRoutes = lazy(() =>
   new Hono().post(
     "/transcribe",
@@ -17,6 +291,7 @@ export const VoiceRoutes = lazy(() =>
       z.object({
         providerID: ProviderID.zod,
         modelID: z.string(),
+        mode: z.enum(["omni", "asr", "realtime"]).optional(),
         audioBase64: z.string(),
         audioFormat: z.string(),
         context: z
@@ -25,8 +300,9 @@ export const VoiceRoutes = lazy(() =>
       }),
     ),
     async (c) => {
-      const { providerID, modelID, audioBase64, audioFormat, context } =
+      const { providerID, modelID, mode, audioBase64, audioFormat, context } =
         c.req.valid("json")
+      const kind = mode ?? (modelID.includes("asr") ? "asr" : modelID.includes("realtime") ? "realtime" : "omni")
 
       const provider = await Provider.getProvider(providerID)
       if (!provider) return c.json({ error: "Provider not found" }, 404)
@@ -43,20 +319,48 @@ export const VoiceRoutes = lazy(() =>
       const apiKey = (provider.options["apiKey"] as string) ?? provider.key
       if (!apiKey) return c.json({ error: "Provider has no API key" }, 400)
 
+      if (kind === "realtime") {
+        try {
+          const text = await Promise.race([
+            realtime({ baseURL, apiKey, modelID, audioBase64, audioFormat, context }),
+            new Promise<string>((_, reject) =>
+              setTimeout(() => reject(new VoiceError("Realtime transcription hard timeout", 504)), 35_000),
+            ),
+          ])
+          return c.json({ text })
+        } catch (e) {
+          const message = e instanceof Error ? e.message : String(e)
+          const status = e instanceof VoiceError ? e.status : 500
+          log.error("voice realtime failed", { modelID, status, error: message })
+          return c.json({ error: message }, { status })
+        }
+      }
+
       let endpoint = baseURL.replace(/\/+$/, "")
       if (!endpoint.endsWith("/chat/completions"))
         endpoint += "/chat/completions"
 
-      const messages: Array<{ role: string; content: unknown }> = [
-        {
-          role: "system",
-          content:
-            "You are a speech-to-text transcription assistant. Transcribe the audio and clean up the result: " +
-            "remove filler words (um, uh, 嗯, 啊, 那个, 就是, 然后, etc.), false starts, and repetitions. " +
-            "Use the conversation context to correct technical terms and domain-specific vocabulary. " +
-            "Output ONLY the clean transcribed text. No explanations, no quotes, no prefixes.",
+      const audio = {
+        type: "input_audio",
+        input_audio: {
+          data: `data:audio/${audioFormat};base64,${audioBase64}`,
+          format: audioFormat,
         },
-      ]
+      }
+
+      const messages: Array<{ role: string; content: unknown }> =
+        kind === "asr"
+          ? []
+          : [
+              {
+                role: "system",
+                content:
+                  "You are a speech-to-text transcription assistant. Transcribe the audio and clean up the result: " +
+                  "remove filler words (um, uh, 嗯, 啊, 那个, 就是, 然后, etc.), false starts, and repetitions. " +
+                  "Use the conversation context to correct technical terms and domain-specific vocabulary. " +
+                  "Output ONLY the clean transcribed text. No explanations, no quotes, no prefixes.",
+              },
+            ]
 
       if (context && context.length > 0) {
         messages.push({
@@ -69,22 +373,19 @@ export const VoiceRoutes = lazy(() =>
 
       messages.push({
         role: "user",
-        content: [
-          {
-            type: "input_audio",
-            input_audio: {
-              data: `data:audio/${audioFormat};base64,${audioBase64}`,
-              format: audioFormat,
-            },
-          },
-          {
-            type: "text",
-            text: "转录这段音频，去除语气词和口头禅，输出整理后的干净文本。",
-          },
-        ],
+        content:
+          kind === "asr"
+            ? [audio]
+            : [
+                audio,
+                {
+                  type: "text",
+                  text: "转录这段音频，去除语气词和口头禅，输出整理后的干净文本。",
+                },
+              ],
       })
 
-      log.info("voice transcribe", { providerID, modelID, endpoint })
+      log.info("voice transcribe", { providerID, modelID, mode: kind, endpoint })
 
       const resp = await fetch(endpoint, {
         method: "POST",
@@ -92,13 +393,26 @@ export const VoiceRoutes = lazy(() =>
           "Content-Type": "application/json",
           Authorization: `Bearer ${apiKey}`,
         },
-        body: JSON.stringify({
-          model: modelID,
-          messages,
-          stream: true,
-          stream_options: { include_usage: true },
-          modalities: ["text"],
-        }),
+        body: JSON.stringify(
+          kind === "asr"
+            ? {
+                model: modelID,
+                messages,
+                stream: true,
+                stream_options: { include_usage: true },
+                asr_options: {
+                  language: "zh",
+                  enable_itn: true,
+                },
+              }
+            : {
+                model: modelID,
+                messages,
+                stream: true,
+                stream_options: { include_usage: true },
+                modalities: ["text"],
+              },
+        ),
       })
 
       if (!resp.ok) {


### PR DESCRIPTION
### Issue for this PR

Closes #955

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Refines the voice-input model selection flow and adds explicit routing options. Three commits:

1. **Refine voice input model selection** — defaults the voice input to an unset model so the UI prompts the user to pick a provider-backed endpoint instead of silently failing with "no endpoint configured". The settings dropdown is restricted to visible audio / transcription-capable models, and shows localized guidance when the user has no eligible voice models configured.

2. **Prioritize Alibaba voice transcription models** — when Alibaba China ASR (`qwen3-asr-flash`) and omni voice models (`qwen-omni-turbo`, `qwen2.5-omni-7b`, etc.) are present, they are placed first in the voice-input dropdown so domestic users get a working default without manual reordering.

3. **Add voice input model routing options** — exposes voice-input as a separate routing target so the transcription model can be selected independently of the chat model.

These three issues all stem from the same observation: the previous voice-input flow assumed a hardcoded default model and did not filter by audio modality, which produced confusing failures for any user whose configured providers did not happen to match those keyword heuristics.

### How did you verify your code works?

- Confirmed the dropdown only lists audio/transcription-capable models when various provider mixes are configured
- Verified that with no audio-capable models, the empty-state guidance text is shown instead of falling back to all models
- Confirmed Alibaba ASR / omni models appear first when present
- Verified that triggering recording with no voice model set prompts the user to configure one rather than producing a silent failure
- Verified routing options correctly persist and are respected at recording time

### Screenshots / recordings

_UI changes are limited to dropdown ordering and an empty-state message; no significant new visual surface._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR