### PR TITLE
feat: support web installs from release artifacts

### DIFF
--- a/Update/install.bat
+++ b/Update/install.bat
@@ -1,0 +1,372 @@
+@echo off
+chcp 65001 >nul
+setlocal EnableExtensions EnableDelayedExpansion
+set "PSH=powershell -NoProfile -WindowStyle Hidden"
+set "PSV=powershell -NoProfile"
+
+if not defined LOCALAPPDATA set "LOCALAPPDATA=%USERPROFILE%\AppData\Local"
+set "DEFAULT=%LOCALAPPDATA%\Programs\aether"
+set "WORK=%USERPROFILE%\.local\share\aether\update\aether"
+set "PATH_ARG="
+set "RESTART=1"
+set "NOHOLD=0"
+set "HOLD=1"
+set "OK=0"
+set "LATEST_OK=20"
+set "RUN_ERR=33"
+set "DIR_ERR=40"
+set "ARG_ERR=50"
+set "PRUNE=0"
+set "MPRUNE=0"
+set "LAUNCH="
+set "NOTE="
+set "COPY_NOTE="
+set "PKG=aether-windows-x64"
+set "SRC_ERR="
+
+if defined LOCALAPPDATA (
+  set "DEBUG_DIR=%LOCALAPPDATA%\aether\update_debug"
+) else (
+  set "DEBUG_DIR=%TEMP%\aether\update_debug"
+)
+for /f "usebackq delims=" %%t in (`%PSH% -Command "Get-Date -Format 'yyyyMMdd_HHmmss'"`) do set "DEBUG_TS=%%t"
+if not defined DEBUG_TS set "DEBUG_TS=%RANDOM%%RANDOM%"
+set "DEBUG_LOG=%DEBUG_DIR%\install_%DEBUG_TS%.log"
+call :debug_log "========== NEW GITHUB INSTALL RUN =========="
+
+:parse
+if "%~1"=="" goto :parse_done
+if /I "%~1"=="--path" (
+  if "%~2"=="" (
+    echo --path needs a value
+    exit /b %ARG_ERR%
+  )
+  set "PATH_ARG=%~2"
+  shift
+  shift
+  goto :parse
+)
+if /I "%~1"=="--no-restart" (
+  set "RESTART=0"
+  shift
+  goto :parse
+)
+if /I "%~1"=="--no-pause" (
+  set "NOHOLD=1"
+  set "HOLD="
+  shift
+  goto :parse
+)
+if /I "%~1"=="help" goto :help
+if /I "%~1"=="-h" goto :help
+if /I "%~1"=="--help" goto :help
+echo Unsupported argument: %~1
+exit /b %ARG_ERR%
+
+:parse_done
+if "%NOHOLD%"=="1" set "HOLD="
+
+set "SELF=%~dp0"
+if "%SELF:~-1%"=="\" set "SELF=%SELF:~0,-1%"
+set "SRC="
+for %%i in ("%SELF%") do set "SELF_NAME=%%~nxi"
+if /I "%SELF_NAME%"=="%PKG%" if exist "%SELF%\aether.exe" if exist "%SELF%\Aether.vbs" set "SRC=%SELF%"
+if not defined SRC if exist "%SELF%\aether.exe" if exist "%SELF%\Aether.vbs" set "SRC_ERR=Package architecture mismatch: expected %PKG%, got %SELF_NAME%"
+if not defined SRC if exist "%SELF%\%PKG%\aether.exe" if exist "%SELF%\%PKG%\Aether.vbs" set "SRC=%SELF%\%PKG%"
+if not defined SRC (
+  if defined SRC_ERR (
+    echo %SRC_ERR%
+  ) else (
+    echo Missing app files ^(aether.exe/Aether.vbs^) in %SELF%
+  )
+  exit /b %RUN_ERR%
+)
+if not exist "%SRC%\.aether_web_version" (
+  echo Missing .aether_web_version in %SRC%
+  exit /b %RUN_ERR%
+)
+set /p VER=<"%SRC%\.aether_web_version"
+if "%VER%"=="" (
+  echo Empty .aether_web_version in %SRC%
+  exit /b %RUN_ERR%
+)
+
+if defined PATH_ARG (
+  call :normalize "%PATH_ARG%" MIRROR
+) else (
+  set "MIRROR=%DEFAULT%"
+)
+set "TARGET=%WORK%\aether_%VER%"
+set "NEXT=%WORK%\.aether_%VER%.next"
+set "RESULT=%WORK%\downloads\web-update-result.env"
+set "AETHER_MIRROR_ROOT=%MIRROR%"
+set "AETHER_CURRENT_DIR=%MIRROR%\aether_%VER%"
+if exist "%RESULT%" del /f /q "%RESULT%" >nul 2>nul
+
+echo Aether Windows GitHub Release Installer
+echo(
+echo Source directory:
+echo   %SRC%
+echo Work directory:
+echo   %WORK%
+echo Install directory:
+echo   %MIRROR%
+echo Version:
+echo   %VER%
+
+if not exist "%WORK%" mkdir "%WORK%" >nul 2>nul || goto :dir_fail
+if not exist "%WORK%\downloads" mkdir "%WORK%\downloads" >nul 2>nul || goto :dir_fail
+if not exist "%MIRROR%" mkdir "%MIRROR%" >nul 2>nul || goto :dir_fail
+
+set "CUR="
+call :installed "%MIRROR%" CUR
+if defined CUR (
+  call :cmp "%CUR%" "%VER%"
+  if /I "!CMP!"=="eq" (
+    call :write_result "up_to_date" "" ""
+    echo(
+    echo Current version: !CUR!
+    echo Package version: %VER%
+    echo Already up to date.
+    call :hold
+    exit /b %LATEST_OK%
+  )
+)
+
+call :active_dir
+call :clean_next
+mkdir "%NEXT%" >nul 2>nul || (
+  call :write_result "failed" "recover" "Failed to prepare next version directory"
+  goto :fail
+)
+robocopy "%SRC%" "%NEXT%" /MIR /NFL /NDL /NJH /NJS /NP /XF install.bat >nul
+set "RC=%ERRORLEVEL%"
+if %RC% GEQ 8 (
+  call :write_result "failed" "recover" "Failed to copy files into %NEXT%"
+  goto :fail
+)
+if exist "%TARGET%" rmdir /s /q "%TARGET%" >nul 2>nul
+move "%NEXT%" "%TARGET%" >nul || (
+  call :write_result "failed" "recover" "Failed to finalize install into %TARGET%"
+  goto :fail
+)
+
+>"%TARGET%\.aether_web_version" echo(%VER%
+if exist "%WORK%\.aether_web_version" del /f /q "%WORK%\.aether_web_version" >nul 2>nul
+if exist "%WORK%\current" rmdir "%WORK%\current" >nul 2>nul
+if exist "%WORK%\current" rmdir /s /q "%WORK%\current" >nul 2>nul
+
+call :prune_versions || goto :fail
+call :in_work "%WORK%"
+if errorlevel 1 (
+  call :mirror || (
+    if not defined COPY_NOTE set "COPY_NOTE=Failed to mirror the new version near %AETHER_CURRENT_DIR%"
+    call :write_result "failed" "mirror" "!COPY_NOTE!"
+    goto :fail
+  )
+) else (
+  set "COPY_NOTE=Current app already runs inside WorkDir; skipped mirror."
+)
+if defined MIRROR_DIR set "START=%MIRROR_DIR%"
+if defined MIRROR_DIR call :prune_mirror
+if not defined START set "START=%TARGET%"
+call :write_launch "%START%"
+call :register_protocol "%START%"
+
+if "%RESTART%"=="1" call :restart
+
+call :write_result "installed" "" ""
+call :print_prune
+echo [4/4] Done
+echo Current version: %VER%
+echo Version directory: %TARGET%
+if defined MIRROR_DIR echo Mirror directory: %MIRROR_DIR%
+if defined MPRUNE if not "%MPRUNE%"=="0" echo Mirror cleanup: removed %MPRUNE% older version directories.
+echo Launch entry: %LAUNCH%
+if defined NOTE echo %NOTE%
+if defined COPY_NOTE echo %COPY_NOTE%
+call :hold
+call :debug_log "========== GITHUB INSTALL RUN COMPLETE =========="
+exit /b %OK%
+
+:normalize
+set "IN=%~1"
+set "BASE_NAME="
+for %%i in ("%IN%") do set "BASE_NAME=%%~nxi"
+if /I "%BASE_NAME%"=="aether" (
+  set "%~2=%IN%"
+) else (
+  set "%~2=%IN%\aether"
+)
+exit /b 0
+
+:cmp
+set "A=%~1"
+set "B=%~2"
+for /f "usebackq delims=" %%i in (`%PSV% -Command "$a=$env:A; $b=$env:B; function norm([string]$v){ if($null -eq $v -or $v -eq ''){ return $null }; $v=$v.Trim(); $v=$v -replace '^v',''; $v=$v.Split('-')[0]; $p=$v.Split('.'); while($p.Count -lt 4){ $p += '0' }; if($p.Count -gt 4){ $p=$p[0..3] }; [string]::Join('.', $p) }; $x=norm $a; $y=norm $b; if($null -eq $x -or $null -eq $y){ if($a -eq $b){ 'eq' } else { 'lt' }; exit 0 }; if(([version]$x) -lt ([version]$y)){ 'lt' } elseif(([version]$x) -gt ([version]$y)){ 'gt' } else { 'eq' }"`) do set "CMP=%%i"
+exit /b 0
+
+:installed
+set "%~2="
+set "DIR=%~1"
+for %%i in ("%DIR%") do set "NAME=%%~nxi"
+for /f "usebackq delims=" %%i in (`%PSV% -Command "$name=$env:NAME; if($name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ [Console]::Write($matches[1]) }"`) do set "%~2=%%i"
+if defined %~2 exit /b 0
+for /f "usebackq delims=" %%i in (`%PSV% -Command "$root=$env:DIR; $best=Get-ChildItem -Path $root -Directory -ErrorAction SilentlyContinue | ForEach-Object { $ver=''; if(Test-Path (Join-Path $_.FullName '.aether_web_version')){ $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim() }; if(-not $ver -and $_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ $ver=$matches[1] }; if($ver){ [PSCustomObject]@{ Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending | Select-Object -First 1 -ExpandProperty Ver; if($best){ [Console]::Write($best) }"`) do set "%~2=%%i"
+exit /b 0
+
+:active_dir
+set "OLD="
+for /f "usebackq delims=" %%i in (`%PSV% -Command "$root=$env:WORK; $pick=Get-ChildItem -Path $root -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { $ver=''; if(Test-Path (Join-Path $_.FullName '.aether_web_version')){ $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim() }; if(-not $ver -and $_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ $ver=$matches[1] }; if($ver){ [PSCustomObject]@{ Dir=$_.FullName; Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending | Select-Object -First 1 -ExpandProperty Dir; if($pick){ [Console]::Write($pick) }"`) do set "OLD=%%i"
+exit /b 0
+
+:in_work
+set "CHK=%~1"
+if not defined AETHER_CURRENT_DIR exit /b 1
+for /f "usebackq delims=" %%i in (`%PSV% -Command "$cur=[IO.Path]::GetFullPath($env:AETHER_CURRENT_DIR); $root=[IO.Path]::GetFullPath($env:CHK); if($cur -eq $root -or $cur.StartsWith($root + [IO.Path]::DirectorySeparatorChar)){ Write-Output '1' } else { Write-Output '0' }"`) do set "IN_WORK=%%i"
+if "!IN_WORK!"=="1" exit /b 0
+exit /b 1
+
+:mirror
+set "MROOT=%MIRROR%"
+set "MIRROR_DIR=%MROOT%\aether_%VER%"
+if exist "%MIRROR_DIR%" (
+  call :stamp TS
+  set "MIRROR_DIR=%MROOT%\aether_%VER%_!TS!"
+)
+set "MCOPY=%MIRROR_DIR%.copy"
+if exist "%MCOPY%" rmdir /s /q "%MCOPY%" >nul 2>nul
+if exist "%MIRROR_DIR%" rmdir /s /q "%MIRROR_DIR%" >nul 2>nul
+mkdir "%MCOPY%" >nul 2>nul || (
+  set "COPY_NOTE=Warning: failed to prepare mirror directory near %AETHER_CURRENT_DIR%"
+  exit /b 1
+)
+robocopy "%TARGET%" "%MCOPY%" /MIR /NFL /NDL /NJH /NJS /NP >nul
+set "RC=!ERRORLEVEL!"
+if !RC! GEQ 8 (
+  set "COPY_NOTE=Warning: failed to copy the new version near %AETHER_CURRENT_DIR%"
+  if exist "%MCOPY%" rmdir /s /q "%MCOPY%" >nul 2>nul
+  exit /b 1
+)
+move "%MCOPY%" "%MIRROR_DIR%" >nul || (
+  set "COPY_NOTE=Warning: failed to finalize the copied version near %AETHER_CURRENT_DIR%"
+  if exist "%MCOPY%" rmdir /s /q "%MCOPY%" >nul 2>nul
+  exit /b 1
+)
+set "COPY_NOTE=Copied the new version near the current app location: %MIRROR_DIR%"
+exit /b 0
+
+:write_launch
+set "CMD=%~1\Aether.vbs"
+set "ICON=%~1\aether-icon.ico"
+set "OUT=%TEMP%\aether-launch-%RANDOM%%RANDOM%.txt"
+if exist "%OUT%" del /f /q "%OUT%" >nul 2>nul
+%PSH% -Command "$cmd=$env:CMD; $icon=$env:ICON; $out=$env:OUT; $w=New-Object -ComObject WScript.Shell; $desk=[Environment]::GetFolderPath('DesktopDirectory'); if(-not $desk){ $desk=$w.SpecialFolders.Item('Desktop') }; $menu=[Environment]::GetFolderPath('Programs'); if(-not $menu){ $menu=Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs' }; $desk2=[Environment]::GetFolderPath('CommonDesktopDirectory'); $menu2=[Environment]::GetFolderPath('CommonPrograms'); $all=@($desk,$menu,$desk2,$menu2) | Where-Object { $_ } | Select-Object -Unique; foreach($dir in $all){ $lnk=Join-Path $dir 'Aether.lnk'; try { if(Test-Path $lnk){ Remove-Item -LiteralPath $lnk -Force -ErrorAction Stop } } catch {} }; $mk={ param($path,$target) try { $dir=Split-Path -Parent $path; if($dir -and -not (Test-Path $dir)){ New-Item -ItemType Directory -Path $dir -Force | Out-Null }; if(Test-Path $path){ Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue }; $s=$w.CreateShortcut($path); $s.TargetPath=$target; $s.WorkingDirectory=(Split-Path -Parent $target); if($icon -and (Test-Path $icon)){$s.IconLocation=$icon}; $s.Save(); if(-not (Test-Path $path)){ return $false }; $hit=$w.CreateShortcut($path); return $hit.TargetPath -eq $target } catch { return $false } }; $launch=''; $note=''; $desk_ok=$false; $menu_ok=$false; $desk2_ok=$false; $menu2_ok=$false; if($desk){ $desk_ok=& $mk (Join-Path $desk 'Aether.lnk') $cmd }; if($menu){ $menu_ok=& $mk (Join-Path $menu 'Aether.lnk') $cmd }; if($desk2){ $desk2_ok=& $mk (Join-Path $desk2 'Aether.lnk') $cmd }; if($menu2){ $menu2_ok=& $mk (Join-Path $menu2 'Aether.lnk') $cmd }; if($desk_ok){ $launch=Join-Path $desk 'Aether.lnk'; $note='Double-click Aether.vbs on your desktop to run it.' } elseif($desk2_ok){ $launch=Join-Path $desk2 'Aether.lnk'; $note='Double-click Aether.vbs on your desktop to run it.' } elseif($menu_ok){ $launch=Join-Path $menu 'Aether.lnk'; $note='Run Aether.vbs from the Start Menu.' } elseif($menu2_ok){ $launch=Join-Path $menu2 'Aether.lnk'; $note='Run Aether.vbs from the Start Menu.' } else { $launch=$cmd; $note='Shortcut creation failed. Open File Explorer, find this path, and double-click the file to run it.' }; [IO.File]::WriteAllLines($out, @($launch,$note))"
+set "LAUNCH=%CMD%"
+set "NOTE=Shortcut creation failed. Open File Explorer, find this path, and double-click the file to run it."
+if exist "%OUT%" (
+  set /p LAUNCH=<"%OUT%"
+  for /f "usebackq skip=1 delims=" %%i in ("%OUT%") do (
+    set "NOTE=%%i"
+    goto :write_launch_done
+  )
+)
+:write_launch_done
+if exist "%OUT%" del /f /q "%OUT%" >nul 2>nul
+exit /b 0
+
+:register_protocol
+set "PROT_DIR=%~1"
+set "PROT_HANDLER=%PROT_DIR%\aether-protocol-handler.vbs"
+if not exist "%PROT_HANDLER%" exit /b 0
+%PSH% -Command "$hkcu='HKCU:\Software\Classes\aether'; $handler=$env:PROT_HANDLER; if(-not (Test-Path $hkcu)){ New-Item -Path $hkcu -Force | Out-Null }; Set-ItemProperty -Path $hkcu -Name '(Default)' -Value 'URL:Aether Protocol' -Force; Set-ItemProperty -Path $hkcu -Name 'URL Protocol' -Value '' -Force; $cmd=$hkcu+'\shell\open\command'; if(-not (Test-Path $cmd)){ New-Item -Path $cmd -Force | Out-Null }; Set-ItemProperty -Path $cmd -Name '(Default)' -Value ('wscript.exe \"' + $handler + '\"') -Force" >nul 2>nul
+exit /b 0
+
+:restart
+call :stop_runtime
+timeout /t 1 /nobreak >nul
+set "AETHER_WEB_OPEN_FALLBACK_MS=3000"
+start "" "%START%\Aether.vbs"
+exit /b 0
+
+:stop_runtime
+%PSH% -Command "$roots=@($env:OLD,$env:TARGET,$env:AETHER_CURRENT_DIR,$env:MIRROR_DIR); if($env:WORK -and (Test-Path -LiteralPath $env:WORK)){ Get-ChildItem -LiteralPath $env:WORK -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { $roots += $_.FullName } }; if($env:MIRROR -and (Test-Path -LiteralPath $env:MIRROR)){ Get-ChildItem -LiteralPath $env:MIRROR -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { $roots += $_.FullName } }; $roots=$roots | Where-Object { $_ } | ForEach-Object { try { [IO.Path]::GetFullPath($_) } catch { $_ } }; $names=@('aether.exe','wscript.exe','cscript.exe','node.exe','bun.exe'); function Hits { Get-CimInstance Win32_Process | Where-Object { $n=$_.Name.ToLowerInvariant(); if($names -notcontains $n){ return $false }; $cmd=$_.CommandLine; $exe=$_.ExecutablePath; foreach($r in $roots){ if(($cmd -and $cmd.IndexOf($r,[StringComparison]::OrdinalIgnoreCase) -ge 0) -or ($exe -and $exe.StartsWith($r,[StringComparison]::OrdinalIgnoreCase))){ return $true } }; return $false } }; $hits=@(Hits); if($hits.Count -gt 0){ Write-Host 'Stopping old Aether processes...'; $hits | Sort-Object ProcessId -Descending | ForEach-Object { Stop-Process -Id $_.ProcessId -ErrorAction SilentlyContinue } }; for($i=0; $i -lt 5; $i++){ Start-Sleep -Seconds 1; $hits=@(Hits); if($hits.Count -eq 0){ exit 0 } }; $hits=@(Hits); if($hits.Count -gt 0){ $hits | Sort-Object ProcessId -Descending | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue } }; Start-Sleep -Seconds 1"
+exit /b 0
+
+:write_result
+set "RESULT_STATUS=%~1"
+set "RESULT_ACTION=%~2"
+set "RESULT_ERROR=%~3"
+if not defined RESULT exit /b 0
+%PSH% -Command "$file=$env:RESULT; $dir=Split-Path -Parent $file; if($dir){ [IO.Directory]::CreateDirectory($dir) | Out-Null }; $err=$env:RESULT_ERROR; if($null -eq $err){ $err='' }; $err=($err -replace [char]10,' ' -replace [char]13,' '); $lines=@(('status=' + $env:RESULT_STATUS),('version=' + $env:VER),('action=' + $env:RESULT_ACTION),('error=' + $err),('at=' + [DateTimeOffset]::UtcNow.ToUnixTimeSeconds())); [IO.File]::WriteAllLines($file, $lines)" >nul
+exit /b 0
+
+:prune_versions
+for /f "usebackq delims=" %%i in (`%PSV% -Command "$root=$env:WORK; $keep=1000; $hold=[IO.Path]::GetFullPath($env:TARGET); $items=Get-ChildItem -Path $root -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { $ver=''; if(Test-Path (Join-Path $_.FullName '.aether_web_version')){ $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim() }; if(-not $ver -and $_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$'){ $ver=$matches[1] }; if($ver){ [PSCustomObject]@{ Dir=$_.FullName; Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending; $keepers=New-Object System.Collections.Generic.List[string]; foreach($dir in @($hold)){ if($dir -and ($items | Where-Object { $_.Dir -eq $dir }) -and -not $keepers.Contains($dir)){ $keepers.Add($dir) } }; foreach($item in $items){ if($keepers.Count -ge $keep){ break }; if(-not $keepers.Contains($item.Dir)){ $keepers.Add($item.Dir) } }; $gone=0; foreach($item in $items){ if($keepers.Contains($item.Dir)){ continue }; Remove-Item $item.Dir -Recurse -Force -ErrorAction SilentlyContinue; if(-not (Test-Path $item.Dir)){ $gone++ } }; Write-Output $gone"`) do set "PRUNE=%%i"
+if not defined PRUNE set "PRUNE=0"
+exit /b 0
+
+:prune_mirror
+for /f "usebackq delims=" %%i in (`%PSV% -Command "$root=$env:MIRROR; $keep=1000; $hold=''; if($env:MIRROR_DIR){ $hold=[IO.Path]::GetFullPath($env:MIRROR_DIR) }; $items=Get-ChildItem -Path $root -Directory -Filter 'aether_*' -ErrorAction SilentlyContinue | ForEach-Object { $ver=''; if(Test-Path (Join-Path $_.FullName '.aether_web_version')){ $ver=(Get-Content (Join-Path $_.FullName '.aether_web_version') -TotalCount 1).Trim() }; if(-not $ver -and $_.Name -match '^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)($|_[0-9]{12}$)'){ $ver=$matches[1] }; if($ver){ [PSCustomObject]@{ Dir=$_.FullName; Ver=$ver } } } | Where-Object { $_ } | Sort-Object @{Expression={ [version](($_.Ver -replace '^v','').Split('-')[0]) }} -Descending; $keepers=New-Object System.Collections.Generic.List[string]; foreach($dir in @($hold)){ if($dir -and ($items | Where-Object { $_.Dir -eq $dir }) -and -not $keepers.Contains($dir)){ $keepers.Add($dir) } }; foreach($item in $items){ if($keepers.Count -ge $keep){ break }; if(-not $keepers.Contains($item.Dir)){ $keepers.Add($item.Dir) } }; $gone=0; foreach($item in $items){ if($keepers.Contains($item.Dir)){ continue }; Remove-Item $item.Dir -Recurse -Force -ErrorAction SilentlyContinue; if(-not (Test-Path $item.Dir)){ $gone++ } }; Write-Output $gone"`) do set "MPRUNE=%%i"
+if not defined MPRUNE set "MPRUNE=0"
+exit /b 0
+
+:stamp
+for /f "usebackq delims=" %%i in (`%PSH% -Command "Get-Date -Format 'yyyyMMddHHmm'"`) do set "%~1=%%i"
+exit /b 0
+
+:print_prune
+if "%PRUNE%"=="0" (
+  echo [3/4] Keeping the latest 1000 versions; no older version directories needed removal.
+  exit /b 0
+)
+echo [3/4] Keeping the latest 1000 versions; removed %PRUNE% older version directories.
+exit /b 0
+
+:clean_next
+if exist "%NEXT%" rmdir /s /q "%NEXT%" >nul 2>nul
+exit /b 0
+
+:dir_fail
+call :write_result "failed" "recover" "Directory creation failed"
+echo Directory creation failed.
+call :hold
+exit /b %DIR_ERR%
+
+:fail
+call :clean_next
+echo Install failed.
+call :hold
+exit /b 1
+
+:hold
+if not defined HOLD exit /b 0
+echo(
+%PSV% -Command "if(-not [Environment]::UserInteractive){ exit 0 }; try { Write-Host 'Press Esc to close...'; while(([Console]::ReadKey($true)).Key -ne 'Escape') {} } catch { exit 0 }"
+exit /b 0
+
+:help
+echo Aether Windows GitHub Release Installer
+echo(
+echo Usage:
+echo   %~nx0 [--path ^<dir^>] [--no-restart] [--no-pause]
+echo(
+echo Options:
+echo   --path ^<dir^>    Install target directory ^(default %DEFAULT%^)
+echo   --no-restart     Do not restart Aether after install
+echo   --no-pause       Do not wait for Esc before closing
+exit /b %OK%
+
+:debug_log
+if not defined DEBUG_LOG exit /b 0
+setlocal DisableDelayedExpansion
+set "LOG=%DEBUG_LOG%"
+set "DIR=%DEBUG_DIR%"
+set "MSG=%~1"
+if not exist "%DIR%" mkdir "%DIR%" >nul 2>nul
+set "STAMP=%DATE% %TIME: =0%"
+setlocal EnableDelayedExpansion
+>>"!LOG!" echo(!STAMP! ^| !MSG! 2>nul
+endlocal
+endlocal
+exit /b 0

--- a/Update/install.command
+++ b/Update/install.command
@@ -1,0 +1,704 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DEBUG_DIR="$HOME/.cache/aether/update_debug"
+if [ -n "${AETHER_DEBUG_LOG:-}" ]; then
+  DEBUG_LOG="$AETHER_DEBUG_LOG"
+else
+  DEBUG_TS="$(date +%Y%m%d_%H%M%S)"
+  DEBUG_LOG="$DEBUG_DIR/install_${DEBUG_TS}.log"
+fi
+mkdir -p "$DEBUG_DIR" 2>/dev/null || true
+
+debug_log() {
+  [ -d "$DEBUG_DIR" ] || return 0
+  printf '%s | %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" >>"$DEBUG_LOG" 2>/dev/null || true
+}
+
+debug_log "========== NEW GITHUB INSTALL RUN =========="
+
+pgid="$(ps -o pgid= -p $$ 2>/dev/null | tr -d ' ')"
+debug_log "PGID | pid=$$ pgid=${pgid:-unknown} ppid=$PPID bash=${BASH_VERSION:-unknown}"
+if [ "${AETHER_REEXECED:-0}" != "1" ] && [ "${pgid:-}" != "$$" ] && [ -n "${pgid:-}" ]; then
+  if command -v python3 >/dev/null 2>&1; then
+    export AETHER_REEXECED=1 AETHER_DEBUG_LOG="$DEBUG_LOG"
+    exec python3 -c "import os,sys; os.setsid(); os.execvp('bash', ['bash'] + sys.argv[1:])" "$0" "$@"
+  fi
+fi
+
+ok=0
+latest_ok=20
+run_err=33
+dir_err=40
+arg_err=50
+
+case "$(uname -m)" in
+  arm64) arch="arm64" ;;
+  x86_64) arch="x64" ;;
+  *)
+    echo "Unsupported macOS architecture: $(uname -m)"
+    exit "$arg_err"
+    ;;
+esac
+
+default="$HOME/Applications/aether"
+work="$HOME/.local/share/aether/update/aether"
+path=""
+restart="1"
+pkg="aether-darwin-$arch"
+next=""
+res=""
+prune="0"
+launch=""
+launch_note=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --path)
+      shift
+      if [ "$#" -eq 0 ]; then
+        echo "--path needs a value"
+        exit "$arg_err"
+      fi
+      path="$1"
+      ;;
+    --no-restart)
+      restart="0"
+      ;;
+    help|-h|--help)
+      cat <<EOF
+Aether macOS GitHub Release Installer
+
+Usage:
+  $(basename "$0") [--path <dir>] [--no-restart]
+
+Options:
+  --path <dir>    Install target directory (default $default)
+  --no-restart    Do not restart Aether after install
+EOF
+      exit "$ok"
+      ;;
+    *)
+      echo "Unsupported argument: $1"
+      exit "$arg_err"
+      ;;
+  esac
+  shift
+done
+
+trap 'debug_log "SIGNAL | received SIGTERM, pid=$$, ppid=$PPID"; exit 1' SIGTERM
+trap 'debug_log "SIGNAL | received SIGINT, pid=$$, ppid=$PPID"; exit 1' SIGINT
+trap 'debug_log "SIGNAL | received SIGHUP, pid=$$, ppid=$PPID"; exit 1' SIGHUP
+trap 'debug_log "SIGNAL | received SIGQUIT, pid=$$, ppid=$PPID"; exit 1' SIGQUIT
+trap 'debug_log "SIGNAL | received SIGPIPE, pid=$$, ppid=$PPID"; exit 1' SIGPIPE
+trap 'debug_log "EXIT | code=$?"' EXIT
+
+fail() {
+  write_result "failed" "${2:-recover}" "$1"
+  debug_log "FAIL | error=$1 action=${2:-recover}"
+  echo "$1"
+  clean
+  exit "$run_err"
+}
+
+flat() {
+  printf "%s" "$1" | tr '\r\n' '  '
+}
+
+write_result() {
+  [ -n "$res" ] || return 0
+  mkdir -p "$(dirname "$res")" 2>/dev/null || true
+  {
+    printf 'status=%s\n' "$(flat "$1")"
+    printf 'version=%s\n' "$(flat "$ver")"
+    printf 'action=%s\n' "$(flat "${2:-}")"
+    printf 'error=%s\n' "$(flat "${3:-}")"
+    printf 'at=%s\n' "$(date +%s)"
+  } >"$res"
+  debug_log "RESULT | status=$(flat "$1") version=$(flat "$ver") action=$(flat "${2:-}") error=$(flat "${3:-}")"
+}
+
+clean() {
+  debug_log "CLEANUP | next=${next:-}"
+  if [ -n "$next" ] && [ -d "$next" ]; then
+    rm -rf "$next"
+  fi
+}
+
+normalize() {
+  local dir base
+  dir="$1"
+  base="$(basename "$dir")"
+  if [ "$base" = "aether" ]; then
+    printf "%s" "$dir"
+    return 0
+  fi
+  printf "%s/aether" "$dir"
+}
+
+source_dir() {
+  local dir="$1"
+  local name
+  name="$(basename "$dir")"
+  if [ -f "$dir/aether" ] && [ -f "$dir/Aether.command" ]; then
+    if [ "$name" != "$pkg" ]; then
+      printf ""
+      return 0
+    fi
+    printf "%s" "$dir"
+    return 0
+  fi
+  if [ -d "$dir/$pkg" ] && [ -f "$dir/$pkg/aether" ] && [ -f "$dir/$pkg/Aether.command" ]; then
+    printf "%s" "$dir/$pkg"
+    return 0
+  fi
+  printf ""
+}
+
+source_error() {
+  local dir="$1"
+  local name
+  name="$(basename "$dir")"
+  if [ -f "$dir/aether" ] && [ -f "$dir/Aether.command" ] && [ "$name" != "$pkg" ]; then
+    printf "Package architecture mismatch: expected %s, got %s" "$pkg" "$name"
+    return 0
+  fi
+  printf "Missing app files (aether/Aether.command) in %s" "$dir"
+}
+
+cmp() {
+  local a b aa bb i x y
+  a="${1#v}"
+  b="${2#v}"
+  a="${a%%-*}"
+  b="${b%%-*}"
+  IFS=. read -r -a aa <<<"$a"
+  IFS=. read -r -a bb <<<"$b"
+  for i in 0 1 2 3; do
+    x="${aa[$i]:-0}"
+    y="${bb[$i]:-0}"
+    x=$((10#$x))
+    y=$((10#$y))
+    if [ "$x" -lt "$y" ]; then
+      echo lt
+      return 0
+    fi
+    if [ "$x" -gt "$y" ]; then
+      echo gt
+      return 0
+    fi
+  done
+  echo eq
+}
+
+installed() {
+  local root name best_ver dir v
+  root="$1"
+  name="$(basename "$root")"
+  if [[ "$name" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
+    printf "%s" "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  best_ver=""
+  shopt -s nullglob
+  for dir in "$root"/aether_* "$root"/aether-*; do
+    [ -d "$dir" ] || continue
+    name="$(basename "$dir")"
+    if [[ "$name" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
+      v="${BASH_REMATCH[1]}"
+      if [ -z "$best_ver" ] || [ "$(cmp "$best_ver" "$v")" = "lt" ]; then
+        best_ver="$v"
+      fi
+    fi
+  done
+  shopt -u nullglob
+  printf "%s" "$best_ver"
+}
+
+has_dir() {
+  local dir="$1"
+  shift
+  local item
+  for item in "$@"; do
+    if [ "$item" = "$dir" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+dir_version() {
+  local dir name v
+  dir="$1"
+  if [ -f "$dir/.aether_web_version" ]; then
+    v="$(tr -d '[:space:]' <"$dir/.aether_web_version")"
+    if [ -n "$v" ]; then
+      printf "%s" "$v"
+      return 0
+    fi
+  fi
+  name="$(basename "$dir")"
+  if [[ "$name" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
+    printf "%s" "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  printf ""
+}
+
+latest_dir() {
+  local root best best_ver dir v
+  root="$1"
+  best=""
+  best_ver=""
+  shopt -s nullglob
+  for dir in "$root"/aether_*; do
+    [ -d "$dir" ] || continue
+    v="$(dir_version "$dir")"
+    [ -n "$v" ] || continue
+    if [ -z "$best" ] || [ "$(cmp "$best_ver" "$v")" = "lt" ]; then
+      best="$dir"
+      best_ver="$v"
+    fi
+  done
+  shopt -u nullglob
+  printf "%s" "$best"
+}
+
+prune_versions() {
+  local root keep hold dir v item tmp i j
+  local -a items=()
+  local -a keepers=()
+  root="$1"
+  keep="$2"
+  hold="$3"
+  prune="0"
+  shopt -s nullglob
+  for dir in "$root"/aether_*; do
+    [ -d "$dir" ] || continue
+    v="$(dir_version "$dir")"
+    [ -n "$v" ] || continue
+    items+=("$v|$dir")
+  done
+  shopt -u nullglob
+  for ((i = 0; i < ${#items[@]}; i++)); do
+    for ((j = i + 1; j < ${#items[@]}; j++)); do
+      if [ "$(cmp "${items[$i]%%|*}" "${items[$j]%%|*}")" = "lt" ]; then
+        tmp="${items[$i]}"
+        items[$i]="${items[$j]}"
+        items[$j]="$tmp"
+      fi
+    done
+  done
+  if [ -n "$hold" ]; then
+    keepers+=("$hold")
+  fi
+  for item in "${items[@]}"; do
+    if [ "${#keepers[@]}" -ge "$keep" ]; then
+      break
+    fi
+    dir="${item#*|}"
+    if [ "${#keepers[@]}" -gt 0 ] && has_dir "$dir" "${keepers[@]}"; then
+      continue
+    fi
+    keepers+=("$dir")
+  done
+  for item in "${items[@]}"; do
+    dir="${item#*|}"
+    if [ "${#keepers[@]}" -gt 0 ] && has_dir "$dir" "${keepers[@]}"; then
+      continue
+    fi
+    rm -rf "$dir"
+    if [ ! -d "$dir" ]; then
+      prune=$((prune + 1))
+    fi
+  done
+}
+
+stamp() {
+  date +"%Y%m%d%H%M"
+}
+
+in_work() {
+  local cur root
+  cur="${AETHER_CURRENT_DIR:-}"
+  root="$1"
+  [ -n "$cur" ] || return 1
+  [ -n "$root" ] || return 1
+  cur="$(cd "$(dirname "$cur")" && pwd)/$(basename "$cur")"
+  root="$(cd "$root" && pwd)"
+  case "$cur" in
+    "$root"|"$root"/*) return 0 ;;
+  esac
+  return 1
+}
+
+mirror_target() {
+  local root dst now
+  root="$1"
+  dst="$root/aether_$ver"
+  if [ ! -e "$dst" ]; then
+    printf "%s" "$dst"
+    return 0
+  fi
+  now="$(stamp)"
+  printf "%s" "$root/aether_${ver}_$now"
+}
+
+mirror_dir() {
+  local root dst tmp
+  root="$mirror"
+  dst="$(mirror_target "$root")"
+  tmp="${dst}.copy"
+  rm -rf "$tmp" "$dst"
+  mkdir -p "$tmp" || return 1
+  ditto "$target" "$tmp" || {
+    rm -rf "$tmp"
+    return 1
+  }
+  mv "$tmp" "$dst" || {
+    rm -rf "$tmp"
+    return 1
+  }
+  printf "%s" "$dst"
+}
+
+build_app() {
+  local dest final app bin cmd icon icon_name lsreg
+  dest="$1"
+  final="$2"
+  app="$dest/Aether.app"
+  bin="$app/Contents/MacOS/Aether"
+  cmd="$final/Aether.command"
+  icon="$final/aether-icon.icns"
+  icon_name="appIcon-$ver.icns"
+  rm -rf "$app"
+  mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
+  cat >"$bin" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+cmd="$cmd"
+port=""
+aether_dir="\$HOME/Library/Application Support/aether"
+ch_dirs=()
+for ch_dir in "\$aether_dir"/*/; do
+  base="\$(basename "\$ch_dir")"
+  if [ "\$base" = "prod" ]; then
+    ch_dirs=("\$ch_dir" "\${ch_dirs[@]}")
+  else
+    ch_dirs+=("\$ch_dir")
+  fi
+done
+for ch_dir in "\${ch_dirs[@]}"; do
+  pf="\${ch_dir}serve-port"
+  if [ -f "\$pf" ]; then
+    p="\$(head -1 "\$pf" 2>/dev/null || true)"
+    if [ -n "\$p" ]; then
+      if curl -s -o /dev/null --max-time 2 "http://127.0.0.1:\$p/" >/dev/null 2>&1; then
+        port="\$p"
+        break
+      fi
+    fi
+  fi
+done
+if [ -n "\$port" ]; then
+  open "http://127.0.0.1:\$port/"
+  exit 0
+fi
+
+if [ -x "\$cmd" ]; then
+  if open "\$cmd"; then
+    exit 0
+  fi
+  nohup "\$cmd" >/dev/null 2>&1 &
+  pid="\$!"
+  sleep 1
+  if kill -0 "\$pid" >/dev/null 2>&1; then
+    exit 0
+  fi
+  exec "\$cmd"
+fi
+
+echo "Launch target not found: $cmd"
+exit 1
+EOF
+  chmod +x "$bin"
+  cat >"$app/Contents/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key>
+  <string>Aether</string>
+  <key>CFBundleDisplayName</key>
+  <string>Aether</string>
+  <key>CFBundleIdentifier</key>
+  <string>cn.aiphys.aether.web</string>
+  <key>CFBundleVersion</key>
+  <string>$ver</string>
+  <key>CFBundleShortVersionString</key>
+  <string>$ver</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleExecutable</key>
+  <string>Aether</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>11.0</string>
+  <key>CFBundleURLTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleURLName</key>
+      <string>Aether</string>
+      <key>CFBundleURLSchemes</key>
+      <array>
+        <string>aether</string>
+      </array>
+    </dict>
+  </array>
+  <key>CFBundleIconFile</key>
+  <string>$icon_name</string>
+</dict>
+</plist>
+EOF
+  if [ -f "$icon" ]; then
+    cp "$icon" "$app/Contents/Resources/$icon_name"
+    touch "$app/Contents/Resources/$icon_name" 2>/dev/null || true
+  fi
+  touch "$app/Contents/Info.plist" 2>/dev/null || true
+  touch "$app"
+  xattr -cr "$app" >/dev/null 2>&1 || true
+  lsreg="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+  if [ -x "$lsreg" ]; then
+    "$lsreg" -f "$app" >/dev/null 2>&1 || true
+  fi
+}
+
+write_launch() {
+  local final dest
+  final="$1"
+  dest="/Applications"
+  if build_app "$dest" "$final" 2>/dev/null; then
+    launch="$dest/Aether.app"
+    launch_note="Run Aether from the application launcher."
+    return 0
+  fi
+  dest="$HOME/Applications"
+  mkdir -p "$dest"
+  build_app "$dest" "$final"
+  launch="$dest/Aether.app"
+  launch_note="Could not write /Applications; fell back to $launch."
+}
+
+stop_roots=()
+
+add_stop_root() {
+  local dir item
+  dir="${1:-}"
+  [ -n "$dir" ] || return 0
+  [ -d "$dir" ] || return 0
+  dir="$(cd "$dir" 2>/dev/null && pwd)" || return 0
+  if [ ${#stop_roots[@]} -gt 0 ]; then
+    for item in "${stop_roots[@]}"; do
+      [ "$item" = "$dir" ] && return 0
+    done
+  fi
+  stop_roots+=("$dir")
+}
+
+collect_stop_roots() {
+  local dir
+  stop_roots=()
+  add_stop_root "$old"
+  add_stop_root "$target"
+  add_stop_root "${AETHER_CURRENT_DIR:-}"
+  add_stop_root "$copy_target"
+  shopt -s nullglob
+  for dir in "$work"/aether_* "$mirror"/aether_*; do
+    add_stop_root "$dir"
+  done
+  shopt -u nullglob
+}
+
+runtime_pids() {
+  local pid cmd root matched
+  ps -axo pid=,command= | while read -r pid cmd; do
+    [ -n "$pid" ] || continue
+    [ "$pid" = "$$" ] && continue
+    case "$cmd" in
+      *install.command*) continue ;;
+    esac
+    matched=""
+    for root in "${stop_roots[@]}"; do
+      case "$cmd" in
+        *"$root/"*)
+          case "$cmd" in
+            *"/aether "*|*"/aether"|*"Aether.command"*|*"Aether.sh"*|*"Aether.sh.real"*)
+              echo "$pid"
+              matched="1"
+              break
+              ;;
+          esac
+          ;;
+      esac
+    done
+    [ -n "$matched" ] || true
+  done | sort -u
+}
+
+wait_runtime() {
+  local tries pids
+  tries="$1"
+  while [ "$tries" -gt 0 ]; do
+    pids="$(runtime_pids)"
+    [ -z "$pids" ] && return 0
+    sleep 1
+    tries=$((tries - 1))
+  done
+  return 1
+}
+
+stop_all_runtime() {
+  local pids
+  collect_stop_roots
+  pids="$(runtime_pids)"
+  [ -n "$pids" ] || return 0
+  echo "Stopping old Aether processes..."
+  kill $pids >/dev/null 2>&1 || true
+  wait_runtime 5 && return 0
+  pids="$(runtime_pids)"
+  if [ -n "$pids" ]; then
+    kill -9 $pids >/dev/null 2>&1 || true
+  fi
+  wait_runtime 3 || echo "Warning: old Aether processes are still running; starting the new version anyway."
+}
+
+boot() {
+  local dir="$1"
+  [ -x "$dir/Aether.command" ] || return 1
+  AETHER_WEB_OPEN_FALLBACK_MS="${AETHER_WEB_OPEN_FALLBACK_MS:-3000}" nohup "$dir/Aether.command" >/dev/null 2>&1 &
+}
+
+self="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+src="$(source_dir "$self")"
+[ -n "$src" ] || fail "$(source_error "$self")"
+[ -f "$src/.aether_web_version" ] || fail "Missing .aether_web_version in $src"
+ver="$(tr -d '[:space:]' <"$src/.aether_web_version")"
+[ -n "$ver" ] || fail "Empty .aether_web_version in $src"
+mirror="$(normalize "${path:-$default}")"
+target="$work/aether_$ver"
+next="$work/.aether_$ver.next"
+res="$work/downloads/web-update-result.env"
+export AETHER_MIRROR_ROOT="$mirror"
+export AETHER_CURRENT_DIR="$mirror/aether_$ver"
+rm -f "$res" >/dev/null 2>&1 || true
+
+echo "Aether macOS GitHub Release Installer"
+echo
+echo "Source directory:"
+echo "  $src"
+echo "Work directory:"
+echo "  $work"
+echo "Install directory:"
+echo "  $mirror"
+echo "Version:"
+echo "  $ver"
+
+mkdir -p "$work" "$work/downloads" "$mirror" || exit "$dir_err"
+
+cur="$(installed "$mirror")"
+if [ -n "$cur" ] && [ "$(cmp "$cur" "$ver")" = "eq" ]; then
+  write_result "up_to_date"
+  echo
+  echo "Current version: $cur"
+  echo "Package version: $ver"
+  echo "Already up to date."
+  exit "$latest_ok"
+fi
+
+old="$(latest_dir "$work")"
+rm -rf "$next" "$target"
+mkdir -p "$next" || fail "Failed to prepare version directory: $next"
+ditto "$src" "$next" || fail "Failed to copy files into $next"
+rm -f "$next/install.command"
+mv "$next" "$target" || fail "Failed to finalize install into $target"
+
+chflags nohidden "$target" >/dev/null 2>&1 || true
+shopt -s nullglob
+for dir in "$work"/aether_*; do
+  [ -d "$dir" ] || continue
+  chflags nohidden "$dir" >/dev/null 2>&1 || true
+done
+shopt -u nullglob
+
+chmod +x "$target/aether" "$target/Aether.command"
+uv=""
+shopt -s nullglob
+for file in "$target"/wechat-bridge/runtime/uv/uv-*apple-darwin*/uv; do
+  [ -f "$file" ] || continue
+  uv="$file"
+  break
+done
+shopt -u nullglob
+if [ -f "$uv" ]; then
+  chmod +x "$uv"
+fi
+xattr -cr "$target/aether" "$target/Aether.command" >/dev/null 2>&1 || true
+if [ -f "$uv" ]; then
+  xattr -cr "$uv" >/dev/null 2>&1 || true
+fi
+printf "%s\n" "$ver" >"$target/.aether_web_version"
+rm -f "$work/.aether_web_version" >/dev/null 2>&1 || true
+rm -rf "$work/current" >/dev/null 2>&1 || true
+prune_versions "$work" 1000 "$target"
+
+copy_target=""
+mirror_prune=""
+if in_work "$work"; then
+  copy_note="Current app already runs inside WorkDir; skipped mirror."
+elif copy_target="$(mirror_dir || true)" && [ -n "$copy_target" ]; then
+  copy_note="Copied the new version near the current app location: $copy_target"
+  prune_versions "$mirror" 1000 "$copy_target"
+  mirror_prune="$prune"
+else
+  fail "Failed to copy the new version near ${AETHER_CURRENT_DIR:-the current app}" mirror
+fi
+
+final_target="$target"
+if [ -n "$copy_target" ]; then
+  final_target="$copy_target"
+fi
+write_launch "$final_target"
+
+if [ "$restart" = "1" ]; then
+  stop_all_runtime
+  if [ -n "$copy_target" ]; then
+    boot "$copy_target" || boot "$target" || fail "Failed to restart Aether from $target/Aether.command"
+  else
+    boot "$target" || fail "Failed to restart Aether from $target/Aether.command"
+  fi
+fi
+
+write_result "installed"
+
+echo
+echo "[4/4] Done"
+echo "Current version: $ver"
+echo "Version directory: $target"
+if [ -n "$copy_target" ]; then
+  echo "Mirror directory: $copy_target"
+fi
+if [ -n "$mirror_prune" ] && [ "$mirror_prune" -gt 0 ]; then
+  echo "Mirror cleanup: removed $mirror_prune older version directories."
+fi
+echo "Launch entry: $launch"
+if [ -n "$launch_note" ]; then
+  echo "$launch_note"
+fi
+if [ -n "${copy_note:-}" ]; then
+  echo "$copy_note"
+fi
+
+debug_log "END | ver=$ver target=$target copy_target=${copy_target:-} launch=$launch restart=$restart prune=$prune"
+debug_log "========== GITHUB INSTALL RUN COMPLETE =========="
+exit "$ok"

--- a/Update/install.sh
+++ b/Update/install.sh
@@ -1,0 +1,834 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DEBUG_DIR="$HOME/.cache/aether/update_debug"
+if [ -n "${AETHER_DEBUG_LOG:-}" ]; then
+  DEBUG_LOG="$AETHER_DEBUG_LOG"
+else
+  DEBUG_TS="$(date +%Y%m%d_%H%M%S)"
+  DEBUG_LOG="$DEBUG_DIR/install_${DEBUG_TS}.log"
+fi
+mkdir -p "$DEBUG_DIR" 2>/dev/null || true
+
+debug_log() {
+  [ -d "$DEBUG_DIR" ] || return 0
+  printf '%s | %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1" >>"$DEBUG_LOG" 2>/dev/null || true
+}
+
+debug_log "========== NEW GITHUB INSTALL RUN =========="
+
+ok=0
+latest_ok=20
+run_err=33
+dir_err=40
+arg_err=50
+
+case "$(uname -m)" in
+  aarch64|arm64) arch="arm64" ;;
+  x86_64|amd64) arch="x64" ;;
+  *)
+    echo "Unsupported Linux architecture: $(uname -m)"
+    exit "$arg_err"
+    ;;
+esac
+
+default="$HOME/.local/share/applications/aether"
+work="$HOME/.local/share/aether/update/aether"
+path=""
+restart="1"
+pkg="aether-linux-$arch"
+next=""
+res=""
+prune="0"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --path)
+      shift
+      if [ "$#" -eq 0 ]; then
+        echo "--path needs a value"
+        exit "$arg_err"
+      fi
+      path="$1"
+      ;;
+    --no-restart)
+      restart="0"
+      ;;
+    help|-h|--help)
+      cat <<EOF
+Aether Linux GitHub Release Installer
+
+Usage:
+  $(basename "$0") [--path <dir>] [--no-restart]
+
+Options:
+  --path <dir>    Install target directory (default $default)
+  --no-restart    Do not restart Aether after install
+EOF
+      exit "$ok"
+      ;;
+    *)
+      echo "Unsupported argument: $1"
+      exit "$arg_err"
+      ;;
+  esac
+  shift
+done
+
+trap 'debug_log "SIGNAL | received SIGTERM, pid=$$, ppid=$PPID"; exit 1' SIGTERM
+trap 'debug_log "SIGNAL | received SIGINT, pid=$$, ppid=$PPID"; exit 1' SIGINT
+trap 'debug_log "SIGNAL | received SIGHUP, pid=$$, ppid=$PPID"; exit 1' SIGHUP
+trap 'debug_log "SIGNAL | received SIGQUIT, pid=$$, ppid=$PPID"; exit 1' SIGQUIT
+trap 'debug_log "SIGNAL | received SIGPIPE, pid=$$, ppid=$PPID"; exit 1' SIGPIPE
+trap 'debug_log "EXIT | code=$?"' EXIT
+
+fail() {
+  write_result "failed" "${2:-recover}" "$1"
+  debug_log "FAIL | error=$1 action=${2:-recover}"
+  echo "$1"
+  clean
+  exit "$run_err"
+}
+
+flat() {
+  printf "%s" "$1" | tr '\r\n' '  '
+}
+
+write_result() {
+  [ -n "$res" ] || return 0
+  mkdir -p "$(dirname "$res")" 2>/dev/null || true
+  {
+    printf 'status=%s\n' "$(flat "$1")"
+    printf 'version=%s\n' "$(flat "$ver")"
+    printf 'action=%s\n' "$(flat "${2:-}")"
+    printf 'error=%s\n' "$(flat "${3:-}")"
+    printf 'at=%s\n' "$(date +%s)"
+  } >"$res"
+  debug_log "RESULT | status=$(flat "$1") version=$(flat "$ver") action=$(flat "${2:-}") error=$(flat "${3:-}")"
+}
+
+clean() {
+  debug_log "CLEANUP | next=${next:-}"
+  if [ -n "$next" ] && [ -d "$next" ]; then
+    rm -rf "$next"
+  fi
+}
+
+normalize() {
+  local dir base
+  dir="$1"
+  base="$(basename "$dir")"
+  if [ "$base" = "aether" ]; then
+    printf "%s" "$dir"
+    return 0
+  fi
+  printf "%s/aether" "$dir"
+}
+
+source_dir() {
+  local dir="$1"
+  local name
+  name="$(basename "$dir")"
+  if [ -f "$dir/aether" ] && [ -f "$dir/Aether.sh" ]; then
+    if [ "$name" != "$pkg" ]; then
+      printf ""
+      return 0
+    fi
+    printf "%s" "$dir"
+    return 0
+  fi
+  if [ -d "$dir/$pkg" ] && [ -f "$dir/$pkg/aether" ] && [ -f "$dir/$pkg/Aether.sh" ]; then
+    printf "%s" "$dir/$pkg"
+    return 0
+  fi
+  printf ""
+}
+
+source_error() {
+  local dir="$1"
+  local name
+  name="$(basename "$dir")"
+  if [ -f "$dir/aether" ] && [ -f "$dir/Aether.sh" ] && [ "$name" != "$pkg" ]; then
+    printf "[install] Package architecture mismatch: expected %s, got %s" "$pkg" "$name"
+    return 0
+  fi
+  printf "[install] Missing app files (aether/Aether.sh) in %s" "$dir"
+}
+
+cmp() {
+  local a b aa bb i x y
+  a="${1#v}"
+  b="${2#v}"
+  a="${a%%-*}"
+  b="${b%%-*}"
+  IFS=. read -r -a aa <<<"$a"
+  IFS=. read -r -a bb <<<"$b"
+  for i in 0 1 2 3; do
+    x="${aa[$i]:-0}"
+    y="${bb[$i]:-0}"
+    x=$((10#$x))
+    y=$((10#$y))
+    if [ "$x" -lt "$y" ]; then
+      echo lt
+      return 0
+    fi
+    if [ "$x" -gt "$y" ]; then
+      echo gt
+      return 0
+    fi
+  done
+  echo eq
+}
+
+installed() {
+  local root name best_ver dir ver
+  root="$1"
+  name="$(basename "$root")"
+  if [[ "$name" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
+    printf "%s" "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  best_ver=""
+  shopt -s nullglob
+  for dir in "$root"/aether_* "$root"/aether-*; do
+    [ -d "$dir" ] || continue
+    name="$(basename "$dir")"
+    if [[ "$name" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
+      ver="${BASH_REMATCH[1]}"
+      if [ -z "$best_ver" ] || [ "$(cmp "$best_ver" "$ver")" = "lt" ]; then
+        best_ver="$ver"
+      fi
+    fi
+  done
+  shopt -u nullglob
+  printf "%s" "$best_ver"
+}
+
+has_dir() {
+  local dir="$1"
+  shift
+  local item
+  for item in "$@"; do
+    if [ "$item" = "$dir" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+dir_version() {
+  local dir name v
+  dir="$1"
+  if [ -f "$dir/.aether_web_version" ]; then
+    v="$(tr -d '[:space:]' <"$dir/.aether_web_version")"
+    if [ -n "$v" ]; then
+      printf "%s" "$v"
+      return 0
+    fi
+  fi
+  name="$(basename "$dir")"
+  if [[ "$name" =~ ^aether[-_]([0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z]+)*)$ ]]; then
+    printf "%s" "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  printf ""
+}
+
+latest_dir() {
+  local root best best_ver dir v
+  root="$1"
+  best=""
+  best_ver=""
+  shopt -s nullglob
+  for dir in "$root"/aether_*; do
+    [ -d "$dir" ] || continue
+    v="$(dir_version "$dir")"
+    [ -n "$v" ] || continue
+    if [ -z "$best" ] || [ "$(cmp "$best_ver" "$v")" = "lt" ]; then
+      best="$dir"
+      best_ver="$v"
+    fi
+  done
+  shopt -u nullglob
+  printf "%s" "$best"
+}
+
+prune_versions() {
+  local root keep hold dir v item tmp i j
+  local -a items=()
+  local -a keepers=()
+  root="$1"
+  keep="$2"
+  hold="$3"
+  prune="0"
+  shopt -s nullglob
+  for dir in "$root"/aether_*; do
+    [ -d "$dir" ] || continue
+    v="$(dir_version "$dir")"
+    [ -n "$v" ] || continue
+    items+=("$v|$dir")
+  done
+  shopt -u nullglob
+  for ((i = 0; i < ${#items[@]}; i++)); do
+    for ((j = i + 1; j < ${#items[@]}; j++)); do
+      if [ "$(cmp "${items[$i]%%|*}" "${items[$j]%%|*}")" = "lt" ]; then
+        tmp="${items[$i]}"
+        items[$i]="${items[$j]}"
+        items[$j]="$tmp"
+      fi
+    done
+  done
+  if [ -n "$hold" ]; then
+    keepers+=("$hold")
+  fi
+  for item in "${items[@]}"; do
+    if [ "${#keepers[@]}" -ge "$keep" ]; then
+      break
+    fi
+    dir="${item#*|}"
+    if [ "${#keepers[@]}" -gt 0 ] && has_dir "$dir" "${keepers[@]}"; then
+      continue
+    fi
+    keepers+=("$dir")
+  done
+  for item in "${items[@]}"; do
+    dir="${item#*|}"
+    if [ "${#keepers[@]}" -gt 0 ] && has_dir "$dir" "${keepers[@]}"; then
+      continue
+    fi
+    rm -rf "$dir"
+    if [ ! -d "$dir" ]; then
+      prune=$((prune + 1))
+    fi
+  done
+}
+
+stamp() {
+  date +"%Y%m%d%H%M"
+}
+
+in_work() {
+  local cur root
+  cur="${AETHER_CURRENT_DIR:-}"
+  root="$1"
+  [ -n "$cur" ] || return 1
+  [ -n "$root" ] || return 1
+  cur="$(cd "$(dirname "$cur")" && pwd)/$(basename "$cur")"
+  root="$(cd "$root" && pwd)"
+  case "$cur" in
+    "$root"|"$root"/*) return 0 ;;
+  esac
+  return 1
+}
+
+mirror_target() {
+  local root dst now
+  root="$1"
+  dst="$root/aether_$ver"
+  if [ ! -e "$dst" ]; then
+    printf "%s" "$dst"
+    return 0
+  fi
+  now="$(stamp)"
+  printf "%s" "$root/aether_${ver}_$now"
+}
+
+mirror_dir() {
+  local root dst tmp
+  root="$mirror"
+  dst="$(mirror_target "$root")"
+  debug_log "MIRROR_DIR | root=$root dst=$dst"
+  tmp="${dst}.copy"
+  rm -rf "$tmp" "$dst" 2>/dev/null || true
+  mkdir -p "$tmp" || return 1
+  cp -R "$target"/. "$tmp" || {
+    rm -rf "$tmp" 2>/dev/null || true
+    return 1
+  }
+  mv "$tmp" "$dst" || {
+    rm -rf "$tmp" 2>/dev/null || true
+    return 1
+  }
+  printf "%s" "$dst"
+}
+
+pick_home() {
+  local home="$HOME"
+  if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ]; then
+    if command -v getent >/dev/null 2>&1; then
+      home="$(getent passwd "$SUDO_USER" 2>/dev/null | cut -d: -f6)"
+    else
+      home=""
+    fi
+    if [ -z "$home" ]; then
+      home="$(eval echo "~$SUDO_USER" 2>/dev/null || true)"
+    fi
+    [ -n "$home" ] || home="$HOME"
+  fi
+  printf "%s" "$home"
+}
+
+list_ssl() {
+  {
+    if command -v ldconfig >/dev/null 2>&1; then
+      ldconfig -p 2>/dev/null | awk '/libssl\.so\./{print $NF}'
+    fi
+    for p in /lib /usr/lib /lib64 /usr/lib64 /usr/local/lib /usr/local/lib64 /lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu /lib/aarch64-linux-gnu /usr/lib/aarch64-linux-gnu; do
+      [ -d "$p" ] || continue
+      find "$p" -maxdepth 2 -type f -name 'libssl.so.*' 2>/dev/null
+    done
+  } | awk 'NF && !seen[$0]++'
+}
+
+list_crypto() {
+  {
+    if command -v ldconfig >/dev/null 2>&1; then
+      ldconfig -p 2>/dev/null | awk '/libcrypto\.so\./{print $NF}'
+    fi
+    for p in /lib /usr/lib /lib64 /usr/lib64 /usr/local/lib /usr/local/lib64 /lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu /lib/aarch64-linux-gnu /usr/lib/aarch64-linux-gnu; do
+      [ -d "$p" ] || continue
+      find "$p" -maxdepth 2 -type f -name 'libcrypto.so.*' 2>/dev/null
+    done
+  } | awk 'NF && !seen[$0]++'
+}
+
+has_ssl3() {
+  if command -v ldconfig >/dev/null 2>&1 && ldconfig -p 2>/dev/null | grep -q '\blibssl\.so\.3\b'; then
+    return 0
+  fi
+  list_ssl | grep -q '/libssl.so.3$'
+}
+
+probe_pair() {
+  local dir="$1"
+  local ssl="$2"
+  local crypto="$3"
+  local probe="$dir/.ssl_probe"
+  rm -rf "$probe" 2>/dev/null || true
+  mkdir -p "$probe" || return 1
+  ln -sf "$ssl" "$probe/libssl.so.3" || return 1
+  ln -sf "$crypto" "$probe/libcrypto.so.3" || return 1
+  if ! command -v ldd >/dev/null 2>&1 || [ ! -x "$dir/aether" ]; then
+    rm -rf "$probe" 2>/dev/null || true
+    return 0
+  fi
+  local out
+  out="$(LD_LIBRARY_PATH="$probe${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ldd "$dir/aether" 2>/dev/null || true)"
+  rm -rf "$probe" 2>/dev/null || true
+  [ -n "$out" ] || return 1
+  if printf "%s\n" "$out" | grep -q 'libssl.so.3 => .*not found'; then
+    return 1
+  fi
+  if printf "%s\n" "$out" | grep -q 'libcrypto.so.3 => .*not found'; then
+    return 1
+  fi
+  return 0
+}
+
+pick_pair() {
+  local dir="$1"
+  local ssl_ref="$2"
+  local crypto_ref="$3"
+  local ssl=""
+  local crypto=""
+  local c=""
+  mapfile -t _ssl < <(list_ssl)
+  mapfile -t _crypto < <(list_crypto)
+  for ssl in "${_ssl[@]}"; do
+    [ -f "$ssl" ] || continue
+    local sdir
+    sdir="$(dirname "$ssl")"
+    crypto=""
+    if [ -f "$sdir/libcrypto.so.1.1" ]; then
+      crypto="$sdir/libcrypto.so.1.1"
+    fi
+    if [ -z "$crypto" ]; then
+      crypto="$(find "$sdir" -maxdepth 1 -type f -name 'libcrypto.so.1.*' 2>/dev/null | head -1)"
+    fi
+    if [ -z "$crypto" ]; then
+      for c in "${_crypto[@]}"; do
+        if [[ "$c" == "$sdir"/* ]]; then
+          crypto="$c"
+          break
+        fi
+      done
+    fi
+    if [ -z "$crypto" ]; then
+      for c in "${_crypto[@]}"; do
+        crypto="$c"
+        break
+      done
+    fi
+    [ -n "$crypto" ] || continue
+    if probe_pair "$dir" "$ssl" "$crypto"; then
+      printf -v "$ssl_ref" '%s' "$ssl"
+      printf -v "$crypto_ref" '%s' "$crypto"
+      return 0
+    fi
+  done
+  return 1
+}
+
+fix_libssl() {
+  local dir="$1"
+  [ -d "$dir" ] || return 0
+  if has_ssl3; then
+    return 0
+  fi
+  local ssl=""
+  local crypto=""
+  if ! pick_pair "$dir" ssl crypto; then
+    echo "[install] Warning: libssl.so.3 is missing, and no usable libssl/libcrypto pair was found."
+    echo "[install] Please install libssl3 (preferred) or a compatible OpenSSL runtime and retry."
+    return 0
+  fi
+  local lib="$dir/lib"
+  mkdir -p "$lib"
+  ln -sf "$ssl" "$lib/libssl.so.3"
+  ln -sf "$crypto" "$lib/libcrypto.so.3"
+  local launch="$dir/Aether.sh"
+  local real="$dir/Aether.sh.real"
+  if [ -f "$launch" ] && [ ! -f "$real" ]; then
+    mv "$launch" "$real"
+    cat >"$launch" <<'EOF'
+#!/usr/bin/env bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+export LD_LIBRARY_PATH="$DIR/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+if [ -x "$DIR/Aether.sh.real" ]; then
+  exec "$DIR/Aether.sh.real" "$@"
+fi
+exec "$DIR/aether" web "$@"
+EOF
+    chmod +x "$launch"
+  fi
+}
+
+lib_exact() {
+  local name="$1"
+  local root="${2:-}"
+  local p
+  if [ -n "$root" ]; then
+    [ -f "$root/$name" ] && printf "%s" "$root/$name"
+    return 0
+  fi
+  for p in /usr/lib/$arch-linux-gnu /lib/$arch-linux-gnu /usr/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu /lib/aarch64-linux-gnu /usr/lib64 /usr/lib /lib64 /lib; do
+    [ -f "$p/$name" ] && printf "%s" "$p/$name" && return 0
+  done
+  printf ""
+}
+
+lib_glob() {
+  local pat="$1"
+  local root="${2:-}"
+  local p f
+  if [ -n "$root" ]; then
+    find "$root" -maxdepth 1 -name "$pat" 2>/dev/null | head -1
+    return 0
+  fi
+  for p in /usr/lib/$arch-linux-gnu /lib/$arch-linux-gnu /usr/lib/x86_64-linux-gnu /lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu /lib/aarch64-linux-gnu /usr/lib64 /usr/lib /lib64 /lib; do
+    f="$(find "$p" -maxdepth 1 -name "$pat" 2>/dev/null | head -1)"
+    [ -n "$f" ] && printf "%s" "$f" && return 0
+  done
+  printf ""
+}
+
+ensure_libssl() {
+  local dir="$1"
+  local ssl crypto sdir lib bin real name
+  [ -d "$dir" ] || return 0
+  [ -z "$(lib_exact "libssl.so.3")" ] || return 0
+  ssl="$(lib_exact "libssl.so.1.1")"
+  [ -n "$ssl" ] || ssl="$(lib_glob "libssl.so.1.*")"
+  [ -n "$ssl" ] || return 0
+  sdir="$(dirname "$ssl")"
+  crypto="$(lib_exact "libcrypto.so.1.1" "$sdir")"
+  [ -n "$crypto" ] || crypto="$(lib_glob "libcrypto.so.1.*" "$sdir")"
+  lib="$dir/ssl_compat"
+  mkdir -p "$lib" 2>/dev/null || return 0
+  ln -sf "$ssl" "$lib/libssl.so.3" 2>/dev/null || true
+  [ -n "$crypto" ] && ln -sf "$crypto" "$lib/libcrypto.so.3" 2>/dev/null || true
+  for bin in "$dir"/aether "$dir"/Aether "$dir"/aether-*/aether "$dir"/resources/../aether; do
+    [ -x "$bin" ] && [ ! -d "$bin" ] || continue
+    name="$(basename "$bin")"
+    real="$(dirname "$bin")/${name}.real"
+    [ -f "$real" ] && return 0
+    mv "$bin" "$real" || return 0
+    cat >"$bin" <<EOF
+#!/usr/bin/env bash
+export LD_LIBRARY_PATH="$lib\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}"
+exec "$real" "\$@"
+EOF
+    chmod +x "$bin"
+    return 0
+  done
+}
+
+write_launch() {
+  local final="$1"
+  local app="$final/Aether.sh"
+  local icon="$final/aether-icon.png"
+  local home apps desk icon_line
+  home="$(pick_home)"
+  apps="$home/.local/share/applications"
+  mkdir -p "$apps" || return 1
+  icon_line=""
+  if [ -f "$icon" ]; then
+    icon_line="Icon=$icon"
+  fi
+  cat >"$apps/aether.desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Name=Aether
+Comment=AI-powered development tool
+Exec="$app"
+$icon_line
+Categories=Development;IDE;
+Terminal=false
+StartupNotify=true
+EOF
+  chmod +x "$apps/aether.desktop" || true
+  if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database "$apps" 2>/dev/null || true
+  fi
+  desk="$home/Desktop"
+  mkdir -p "$desk" || return 1
+  cp "$apps/aether.desktop" "$desk/aether.desktop" 2>/dev/null || true
+  chmod +x "$desk/aether.desktop" 2>/dev/null || true
+  printf "%s" "$apps/aether.desktop"
+}
+
+register_protocol() {
+  local final="$1"
+  local handler="$final/aether-protocol-handler.sh"
+  [ -f "$handler" ] || return 0
+  local icon="$final/aether-icon.png"
+  local apps="$HOME/.local/share/applications"
+  mkdir -p "$apps" || return 0
+  local desk="$apps/aether-url-handler.desktop"
+  local icon_line=""
+  if [ -f "$icon" ]; then
+    icon_line="Icon=$icon"
+  fi
+  cat >"$desk" <<EOF
+[Desktop Entry]
+Type=Application
+Name=Aether URL Handler
+Exec="$handler" %u
+MimeType=x-scheme-handler/aether;
+NoDisplay=true
+$icon_line
+EOF
+  chmod +x "$desk" || return 0
+  if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database "$apps" 2>/dev/null || true
+  fi
+  if command -v xdg-mime >/dev/null 2>&1; then
+    xdg-mime default aether-url-handler.desktop x-scheme-handler/aether 2>/dev/null || true
+  fi
+}
+
+stop_roots=()
+
+add_stop_root() {
+  local dir item
+  dir="${1:-}"
+  [ -n "$dir" ] || return 0
+  [ -d "$dir" ] || return 0
+  dir="$(cd "$dir" 2>/dev/null && pwd)" || return 0
+  if [ ${#stop_roots[@]} -gt 0 ]; then
+    for item in "${stop_roots[@]}"; do
+      [ "$item" = "$dir" ] && return 0
+    done
+  fi
+  stop_roots+=("$dir")
+}
+
+collect_stop_roots() {
+  local dir
+  stop_roots=()
+  add_stop_root "$old"
+  add_stop_root "$target"
+  add_stop_root "${AETHER_CURRENT_DIR:-}"
+  add_stop_root "$copy_target"
+  shopt -s nullglob
+  for dir in "$work"/aether_* "$mirror"/aether_*; do
+    add_stop_root "$dir"
+  done
+  shopt -u nullglob
+}
+
+runtime_pids() {
+  local pid cmd root matched
+  ps -axo pid=,command= | while read -r pid cmd; do
+    [ -n "$pid" ] || continue
+    [ "$pid" = "$$" ] && continue
+    case "$cmd" in
+      *install.sh*) continue ;;
+    esac
+    matched=""
+    for root in "${stop_roots[@]}"; do
+      case "$cmd" in
+        *"$root/"*)
+          case "$cmd" in
+            *"/aether "*|*"/aether"|*"Aether.command"*|*"Aether.sh"*|*"Aether.sh.real"*)
+              echo "$pid"
+              matched="1"
+              break
+              ;;
+          esac
+          ;;
+      esac
+    done
+    [ -n "$matched" ] || true
+  done | sort -u
+}
+
+wait_runtime() {
+  local tries pids
+  tries="$1"
+  while [ "$tries" -gt 0 ]; do
+    pids="$(runtime_pids)"
+    [ -z "$pids" ] && return 0
+    sleep 1
+    tries=$((tries - 1))
+  done
+  return 1
+}
+
+stop_all_runtime() {
+  local pids
+  collect_stop_roots
+  pids="$(runtime_pids)"
+  [ -n "$pids" ] || return 0
+  echo "[install] Stopping old Aether processes..."
+  kill $pids >/dev/null 2>&1 || true
+  wait_runtime 5 && return 0
+  pids="$(runtime_pids)"
+  if [ -n "$pids" ]; then
+    kill -9 $pids >/dev/null 2>&1 || true
+  fi
+  wait_runtime 3 || echo "[install] Warning: old Aether processes are still running; starting the new version anyway."
+}
+
+boot() {
+  local app="$1/Aether.sh"
+  [ -x "$app" ] || return 1
+  if command -v setsid >/dev/null 2>&1; then
+    AETHER_WEB_OPEN_FALLBACK_MS="${AETHER_WEB_OPEN_FALLBACK_MS:-3000}" setsid "$app" >/dev/null 2>&1 < /dev/null &
+    return 0
+  fi
+  AETHER_WEB_OPEN_FALLBACK_MS="${AETHER_WEB_OPEN_FALLBACK_MS:-3000}" nohup "$app" >/dev/null 2>&1 < /dev/null &
+}
+
+self="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+src="$(source_dir "$self")"
+[ -n "$src" ] || fail "$(source_error "$self")"
+[ -f "$src/.aether_web_version" ] || fail "[install] Missing .aether_web_version in $src"
+ver="$(tr -d '[:space:]' <"$src/.aether_web_version")"
+[ -n "$ver" ] || fail "[install] Empty .aether_web_version in $src"
+mirror="$(normalize "${path:-$default}")"
+target="$work/aether_$ver"
+next="$work/.aether_$ver.next"
+res="$work/downloads/web-update-result.env"
+export AETHER_MIRROR_ROOT="$mirror"
+export AETHER_CURRENT_DIR="$mirror/aether_$ver"
+rm -f "$res" 2>/dev/null || true
+
+echo "Aether Linux GitHub Release Installer"
+echo
+echo "Source directory:"
+echo "  $src"
+echo "Work directory:"
+echo "  $work"
+echo "Install directory:"
+echo "  $mirror"
+echo "Version:"
+echo "  $ver"
+
+mkdir -p "$work" "$work/downloads" "$mirror" || exit "$dir_err"
+
+cur="$(installed "$mirror")"
+if [ -n "$cur" ] && [ "$(cmp "$cur" "$ver")" = "eq" ]; then
+  write_result "up_to_date"
+  echo
+  echo "Current version: $cur"
+  echo "Package version: $ver"
+  echo "Already up to date."
+  exit "$latest_ok"
+fi
+
+old="$(latest_dir "$work")"
+rm -rf "$next" "$target"
+mkdir -p "$next" || fail "[install] Failed to prepare version directory: $next"
+cp -R "$src"/. "$next" || fail "[install] Failed to copy files into $next"
+rm -f "$next/install.sh"
+mv "$next" "$target" || fail "[install] Failed to finalize install into $target"
+
+chmod +x "$target/aether" "$target/Aether.sh" 2>/dev/null || true
+chmod +x "$target/aether-protocol-handler.sh" 2>/dev/null || true
+shopt -s nullglob
+for file in "$target"/wechat-bridge/runtime/uv/uv-*linux*/uv; do
+  chmod +x "$file" 2>/dev/null || true
+done
+shopt -u nullglob
+printf "%s\n" "$ver" >"$target/.aether_web_version"
+rm -f "$work/.aether_web_version" 2>/dev/null || true
+rm -rf "$work/current" 2>/dev/null || true
+
+fix_libssl "$target"
+prune_versions "$work" 1000 "$target"
+
+copy_target=""
+mirror_prune=""
+if in_work "$work"; then
+  copy_note="[install] Current app already runs inside WorkDir; skipped mirror."
+elif copy_target="$(mirror_dir || true)" && [ -n "$copy_target" ]; then
+  copy_note="[install] Copied the new version near the current app location: $copy_target"
+  prune_versions "$mirror" 1000 "$copy_target"
+  mirror_prune="$prune"
+else
+  fail "[install] Failed to copy the new version near ${AETHER_CURRENT_DIR:-the current app}" mirror
+fi
+
+start_target="$target"
+if [ -n "$copy_target" ]; then
+  start_target="$copy_target"
+fi
+fix_libssl "$start_target"
+ensure_libssl "$start_target"
+launch="$(write_launch "$start_target" || true)"
+register_protocol "$start_target"
+
+if [ "$restart" = "1" ]; then
+  stop_all_runtime
+  if [ -n "$copy_target" ]; then
+    boot "$copy_target" || boot "$target" || fail "[install] Failed to restart Aether from $target/Aether.sh"
+  else
+    boot "$target" || fail "[install] Failed to restart Aether from $target/Aether.sh"
+  fi
+fi
+
+write_result "installed"
+
+echo
+echo "[4/4] Done"
+echo "Version directory: $target"
+if [ -n "$copy_target" ]; then
+  echo "Mirror directory: $copy_target"
+fi
+if [ -n "$mirror_prune" ] && [ "$mirror_prune" -gt 0 ]; then
+  echo "Mirror cleanup: removed $mirror_prune older version directories."
+fi
+if [ -n "$launch" ]; then
+  echo "[install] Desktop launcher: $launch"
+else
+  echo "[install] Warning: failed to create Desktop launcher."
+fi
+if [ -n "${copy_note:-}" ]; then
+  echo "$copy_note"
+fi
+
+debug_log "END | ver=$ver target=$target copy_target=${copy_target:-} launch=${launch:-} restart=$restart prune=$prune"
+debug_log "========== GITHUB INSTALL RUN COMPLETE =========="
+exit "$ok"

--- a/Update/release-and-upload-mac-web.sh
+++ b/Update/release-and-upload-mac-web.sh
@@ -43,20 +43,23 @@ echo "[2/4] Creating DMG ..."
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
-pkg="$tmp/aether-darwin-arm64-web"
+pkg="$tmp/aether-darwin-arm64"
 
 mkdir -p "$pkg"
 cp -R "$src"/. "$pkg"/
+rm -f "$pkg/aether_darwin_installer.command" "$pkg/aether_darwin_x64_installer.command" "$pkg/aether_darwin_installer_beta.command" "$pkg/aether_darwin_installer_devtest.command"
 
 # Write version file
 rm -f "$pkg/.aether_version"
 printf "%s\n" "$ver" > "$pkg/.aether_web_version"
 
-ins="$root/Update/aether_darwin_installer.command"
-if [ -f "$ins" ]; then
-  cp "$ins" "$pkg/aether_darwin_installer.command"
-  chmod +x "$pkg/aether_darwin_installer.command"
-fi
+ins="$root/Update/install.command"
+[ -f "$ins" ] || {
+  echo "Error: $ins not found."
+  exit 1
+}
+cp "$ins" "$pkg/install.command"
+chmod +x "$pkg/install.command"
 
 # Ensure executables are +x
 [ -f "$pkg/aether" ] && chmod +x "$pkg/aether"
@@ -67,17 +70,18 @@ cat > "$pkg/README_FIRST.txt" <<'EOFREADME'
 Aether Web (macOS arm64)
 
 Quick start
-1) Open this DMG and copy the folder to a local path, e.g. ~/Applications/Aether-Web
-2) In Finder, right-click Aether.command and choose Open
-3) If macOS asks again, click Open in the security prompt
+1) Open this DMG
+2) In Finder, open the aether-darwin-arm64 folder
+3) Right-click install.command and choose Open
+4) If macOS asks again, click Open in the security prompt
 
 Troubleshooting
 - "cannot be opened" / "unidentified developer":
-  Right-click Aether.command -> Open, then confirm
+  Right-click install.command -> Open, then confirm
 - "is damaged and cannot be opened":
-  Open Terminal in the folder and run: xattr -cr ./aether ./Aether.command
+  Open Terminal in the folder and run: xattr -cr ./install.command
 - Permission denied:
-  chmod +x ./aether ./Aether.command
+  chmod +x ./install.command
 
 Updates
 - Use Aether's in-app update flow to download and install newer versions.

--- a/docs/plan-github-release-install.md
+++ b/docs/plan-github-release-install.md
@@ -1,0 +1,541 @@
+# 方案：支持从 GitHub Release 产物直接安装/更新 Aether Web 版
+
+## 一、需求背景
+
+当前 Aether Web 版的安装和更新仅能通过 aiphys 服务器完成：
+- **安装**：运行 `aether_*_installer.*` 脚本，从 `aether.aiphys.cn` 下载 archive 和 update script，再调用 update script 执行安装
+- **更新**：in-app 自动更新检查指向 `aether.aiphys.cn`，下载后调用 update script 执行更新
+
+用户无法从 GitHub Releases 下载的 DMG/ZIP 直接完成同等功能的安装。本方案旨在新增一套安装脚本，使用户从 GitHub 下载产物后，运行脚本即可完成与 aiphys 安装流程一致的全新安装或更新。
+
+## 二、核心设计原则
+
+1. **文件来源替换**：新脚本做与现有 installer + update 脚本几乎完全一样的事情，唯一区别是将所需文件的来源从"从 aiphys 远程下载"变为"从脚本所在目录（即 archive 解压/挂载后的目录）直接获取"
+2. **不修改现有 aiphys 流程**：现有 `aether_*_installer.*` 和 `update_*` 脚本保持不变，in-app 更新仍走 aiphys
+3. **安装后运行时结构一致**：GitHub 安装后产生的 `work/aether_$ver`、mirror 目录、`.aether_web_version`、桌面入口、协议注册、重启和 prune 语义必须与 aiphys 流程一致，确保 in-app 更新系统能正确发现已安装版本。GitHub 产物内的安装入口脚本差异是刻意差异：不再包含 `aether_*_installer.*`，改为 `install.*`
+4. **不依赖安装来源**：程序内部行为不因安装来源不同而有差异
+5. **程序内容不变**：不修改主程序、launcher、web、skills、wechat-bridge 等程序内容；`install.*` 只作为 GitHub 产物内的安装入口
+
+## 三、现有流程分析
+
+### 3.1 现有两阶段流程
+
+#### 阶段一：Installer（从远程下载文件）
+
+**macOS** (`Update/aether_darwin_installer.command`):
+1. 检测架构 (`uname -m` → arm64/x64)
+2. 确定工作目录 (`work = ~/.local/share/aether/update/aether`)
+3. 确定安装目标目录 (`mirror = ~/Applications/aether`)
+4. 从 `aether.aiphys.cn/download/latest/mac-{arch}.yml` 获取 manifest
+5. 从 manifest 解析出版本号、archive URL、update script URL
+6. 下载 archive (DMG) 和 update script 到 `work/downloads/`
+7. 校验 SHA-512
+8. 设置 `AETHER_MIRROR_ROOT` 和 `AETHER_CURRENT_DIR` 环境变量
+9. 调用 update script: `bash update_darwin-{ver}.command {ver} --restart`
+
+**Linux** (`Update/aether_linux_installer.sh`):
+1. 检测架构 (`uname -m` → arm64/x64)
+2. 确定工作目录 (`work = ~/.local/share/aether/update/aether`)
+3. 确定安装目标目录 (`mirror = ~/.local/share/applications/aether`)
+4. 从 `aether.aiphys.cn/download/latest/linux-{arch}.yml` 获取 manifest
+5. 下载 archive (ZIP) 和 update script
+6. 校验 SHA-512
+7. 调用 update script: `bash update_linux-{ver}.sh install {ver} --restart`
+8. 额外步骤：`ensure_libssl()` (libssl.so.3 兼容)
+
+**Windows** (`Update/aether_windows_installer.bat`):
+1. 确定工作目录 (`work = %USERPROFILE%\.local\share\aether\update\aether`)
+2. 确定安装目标目录 (`mirror = %LOCALAPPDATA%\Programs\aether`)
+3. 从 `aether.aiphys.cn/download/latest/windows-x64.yml` 获取 manifest
+4. 下载 archive (ZIP) 和 update script
+5. 校验 SHA-512
+6. 调用 update script: `call update_windows-{ver}.bat {ver} --restart`
+
+#### 阶段二：Update Script（执行实际安装）
+
+**macOS** (`Update/update_darwin.command`):
+1. 验证自身位于 `.../aether/downloads/` 目录
+2. 在 `downloads/` 中查找 DMG 文件
+3. `hdiutil attach` 挂载 DMG
+4. `ditto` 从挂载卷拷贝文件到 `work/aether_{ver}/`
+5. `chmod +x` 设置可执行权限
+6. `xattr -cr` 清除隔离属性
+7. 写 `.aether_web_version` 文件
+8. `prune_versions()` 清理旧版本 (保留 1000 个)
+9. Mirror: `ditto` 拷贝到 `mirror/aether_{ver}/`
+10. 创建 `/Applications/Aether.app` (App Bundle):
+    - `Contents/MacOS/Aether` — 探测已运行实例或启动 Aether.command 的 shell 脚本
+    - `Contents/Info.plist` — 含 CFBundleIdentifier `cn.aiphys.aether.web`、URL scheme `aether://`
+    - `Contents/Resources/appIcon-{ver}.icns` — 应用图标
+    - `lsregister` 注册 App
+11. 若 `--restart`: `stop_all_runtime()` → `boot()`
+
+**Linux** (`Update/update_linux.sh`):
+1. 验证自身位于 `.../aether/downloads/` 目录
+2. 在 `downloads/` 中查找 ZIP 文件
+3. 解压到临时目录
+4. `pick_src()` 定位含 `aether` + `Aether.sh` 的目录
+5. `cp -R` 拷贝到 `work/aether_{ver}/`
+6. `chmod +x` 设置可执行权限
+7. 写 `.aether_web_version` 文件
+8. `fix_libssl()` — libssl.so.3 兼容修复:
+   - 若系统缺少 `libssl.so.3`，查找兼容的 `libssl.so.1.x` + `libcrypto.so.1.x`
+   - 用 `ldd` 验证兼容性
+   - 创建 `$target/lib/` 目录及符号链接
+   - 重命名 `Aether.sh` → `Aether.sh.real`，创建新的 wrapper 设置 `LD_LIBRARY_PATH`
+9. `prune_versions()` 清理旧版本
+10. Mirror: `cp -R` + `mv` 拷贝到 `mirror/aether_{ver}/`
+11. `write_launch()`:
+    - 创建 `~/.local/share/applications/aether.desktop`
+    - 拷贝到 `~/Desktop/aether.desktop`
+    - `update-desktop-database`
+12. `register_protocol()`:
+    - 创建 `~/.local/share/applications/aether-url-handler.desktop`
+    - `xdg-mime default` 注册 `aether://` scheme
+13. 若 `--restart`: `stop_all_runtime()` → `boot()`
+
+**Windows** (`Update/update_windows.bat`):
+1. 验证自身位于 `...\aether\downloads\` 目录
+2. 在 `downloads\` 中查找 ZIP 文件
+3. PowerShell `Expand-Archive` 解压
+4. 递归搜索 `aether.exe` + `Aether.vbs` 所在目录
+5. `robocopy /MIR` 拷贝到 `work\aether_{ver}\`
+6. 写 `.aether_web_version` 文件
+7. `prune_versions()` 清理旧版本
+8. Mirror: `robocopy /MIR` 拷贝到 `mirror\aether_{ver}\`
+9. `write_launch()`:
+    - 创建桌面快捷方式 `Aether.lnk` → `Aether.vbs`
+    - 创建开始菜单快捷方式
+    - 设置图标 (从 `aether-icon.ico`)
+10. `register_protocol()`:
+    - 注册表 `HKCU:\Software\Classes\aether` 注册 `aether://` scheme
+11. 若 `--restart`: `stop_runtime()` → 启动 `Aether.vbs`
+
+### 3.2 当前 GitHub Release 产物内容
+
+| 文件 | 平台 |
+|------|------|
+| `aether-darwin-arm64.dmg` | macOS ARM64 |
+| `aether-darwin-x64.dmg` | macOS x64 |
+| `latest-web-mac.yml` | macOS ARM64 manifest |
+| `latest-web-mac-x64.yml` | macOS x64 manifest |
+| `aether-linux-x64.zip` | Linux x64 |
+| `aether-linux-arm64.zip` | Linux ARM64 |
+| `latest-web-linux.yml` | Linux x64 manifest |
+| `latest-web-linux-arm64.yml` | Linux ARM64 manifest |
+| `aether-windows-x64.zip` | Windows x64 |
+| `latest-web-windows.yml` | Windows x64 manifest |
+
+#### archive 内部结构
+
+**macOS DMG** (卷名 `Aether Web`):
+```
+aether-darwin-{arch}/
+├── .aether_web_version
+├── aether                        ← 主二进制 (+x)
+├── Aether.command                ← 启动器 (+x)
+├── aether_darwin_installer.command  ← 当前 GitHub 产物中的 aiphys 安装脚本 (本方案替换为 install.command)
+├── aether-icon.icns
+├── README_FIRST.txt
+├── web/                          ← 前端 SPA
+├── .opencode/skills/             ← 默认技能包
+└── wechat-bridge/                ← 微信桥接 (条件包含)
+```
+
+**Linux ZIP**:
+```
+aether-linux-{arch}/
+├── .aether_web_version
+├── aether                        ← 主二进制 (+x)
+├── Aether.sh                     ← 启动器 (+x)
+├── aether-protocol-handler.sh    ← 协议处理器 (+x)
+├── aether_linux_installer.sh     ← 当前 GitHub 产物中的 aiphys 安装脚本 (本方案替换为 install.sh)
+├── aether-icon.png
+├── aether-icon.svg
+├── README_FIRST.txt
+├── web/
+├── .opencode/skills/
+└── wechat-bridge/
+```
+
+**Windows ZIP**:
+```
+aether-windows-x64\
+├── .aether_web_version
+├── aether.exe                    ← 主二进制
+├── Aether.vbs                    ← 启动器
+├── aether-protocol-handler.vbs   ← 协议处理器
+├── aether_windows_installer.bat  ← 当前 GitHub 产物中的 aiphys 安装脚本 (本方案替换为 install.bat)
+├── aether-icon.ico
+├── README_FIRST.txt
+├── web\
+├── .opencode\skills\
+└── wechat-bridge\
+```
+
+## 四、实施方案
+
+### 4.1 新建 3 个安装脚本
+
+| 平台 | 源文件路径 | 产物中位置 |
+|------|-----------|-----------|
+| macOS | `Update/install.command` | `aether-darwin-{arch}/install.command` |
+| Linux | `Update/install.sh` | `aether-linux-{arch}/install.sh` |
+| Windows | `Update/install.bat` | `aether-windows-x64/install.bat` |
+
+这 3 个脚本是新增源文件。现有 `Update/aether_*_installer.*` 和 `Update/update_*` 源文件不修改、不删除；但 GitHub web 打包产物中不再放入 `aether_*_installer.*`，改为放入对应的 `install.*`。
+
+### 4.2 各脚本执行流程
+
+#### macOS `install.command`
+
+```
+1.  架构检测:
+    - `uname -m=arm64` → `arch=arm64`
+    - `uname -m=x86_64` → `arch=x64`
+    - 其他架构直接失败
+2.  Debug logging 设置 (与 update_darwin.command 一致)
+3.  Session re-exec (与 update_darwin.command 一致，防父进程组被杀)
+4.  信号捕获 (SIGTERM/SIGINT/SIGHUP/SIGQUIT/SIGPIPE)
+5.  参数解析:
+    - [--path <dir>]  — 指定安装目录 (默认 ~/Applications/aether)
+    - [--no-restart]  — 安装后不重启
+    - [help]          — 显示帮助
+6.  确定 SRC = 脚本自身所在目录 (已解析为绝对路径)
+    - 先检查 SRC 是否直接包含 aether 和 Aether.command
+    - 若不包含，再检查 SRC/aether-darwin-$arch/
+    - 若当前目录或子目录架构与当前机器不一致，直接失败
+7.  校验 SRC 中存在 aether 和 Aether.command
+8.  从 SRC/.aether_web_version 读取版本号
+9.  确定 work = ~/.local/share/aether/update/aether
+10. 确定 mirror_root = --path 值 或 ~/Applications/aether (normalize: basename 非 aether 则追加)，并在脚本内部等价设置:
+    - `AETHER_MIRROR_ROOT=mirror_root`
+    - `AETHER_CURRENT_DIR=mirror_root/aether_$ver`
+11. 创建 work 和 mirror_root 目录
+12. 检测当前已安装版本 (只扫描 mirror_root/aether_* 目录，不用 work/aether_* 作为同版本短路依据)
+13. 若 mirror_root 下已安装同版本 → 提示 "already up to date" 并退出；若仅 work/aether_$ver 存在，则不得退出，必须继续执行 mirror、桌面入口、协议注册和 restart 相关 post-install 步骤
+14. target = work/aether_$ver
+15. next = work/.aether_$ver.next (临时暂存目录)
+16. rm -rf next, mkdir -p next
+17. 将 SRC 内容拷贝到 next，保留 macOS 元数据：先 `ditto "$SRC" "$next"`（`ditto` 不支持排除参数），随后 `rm -f "$next/install.command"`，避免把安装入口脚本作为程序内容复制进最终版本目录
+18. rm -rf target, mv next target (原子重命名)
+19. chflags nohidden target 及其兄弟版本目录
+20. chmod +x target/aether, target/Aether.command
+21. 查找并 chmod +x wechat-bridge/runtime/uv/ 下的 uv 二进制
+22. xattr -cr target/aether target/Aether.command (清除隔离属性)
+23. 写 target/.aether_web_version
+24. 删除 work/.aether_web_version (旧版遗留清理)
+25. 删除 work/current (旧版遗留清理)
+26. prune_versions(work, 1000, target)
+27. Mirror 逻辑:
+    - 使用第 10 步确定的 mirror_root/current_dir 语义
+    - 若 current_dir 在 work 内 → 跳过 mirror
+    - 否则: mirror_root 固定为第 10 步的安装目标目录
+    - ditto target → mirror_root/aether_$ver
+    - prune_versions(mirror_root, 1000, copy_target)
+28. build_app (创建 /Applications/Aether.app 或 ~/Applications/Aether.app):
+    - Contents/MacOS/Aether — shell 脚本: 探测已运行实例端口或启动 Aether.command
+    - Contents/Info.plist — CFBundleIdentifier cn.aiphys.aether.web, URL scheme aether://
+    - Contents/Resources/appIcon-{ver}.icns — 从 target/aether-icon.icns 拷贝
+    - xattr -cr, lsregister
+29. 若非 --no-restart:
+    - stop_all_runtime (SIGTERM → 5s wait → SIGKILL)
+    - boot (nohup Aether.command, AETHER_WEB_OPEN_FALLBACK_MS=3000)
+30. 写结果文件 (web-update-result.env)
+31. 打印安装摘要
+```
+
+与 `update_darwin.command` 的差异：
+- **删除**：DMG 查找/挂载/卸载逻辑 (hdiutil attach/detach)、`downloads/` 目录验证、mount point 管理
+- **替换**：文件来源从"挂载 DMG 后 ditto 挂载卷内容"变为"ditto 脚本所在目录内容"
+- **新增**：`--path` 参数、`--no-restart` 参数、work/mirror 目录的创建，以及 installer 阶段原本传给 update script 的 mirror_root/current_dir 语义内置到本地脚本中
+- **保留**：全部桌面集成 (App Bundle)、进程管理、prune、mirror、debug logging、session re-exec
+
+#### Linux `install.sh`
+
+```
+1.  架构检测:
+    - `uname -m=aarch64|arm64` → `arch=arm64`
+    - `uname -m=x86_64|amd64` → `arch=x64`
+    - 其他架构直接失败
+2.  Debug logging 设置
+3.  信号捕获
+4.  参数解析:
+    - [--path <dir>]  — 指定安装目录 (默认 ~/.local/share/applications/aether)
+    - [--no-restart]  — 安装后不重启
+    - [help]          — 显示帮助
+5.  确定 SRC = 脚本自身所在目录 (已解析为绝对路径)
+    - 先检查 SRC 是否直接包含 aether 和 Aether.sh
+    - 若不包含，再检查 SRC/aether-linux-$arch/
+    - 若当前目录或子目录架构与当前机器不一致，直接失败
+6.  校验 SRC 中存在 aether 和 Aether.sh
+7.  从 SRC/.aether_web_version 读取版本号
+8.  确定 work = ~/.local/share/aether/update/aether
+9.  确定 mirror_root = --path 值 或 ~/.local/share/applications/aether (normalize)，并在脚本内部等价设置:
+    - `AETHER_MIRROR_ROOT=mirror_root`
+    - `AETHER_CURRENT_DIR=mirror_root/aether_$ver`
+10. 创建 work 和 mirror_root 目录
+11. 检测当前已安装版本 (只扫描 mirror_root/aether_* 目录，不用 work/aether_* 作为同版本短路依据)
+12. 若 mirror_root 下已安装同版本 → 提示并退出；若仅 work/aether_$ver 存在，则不得退出，必须继续执行 mirror、桌面入口、协议注册和 restart 相关 post-install 步骤
+13. target = work/aether_$ver
+14. next = work/.aether_$ver.next
+15. rm -rf next, mkdir -p next
+16. 将 SRC 内容拷贝到 next：先 `cp -R "$SRC"/. "$next"/`（`cp -R` 不支持排除参数），随后 `rm -f "$next/install.sh"`，避免把安装入口脚本作为程序内容复制进最终版本目录
+17. rm -rf target, mv next target
+18. 权限修复:
+    - chmod +x target/aether
+    - chmod +x target/Aether.sh
+    - chmod +x target/aether-protocol-handler.sh (若存在)
+    - chmod +x target/wechat-bridge/runtime/uv/uv-*linux*/uv (若存在)
+19. 写 target/.aether_web_version
+20. 删除 work/.aether_web_version, work/current
+21. fix_libssl(target):
+    - 若系统有 libssl.so.3 → 跳过
+    - 否则: pick_pair() 用 ldd 验证兼容性
+    - 创建 target/lib/ 及符号链接
+    - 重命名 Aether.sh → Aether.sh.real，创建 wrapper 设置 LD_LIBRARY_PATH
+22. prune_versions(work, 1000, target)
+23. Mirror:
+    - 使用第 9 步确定的 mirror_root/current_dir 语义
+    - 若 current_dir 在 work 内 → 跳过
+    - 否则: cp -R + mv 到 mirror_root/aether_$ver
+    - prune_versions(mirror_root, 1000, copy_target)
+24. ensure_libssl(start_target):
+    - mirror 完成后，对最终启动目录执行与现有 Linux installer 阶段一致的 libssl 兼容保险
+    - 若系统已有 libssl.so.3 → 跳过
+    - 否则在最终启动目录创建兼容 symlink/wrapper；该步骤用于保持 aiphys init 安装流程一致
+25. write_launch:
+    - 创建 ~/.local/share/applications/aether.desktop
+    - 拷贝到 ~/Desktop/aether.desktop
+    - update-desktop-database
+26. register_protocol:
+    - 创建 ~/.local/share/applications/aether-url-handler.desktop
+    - xdg-mime default 注册 aether:// scheme
+27. 若非 --no-restart:
+    - stop_all_runtime (SIGTERM → 5s → SIGKILL)
+    - boot (setsid Aether.sh)
+28. 写结果文件
+29. 打印安装摘要
+```
+
+与 `update_linux.sh` 的差异：
+- **删除**：ZIP 查找/解压逻辑 (unzip/tar)、`downloads/` 目录验证、临时解压目录管理
+- **替换**：文件来源从"解压 ZIP 后 cp -R"变为"cp -R 脚本所在目录"
+- **新增**：`--path` 参数、`--no-restart` 参数、work/mirror 目录的创建，以及 installer 阶段原本传给 update script 的 mirror_root/current_dir 语义内置到本地脚本中
+- **保留**：全部 libssl 修复 (包含 update 阶段 target 修复和 installer 阶段 mirror 后兼容保险)、.desktop 创建、协议注册、进程管理、prune、mirror、debug logging
+
+#### Windows `install.bat`
+
+```
+1.  平台限制: 仅支持 Windows x64 GitHub web 产物 `aether-windows-x64`
+2.  参数解析:
+    - [--path <dir>]      — 指定安装目录 (默认 %LOCALAPPDATA%\Programs\aether)
+    - [--no-restart]      — 安装后不重启
+    - [--no-pause]        — 结束后不等待用户关闭窗口
+    - [help]              — 显示帮助
+3.  若非 --no-pause，则默认启用 hold，成功或失败后提示 `Press Esc to close...`，与现有 Windows installer 一致；非交互环境不阻塞
+4.  确定 SRC = 脚本自身所在目录
+    - 先检查 SRC 是否直接包含 aether.exe 和 Aether.vbs
+    - 若不包含，再检查 SRC\aether-windows-x64\
+    - 若目录名或内容不匹配 Windows x64 产物，直接失败
+5.  校验 SRC 中存在 aether.exe 和 Aether.vbs
+6.  从 SRC\.aether_web_version 读取版本号
+7.  确定 work = %USERPROFILE%\.local\share\aether\update\aether
+8.  确定 mirror_root = --path 值 或 %LOCALAPPDATA%\Programs\aether，并在脚本内部等价设置:
+    - `AETHER_MIRROR_ROOT=mirror_root`
+    - `AETHER_CURRENT_DIR=mirror_root\aether_%VER%`
+9.  创建 work 和 mirror_root 目录
+10. 检测当前已安装版本 (只扫描 mirror_root\aether_* 目录，不用 work\aether_* 作为同版本短路依据)
+11. 若 mirror_root 下已安装同版本 → 提示并退出；若仅 work\aether_%VER% 存在，则不得退出，必须继续执行 mirror、快捷方式、协议注册和 restart 相关 post-install 步骤
+12. target = work\aether_%VER%
+13. next = work\.aether_%VER%.next
+14. robocopy SRC next /MIR /NFL /NDL /NJH /NJS /NP /XF install.bat，避免把安装入口脚本作为程序内容复制进最终版本目录
+15. 若 robocopy exit >= 8 → 失败
+16. 删除旧 target (rmdir /s /q)
+17. move next target
+18. 写 target\.aether_web_version
+19. 删除 work\.aether_web_version, work\current
+20. prune_versions(work, 1000, target)
+21. Mirror:
+    - 使用第 8 步确定的 mirror_root/current_dir 语义
+    - 若 current_dir 不在 work 内:
+      - robocopy target → mirror_root\aether_%VER%
+      - prune_versions(mirror_root, 1000, mirror)
+    - 若 current_dir 在 work 内 → 跳过 mirror
+22. write_launch:
+    - 创建桌面 Aether.lnk → Aether.vbs (含图标)
+    - 创建开始菜单 Aether.lnk
+23. register_protocol:
+    - 注册表 HKCU:\Software\Classes\aether 注册 aether:// scheme
+24. 若非 --no-restart:
+    - stop_runtime (PowerShell WMI 查询 aether.exe 等进程)
+    - 启动 Aether.vbs (AETHER_WEB_OPEN_FALLBACK_MS=3000)
+25. 写结果文件
+26. 打印安装摘要
+27. 若 hold 已启用，等待 Esc 关闭窗口
+```
+
+与 `update_windows.bat` 的差异：
+- **删除**：ZIP 查找/解压逻辑 (Expand-Archive)、`downloads\` 目录验证、临时解压目录
+- **替换**：文件来源从"解压 ZIP 后 robocopy"变为"robocopy 脚本所在目录"
+- **新增**：`--path` 参数、`--no-restart` 参数、`--no-pause` 参数、work/mirror 目录的创建，以及 installer 阶段原本传给 update script 的 mirror_root/current_dir 语义内置到本地脚本中
+- **保留**：全部快捷方式创建、协议注册、进程管理、prune、mirror、debug logging
+
+### 4.3 SRC 目录的自动检测
+
+新脚本需要处理两种用户场景：
+
+**场景 A — macOS**: 用户双击 DMG 挂载后，在 DMG 卷内运行脚本。此时脚本所在目录是 `aether-darwin-{arch}/`，里面直接有 `aether`、`Aether.command` 等文件。
+
+**场景 B — 通用**: 用户先将文件夹从 DMG/ZIP 拷贝到本地，再运行脚本。此时脚本可能在 `aether-darwin-{arch}/` 目录内。
+
+**场景 C — Linux/Windows ZIP**: ZIP 解压后有 `aether-linux-{arch}/` 或 `aether-windows-x64\` 子目录，脚本在该子目录内。
+
+唯一检测逻辑：
+1. 初始 `SRC = 脚本所在目录`
+2. 先检查 `SRC` 是否直接包含当前平台必需文件：
+   - macOS: `aether` + `Aether.command`
+   - Linux: `aether` + `Aether.sh`
+   - Windows: `aether.exe` + `Aether.vbs`
+3. 若当前目录不满足，再检查当前目录下匹配当前平台和当前架构的子目录：
+   - macOS: `SRC/aether-darwin-$arch`
+   - Linux: `SRC/aether-linux-$arch`
+   - Windows: `SRC\aether-windows-x64`
+4. 找到后将 `SRC` 设为该子目录
+5. 找不到、找到多个候选、或候选架构与当前机器不匹配，都报错退出
+
+### 4.4 版本比较约束
+
+新脚本必须完全沿用现有 installer/update 脚本的版本比较语义，不引入新的 semver 规则：
+
+- bash 侧 `cmp()`：去掉前导 `v`，忽略 `-` 及其后的 prerelease 部分，最多比较 4 段数字
+- Windows 侧 `cmp` / 排序：去掉前导 `v`，忽略 `-` 及其后的 prerelease 部分，再按 PowerShell `[version]` 比较
+- `installed()`、`dir_version()`、`latest_dir()`、`prune_versions()` 中对版本目录的识别和排序也必须沿用现有脚本逻辑
+- 这样可避免 GitHub 安装脚本与 aiphys 更新脚本对同一版本得出不同判断
+
+### 4.5 修改 packing scripts
+
+| 文件 | 修改内容 |
+|------|---------|
+| `packing_scripts/release-mac-web.sh` | 将 `cp "$root/Update/aether_darwin_installer.command"` 替换为 `cp "$root/Update/install.command"`；chmod +x；更新 README_FIRST.txt |
+| `packing_scripts/release-linux-web.sh` | 将 `cp "$root/Update/aether_linux_installer.sh"` 替换为 `cp "$root/Update/install.sh"`；chmod +x；更新 README_FIRST.txt |
+| `packing_scripts/release-windows-web.bat` | 将 `copy "%ROOT%\Update\aether_windows_installer.bat"` 替换为 `copy "%ROOT%\Update\install.bat"`；更新 README_FIRST.txt |
+
+上述修改只改变 GitHub web 产物内的安装入口，不修改 `Update/aether_*_installer.*` 源文件。
+
+### 4.6 README_FIRST.txt 更新
+
+**macOS** (新内容):
+```
+Aether Web (macOS {ARCH})
+
+Quick start
+1) Open this DMG
+2) In Finder, open the aether-darwin-{arch} folder
+3) Right click install.command and choose Open
+4) If macOS asks again, click Open in the security prompt
+
+Troubleshooting
+- If you see "cannot be opened" or "unidentified developer":
+  Right click install.command -> Open, then confirm Open
+- If execution permission is missing:
+    chmod +x ./install.command
+
+Updates
+- Use Aether's in-app update flow to download and install newer versions.
+```
+
+**Linux** (新内容):
+```
+Aether Web (Linux {ARCH})
+
+Quick start
+1) Extract this ZIP
+2) Open Terminal in the aether-linux-{arch} folder
+3) Run: chmod +x install.sh && ./install.sh
+
+Updates
+- Use Aether's in-app update flow to download and install newer versions.
+```
+
+**Windows** (新内容):
+```
+Aether Web (Windows x64)
+
+Quick start
+1) Extract this ZIP
+2) Open the aether-windows-x64 folder
+3) Double click install.bat
+
+Updates
+- Use Aether's in-app update flow to download and install newer versions.
+```
+
+### 4.7 安装后运行时结构 (与 aiphys 流程一致)
+
+```
+# macOS
+~/.local/share/aether/update/aether/     ← work 目录
+  aether_1.2.3/                           ← 版本化安装目录
+~/Applications/aether/                    ← mirror 目录
+  aether_1.2.3/                           ← 镜像副本 (实际运行位置)
+/Applications/Aether.app/                 ← App Bundle
+
+# Linux
+~/.local/share/aether/update/aether/     ← work 目录
+  aether_1.2.3/
+~/.local/share/applications/aether/      ← mirror 目录
+  aether_1.2.3/
+~/.local/share/applications/aether.desktop
+~/.local/share/applications/aether-url-handler.desktop
+
+# Windows
+%USERPROFILE%\.local\share\aether\update\aether\   ← work 目录
+  aether_1.2.3\
+%LOCALAPPDATA%\Programs\aether\                     ← mirror 目录
+  aether_1.2.3\
+<Desktop>\Aether.lnk
+<Start Menu>\Aether.lnk
+HKCU:\Software\Classes\aether                       ← 协议注册
+```
+
+注：GitHub release 包内安装入口从 `aether_*_installer.*` 改为 `install.*` 是刻意差异。安装后的运行时目录不应依赖这些安装入口脚本；主程序、launcher、web、skills、wechat-bridge、版本 marker、桌面入口和协议注册保持与 aiphys 流程一致。
+
+### 4.8 不修改的部分
+
+- `packages/opencode/src/server/web-update.ts` — in-app 更新仍走 aiphys
+- `packages/app/src/` — 前端更新逻辑不变
+- `packages/opencode/launcher/Aether.{sh,command,vbs}` — 启动器不变
+- `Update/update_darwin.command` / `update_linux.sh` / `update_windows.bat` — aiphys 流程的 update scripts 不变
+- `Update/aether_*_installer.*` — aiphys 流程的 installers 不变
+- `latest-web-*.yml` 格式 — 暂不增强
+- `.github/workflows/publish.yml` — workflow 本身不修改，仅因 packing scripts 变更而间接影响产物内容
+- `packages/opencode/script/build.ts` — 构建脚本不变 (launcher 脚本不变)
+
+### 4.9 --path 默认值 (与现有 installer 一致)
+
+| 平台 | 默认 mirror 目录 |
+|------|----------------|
+| macOS | `~/Applications/aether` |
+| Linux | `~/.local/share/applications/aether` |
+| Windows | `%LOCALAPPDATA%\Programs\aether` |
+
+## 五、用户使用流程
+
+### 全新安装
+
+1. 用户在 GitHub Releases 页面下载对应平台的 DMG/ZIP
+2. macOS: 双击 DMG 挂载 → 打开文件夹 → 右键 `install.command` → Open
+3. Linux: 解压 ZIP → `chmod +x install.sh && ./install.sh`
+4. Windows: 解压 ZIP → 双击 `install.bat`，或在普通命令提示符中运行 `install.bat`
+5. 脚本自动完成：版本化安装、权限修复、桌面集成、启动应用
+
+### 更新 (已安装旧版本)
+
+1. 下载新版本的 DMG/ZIP
+2. 运行 `install.*` 脚本
+3. 脚本自动完成：停止旧进程、安装新版本到新版本化目录、更新桌面集成、清理旧版本、启动新版本
+
+### 后续 in-app 更新
+
+安装后，in-app 自动更新检查仍通过 aiphys 进行，不受安装来源影响。

--- a/packing_scripts/release-linux-web.sh
+++ b/packing_scripts/release-linux-web.sh
@@ -58,12 +58,15 @@ out="$tmp/$pkg"
 
 mkdir -p "$out"
 cp -R "$src"/. "$out"/
+rm -f "$out/aether_linux_installer.sh" "$out/aether_linux_installer_beta.sh" "$out/aether_linux_installer_devtest.sh"
 
-ins="$root/Update/aether_linux_installer.sh"
-if [ -f "$ins" ]; then
-  cp "$ins" "$out/aether_linux_installer.sh"
-  chmod +x "$out/aether_linux_installer.sh"
-fi
+ins="$root/Update/install.sh"
+[ -f "$ins" ] || {
+  echo "Missing $ins"
+  exit 1
+}
+cp "$ins" "$out/install.sh"
+chmod +x "$out/install.sh"
 icon="$root/icon-source/gen/icon.png"
 if [ -f "$icon" ]; then
   cp "$icon" "$out/aether-icon.png"
@@ -91,9 +94,9 @@ cat >"$out/README_FIRST.txt" <<'EOF'
 Aether Web (Linux ARCH)
 
 Quick start
-1) Extract this ZIP and copy the folder PACKAGE to a local path, for example: ~/Applications/Aether-Web
-2) Open Terminal in that folder and run: ./Aether.sh
-3) Optional base path: VITE_BASE_PATH=/aether ./Aether.sh
+1) Extract this ZIP
+2) Open Terminal in the aether-linux-ARCH folder
+3) Run: chmod +x install.sh && ./install.sh
 
 Updates
 - Use Aether's in-app update flow to download and install newer versions.
@@ -122,4 +125,4 @@ popd >/dev/null
 echo "Done"
 echo "Asset: packages/opencode/$zip"
 echo "YML:   packages/opencode/dist/$yml.yml"
-echo "Note:  ZIP includes folder $pkg and aether_linux_installer.sh"
+echo "Note:  ZIP includes folder $pkg and install.sh"

--- a/packing_scripts/release-mac-web.sh
+++ b/packing_scripts/release-mac-web.sh
@@ -59,12 +59,15 @@ out="$tmp/$pkg"
 
 mkdir -p "$out"
 cp -R "$src"/. "$out"/
+rm -f "$out/aether_darwin_installer.command" "$out/aether_darwin_x64_installer.command" "$out/aether_darwin_installer_beta.command" "$out/aether_darwin_installer_devtest.command"
 
-ins="$root/Update/aether_darwin_installer.command"
-if [ -f "$ins" ]; then
-  cp "$ins" "$out/aether_darwin_installer.command"
-  chmod +x "$out/aether_darwin_installer.command"
-fi
+ins="$root/Update/install.command"
+[ -f "$ins" ] || {
+  echo "Missing $ins"
+  exit 1
+}
+cp "$ins" "$out/install.command"
+chmod +x "$out/install.command"
 
 icon="$root/packages/desktop-web/icons/prod/icon.icns"
 if [ -f "$icon" ]; then
@@ -86,23 +89,17 @@ cat >"$out/README_FIRST.txt" <<'EOF'
 Aether Web (macOS ARCH)
 
 Quick start
-1) Open this DMG and copy the folder PACKAGE to a local path, for example: ~/Applications/Aether-Web
-2) In Finder, right click Aether.command and choose Open
-3) If macOS asks again, click Open in the security prompt
+1) Open this DMG
+2) In Finder, open the aether-darwin-ARCH folder
+3) Right click install.command and choose Open
+4) If macOS asks again, click Open in the security prompt
 
 Troubleshooting
 - If you see "cannot be opened" or "unidentified developer":
-  Right click Aether.command -> Open, then confirm Open
-
-- If you see "is damaged and cannot be opened":
-  Open Terminal in the install folder and run:
-    xattr -cr ./aether ./Aether.command
+  Right click install.command -> Open, then confirm Open
 
 - If execution permission is missing:
-    chmod +x ./aether ./Aether.command
-
-- If Gatekeeper still blocks it:
-  System Settings -> Privacy & Security -> scroll down and allow the blocked item, then retry Open
+    chmod +x ./install.command
 
 Updates
 - Use Aether's in-app update flow to download and install newer versions.
@@ -129,4 +126,4 @@ popd >/dev/null
 echo "Done"
 echo "Asset: packages/opencode/$dmg"
 echo "YML:   packages/opencode/dist/$yml.yml"
-echo "Note:  DMG includes README_FIRST.txt and aether_darwin_installer.command"
+echo "Note:  DMG includes README_FIRST.txt and install.command"

--- a/packing_scripts/release-windows-web.bat
+++ b/packing_scripts/release-windows-web.bat
@@ -37,11 +37,16 @@ if %RC% GEQ 8 (
   rmdir /s /q "%TMP%" >nul 2>nul
   exit /b 1
 )
+if exist "%OUT%\aether_windows_installer.bat" del /f /q "%OUT%\aether_windows_installer.bat" >nul 2>nul
+if exist "%OUT%\aether_windows_installer_beta.bat" del /f /q "%OUT%\aether_windows_installer_beta.bat" >nul 2>nul
+if exist "%OUT%\aether_windows_installer_devtest.bat" del /f /q "%OUT%\aether_windows_installer_devtest.bat" >nul 2>nul
 
-set "INS=%ROOT%\Update\aether_windows_installer.bat"
-if exist "%INS%" (
-  copy /y "%INS%" "%OUT%\aether_windows_installer.bat" >nul || exit /b 1
+set "INS=%ROOT%\Update\install.bat"
+if not exist "%INS%" (
+  echo Missing %INS%
+  exit /b 1
 )
+copy /y "%INS%" "%OUT%\install.bat" >nul || exit /b 1
 
 set "ICON=%ROOT%\icon-source\gen\icon.ico"
 if exist "%ICON%" copy /y "%ICON%" "%OUT%\aether-icon.ico" >nul
@@ -49,7 +54,7 @@ if exist "%ICON%" copy /y "%ICON%" "%OUT%\aether-icon.ico" >nul
 if exist "%OUT%\.aether_version" del /f /q "%OUT%\.aether_version" >nul 2>nul
 powershell -NoProfile -Command "& { [IO.File]::WriteAllText((Join-Path $env:OUT '.aether_web_version'), $env:VERSION) }" || exit /b 1
 
-powershell -NoProfile -Command "& { $crlf=[char]13+[char]10; $txt=@('Aether Web (Windows x64)','', 'Quick start', '1) Extract this ZIP and copy the folder aether-windows-x64 to a local path, for example: C:\Aether-Web', '2) In that folder, double click Aether.vbs', '', 'Updates', '- Use Aether''s in-app update flow to download and install newer versions.') -join $crlf; Set-Content -Path (Join-Path $env:OUT 'README_FIRST.txt') -Value ($txt + $crlf) -Encoding ascii }" || exit /b 1
+powershell -NoProfile -Command "& { $crlf=[char]13+[char]10; $txt=@('Aether Web (Windows x64)','', 'Quick start', '1) Extract this ZIP', '2) Open the aether-windows-x64 folder', '3) Double click install.bat', '', 'Updates', '- Use Aether''s in-app update flow to download and install newer versions.') -join $crlf; Set-Content -Path (Join-Path $env:OUT 'README_FIRST.txt') -Value ($txt + $crlf) -Encoding ascii }" || exit /b 1
 
 set "ZIP=%CD%\dist\aether-windows-x64.zip"
 if exist "%ZIP%" del /f /q "%ZIP%"
@@ -65,4 +70,4 @@ rmdir /s /q "%TMP%" >nul 2>nul
 echo Done
 echo Asset: %ZIP%
 echo YML:   %YML%
-echo Note:  ZIP includes folder %PKG% and aether_windows_installer.bat
+echo Note:  ZIP includes folder %PKG% and install.bat


### PR DESCRIPTION
### Issue for this PR

Closes #984

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds platform-specific local install scripts for Aether Web release artifacts so users can install or update directly from GitHub release and downloadbeta archives.

The new scripts mirror the existing installer/update behavior while sourcing files from the extracted archive instead of downloading payloads from the aiphys site. They also reject wrong-architecture packages, clear and rewrite update result state for same-version exits, preserve Windows shortcut behavior, and align Linux libssl compatibility handling with the existing install flow.

Release packaging now places install.sh, install.command, or install.bat into the platform artifact and removes the old aiphys installer scripts from compressed web artifacts.

### How did you verify your code works?

- bash -n Update/install.sh
- bash -n Update/install.command
- bash -n packing_scripts/release-linux-web.sh
- bash -n packing_scripts/release-mac-web.sh
- bash -n Update/release-and-upload-mac-web.sh
- git diff --check
- git diff --cached --check
- Tested Linux fake package install and same-version rerun, confirming exit code 20 and status=up_to_date
- Tested Linux wrong-architecture fake package rejection, confirming exit code 33
- Tested macOS install script source-directory architecture rejection path on a mismatched fake package

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR