### PR TITLE
fix: remove dead hasOrphanedDb field from Worktree RemoveResult

### DIFF
--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -83,7 +83,6 @@ export namespace Worktree {
     }),
     z.object({
       status: z.literal("forceOk"),
-      hasOrphanedDb: z.boolean(),
     }),
   ])
 
@@ -437,7 +436,7 @@ export namespace Worktree {
           if (dirExists) yield* disposeAndClean(directory)
           yield* pruneWorktree()
 
-          return { status: "forceOk" as const, hasOrphanedDb: false }
+          return { status: "forceOk" as const }
         }
 
         const list = yield* git(["worktree", "list", "--porcelain"], { cwd: Instance.worktree })

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -437,28 +437,7 @@ export namespace Worktree {
           if (dirExists) yield* disposeAndClean(directory)
           yield* pruneWorktree()
 
-          const staleId = ProjectID.fromDirectory(ProjectIdentity.norm(directory))
-          const hasOrphanedDb = Database.hasProject(staleId)
-            ? (() => {
-                const row = Database.useProject(staleId, (d) =>
-                  d.select().from(ProjectTable).where(eq(ProjectTable.id, staleId)).get(),
-                )
-                return row?.worktree === directory
-              })()
-            : false
-
-          if (hasOrphanedDb) {
-            Database.detach(staleId)
-            const dbPath = Database.projectPath(staleId)
-            for (const suffix of ["", "-wal", "-shm"]) {
-              const p = dbPath + suffix
-              if (yield* fsys.exists(p).pipe(Effect.orDie)) {
-                yield* cleanDirectory(p)
-              }
-            }
-          }
-
-          return { status: "forceOk" as const, hasOrphanedDb }
+          return { status: "forceOk" as const, hasOrphanedDb: false }
         }
 
         const list = yield* git(["worktree", "list", "--porcelain"], { cwd: Instance.worktree })

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -8491,6 +8491,7 @@ export class OpencodeClient extends HeyApiClient {
       workspace?: string
       providerID?: string
       modelID?: string
+      mode?: "omni" | "asr" | "realtime"
       audioBase64?: string
       audioFormat?: string
       context?: Array<{
@@ -8509,6 +8510,7 @@ export class OpencodeClient extends HeyApiClient {
             { in: "query", key: "workspace" },
             { in: "body", key: "providerID" },
             { in: "body", key: "modelID" },
+            { in: "body", key: "mode" },
             { in: "body", key: "audioBase64" },
             { in: "body", key: "audioFormat" },
             { in: "body", key: "context" },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3718,7 +3718,6 @@ export type WorktreeRemoveResponses = {
       }
     | {
         status: "forceOk"
-        hasOrphanedDb: boolean
       }
 }
 
@@ -8529,6 +8528,7 @@ export type PostVoiceTranscribeData = {
   body?: {
     providerID: string
     modelID: string
+    mode?: "omni" | "asr" | "realtime"
     audioBase64: string
     audioFormat: string
     context?: Array<{


### PR DESCRIPTION
## Summary

- Remove the `hasOrphanedDb` field from `Worktree.RemoveResult` schema and the generated SDK, since it was hardcoded to `false` since db5382c4e removed the orphan DB detection logic in the force path
- Sandbox shares the main project DB, so orphan detection is never applicable in the force removal path — the field carried no information

## Context

Follow-up to db5382c4e which removed the orphan DB deletion logic to fix EBUSY on Windows. That commit left `hasOrphanedDb` hardcoded to `false`, making it a dead field with no semantic value. This PR cleans it up entirely.