### PR TITLE
fix: tighten skill evolution review prompt to reduce over-creation and over-writing

### DIFF
--- a/packages/opencode/src/skill-evolution/constants.ts
+++ b/packages/opencode/src/skill-evolution/constants.ts
@@ -2,12 +2,12 @@ export const DEFAULT_NUDGE_INTERVAL = 10
 
 // Version snapshot settings
 export const VERSION_CAPACITY = 100
-export const ACTIVE_REGION_RATIO = 0.5   // latest 50% always kept
+export const ACTIVE_REGION_RATIO = 0.5 // latest 50% always kept
 
 // Security scan limits
 export const MAX_SCAN_FILES = 50
-export const MAX_TOTAL_SIZE_BYTES = 1024 * 1024  // 1024 KB
-export const MAX_FILE_SIZE_BYTES = 256 * 1024     // 256 KB
+export const MAX_TOTAL_SIZE_BYTES = 1024 * 1024 // 1024 KB
+export const MAX_FILE_SIZE_BYTES = 256 * 1024 // 256 KB
 
 // Watcher cool-down to avoid flagging our own writes as external edits
 export const WATCHER_COOL_DOWN_MS = 500
@@ -17,44 +17,41 @@ export const SKILL_REVIEW_PROMPT_BASE = `You are a skill evolution agent — a s
 
 Work in TWO ordered stages — do the gate first, the rules only after it passes.
 
-STAGE 1 — Gate: decide whether to save at all. State your verdict on EACH dimension explicitly — "A: yes/no — <one-line reason>", "B: yes/no — <one-line reason>", "C: yes/no — <one-line reason>". Do not skip straight to writing.
+STAGE 1 — Gate: decide whether to save at all. Default answer is NO on every dimension. You need strong evidence on ALL four to override — not just "maybe useful" but "clearly verified, clearly reusable, clearly novel, and likely to be repeated many times". State your verdict on EACH dimension explicitly — "A: yes/no — <one-line reason>", "B: yes/no — <one-line reason>", "C: yes/no — <one-line reason>", "D: yes/no — <one-line reason>". Do not skip straight to writing.
 
-A. REUSABLE — does the conversation contain a transferable method, not a one-off exchange?
-   - The core question: "next month, on a DIFFERENT but similar task, could someone follow this and save time?" If yes → A is yes.
-   - Counts: a procedure discovered through trial-and-error, a non-obvious sequence of steps, or a working style the user explicitly demanded ("always do X this way").
-   - Does NOT count: plain Q&A, a single fact lookup, casual chat, or anything a capable model would already do by default.
+A. REUSABLE — NO by default. Override to YES only if:
+   - The conversation revealed a multi-step PROCEDURE (not a single command or fact) that took trial-and-error to discover.
+   - A capable model encountering the same task WITHOUT this skill would likely repeat the same dead ends or mistakes.
+   - One-off Q&A, single tool calls, or anything a competent model already does by default → always NO.
 
-B. VERIFIED — was this method actually confirmed to work in THIS conversation, not just assumed?
-   - The core question: "did I actually see it succeed here?" If yes → B is yes.
-   - Counts: a command ran and succeeded, a test passed, or the user explicitly confirmed the result.
-   - Does NOT count: mistakes, abandoned dead ends, or any step whose outcome was never checked.
+B. VERIFIED — NO by default. Override to YES only if:
+   - You can point to at least one tool-call output that SUCCEEDED and CONFIRMED the method works.
+   - Assumed, guessed, or untested steps → always NO, even if they "seem right".
 
-C. NOVEL (only check if a skill on this topic already exists) — does this conversation teach something the existing skill doesn't already cover correctly?
-   - The core question: "if I diffed what I'd want to add against the existing skill, would there be a real delta in method, decision criteria, or a newly-discovered pitfall?" If yes → C is yes.
-   - Counts: the existing skill is silent on a case you just navigated; a step the existing skill prescribes turned out to be wrong; a new gotcha worth recording.
-   - Does NOT count: rephrasing existing content, adding examples that don't change the method, "tightening" wording, or anything that would just churn the file.
-   - If no existing skill covers this topic, C is automatically yes — skip the check.
+C. NOVEL — NO by default. Override to YES only if:
+   - An existing skill on this topic is MISSING something this conversation proved — a new step, a corrected error, or a newly discovered pitfall.
+   - Rephrasing existing content, adding examples that don't change the method, "tightening" wording, or anything that would just churn the file → always NO.
+   - If no existing skill covers this topic: C defaults to YES — skip the check.
 
-> If any of A, B, C is NO: respond with exactly "Nothing to save." and STOP — do not read the rules, do not call the tool.
-> If ALL are YES: proceed to STAGE 2, then you MUST call the skill_manage tool (action: create / patch / edit / delete).
+D. REPEATABLE — NO by default. Override to YES only if:
+   - The exploration path uncovered here is likely to be WALKED AGAIN by future users or agents on SIMILAR tasks — not just a rare edge case.
+   - The core question: "will this specific sequence of steps or this specific pitfall arise again in typical usage?" If yes → D is yes.
+   - A one-time environment anomaly, a project-specific quirk, or a setup that most projects won't encounter → always NO.
+
+If ANY of A, B, C, D is NO: respond with exactly "Nothing to save." and STOP — do not read the rules, do not call the tool.
+If ALL are YES: proceed to STAGE 2, then you MUST call the skill_manage tool (action: create / patch / edit / delete).
 
 STAGE 2 — Write: only reached when the gate passed. The gate already decided this material is worth saving; your job here is to make it GOOD, not to abandon it. Do not respond "Nothing to save." from Stage 2 — if something feels off, revise.
 
-## What a GOOD skill looks like (positive checklist, mirror of the Stage 1 gate)
+## What a GOOD skill looks like
 
-Before writing, know the target. A well-written skill passes ALL of these — state your verdict on each before finalizing:
+Before writing, verify your draft against each:
 
-- SELF-CONTAINED — a future AI instance that NEVER saw this conversation can follow SKILL.md alone and complete the task. If it would need to "remember what happened here", the skill is under-written.
-  ✓ "List the tables, then match candidates by name pattern (message/chat/conversation)."
-  ✗ "Query the messages table we found earlier." — depends on this run's discovery; breaks on any other project.
-- SAVES THE NEXT READER FROM THIS RUN'S PITFALLS — a capable model meeting this task for the first time comes out ahead: it avoids a trap you hit, or skips a dead end you wasted time on.
-  ✓ "Pass --dry-run FIRST; the tool commits immediately without it — there is no undo."
-  ✗ "Open the file and read it." — anything the model would already do by default; wastes its tokens.
-- EXPLAINS THE WHY — every hard rule the skill imposes ("do X", "never Y") carries a one-line reason, so the next instance can generalize to cases the skill did not spell out.
-  ✓ "Delete the temp dir when done — it survives reboots and silently fills the disk."
-  ✗ "Delete the temp dir when done." — a bare command; the reader can't tell if it's safe to skip when disk is fine.
+- ESSENTIAL — every line is trial-and-error insight AND verified fact AND information likely to be reused on future tasks. No trivial steps, no guesses, no session-specific data. A future AI that never saw this conversation can follow it alone.
+- PITFALL-AWARE — a capable model meeting this task for the first time avoids a trap you hit, or skips a dead end you wasted time on. If your skill contains nothing a model wouldn't already do → it's too thin.
+- REASONED — every hard rule ("do X", "never Y") carries a one-line reason, so the next instance can generalize to cases the skill didn't spell out.
 
-State the verdict on each — "Self-contained: yes — <reason>", etc. If any is NO, REVISE the body and re-check until all three pass.
+State your verdict: "Essential: yes/no — <reason>", "Pitfall-aware: yes/no — <reason>", "Reasoned: yes/no — <reason>". If any is NO, REVISE the body and re-check until all three pass.
 
 ## Skill Writing Rules (MUST follow — higher priority than any other instinct)
 
@@ -62,23 +59,19 @@ A skill is procedural knowledge for a FUTURE task — steps, methods, decision c
 
 > META-RULE on phrasing INSIDE the skill you produce: when you write rules into the skill itself, use the form "DO X — because Y" or "DO NOT X — because Y". Keep the hard verb (MUST / NEVER / FORBIDDEN) AND give the reason in the same sentence. The reader of your skill is a capable model; a reason lets it generalize to cases you did not spell out, while the hard verb sets the floor. Bare commands without reasons are a yellow flag — they fail on the next edge case. (This meta-rule applies to the skill you OUTPUT. The rules below — which govern YOUR behavior right now — already follow it.)
 
-### 1. NEVER bake one-off data into a skill — because next month's task has different data, and a skill frozen to this run's answers is useless then
-- Forbidden in a SKILL.md: paper IDs, ticket numbers, concrete file paths, query outputs, dataset rows, sample answers from this run.
-- Save the METHOD that produced the result, never the result. Test: "could this value be reused on a different task next month?" If no, it does not belong in the skill.
-- Counter-example (do NOT do this): a research skill body listing "2605.24326, 2605.24327, ..." — one-off, likely hallucinated, useless next time.
+### 1–3. Content filter — write only the essential, strip everything else
 
-### 2. Keep the abstraction on "method", not "instance" — because tables of "what to look for" transfer, tables of "what we found" do not
-- Tables/lists describe WHAT to look for and HOW to decide — never the specific answers found this time.
-- A column "what feature to look for" is correct. A column "example matches from this run" is contamination — drop the column, keep the method.
+Describe the core procedure as concisely as possible. Every line must earn its place: it should be trial-and-error insight AND verified fact AND likely to be reused on future tasks. Anything that fails this test — remove it before calling skill_manage.
 
-### 3. Write only VERIFIED facts — because a confident-but-wrong skill is worse than no skill; the next reader trusts it and fails
-- Do not record a schema, table/column name, command flag, API shape, or script unless a tool call actually ran and succeeded in this conversation.
-- If a fact was assumed, guessed, or never executed: leave it out.
-- If you are unsure whether a name/field is real: omit it, do not invent it. Write the lean version that consists only of verified facts — even one verified step beats five guessed ones. Never pad with guesses to bulk it up.
-- Counter-example (do NOT do this): writing "query the 'messages' table, columns content/role" when you never ran that query — it will fail for the next reader.
+Specifically, NEVER include:
+- Trivial steps a capable model would do by default ("open the file", "read the output"). If the model already knows to do it, the line wastes tokens.
+- Unverified assumptions — names, schemas, flags, or API shapes you never actually ran and confirmed. Omit them; one verified step beats five guessed ones.
+- Session-specific data — concrete file paths, ticket numbers, paper IDs, dataset rows, or outputs from this particular run. Save the METHOD, not the result.
+
+If you find yourself padding the skill with examples, rationale paragraphs, or "nice-to-know" context — you are over-writing. Cut it down to the minimal sequence of steps plus critical pitfalls only.
 
 ### 4. Obey progressive disclosure — because the body is paid for in tokens on every trigger, and references are paid for only when needed
-- SKILL.md body = the core reusable procedure only. Keep it lean (well under 500 lines).
+- SKILL.md body = the core reusable procedure only. Keep it lean.
 - Long lists, schemas, large reference material → a sub-file via the write_file action (references/ by convention, but scripts/ assets/ templates/ or any sub-path works — the only hard limit is the file must stay inside the skill directory), linked from the body. Never inline them.
 - References stay ONE level deep: every reference file links directly from SKILL.md — never a reference that links to another reference. For a reference file over ~100 lines, put a short table of contents at its top.
 - Put trigger conditions ("when to use") ONLY in the frontmatter 'description', NEVER in the body — because the body is not loaded until after triggering, so it cannot help the trigger decision. In that description, state both WHAT the skill does and WHEN it should fire (concrete contexts, user phrasings). Err on the pushy side; models tend to under-trigger skills they would benefit from.
@@ -105,7 +98,7 @@ For every line you write, also ask: "is this worth its tokens?" Add only procedu
 ### 8. Preserve good content when editing an existing skill — because churn destroys reusable knowledge that already passed real use
 - On patch/edit, change only what the new lesson requires. Do NOT rewrite or drop reusable content the skill already has correctly.
 - Prefer the 'patch' action (targeted old_str → new_str) over 'edit' (full-body rewrite) whenever a localized change suffices.
-- DO make a larger rewrite when: the existing content is wrong (violates rules 1-3 — stale one-off data, unverified facts), directly contradicts the new lesson, or is so disorganized the lesson cannot be added cleanly. In that case fix it; the fix outweighs preservation.
+- DO make a larger rewrite when: the existing content is wrong (stale one-off data, unverified facts), directly contradicts the new lesson, or is so disorganized the lesson cannot be added cleanly. In that case fix it; the fix outweighs preservation.
 
 > ALWAYS, on every create/edit: include a 'category' field — a short label grouping related skills (e.g. 'research', 'productivity', 'engineering', 'skill-management'). Prefer an existing category from the list below; add a new one only if none fit.
 


### PR DESCRIPTION
Closes #981

## Problem

The skill evolution review prompt (`SKILL_REVIEW_PROMPT_BASE` in `constants.ts`) causes two systematic issues:

1. **Over-creation**: The Stage 1 gate was too easy to pass. A single successful command, a minor config tweak, or any non-trivial interaction could be framed as a "transferable method." No dimension checked whether the path would be *repeatedly* encountered — rare edge cases got saved as skills.

2. **Over-writing**: Rules 1–3 were separate rules with OR-like compliance — an agent could satisfy "verified" while including trivial or session-specific content. The positive checklist didn't force conciseness. Rule 4's "well under 500 lines" ceiling was too high to exert real pressure toward brevity. The result: skills 3–5x longer than justified, padded with trivial steps, unverified assumptions, and session-specific data.

See #981 for full analysis.

## Changes

All changes are in the `SKILL_REVIEW_PROMPT_BASE` string in `packages/opencode/src/skill-evolution/constants.ts`. No code changes outside the prompt text.

### Gate: default-NO posture + REPEATABLE dimension

- Flip A (REUSABLE), B (VERIFIED), C (NOVEL) to **default NO** — override requires strong evidence, not just "seems useful"
- Add **D. REPEATABLE** — the exploration path must be likely to be walked again by future agents on similar tasks, not just a rare edge case
- One-time environment anomalies, project-specific quirks, or setups most projects won't encounter → always NO on D

### Content filter: AND conjunction

- Merge Rules 1–3 into a single "Content filter" section: **every line must be trial-and-error insight AND verified fact AND likely to be reused on future tasks**
- The AND makes it impossible to comply with one conjunct while violating another — anything failing *any* conjunct must be removed
- Three explicit NEVER-include categories: trivial steps, unverified assumptions, session-specific data

### Positive checklist: Essential / Pitfall-aware / Reasoned

- Replace Self-contained / Saves pitfalls / Explains why with criteria that directly enforce the AND filter:
  - **ESSENTIAL** — every line earns its place (AND of all three conjuncts)
  - **PITFALL-AWARE** — must contain something a model wouldn't already know
  - **REASONED** — every hard rule carries a one-line reason

### Length guidance

- Remove "well under 500 lines" and any line-count target from Rule 4
- Keep "Keep it lean" as a qualitative directive — works regardless of whether the existing skill body is already long (which happens when editing older skills)

## Testing

- Prompt is a static string — typecheck passes (verified by pre-push hook)
- Behavioral validation requires running skill evolution in production and observing whether the rate of skill creation drops and the average skill length decreases

## Diff summary

- `-45 lines, +38 lines` — the prompt is actually shorter after merging Rules 1–3
- Only `constants.ts` changed; no other files affected