### PR TITLE
fix(memory): harden daily reflection

### DIFF
--- a/packages/opencode/src/memory/index.ts
+++ b/packages/opencode/src/memory/index.ts
@@ -163,6 +163,37 @@ function isAbortLike(error: unknown) {
   return false
 }
 
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return `${error.name} ${error.message} ${errorMessage(error.cause)}`
+  if (typeof error === "object" && error !== null) {
+    try {
+      return JSON.stringify(error)
+    } catch {
+      return String(error)
+    }
+  }
+  return String(error ?? "")
+}
+
+function isRetryableReflectionProviderError(error: unknown) {
+  if (isAbortLike(error)) return false
+  const message = errorMessage(error)
+  if (!/badrequest|bad request|invalid request|validation|400/i.test(message)) return false
+  return /reasoning[_\s-]?effort|reasoning|provider.?options?|temperature|top[_\s-]?p|topP|unsupported/i.test(message)
+}
+
+function safeReflectionProviderOptions(model: Provider.Model) {
+  const options = { ...ProviderTransform.smallOptions(model) }
+  const lower = `${model.providerID} ${model.api.npm} ${model.api.id}`.toLowerCase()
+  if (lower.includes("gpt-5") || options.reasoningEffort !== undefined) {
+    options.reasoningEffort = "low"
+  }
+  if (model.providerID === "openai" || model.api.npm === "@ai-sdk/openai" || model.api.npm === "@ai-sdk/openai-compatible") {
+    options.store = false
+  }
+  return Object.keys(options).length ? options : undefined
+}
+
 function initializationWasCancelled(signal?: AbortSignal) {
   return initializeCancelled || signal?.aborted === true
 }
@@ -683,6 +714,7 @@ async function llmReflector(input: {
   doc: MemoryDocument
   mode: ReflectionMode
   signal?: AbortSignal
+  safeProviderOptions?: boolean
 }): Promise<ReflectionCandidate[]> {
   throwIfAborted(input.signal)
   if (!input.events.length) return []
@@ -733,15 +765,21 @@ async function llmReflector(input: {
       2,
     ),
   }
+  const retryProviderOptions = input.safeProviderOptions ? safeReflectionProviderOptions(resolved) : undefined
   const params = {
     model: language,
-    temperature: 0,
+    ...(input.safeProviderOptions ? {} : { temperature: 0 }),
     schema: ReflectionOutput,
     abortSignal: input.signal,
     messages: [
       { role: "system", content: system },
       userMessage,
     ],
+    ...(retryProviderOptions
+      ? {
+          providerOptions: ProviderTransform.providerOptions(resolved, retryProviderOptions),
+        }
+      : {}),
   } satisfies Parameters<typeof generateObject>[0]
   throwIfAborted(input.signal)
 
@@ -754,6 +792,7 @@ async function llmReflector(input: {
             ...params,
             messages: [userMessage],
             providerOptions: ProviderTransform.providerOptions(resolved, {
+              ...(retryProviderOptions ?? {}),
               store: false,
               instructions: system,
             }),
@@ -964,8 +1003,15 @@ async function defaultForgetDecision(input: { query: string; candidates: MemoryB
 
 async function runReflector(input: ReflectionInput) {
   throwIfAborted(input.signal)
-  if (reflectorForTest) return reflectorForTest(input)
-  return await llmReflector(input)
+  const reflect = (safeProviderOptions: boolean) =>
+    reflectorForTest ? reflectorForTest(input) : llmReflector({ ...input, safeProviderOptions })
+  try {
+    return await reflect(false)
+  } catch (error) {
+    if (!isRetryableReflectionProviderError(error)) throw error
+    throwIfAborted(input.signal)
+    return await reflect(true)
+  }
 }
 
 function mergeCandidates(doc: MemoryDocument, candidates: ReflectionCandidate[], events: MemoryEvent[] = []) {

--- a/packages/opencode/src/memory/installer.ts
+++ b/packages/opencode/src/memory/installer.ts
@@ -3,6 +3,8 @@ import { Memory } from "."
 
 export const MEMORY_DAILY_REFLECT_ACTION = "memory.reflect.daily"
 export const MEMORY_DAILY_REFLECT_JOB_ID = "builtin.memory.daily_reflect"
+const MEMORY_DAILY_REFLECT_LEGACY_ACTION = "memory_reflect"
+const MEMORY_DAILY_REFLECT_LEGACY_JOB_IDS = ["builtin-memory-reflection-daily"]
 
 export type InstalledMemory = {
   service: typeof Memory
@@ -21,43 +23,63 @@ function scheduleFromTime(time: string | undefined) {
   return `${minute} ${hour} * * *`
 }
 
+function dailyReflectDefinitionPatch(input: { enabled: boolean; schedule: string }) {
+  return {
+    name: "Daily memory reflection",
+    enabled: input.enabled,
+    mode: "direct" as const,
+    project_id: null,
+    session_id: null,
+    schedule_type: "cron" as const,
+    schedule_value: input.schedule,
+    payload: {
+      action: MEMORY_DAILY_REFLECT_ACTION,
+    },
+  }
+}
+
+async function disableLegacyDailyReflectJobs(schedule: string) {
+  for (const id of MEMORY_DAILY_REFLECT_LEGACY_JOB_IDS) {
+    const existing = await Cron.getJob(id).catch(() => undefined)
+    if (!existing) continue
+    await Cron.updateJob({
+      id,
+      patch: dailyReflectDefinitionPatch({
+        enabled: false,
+        schedule,
+      }),
+    })
+  }
+}
+
 export async function syncDailyReflectJob(input?: { preserveExisting?: boolean }) {
   const cfg = await Memory.settings()
   const enabled = cfg.enabled && cfg.dailyReflectEnabled
   const schedule = scheduleFromTime(cfg.dailyReflectTime)
+  await disableLegacyDailyReflectJobs(schedule)
   const existing = await Cron.getJob(MEMORY_DAILY_REFLECT_JOB_ID).catch(() => undefined)
   if (existing && input?.preserveExisting !== false) return existing
   if (existing) {
     return Cron.updateJob({
       id: MEMORY_DAILY_REFLECT_JOB_ID,
-      patch: {
-        enabled,
-        schedule_value: schedule,
-      },
+      patch: dailyReflectDefinitionPatch({ enabled, schedule }),
     })
   }
   return Cron.ensureJob({
     id: MEMORY_DAILY_REFLECT_JOB_ID,
-    name: "Daily memory reflection",
-    enabled,
-    mode: "direct",
-    project_id: null,
-    session_id: null,
-    schedule_type: "cron",
-    schedule_value: schedule,
-    payload: {
-      action: MEMORY_DAILY_REFLECT_ACTION,
-    },
+    ...dailyReflectDefinitionPatch({ enabled, schedule }),
   })
 }
 
 export function registerMemoryDirectActions() {
-  Cron.registerDirectAction(MEMORY_DAILY_REFLECT_ACTION, async () => {
+  const handler = async () => {
     const result = await Memory.reflect({ mode: "daily", reason: "cron" })
     return {
       output_summary: result.summary,
     }
-  })
+  }
+  Cron.registerDirectAction(MEMORY_DAILY_REFLECT_ACTION, handler)
+  Cron.registerDirectAction(MEMORY_DAILY_REFLECT_LEGACY_ACTION, handler)
 }
 
 export async function installMemory(): Promise<InstalledMemory> {

--- a/packages/opencode/test/memory/memory.test.ts
+++ b/packages/opencode/test/memory/memory.test.ts
@@ -1096,6 +1096,37 @@ describe("memory service", () => {
     const found = await Memory.search({ query: "回答风格 中文 结论", limit: 5 })
     expect(found.results[0]?.memory).toContain("回答风格")
   })
+
+  test("reflection retries once with safer provider settings after provider option BadRequest", async () => {
+    let calls = 0
+    Memory.setReflectorForTest(async ({ events }) => {
+      calls++
+      if (calls === 1) {
+        throw new Error("litellm.BadRequestError: reasoning_effort input should be none, low, medium or high")
+      }
+      return events.map((event) => ({
+        eventID: event.id,
+        type: "preference" as const,
+        scope: "global" as const,
+        memory: event.raw_text,
+        confidence: 0.9,
+        weight: 0.86,
+        evidence: "retried after provider option BadRequest",
+      }))
+    })
+
+    await Memory.remember({
+      text: "我希望默认用中文回答",
+      type: "preference",
+      intent: "observed",
+      source: { createdAt: Date.now(), role: "user" },
+    })
+
+    const reflected = await Memory.reflect({ mode: "daily", reason: "test" })
+    expect(reflected.changed).toBe(true)
+    expect(calls).toBe(2)
+    expect((await Memory.search({ query: "中文回答", limit: 5 })).results[0]?.memory).toContain("中文回答")
+  })
 })
 
 describe("memory agent tools", () => {
@@ -1247,6 +1278,79 @@ describe("memory installer", () => {
     await Cron.runJobNow({ id: "builtin.memory.daily_reflect" })
     const runs = await Cron.listRuns({ id: "builtin.memory.daily_reflect", count: 1 })
     expect(runs[0]?.status).toBe("success")
+  })
+
+  test("repairs stale builtin daily reflect cron payloads during install", async () => {
+    await using tmp = await tmpdir()
+    const previousCronDir = process.env.OPENCODE_CRON_DIR
+    process.env.OPENCODE_CRON_DIR = path.join(tmp.path, "cron-jobs")
+    try {
+      Memory.configureForTest({
+        globalMemoryDir: path.join(tmp.path, "global-memory"),
+        channelRootDir: path.join(tmp.path, "channels"),
+        channelID: "latest",
+        settings: { enabled: true, dailyReflectEnabled: true, dailyReflectTime: "03:00" },
+      })
+      await Memory.purge()
+      await Cron.ensureJob({
+        id: "builtin.memory.daily_reflect",
+        name: "Daily memory reflection",
+        enabled: true,
+        mode: "direct",
+        schedule_type: "cron",
+        schedule_value: "0 2 * * *",
+        payload: { action: "memory_reflect" },
+      })
+
+      await installMemory()
+
+      const job = await Cron.getJob("builtin.memory.daily_reflect")
+      expect(job.definition.mode).toBe("direct")
+      expect(job.definition.project_id).toBeNull()
+      expect(job.definition.session_id).toBeNull()
+      expect(job.definition.payload).toEqual({ action: "memory.reflect.daily" })
+
+      const run = await Cron.runJobNow({ id: "builtin.memory.daily_reflect" })
+      expect(run.status).toBe("success")
+    } finally {
+      process.env.OPENCODE_CRON_DIR = previousCronDir
+    }
+  })
+
+  test("disables legacy daily reflect cron jobs after installing the canonical job", async () => {
+    await using tmp = await tmpdir()
+    const previousCronDir = process.env.OPENCODE_CRON_DIR
+    process.env.OPENCODE_CRON_DIR = path.join(tmp.path, "cron-jobs")
+    try {
+      Memory.configureForTest({
+        globalMemoryDir: path.join(tmp.path, "global-memory"),
+        channelRootDir: path.join(tmp.path, "channels"),
+        channelID: "latest",
+        settings: { enabled: true, dailyReflectEnabled: true, dailyReflectTime: "03:00" },
+      })
+      await Memory.purge()
+      await Cron.ensureJob({
+        id: "builtin-memory-reflection-daily",
+        name: "Daily memory reflection",
+        enabled: true,
+        mode: "direct",
+        schedule_type: "cron",
+        schedule_value: "0 2 * * *",
+        payload: { action: "memory_reflect" },
+      })
+
+      await installMemory()
+
+      const legacy = await Cron.getJob("builtin-memory-reflection-daily")
+      expect(legacy.definition.enabled).toBe(false)
+      expect(legacy.definition.payload).toEqual({ action: "memory.reflect.daily" })
+
+      const current = await Cron.getJob("builtin.memory.daily_reflect")
+      expect(current.definition.enabled).toBe(true)
+      expect(current.definition.payload).toEqual({ action: "memory.reflect.daily" })
+    } finally {
+      process.env.OPENCODE_CRON_DIR = previousCronDir
+    }
   })
 })
 


### PR DESCRIPTION
### Issue for this PR

Closes #960

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes two failure paths in memory reflection without changing cron core behavior or the agent runtime.

First, memory installation now repairs the canonical daily reflection cron job to the current direct action payload, `memory.reflect.daily`. It also disables the old `builtin-memory-reflection-daily` job so upgraded installs do not run duplicate daily reflection jobs. The old `memory_reflect` direct action remains registered as a compatibility alias for old/custom job files.

Second, memory reflection now retries once when the LLM call fails with a provider-option BadRequest or validation-style error. The retry uses safer provider options, including a conservative `reasoningEffort: "low"` for GPT-5/OpenAI-compatible cases, and avoids retrying abort/cancel errors.

The changes are intentionally localized to:
- `packages/opencode/src/memory/index.ts`
- `packages/opencode/src/memory/installer.ts`
- `packages/opencode/test/memory/memory.test.ts`

No cron core, UI, session, or agent runtime behavior is changed.

### How did you verify your code works?

- `bun test test/memory/memory.test.ts test/cron/cron.test.ts --timeout 120000`
- Result: 72 pass, 0 fail
- `git diff --check`

Note: local `bun run typecheck` currently reports unrelated TUI/session-list and local dependency-resolution errors outside this PR’s modified files.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR