### PR TITLE
fix: preserve compacted marks set before revert point to match original context

### DIFF
--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -181,12 +181,16 @@ export namespace SessionRevert {
       })
       if (msg === target) target = undefined
     }
+    const boundaryMsg = msgs.find((m) => m.info.id === messageID)
+    const revertTime = (boundaryMsg?.info as MessageV2.Assistant | MessageV2.User)?.time?.created ?? 0
     for (const msg of preserve) {
       for (const part of msg.parts) {
         if (part.type === "tool" && part.state.status === "completed" && part.state.time.compacted) {
-          const time = { ...part.state.time }
-          delete time.compacted
-          await Session.updatePart({ ...part, state: { ...part.state, time } })
+          if (part.state.time.compacted > revertTime) {
+            const time = { ...part.state.time }
+            delete time.compacted
+            await Session.updatePart({ ...part, state: { ...part.state, time } })
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

- Fix `SessionRevert.cleanup()` to preserve `time.compacted` marks that were set **before** the revert point, instead of unconditionally clearing all compacted marks on preserved messages.

## Problem

Previously, `cleanup()` deleted all `time.compacted` marks from tool parts in preserved messages after a revert. This caused the revert context to differ from the original context at that position:

- Tool outputs that had been **pruned before** the revert point (showing `"[Old tool result content cleared]"` at the original position) were restored to their full text after revert — giving the LLM **more** information than it originally had.
- This increased token count beyond the original state, potentially triggering overflow/compaction again.

## Fix

Compare `part.state.time.compacted` against the revert point's `time.created`:
- `compacted <= revertTime`: mark was set before the revert point → **preserve** (LLM saw `"[Old...]"` at this position originally)
- `compacted > revertTime`: mark was set after the revert point → **clear** (LLM saw full text at this position originally, the mark was set by later prune runs)

This ensures the context after revert matches exactly what the LLM saw when the conversation was naturally at that position.