### PR TITLE
fix: preserve dotted Electron store keys

### DIFF
--- a/packages/desktop-electron/src/main/store.test.ts
+++ b/packages/desktop-electron/src/main/store.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, mock, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+let home = ""
+
+const app = {
+  isPackaged: false,
+  getPath: () => home,
+  getVersion: () => "0.0.0",
+  setAppLogsPath: () => undefined,
+  setName: () => undefined,
+  setPath: () => undefined,
+}
+
+mock.module("electron", () => ({
+  default: { app },
+  app,
+}))
+
+describe("electron store", () => {
+  test("keeps dotted persisted keys as top-level keys", async () => {
+    home = mkdtempSync(join(tmpdir(), "aether-store-"))
+    process.env.OPENCODE_TEST_HOME = home
+
+    try {
+      const mod = await import("./store")
+      const item = mod.getStore("opencode.global.dat")
+
+      item.clear()
+      item.set("layout", "LAYOUT")
+      item.set("layout.page", "PAGE")
+
+      expect(item.store).toEqual({
+        layout: "LAYOUT",
+        "layout.page": "PAGE",
+      })
+    } finally {
+      delete process.env.OPENCODE_TEST_HOME
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/desktop-electron/src/main/store.ts
+++ b/packages/desktop-electron/src/main/store.ts
@@ -12,7 +12,7 @@ export function getStore(name = SETTINGS_STORE) {
   ensureDesktopPersist()
   const nextName = ensureStoreFile(name)
   const cwd = shared(nextName) ? aetherDataDir() : userDataDir()
-  const next = new Store({ name: nextName, fileExtension: "", cwd })
+  const next = new Store({ name: nextName, fileExtension: "", cwd, accessPropertiesByDotNotation: false })
   cache.set(name, next)
   return next
 }


### PR DESCRIPTION
### Issue for this PR

Closes #977

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes Electron desktop persistence for shared app state keys that contain dots.

The shared app persistence layer stores keys such as `layout` and `layout.page` as separate top-level entries. Electron uses `electron-store`, which treats dotted keys as nested object paths by default. That allowed `layout.page` to collide with `layout`, causing workspace-enabled state under `layout.sidebar.workspaces` to fall back to disabled after restart.

This PR disables dot-notation access for Electron stores so dotted persisted keys are kept as top-level keys, matching web localStorage behavior.

### How did you verify your code works?

- `bun test src/main/store.test.ts`
- `bun typecheck`
- pre-push `bun turbo typecheck`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR