### PR TITLE
feat: add opt-in prompt dump for debugging LLM requests

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -50,11 +50,15 @@ export namespace LLM {
     return cached
   }
 
-  async function dump(sessionID: string, messages: ModelMessage[]) {
-    const ts = new Date().toISOString().replace(/[-:T]/g, "").slice(0, 15)
-    const file = path.join(Global.Path.data, "llm", `${sessionID}-${ts}.json`)
+  async function dump(sessionID: string, prompt: unknown, suffix?: string) {
+    const ts = new Date()
+      .toISOString()
+      .replace(/[.:-TZ]/g, "")
+      .slice(0, 15)
+    const name = suffix ? `${sessionID}-${ts}-${suffix}.json` : `${sessionID}-${ts}.json`
+    const file = path.join(Global.Path.data, "llm", name)
     try {
-      await Filesystem.write(file, JSON.stringify(messages, null, 2))
+      await Filesystem.write(file, JSON.stringify(prompt, null, 2))
       log.info("dumped prompt", { path: file })
     } catch (e) {
       log.error("failed to dump prompt", { error: e })
@@ -79,36 +83,41 @@ export namespace LLM {
 
   export type StreamOutput = StreamTextResult<ToolSet, unknown>
 
-  const finish: LanguageModelMiddleware = {
-    async wrapStream(input) {
-      const result = await input.doStream()
-      let calls = false
-      return {
-        ...result,
-        stream: result.stream.pipeThrough(
-          new TransformStream({
-            transform(part, controller) {
-              if (part.type === "tool-call") calls = true
-              if (part.type === "finish" && (part.finishReason as string) === "unknown") {
-                controller.enqueue({
-                  ...part,
-                  finishReason: (calls ? "tool-calls" : "stop") as typeof part.finishReason,
-                })
-                return
-              }
-              if (part.type === "finish" && calls && part.finishReason === "stop") {
-                controller.enqueue({
-                  ...part,
-                  finishReason: "tool-calls" as typeof part.finishReason,
-                })
-                return
-              }
-              controller.enqueue(part)
-            },
-          }),
-        ),
-      }
-    },
+  function finish(sessionID: string): LanguageModelMiddleware {
+    return {
+      async wrapStream(input) {
+        const result = await input.doStream()
+        if ((await dumpEnabled()) && result.request?.body) {
+          await dump(sessionID, result.request.body, "final")
+        }
+        let calls = false
+        return {
+          ...result,
+          stream: result.stream.pipeThrough(
+            new TransformStream({
+              transform(part, controller) {
+                if (part.type === "tool-call") calls = true
+                if (part.type === "finish" && (part.finishReason as string) === "unknown") {
+                  controller.enqueue({
+                    ...part,
+                    finishReason: (calls ? "tool-calls" : "stop") as typeof part.finishReason,
+                  })
+                  return
+                }
+                if (part.type === "finish" && calls && part.finishReason === "stop") {
+                  controller.enqueue({
+                    ...part,
+                    finishReason: "tool-calls" as typeof part.finishReason,
+                  })
+                  return
+                }
+                controller.enqueue(part)
+              },
+            }),
+          ),
+        }
+      },
+    }
   }
 
   export async function stream(input: StreamInput) {
@@ -194,8 +203,6 @@ export namespace LLM {
             ),
             ...input.messages,
           ]
-
-    if (await dumpEnabled()) await dump(input.sessionID, messages)
 
     const params = await Plugin.trigger(
       "chat.params",
@@ -344,13 +351,14 @@ export namespace LLM {
       model: wrapLanguageModel({
         model: language,
         middleware: [
-          finish,
+          finish(input.sessionID),
           {
             async transformParams(args) {
               if (args.type === "stream") {
                 // @ts-expect-error
                 args.params.prompt = ProviderTransform.message(args.params.prompt, input.model, options)
               }
+              if (await dumpEnabled()) await dump(input.sessionID, args.params.prompt)
               return args.params
             },
           },

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -6,8 +6,8 @@ import {
   wrapLanguageModel,
   type ModelMessage,
   type StreamTextResult,
-  type ToolSet,
   type Tool,
+  type ToolSet,
   tool,
   jsonSchema,
   type LanguageModelMiddleware,
@@ -26,32 +26,39 @@ import { Permission } from "@/permission"
 import { Auth } from "@/auth"
 import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
-import { parse as parseJsonc } from "jsonc-parser"
+import { parse as parseJsonc, type ParseError } from "jsonc-parser"
 import path from "path"
 
 export namespace LLM {
   const log = Log.create({ service: "llm" })
   export const OUTPUT_TOKEN_MAX = ProviderTransform.OUTPUT_TOKEN_MAX
 
-  async function shouldDumpPrompt(): Promise<boolean> {
+  let cached: boolean | undefined = undefined
+
+  async function dumpEnabled(): Promise<boolean> {
+    if (cached !== undefined) return cached
     const cfgPath = path.join(Global.Path.config, "aether-prompt.jsonc")
     try {
       const text = await Filesystem.readText(cfgPath)
-      const errors: any[] = []
+      const errors: ParseError[] = []
       const data = parseJsonc(text, errors, { allowTrailingComma: true })
-      return data === true
+      cached = data === true
+      if (errors.length > 0) log.warn("aether-prompt.jsonc has parse errors", { errors })
     } catch {
-      return false
+      cached = false
     }
+    return cached
   }
 
-  async function dumpPrompt(sessionID: string, messages: ModelMessage[]) {
-    const now = new Date()
-    const ts = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, "0")}${String(now.getDate()).padStart(2, "0")}-${String(now.getHours()).padStart(2, "0")}${String(now.getMinutes()).padStart(2, "0")}${String(now.getSeconds()).padStart(2, "0")}`
-    const filename = `${sessionID}-${ts}.json`
-    const dir = path.join(Global.Path.data, "llm")
-    await Filesystem.write(path.join(dir, filename), JSON.stringify(messages, null, 2))
-    log.info("dumped prompt", { path: path.join(dir, filename) })
+  async function dump(sessionID: string, messages: ModelMessage[]) {
+    const ts = new Date().toISOString().replace(/[-:T]/g, "").slice(0, 15)
+    const file = path.join(Global.Path.data, "llm", `${sessionID}-${ts}.json`)
+    try {
+      await Filesystem.write(file, JSON.stringify(messages, null, 2))
+      log.info("dumped prompt", { path: file })
+    } catch (e) {
+      log.error("failed to dump prompt", { error: e })
+    }
   }
 
   export type StreamInput = {
@@ -188,7 +195,7 @@ export namespace LLM {
             ...input.messages,
           ]
 
-    if (await shouldDumpPrompt()) await dumpPrompt(input.sessionID, messages)
+    if (await dumpEnabled()) await dump(input.sessionID, messages)
 
     const params = await Plugin.trigger(
       "chat.params",

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -6,8 +6,8 @@ import {
   wrapLanguageModel,
   type ModelMessage,
   type StreamTextResult,
-  type Tool,
   type ToolSet,
+  type Tool,
   tool,
   jsonSchema,
   type LanguageModelMiddleware,
@@ -24,10 +24,35 @@ import { SystemPrompt } from "./system"
 import { Flag } from "@/flag/flag"
 import { Permission } from "@/permission"
 import { Auth } from "@/auth"
+import { Global } from "@/global"
+import { Filesystem } from "@/util/filesystem"
+import { parse as parseJsonc } from "jsonc-parser"
+import path from "path"
 
 export namespace LLM {
   const log = Log.create({ service: "llm" })
   export const OUTPUT_TOKEN_MAX = ProviderTransform.OUTPUT_TOKEN_MAX
+
+  async function shouldDumpPrompt(): Promise<boolean> {
+    const cfgPath = path.join(Global.Path.config, "aether-prompt.jsonc")
+    try {
+      const text = await Filesystem.readText(cfgPath)
+      const errors: any[] = []
+      const data = parseJsonc(text, errors, { allowTrailingComma: true })
+      return data === true
+    } catch {
+      return false
+    }
+  }
+
+  async function dumpPrompt(sessionID: string, messages: ModelMessage[]) {
+    const now = new Date()
+    const ts = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, "0")}${String(now.getDate()).padStart(2, "0")}-${String(now.getHours()).padStart(2, "0")}${String(now.getMinutes()).padStart(2, "0")}${String(now.getSeconds()).padStart(2, "0")}`
+    const filename = `${sessionID}-${ts}.json`
+    const dir = path.join(Global.Path.data, "llm")
+    await Filesystem.write(path.join(dir, filename), JSON.stringify(messages, null, 2))
+    log.info("dumped prompt", { path: path.join(dir, filename) })
+  }
 
   export type StreamInput = {
     user: MessageV2.User
@@ -162,6 +187,8 @@ export namespace LLM {
             ),
             ...input.messages,
           ]
+
+    if (await shouldDumpPrompt()) await dumpPrompt(input.sessionID, messages)
 
     const params = await Plugin.trigger(
       "chat.params",


### PR DESCRIPTION
### Issue for this PR

Closes #972

### Type of change

- [x] New feature

### What does this PR do?

This PR adds an opt-in diagnostic feature that dumps the final prompt sent to LLM providers to a JSON file, controlled by the presence of a `aether-prompt.jsonc` config file containing `true`.

**Problem:** When debugging LLM behavior, there was no way to inspect the actual prompt payload that gets sent to providers. The AI SDK transforms the internal `ModelMessage[]` format into provider-specific request bodies (OpenAI `tool_calls`, Anthropic `tool_use` blocks, etc.) before making the HTTP call. This conversion is opaque — you could only see pre-conversion messages, not the final payload.

**Solution:** Three commits implement this feature with progressive improvements:

1. **`1d0fca613` — Initial implementation:** Reads `aether-prompt.jsonc` config, dumps assembled messages to `<data>/llm/` directory before the `streamText()` call.

2. **`d93f9d1cd` — Harden prompt dump:** Fixes four issues from review:
   - Cache config read in memory (`cached` variable) to avoid hot-path file I/O on every LLM call
   - Wrap `dump()` in try/catch so diagnostic errors never interrupt the main LLM flow
   - Replace `any[]` with `ParseError[]` for JSONC parse errors and log warnings on parse errors
   - Shorten function names (`shouldDumpPrompt` → `dumpEnabled`, `dumpPrompt` → `dump`) per style guide

3. **`d8ad23f36` — Move dump to provider transform layer:** Moves the dump point from before `streamText()` into the `wrapLanguageModel` middleware chain, capturing the prompt **after** `ProviderTransform.message()` converts it. This means the dumped JSON is the actual provider-specific format that gets sent, not the internal `ModelMessage[]` representation.

**Dump output:** Two files per request:
- `<data>/llm/<sessionID>-<timestamp>.json` — provider-converted prompt from `transformParams`
- `<data>/llm/<sessionID>-<timestamp>-final.json` — exact HTTP request body from `result.request.body` in `wrapStream`

**How it works:**

Create `<config>/aether-prompt.jsonc` with content `true`. On the next LLM call, the config is read once and cached. Every subsequent call will dump the final prompt to the `llm` directory under Aether's data path. Delete the config file or set it to `false` to disable (note: the cached value persists for the process lifetime; a restart is needed to re-read).

### How did you verify your code works?

- Ran `bun typecheck` from `packages/opencode` — all types pass
- Created `aether-prompt.jsonc` with `true` in the config directory, triggered an LLM session, verified that:
  - JSON files are generated under `<data>/llm/`
  - The dumped content contains provider-specific format (e.g. Anthropic-style `tool_use` blocks, OpenAI-style `tool_calls`), not raw `ModelMessage[]`
  - Removing the config file or setting it to `false` stops generating dump files after process restart
  - Deliberately causing a write error (e.g. read-only directory) does not interrupt the LLM session

### Screenshots / recordings

Not applicable — this is a backend diagnostic feature with no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR