### PR TITLE
fix: remove memory initialization toast notification on refresh

### DIFF
--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -21,8 +21,6 @@ const abortError = z.object({
   name: z.literal("AbortError"),
 })
 
-let memoryInitializationToastShown = false
-
 export type GlobalSDKValue = {
   url: string
   client: AppClient
@@ -234,18 +232,6 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
     addMemoryMethods(sdk, server.current.http.url, authHeader(server.current.http), { throwOnError: true })
     addProjectDeleteMethod(sdk, server.current.http.url, authHeader(server.current.http), { throwOnError: true })
     addGlobalScriptsMethod(sdk, server.current.http.url, authHeader(server.current.http), { throwOnError: true })
-    if (!memoryInitializationToastShown) {
-      memoryInitializationToastShown = true
-      void sdk.memory.status().then((result) => {
-        const data = result.data ?? {}
-        if (data.needs_initialization && data.has_history_sessions) {
-          showToast({
-            title: "Memory initialization available",
-            description: "Open Settings > Memory to import useful memories from previous conversations.",
-          })
-        }
-      })
-    }
 
     return {
       url: currentServer.http.url,


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [x] Bug fix

### What does this PR do?

Remove the "Memory initialization available" toast notification that appears on every app refresh, along with its unused guard variable `memoryInitializationToastShown`.

### How did you verify your code works?

Verified the change compiles by running `bun typecheck` from `packages/app`.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR