### PR TITLE
feat(desktop-electron): add automatic update check polling

### DIFF
--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -387,48 +387,60 @@ function setupAutoUpdater() {
     allowDowngrade: autoUpdater.allowDowngrade,
     currentVersion: app.getVersion(),
   })
+
+  const INTERVAL = 24 * 60 * 60 * 1000
+  setTimeout(() => {
+    void checkForUpdates(false)
+    setInterval(() => void checkForUpdates(false), INTERVAL)
+  }, 10_000)
 }
 
 let updateReady = false
+let updateChecking = false
 
 async function checkUpdate() {
-  if (!UPDATER_ENABLED) return { updateAvailable: false }
-  autoUpdater.allowPrerelease = prerelease()
-  autoUpdater.allowDowngrade = false
-  updateReady = false
-  logger.log("checking for updates", {
-    currentVersion: app.getVersion(),
-    allowPrerelease: autoUpdater.allowPrerelease,
-    allowDowngrade: autoUpdater.allowDowngrade,
-  })
+  if (!UPDATER_ENABLED || updateChecking) return { updateAvailable: false }
+  updateChecking = true
   try {
-    const result = await autoUpdater.checkForUpdates()
-    const updateInfo = result?.updateInfo
-    logger.log("update metadata fetched", {
-      releaseVersion: updateInfo?.version ?? null,
-      releaseDate: updateInfo?.releaseDate ?? null,
-      releaseName: updateInfo?.releaseName ?? null,
-      files: updateInfo?.files?.map((file) => file.url) ?? [],
+    autoUpdater.allowPrerelease = prerelease()
+    autoUpdater.allowDowngrade = false
+    updateReady = false
+    logger.log("checking for updates", {
+      currentVersion: app.getVersion(),
+      allowPrerelease: autoUpdater.allowPrerelease,
+      allowDowngrade: autoUpdater.allowDowngrade,
     })
-    const version = result?.updateInfo?.version
-    if (result?.isUpdateAvailable === false || !version) {
-      logger.log("no update available", {
-        reason: "provider returned no newer version",
+    try {
+      const result = await autoUpdater.checkForUpdates()
+      const updateInfo = result?.updateInfo
+      logger.log("update metadata fetched", {
+        releaseVersion: updateInfo?.version ?? null,
+        releaseDate: updateInfo?.releaseDate ?? null,
+        releaseName: updateInfo?.releaseName ?? null,
+        files: updateInfo?.files?.map((file) => file.url) ?? [],
       })
-      return { updateAvailable: false }
-    }
-    logger.log("update available", { version })
-    if (MANUAL_INSTALL_UPDATE) {
-      logger.log("update available; manual install required", { version, platform: process.platform })
+      const version = result?.updateInfo?.version
+      if (result?.isUpdateAvailable === false || !version) {
+        logger.log("no update available", {
+          reason: "provider returned no newer version",
+        })
+        return { updateAvailable: false }
+      }
+      logger.log("update available", { version })
+      if (MANUAL_INSTALL_UPDATE) {
+        logger.log("update available; manual install required", { version, platform: process.platform })
+        return { updateAvailable: true, version }
+      }
+      await autoUpdater.downloadUpdate()
+      logger.log("update download completed", { version })
+      updateReady = true
       return { updateAvailable: true, version }
+    } catch (error) {
+      logger.error("update check failed", error)
+      return { updateAvailable: false, failed: true }
     }
-    await autoUpdater.downloadUpdate()
-    logger.log("update download completed", { version })
-    updateReady = true
-    return { updateAvailable: true, version }
-  } catch (error) {
-    logger.error("update check failed", error)
-    return { updateAvailable: false, failed: true }
+  } finally {
+    updateChecking = false
   }
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #968

### Type of change

- [x] New feature

### What does this PR do?

在主进程 `setupAutoUpdater()` 中添加定时轮询：启动后 10 秒首次检查更新，之后每 24 小时自动调用 `checkForUpdates(false)`。同时在 `checkUpdate()` 中添加 `updateChecking` 并发 guard，防止定时轮询和手动菜单点击同时触发检查。

macOS 上发现新版本后的弹窗逻辑（跳转 GitHub Releases 手动下载）保持不变。`alertOnFail=false` 时无更新或检查失败均静默返回。

仅修改 `packages/desktop-electron/src/main/index.ts` 一个文件，不改渲染层、IPC、preload 或其他模块。

### How did you verify your code works?

- 确认 `checkForUpdates(false)` 在 `alertOnFail=false` 时：无更新静默返回、检查失败静默返回、有更新走现有 `MANUAL_INSTALL_UPDATE` 弹窗分支
- 确认 `updateChecking` guard 防止并发调用 `autoUpdater.checkForUpdates()`
- 代码审查确认无其他文件受影响

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR