### PR TITLE
fix: set finish field on recovered interrupted messages

### DIFF
--- a/packages/opencode/src/session/recovery.ts
+++ b/packages/opencode/src/session/recovery.ts
@@ -44,6 +44,7 @@ export namespace SessionRecovery {
             ),
           Session.updateMessage({
             ...msg.info,
+            finish: msg.info.finish ?? "error",
             error:
               msg.info.error ??
               MessageV2.fromError(new Error(input.message), {


### PR DESCRIPTION
### Issue for this PR

Closes #964

### Type of change

- [x] Bug fix

### What does this PR do?

`SessionRecovery.repair` sets `error` and `time.completed` on interrupted assistant messages but was missing `finish`. Without `finish`, downstream logic treats the message as still-in-progress: `filterCompacted` cannot establish a compaction boundary, so all history remains in context until it overflows the model window and the session stops. This PR adds `finish: msg.info.finish ?? "error"` so the interrupted message is properly marked as completed.

### How did you verify your code works?

- `bun typecheck` passes in `packages/opencode`
- Inspected the per-project DB confirming the bug pattern: a message with `error IS NOT NULL` but `finish IS NULL`, zero compaction boundaries, and context growing to 127K tokens before stop

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR