### PR TITLE
mobile: limit session list to 30, add /header toggle, and improve hints

### DIFF
--- a/packages/opencode/src/mobile/base.ts
+++ b/packages/opencode/src/mobile/base.ts
@@ -60,10 +60,10 @@ function localISOString(d = new Date()): string {
 }
 
 const HELP_TEXT =
-  "📋 可用命令：\n\n/n, /new            开启新对话\n/stop               停止当前执行\n/steer <text>       在AI回复时追加引导\n/c, /compact        压缩当前上下文\n\n/m, /model          查看可用模型\n/m l                查看全部模型\n/m n                切换编号模型\n\n/a, /agent          查看当前模式\n/a n | /a <name>    切换指定模式\n\n/variant            查看思考等级\n/variant n          切换编号思考等级\n\n/autoaccept         查看审批模式\n/autoaccept n       切换编号审批模式\n\n/p, /project        查看最近项目\n/p l                查看全部项目\n/p n                切换编号项目\n/p <path>           切换到指定路径\n\n/s, /session        查看最近会话\n/s l                查看全部会话\n/s n                切换编号会话\n\n/h, /help           显示帮助信息\n/help list          显示全部命令"
+  "📋 可用命令：\n\n/n, /new            开启新对话\n/stop               停止当前执行\n/steer <text>       在AI回复时追加引导\n/c, /compact        压缩当前上下文\n\n/m, /model          查看可用模型\n/m l                查看全部模型\n/m n                切换编号模型\n\n/a, /agent          查看当前模式\n/a n ； /a <name>    切换指定模式\n\n/variant            查看思考等级\n/variant n          切换编号思考等级\n\n/autoaccept         查看审批模式\n/autoaccept n       切换编号审批模式\n\n/p, /project        查看最近项目\n/p l                查看全部项目\n/p n                切换编号项目\n/p <path>           切换到指定路径\n\n/s, /session        查看最近会话\n/s l                查看最近30个会话\n/s n                切换编号会话\n\n/h, /help           显示帮助信息\n/help list          显示全部命令"
 
 const HELP_LIST_TEXT =
-  "📋 全部命令：\n\n/n, /new\n  开启新对话，清空当前会话上下文\n\n/stop\n  停止当前执行中的任务\n\n/steer <text>\n  在AI正在回复时追加引导信息，影响下一轮处理\n\n/c, /compact\n  压缩当前会话上下文\n\n/m, /model\n  查看可用模型\n/m l, /model list\n  查看全部模型（l = list）\n/m n, /model n\n  切换到编号 n 的模型（n 为全量模型编号）\n\n/a, /agent\n  查看当前模式\n/a n, /agent n\n  按编号切换模式\n/a <name>, /agent <name>\n  按名称切换模式（如 build、plan、docs）\n\n/variant\n  查看当前模型可用的思考等级\n/variant n\n  按编号切换思考等级\n/variant <name>\n  按名称切换思考等级\n\n/autoaccept\n  查看审批模式\n/autoaccept n\n  按编号切换审批模式（1=auto, 2=ask）\n/autoaccept <name>\n  切换审批模式（name 可选：auto、ask）\n\n/p, /project\n  查看最近项目\n/p l, /project list\n  查看全部项目（l = list）\n/p n, /project n\n  切换到编号 n 的项目\n/p <path>, /project <path>\n  切换到指定路径（如 /p E:\\work\\foo 或 /p /home/user/foo）\n/project hide n\n  隐藏编号 n 的项目，重新在桌面端或消息端使用后自动恢复\n\n/s, /session\n  查看最近会话\n/s l, /session list\n  查看当前项目下全部会话（l = list）\n/s n, /session n\n  切换到当前项目下编号 n 的会话\n\n/h, /help\n  显示常用命令\n/help list\n  显示全部命令"
+  "📋 全部命令：\n\n/n, /new\n  开启新对话，清空当前会话上下文\n\n/stop\n  停止当前执行中的任务\n\n/steer <text>\n  在AI正在回复时追加引导信息，影响下一轮处理\n\n/c, /compact\n  压缩当前会话上下文\n\n/m, /model\n  查看可用模型\n/m l, /model list\n  查看全部模型（l = list）\n/m n, /model n\n  切换到编号 n 的模型（n 为全量模型编号）\n\n/a, /agent\n  查看当前模式\n/a n, /agent n\n  按编号切换模式\n/a <name>, /agent <name>\n  按名称切换模式（如 build、plan、docs）\n\n/variant\n  查看当前模型可用的思考等级\n/variant n\n  按编号切换思考等级\n/variant <name>\n  按名称切换思考等级\n\n/autoaccept\n  查看审批模式\n/autoaccept n\n  按编号切换审批模式（1=auto, 2=ask）\n/autoaccept <name>\n  切换审批模式（name 可选：auto、ask）\n\n/p, /project\n  查看最近项目\n/p l, /project list\n  查看全部项目（l = list）\n/p n, /project n\n  切换到编号 n 的项目\n/p <path>, /project <path>\n  切换到指定路径（如 /p E:\\work\\foo 或 /p /home/user/foo）\n/project hide n\n  隐藏编号 n 的项目，重新在桌面端或消息端使用后自动恢复\n\n/s, /session\n  查看最近会话\n/s l, /session list\n  查看当前项目下最近30个会话（l = list）\n/s n, /session n\n  切换到当前项目下编号 n 的会话\n\n/h, /help\n  显示常用命令\n/help list\n  显示全部命令"
 
 export interface ModelRef {
   providerID: string
@@ -1041,7 +1041,7 @@ export abstract class MobileManagerBase {
     }
 
     lines.push("")
-    lines.push("💡 /m n 切换模型 | /m l 查看全部")
+    lines.push("💡 /m n 切换模型 ； /m l 查看全部")
     return lines.join("\n")
   }
 
@@ -1313,7 +1313,7 @@ export abstract class MobileManagerBase {
       count++
     }
     lines.push("")
-    lines.push("💡 /p n 切换 | /p l 查看全部 | /p <path> 指定路径（[sandbox] = 非主worktree）")
+    lines.push("💡 /p n 切换 ； /p l 查看全部 ； /p <path> 指定路径（[sandbox] = 非主worktree）")
     if (Object.keys(this._hiddenDirs).length > 0) {
       lines.push(`ℹ️ 已隐藏 ${Object.keys(this._hiddenDirs).length} 个项目（重新使用后自动恢复）`)
     }
@@ -1476,7 +1476,7 @@ export abstract class MobileManagerBase {
         fn: async () => {
           sessionSnapshots.set(
             dirKey,
-            this.buildSessionEntries([...Session.list({ directory: effectiveDir, limit: 200 })]),
+            this.buildSessionEntries([...Session.list({ directory: effectiveDir, limit: 30 })]),
           )
         },
       })
@@ -1487,7 +1487,7 @@ export abstract class MobileManagerBase {
         fn: async () => {
           sessionSnapshots.set(
             dirKey,
-            this.buildSessionEntries([...Session.list({ directory: effectiveDir, limit: 200 })]),
+            this.buildSessionEntries([...Session.list({ directory: effectiveDir, limit: 30 })]),
           )
         },
       })
@@ -1555,7 +1555,7 @@ export abstract class MobileManagerBase {
       lines.push(`${i + 1}. ${forkTag}${s.title}${tag} (${this.formatSessionTime(s.time.updated)})`)
     }
     lines.push("")
-    lines.push("💡 /s n 切换会话 | /s l 查看全部（↗ = fork分支）")
+    lines.push("💡 /s n 切换会话 ； /s l 查看最近30个会话（↗ = fork分支）")
     await this.replyCmd(targetId, scope, lines.join("\n"))
   }
 

--- a/packages/opencode/src/mobile/base.ts
+++ b/packages/opencode/src/mobile/base.ts
@@ -60,10 +60,10 @@ function localISOString(d = new Date()): string {
 }
 
 const HELP_TEXT =
-  "📋 可用命令：\n\n/n, /new            开启新对话\n/stop               停止当前执行\n/steer <text>       在AI回复时追加引导\n/c, /compact        压缩当前上下文\n\n/m, /model          查看可用模型\n/m l                查看全部模型\n/m n                切换编号模型\n\n/a, /agent          查看当前模式\n/a n ； /a <name>    切换指定模式\n\n/variant            查看思考等级\n/variant n          切换编号思考等级\n\n/autoaccept         查看审批模式\n/autoaccept n       切换编号审批模式\n\n/p, /project        查看最近项目\n/p l                查看全部项目\n/p n                切换编号项目\n/p <path>           切换到指定路径\n\n/s, /session        查看最近会话\n/s l                查看最近30个会话\n/s n                切换编号会话\n\n/h, /help           显示帮助信息\n/help list          显示全部命令"
+  "📋 可用命令：\n\n/n, /new            开启新对话\n/stop               停止当前执行\n/steer <text>       在AI回复时追加引导\n/c, /compact        压缩当前上下文\n\n/m, /model          查看可用模型\n/m l                查看全部模型\n/m n                切换编号模型\n\n/a, /agent          查看当前模式\n/a n ； /a <name>    切换指定模式\n\n/variant            查看思考等级\n/variant n          切换编号思考等级\n\n/autoaccept         查看审批模式\n/autoaccept n       切换编号审批模式\n\n/p, /project        查看最近项目\n/p l                查看全部项目\n/p n                切换编号项目\n/p <path>           切换到指定路径\n\n/s, /session        查看最近会话\n/s l                查看最近30个会话\n/s n                切换编号会话\n\n/header             切换回复头部显示\n\n/h, /help           显示帮助信息\n/help list          显示全部命令"
 
 const HELP_LIST_TEXT =
-  "📋 全部命令：\n\n/n, /new\n  开启新对话，清空当前会话上下文\n\n/stop\n  停止当前执行中的任务\n\n/steer <text>\n  在AI正在回复时追加引导信息，影响下一轮处理\n\n/c, /compact\n  压缩当前会话上下文\n\n/m, /model\n  查看可用模型\n/m l, /model list\n  查看全部模型（l = list）\n/m n, /model n\n  切换到编号 n 的模型（n 为全量模型编号）\n\n/a, /agent\n  查看当前模式\n/a n, /agent n\n  按编号切换模式\n/a <name>, /agent <name>\n  按名称切换模式（如 build、plan、docs）\n\n/variant\n  查看当前模型可用的思考等级\n/variant n\n  按编号切换思考等级\n/variant <name>\n  按名称切换思考等级\n\n/autoaccept\n  查看审批模式\n/autoaccept n\n  按编号切换审批模式（1=auto, 2=ask）\n/autoaccept <name>\n  切换审批模式（name 可选：auto、ask）\n\n/p, /project\n  查看最近项目\n/p l, /project list\n  查看全部项目（l = list）\n/p n, /project n\n  切换到编号 n 的项目\n/p <path>, /project <path>\n  切换到指定路径（如 /p E:\\work\\foo 或 /p /home/user/foo）\n/project hide n\n  隐藏编号 n 的项目，重新在桌面端或消息端使用后自动恢复\n\n/s, /session\n  查看最近会话\n/s l, /session list\n  查看当前项目下最近30个会话（l = list）\n/s n, /session n\n  切换到当前项目下编号 n 的会话\n\n/h, /help\n  显示常用命令\n/help list\n  显示全部命令"
+  "📋 全部命令：\n\n/n, /new\n  开启新对话，清空当前会话上下文\n\n/stop\n  停止当前执行中的任务\n\n/steer <text>\n  在AI正在回复时追加引导信息，影响下一轮处理\n\n/c, /compact\n  压缩当前会话上下文\n\n/m, /model\n  查看可用模型\n/m l, /model list\n  查看全部模型（l = list）\n/m n, /model n\n  切换到编号 n 的模型（n 为全量模型编号）\n\n/a, /agent\n  查看当前模式\n/a n, /agent n\n  按编号切换模式\n/a <name>, /agent <name>\n  按名称切换模式（如 build、plan、docs）\n\n/variant\n  查看当前模型可用的思考等级\n/variant n\n  按编号切换思考等级\n/variant <name>\n  按名称切换思考等级\n\n/autoaccept\n  查看审批模式\n/autoaccept n\n  按编号切换审批模式（1=auto, 2=ask）\n/autoaccept <name>\n  切换审批模式（name 可选：auto、ask）\n\n/p, /project\n  查看最近项目\n/p l, /project list\n  查看全部项目（l = list）\n/p n, /project n\n  切换到编号 n 的项目\n/p <path>, /project <path>\n  切换到指定路径（如 /p E:\\work\\foo 或 /p /home/user/foo）\n/project hide n\n  隐藏编号 n 的项目，重新在桌面端或消息端使用后自动恢复\n\n/s, /session\n  查看最近会话\n/s l, /session list\n  查看当前项目下最近30个会话（l = list）\n/s n, /session n\n  切换到当前项目下编号 n 的会话\n\n/header\n  切换回复头部信息的显示/隐藏（默认显示）\n\n/h, /help\n  显示常用命令\n/help list\n  显示全部命令"
 
 export interface ModelRef {
   providerID: string
@@ -116,6 +116,7 @@ export abstract class MobileManagerBase {
   protected sessionMap: SessionMapKey = {}
   protected _scopeDirs: Record<string, string> = {}
   protected _hiddenDirs: Record<string, number> = {}
+  protected _showHeader: boolean = true
   protected _initialDir: string = ""
   protected _initialSessionId: string = ""
   protected _initialized: boolean = false
@@ -479,7 +480,8 @@ export abstract class MobileManagerBase {
       await this.adapter.replyText(targetId, body)
       return
     }
-    await this.adapter.replyText(targetId, this.commandHeader(await this.commandCtx(scope)) + body)
+    const text = this._showHeader ? this.commandHeader(await this.commandCtx(scope)) + body : body
+    await this.adapter.replyText(targetId, text)
   }
 
   protected async setPref(scope: string, patch: Record<string, any>): Promise<void> {
@@ -779,7 +781,6 @@ export abstract class MobileManagerBase {
               }),
           })
         }
-        const header = await this.formatHeader(scope)
         console.log(`[${this.adapter.platform}] replying:`, responseText.slice(0, 100), localISOString())
         await this.replySession(scope, reply, responseText)
       } else {
@@ -936,6 +937,8 @@ export abstract class MobileManagerBase {
         await this.cmdProject(targetId, scope, arg)
       } else if (command === "/s" || command === "/session") {
         await this.cmdSession(targetId, scope, rest === "l" ? "list" : rest)
+      } else if (command === "/header") {
+        await this.cmdHeader(targetId, scope)
       } else if (command === "/h" || command === "/help") {
         await this.adapter.replyText(targetId, rest.toLowerCase() === "list" ? HELP_LIST_TEXT : HELP_TEXT)
       } else {
@@ -949,6 +952,15 @@ export abstract class MobileManagerBase {
       const errMsg = err instanceof Error ? err.message : String(err)
       await this.adapter.replyText(targetId, `命令执行出错: ${errMsg}`).catch(() => {})
     }
+  }
+
+  protected async cmdHeader(targetId: string, scope: string): Promise<void> {
+    this._showHeader = !this._showHeader
+    await this.saveHeaderState()
+    const msg = this._showHeader
+      ? "✅ 回复头部已恢复显示（再次 /header 可隐藏）"
+      : "✅ 回复头部已隐藏（再次 /header 可恢复显示）"
+    await this.replyCmd(targetId, scope, msg)
   }
 
   protected async cmdNew(targetId: string, scope: string): Promise<void> {
@@ -1586,8 +1598,8 @@ export abstract class MobileManagerBase {
   }
 
   protected async replySession(scope: string, targetId: string, body: string): Promise<void> {
-    const header = await this.formatHeader(scope)
-    await this.adapter.replyText(targetId, header + body)
+    const text = this._showHeader ? (await this.formatHeader(scope)) + body : body
+    await this.adapter.replyText(targetId, text)
   }
 
   private async sessionTitle(sessionId: string, directory: string): Promise<string> {
@@ -1826,6 +1838,22 @@ export abstract class MobileManagerBase {
     await writeFile(this.file("hidden_projects.json"), JSON.stringify(this._hiddenDirs, null, 2))
   }
 
+  protected async saveHeaderState(): Promise<void> {
+    await mkdir(this.dir(), { recursive: true })
+    await writeFile(this.file("header_state.json"), JSON.stringify({ show: this._showHeader }, null, 2))
+  }
+
+  protected async loadHeaderState(): Promise<boolean> {
+    try {
+      const next = this.readPath("header_state.json")
+      if (existsSync(next)) {
+        const data = await readFile(next, "utf-8")
+        return JSON.parse(data).show ?? true
+      }
+    } catch {}
+    return true
+  }
+
   protected async loadHiddenDirs(): Promise<Record<string, number>> {
     try {
       const next = this.readPath("hidden_projects.json")
@@ -1841,8 +1869,10 @@ export abstract class MobileManagerBase {
     try {
       await rm(this.file("sessions.json"), { force: true })
       await rm(this.file("hidden_projects.json"), { force: true })
+      await rm(this.file("header_state.json"), { force: true })
       this.sessionMap = {}
       this._hiddenDirs = {}
+      this._showHeader = true
     } catch {}
     await this.adapter.clearAuth()
   }

--- a/packages/opencode/src/mobile/feishu.ts
+++ b/packages/opencode/src/mobile/feishu.ts
@@ -200,6 +200,7 @@ class FeishuManagerImpl extends MobileManagerBase {
     await this.saveConfig(cfg)
     this.sessionMap = await this.loadSessionMap()
     this._hiddenDirs = await this.loadHiddenDirs()
+    this._showHeader = await this.loadHeaderState()
     void this._doStart(cfg, model ?? null)
     return { success: true }
   }
@@ -439,9 +440,11 @@ class FeishuManagerImpl extends MobileManagerBase {
       await rm(this.file("config.json"), { force: true })
       await rm(this.file("sessions.json"), { force: true })
       await rm(this.file("hidden_projects.json"), { force: true })
+      await rm(this.file("header_state.json"), { force: true })
       this._feishuSession = null
       this.sessionMap = {}
       this._hiddenDirs = {}
+      this._showHeader = true
     } catch {}
     await this.feishuAdapter.clearAuth()
   }

--- a/packages/opencode/src/mobile/qq.ts
+++ b/packages/opencode/src/mobile/qq.ts
@@ -257,6 +257,7 @@ class QQManagerImpl extends MobileManagerBase {
     await this.saveConfig(cfg)
     this.sessionMap = await this.loadSessionMap()
     this._hiddenDirs = await this.loadHiddenDirs()
+    this._showHeader = await this.loadHeaderState()
     void this._doStart(cfg, model ?? null)
     return { success: true }
   }
@@ -549,9 +550,11 @@ class QQManagerImpl extends MobileManagerBase {
       await rm(this.file("config.json"), { force: true })
       await rm(this.file("sessions.json"), { force: true })
       await rm(this.file("hidden_projects.json"), { force: true })
+      await rm(this.file("header_state.json"), { force: true })
       this._qqSession = null
       this.sessionMap = {}
       this._hiddenDirs = {}
+      this._showHeader = true
     } catch {}
     await this.qqAdapter.clearAuth()
   }

--- a/packages/opencode/src/mobile/wechat.ts
+++ b/packages/opencode/src/mobile/wechat.ts
@@ -224,6 +224,7 @@ class WeChatManagerImpl extends MobileManagerBase {
 
     this.sessionMap = await this.loadSessionMap()
     this._hiddenDirs = await this.loadHiddenDirs()
+    this._showHeader = await this.loadHeaderState()
 
     const savedSession = await this.adapter.loadSession()
     if (!rescan && savedSession?.connected && savedSession.user) {
@@ -514,6 +515,7 @@ class WeChatManagerImpl extends MobileManagerBase {
       await rm(wcFile("ilink_state.json"), { force: true })
       this._wcSession = null
     } catch {}
+    await super.clearSession()
     await this.adapter.clearAuth()
   }
 


### PR DESCRIPTION
## Summary
- Limit `/s l` session list to recent 30 entries instead of 200
- Replace `|` with `；` in user-facing hint text to avoid confusion with letter `l`
- Add `/header` toggle command to show/hide reply header info (persisted across restarts)