### PR TITLE
fix: prevent file watching anomaly during Sandbox creation and deletion

### DIFF
--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -66,6 +66,7 @@ function createGlobalSync() {
   const booting = new Map<string, Promise<void>>()
   const sessionLoads = new Map<string, Promise<void>>()
   const sessionMeta = new Map<string, { limit: number }>()
+  const deleting = new Set<string>()
 
   const [projectCache, setProjectCache, projectInit] = persisted(
     Persist.global("globalSync.project", ["globalSync.project.v1"]),
@@ -416,6 +417,8 @@ function createGlobalSync() {
       children.peek(directory, { bootstrap: true })
     }
 
+    if (event.type === "server.instance.disposed" && deleting.has(normalizeDir(directory))) return
+
     const existing = children.getChild(directory)
     if (!existing) return
     children.mark(directory)
@@ -512,12 +515,21 @@ function createGlobalSync() {
       })
     },
     removeSandbox(root: string, directory: string) {
+      const dir = normalizeDir(directory)
+      deleting.delete(dir)
+      queue.clear(dir)
+      children.disposeDirectory(dir)
       setProjects((draft) => {
         const item = draft.find((project) => normalizeDir(project.worktree) === normalizeDir(root))
         if (!item) return
-        const nd = normalizeDir(directory)
-        item.sandboxes = (item.sandboxes ?? []).filter((sandbox) => normalizeDir(sandbox) !== nd)
+        item.sandboxes = (item.sandboxes ?? []).filter((sandbox) => normalizeDir(sandbox) !== dir)
       })
+    },
+    beginRemove(directory: string) {
+      deleting.add(normalizeDir(directory))
+    },
+    cancelRemove(directory: string) {
+      deleting.delete(normalizeDir(directory))
     },
     refreshRecent,
     meta(directory: string, patch: ProjectMeta) {

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1839,6 +1839,7 @@ export default function Layout(props: ParentProps) {
     }
 
     setBusy(directory, true)
+    globalSync.project.beginRemove(directory)
 
     const result = await globalSDK.client.worktree
       .remove({ directory: root, worktreeRemoveInput: { directory } })
@@ -1852,11 +1853,13 @@ export default function Layout(props: ParentProps) {
       })
 
     if (!result) {
+      globalSync.project.cancelRemove(directory)
       setBusy(directory, false)
       return
     }
 
     if (result && typeof result === "object" && result.status === "stale") {
+      globalSync.project.cancelRemove(directory)
       setBusy(directory, false)
       dialog.show(() => <DialogForceDeleteWorkspace root={root} directory={directory} gitStderr={result.gitStderr} />)
       return
@@ -2078,6 +2081,7 @@ export default function Layout(props: ParentProps) {
     const handleForceDelete = async () => {
       dialog.close()
       setBusy(props.directory, true)
+      globalSync.project.beginRemove(props.directory)
       const result = await globalSDK.client.worktree
         .remove({ directory: props.root, worktreeRemoveInput: { directory: props.directory, force: true } })
         .then((x) => x.data)
@@ -2089,7 +2093,10 @@ export default function Layout(props: ParentProps) {
           return undefined
         })
       setBusy(props.directory, false)
-      if (!result) return
+      if (!result) {
+        globalSync.project.cancelRemove(props.directory)
+        return
+      }
       if (workspaceKey(store.lastProjectSession[props.root]?.directory ?? "") === workspaceKey(props.directory)) {
         clearLastProjectSession(props.root)
       }

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -598,6 +598,7 @@ export default function Layout(props: ParentProps) {
         if (e.details?.type === "worktree.ready") {
           setBusy(e.name, false)
           WorktreeState.ready(e.name)
+          globalSync.child(e.name)
           return
         }
 
@@ -2399,7 +2400,7 @@ export default function Layout(props: ParentProps) {
       return [...next, created.directory]
     })
 
-    globalSync.child(created.directory)
+    globalSync.child(created.directory, { bootstrap: false })
     navigateWithSidebarReset(`/${base64Encode(created.directory)}/session`)
   }
 


### PR DESCRIPTION
### Issue for this PR

Closes #962

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

前端创建 sandbox 后先注册本地 child 但不 bootstrap，等收到 worktree.ready 再启动同步
删除 sandbox 时，前端先把该 directory 标记成 deleting，server.instance.disposed 对这些目录不再 queue.push(directory)

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
bun typecheck

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
