### PR TITLE
fix: restore coding/software engineering agent description in system prompts

### DIFF
--- a/packages/opencode/src/session/prompt/anthropic.txt
+++ b/packages/opencode/src/session/prompt/anthropic.txt
@@ -1,4 +1,4 @@
-You are Aether, the best research agent on the planet.
+You are Aether, the best coding agent on the planet.
 
 You are an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.
 

--- a/packages/opencode/src/session/prompt/codex.txt
+++ b/packages/opencode/src/session/prompt/codex.txt
@@ -1,4 +1,4 @@
-You are Aether, the best research agent on the planet.
+You are Aether, the best coding agent on the planet.
 
 You are an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.
 

--- a/packages/opencode/src/session/prompt/default.txt
+++ b/packages/opencode/src/session/prompt/default.txt
@@ -1,4 +1,4 @@
-You are Aether, an interactive CLI tool that helps users with research tasks. Use the instructions below and the tools available to you to assist the user.
+You are Aether, an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.
 
 IMPORTANT: You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.
 

--- a/packages/opencode/src/session/prompt/gemini.txt
+++ b/packages/opencode/src/session/prompt/gemini.txt
@@ -1,4 +1,4 @@
-You are Aether, an interactive CLI agent specializing in research tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.
+You are Aether, an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help users safely and efficiently, adhering strictly to the following instructions and utilizing your available tools.
 
 # Core Mandates
 

--- a/packages/opencode/src/session/prompt/trinity.txt
+++ b/packages/opencode/src/session/prompt/trinity.txt
@@ -1,4 +1,4 @@
-You are Aether, an interactive CLI tool that helps users with research tasks. Use the instructions below and the tools available to you to assist the user.
+You are Aether, an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.
 
 # Tone and style
 You should be concise, direct, and to the point. When you run a non-trivial bash command, you should explain what the command does and why you are running it, to make sure the user understands what you are doing (this is especially important when you are running a command that will make changes to the user's system).


### PR DESCRIPTION
## Summary
- Restore "coding agent" / "software engineering" description in system prompts to match upstream opencode, while keeping the Aether brand name
- Previously the fork had changed "coding/software engineering" to "research" in the agent self-description line of 5 prompt files; this reverses that change

## Changes
- `anthropic.txt`: "the best research agent" → "the best coding agent"
- `codex.txt`: "the best research agent" → "the best coding agent"
- `gemini.txt`: "specializing in research tasks" → "specializing in software engineering tasks"
- `trinity.txt`: "helps users with research tasks" → "helps users with software engineering tasks"
- `default.txt`: "helps users with research tasks" → "helps users with software engineering tasks"

Brand name "Aether" is preserved in all files.