### PR TITLE
feat: add manual install update CI

### DIFF
--- a/.github/scripts/install-update-ci.ts
+++ b/.github/scripts/install-update-ci.ts
@@ -1,0 +1,941 @@
+#!/usr/bin/env bun
+import { spawn } from "node:child_process"
+import { existsSync } from "node:fs"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+
+type Asset = {
+  name: string
+  browser_download_url: string
+}
+
+type Release = {
+  tag_name: string
+  prerelease: boolean
+  draft: boolean
+  assets: Asset[]
+}
+
+type Meta = {
+  version: string
+  package?: {
+    url?: string
+    sha512?: string
+    size?: number
+  }
+}
+
+type Cmd = {
+  cwd?: string
+  env?: Record<string, string>
+  ok?: number[]
+  timeout?: number
+}
+
+const cfg = {
+  id: env("AETHER_CI_ID"),
+  product: env("AETHER_CI_PRODUCT"),
+  task: env("AETHER_CI_TASK"),
+  platform: env("AETHER_CI_PLATFORM"),
+  arch: env("AETHER_CI_ARCH"),
+  format: process.env.AETHER_CI_FORMAT ?? "",
+}
+
+const root = process.cwd()
+const tmp = path.join(process.env.RUNNER_TEMP ?? os.tmpdir(), "aether-install-update", cfg.id)
+const out = path.join(root, "install-update-artifacts", cfg.id)
+const summary = process.env.GITHUB_STEP_SUMMARY
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || ""
+let page: { screenshot: (opts: { path: string; fullPage: boolean }) => Promise<unknown> } | null = null
+
+await fs.mkdir(tmp, { recursive: true })
+await fs.mkdir(out, { recursive: true })
+
+try {
+  await main()
+} catch (cause) {
+  await screenshot().catch(() => undefined)
+  await collect().catch(() => undefined)
+  await note(`## ${cfg.id}\n\nfailed: ${message(cause)}\n`)
+  await write("result.json", JSON.stringify({ status: "failed", cfg, error: message(cause) }, null, 2))
+  throw cause
+}
+
+async function main() {
+  await note(`## ${cfg.id}\n\n- product: ${cfg.product}\n- task: ${cfg.task}\n- platform: ${cfg.platform}\n- arch: ${cfg.arch}\n- format: ${cfg.format || "-"}\n`)
+  if (cfg.product === "web" && cfg.task === "site-install") return await webSite()
+  if (cfg.product === "web" && cfg.task === "github-install") return await webGithub()
+  if (cfg.product === "web" && cfg.task === "auto-update") return await webAuto()
+  if (cfg.product === "web" && cfg.task === "manual-update") return await webManual()
+  if (cfg.product === "electron" && cfg.task === "github-install") return await electronGithub()
+  if (cfg.product === "electron" && cfg.task === "auto-update") return await electronAuto()
+  if (cfg.product === "electron" && cfg.task === "manual-update") return await electronManual()
+  throw new Error(`Unsupported matrix item: ${JSON.stringify(cfg)}`)
+}
+
+async function webSite() {
+  const item = webSiteInstaller()
+  if (!item) return await skip("missing website installer mapping")
+  if (!(await okUrl(item.url))) return await skip(`missing website installer: ${item.url}`)
+  if (!(await webStable())) return await skip("missing website stable manifest")
+  const file = await download(item.url, item.name)
+  await runWebInstaller(file)
+  const hit = await webReady()
+  await pass(`website install started web app at ${hit.url} with version ${hit.version}`)
+}
+
+async function webGithub() {
+  const rel = await pre()
+  if (!rel) return await skip("missing GitHub prerelease")
+  const asset = webAsset(rel)
+  if (!asset) return await skip(`missing GitHub web prerelease asset in ${rel.tag_name}`)
+  await installWebAsset(asset)
+  const hit = await webReady()
+  const want = ver(rel)
+  if (cmp(hit.version, want) < 0) throw new Error(`Expected web version ${want}, got ${hit.version}`)
+  await pass(`GitHub web install started version ${hit.version}`)
+}
+
+async function webAuto() {
+  const item = webSiteInstaller()
+  if (!item) return await skip("missing website installer mapping")
+  const stable = await webStable()
+  if (!stable) return await skip("missing website stable manifest")
+  const beta = await webBeta()
+  if (!beta) return await skip("missing downloadbeta manifest")
+  if (cmp(beta.version, stable.version) <= 0) return await skip(`downloadbeta ${beta.version} is not newer than stable ${stable.version}`)
+  const file = await download(item.url, item.name)
+  await writeWebCfg()
+  await runWebInstaller(file)
+  const hit = await webPage()
+  const state = { reload: false }
+  hit.page.on("framenavigated", () => {
+    state.reload = true
+  })
+  await waitWebToast(hit.page)
+  await hit.page.getByRole("button", { name: /更新并重启|Update & Restart/i }).click()
+  const next = await waitWebVersion(hit.url, beta.version, state)
+  await hit.browser.close()
+  if (!next.reload) throw new Error("Web automatic update did not reload the original browser page")
+  await pass(`web auto update reloaded page to ${next.version}`)
+}
+
+async function webManual() {
+  const item = webSiteInstaller()
+  if (!item) return await skip("missing website installer mapping")
+  if (!(await webStable())) return await skip("missing website stable manifest")
+  const rel = await pre()
+  if (!rel) return await skip("missing GitHub prerelease")
+  const asset = webAsset(rel)
+  if (!asset) return await skip(`missing GitHub web prerelease asset in ${rel.tag_name}`)
+  const file = await download(item.url, item.name)
+  await runWebInstaller(file)
+  const hit = await webPage()
+  await hit.browser.close()
+  await installWebAsset(asset)
+  const next = await webReady()
+  const want = ver(rel)
+  if (cmp(next.version, want) < 0) throw new Error(`Expected web version ${want}, got ${next.version}`)
+  await pass(`web manual update restarted page at version ${next.version}`)
+}
+
+async function electronGithub() {
+  const rel = await pre()
+  if (!rel) return await skip("missing GitHub prerelease")
+  const asset = electronAsset(rel)
+  if (!asset) return await skip(`missing GitHub Electron prerelease asset in ${rel.tag_name}`)
+  await installElectron(asset)
+  await launchElectron(asset)
+  await electronReady()
+  await assertElectronVersion(ver(rel))
+  await pass(`Electron GitHub install started version ${ver(rel)}`)
+}
+
+async function electronAuto() {
+  const base = await stableOrFallback()
+  if (base.fallback) return await skip(base.reason)
+  const asset = electronAsset(base.release)!
+  const target = await pre()
+  if (!target) return await skip("missing GitHub prerelease")
+  const next = electronAsset(target)
+  if (!next) return await skip(`missing prerelease Electron asset in ${target.tag_name}`)
+  if (cmp(ver(target), ver(base.release)) <= 0) return await skip(`prerelease ${ver(target)} is not newer than stable ${ver(base.release)}`)
+  await installElectron(asset)
+  await writeElectronCfg()
+  await launchElectron(asset)
+  await electronReady()
+  if (manualElectron()) {
+    await waitElectronLog(/update available; manual install required/i)
+    await acceptDialog()
+    await verifyReleaseLink(ver(target))
+    await installElectron(next)
+    await launchElectron(next)
+    await electronReady()
+    await assertElectronVersion(ver(target))
+    await pass(`Electron manual-install update prompt opened release and updated to ${ver(target)}`)
+    return
+  }
+  await waitElectronLog(/update download completed/i)
+  await acceptDialog()
+  await waitElectronVersion(ver(target))
+  await electronReady()
+  await pass(`Electron automatic update restarted to ${ver(target)}`)
+}
+
+async function electronManual() {
+  const base = await stableOrFallback()
+  if (base.fallback) return await skip(base.reason)
+  const asset = electronAsset(base.release)!
+  const target = await pre()
+  if (!target) return await skip("missing GitHub prerelease")
+  const next = electronAsset(target)
+  if (!next) return await skip(`missing prerelease Electron asset in ${target.tag_name}`)
+  await installElectron(asset)
+  await launchElectron(asset)
+  await electronReady()
+  await installElectron(next)
+  await launchElectron(next)
+  await electronReady()
+  await assertElectronVersion(ver(target))
+  await pass(`Electron manual update started version ${ver(target)}`)
+}
+
+async function runWebInstaller(file: string) {
+  if (cfg.platform === "windows") {
+    await run("cmd.exe", ["/d", "/c", file], { timeout: 20 * 60_000 })
+    return
+  }
+  await run("chmod", ["+x", file])
+  await run(file, [], { timeout: 20 * 60_000 })
+}
+
+async function installWebAsset(asset: Asset) {
+  const file = await download(asset.browser_download_url, asset.name)
+  const dir = await unpack(file)
+  const name = cfg.platform === "windows" ? "install.bat" : cfg.platform === "darwin" ? "install.command" : "install.sh"
+  const runfile = await find(dir, name)
+  if (!runfile) throw new Error(`Missing ${name} in ${asset.name}`)
+  await runWebInstaller(runfile)
+  if (file.endsWith(".dmg")) await unmount(dir)
+}
+
+async function installElectron(asset: Asset) {
+  const file = await download(asset.browser_download_url, asset.name)
+  if (cfg.platform === "darwin") {
+    const dir = await mount(file)
+    const app = await find(dir, ".app")
+    if (!app) throw new Error(`No .app found in ${asset.name}`)
+    const dest = path.join("/Applications", path.basename(app))
+    await run("rm", ["-rf", dest])
+    await run("cp", ["-R", app, dest])
+    await unmount(dir)
+    return
+  }
+  if (cfg.platform === "linux" && cfg.format === "appimage") {
+    await run("chmod", ["+x", file])
+    await write("electron-appimage-path.txt", file)
+    return
+  }
+  if (cfg.platform === "linux" && cfg.format === "deb") {
+    await run("sudo", ["apt-get", "install", "-y", file], { timeout: 20 * 60_000 })
+    return
+  }
+  if (cfg.platform === "linux" && cfg.format === "rpm") {
+    await elevate("dnf", ["install", "-y", file], { timeout: 20 * 60_000 })
+    return
+  }
+  if (cfg.platform === "windows") {
+    const proc = spawn(file, [], { detached: true, stdio: "ignore" })
+    proc.unref()
+    await driveInstaller()
+    return
+  }
+  throw new Error(`Unsupported Electron install target: ${cfg.platform} ${cfg.format}`)
+}
+
+async function launchElectron(asset?: Asset) {
+  await clearElectronLogs()
+  if (cfg.platform === "darwin") {
+    await run("open", ["-a", "Aether Desktop"])
+    return
+  }
+  if (cfg.platform === "linux" && cfg.format === "appimage") {
+    const file = (await fs.readFile(path.join(out, "electron-appimage-path.txt"), "utf8")).trim()
+    const child = spawn(file, [], { detached: true, stdio: "ignore", env: process.env })
+    child.unref()
+    return
+  }
+  if (cfg.platform === "linux") {
+    const bin = (await which("aether-desktop")) ?? (await first(["/opt/Aether Desktop/aether-desktop", "/opt/aether-desktop/aether-desktop"]))
+    if (!bin) throw new Error("Could not find installed Electron Linux launcher")
+    const child = spawn(bin, [], { detached: true, stdio: "ignore", env: process.env })
+    child.unref()
+    return
+  }
+  if (cfg.platform === "windows") {
+    const exe = await winExe()
+    if (!exe) throw new Error(`Could not find installed Electron exe after ${asset?.name ?? "install"}`)
+    await run("powershell", ["-NoProfile", "-Command", `Start-Process -FilePath ${ps(exe)}`])
+  }
+}
+
+async function webPage() {
+  const hit = await webReady()
+  const mod = (await Function("return import('playwright')")()) as {
+    chromium: {
+      launch: () => Promise<{
+        newPage: () => Promise<{
+          goto: (url: string) => Promise<unknown>
+          screenshot: (opts: { path: string; fullPage: boolean }) => Promise<unknown>
+          close?: () => Promise<unknown>
+          on: (name: string, fn: () => void) => void
+          getByText: (pat: RegExp) => { waitFor: (opts: { timeout: number }) => Promise<void> }
+          getByRole: (role: string, opts: { name: RegExp }) => { click: () => Promise<void> }
+        }>
+        close: () => Promise<unknown>
+      }>
+    }
+  }
+  const browser = await mod.chromium.launch()
+  page = await browser.newPage()
+  await page.goto(hit.url)
+  return { browser, page, url: hit.url, version: hit.version }
+}
+
+async function webReady() {
+  const ports = Array.from({ length: 16 }, (_, idx) => 4096 + idx)
+  const end = Date.now() + 120_000
+  while (Date.now() < end) {
+    for (const port of ports) {
+      const url = `http://127.0.0.1:${port}`
+      const version = await webHealth(url)
+      if (version) return { url, version }
+    }
+    await sleep(1000)
+  }
+  throw new Error("Timed out waiting for Web app health")
+}
+
+async function waitWebVersion(url: string, want: string, state: { reload: boolean }) {
+  const end = Date.now() + 180_000
+  while (Date.now() < end) {
+    const version = await webHealth(url)
+    if (version && cmp(version, want) >= 0) {
+      for (let i = 0; i < 20 && !state.reload; i++) await sleep(250)
+      return { version, reload: state.reload }
+    }
+    await sleep(1000)
+  }
+  throw new Error(`Timed out waiting for Web version ${want}`)
+}
+
+async function waitWebToast(page: { getByText: (pat: RegExp) => { waitFor: (opts: { timeout: number }) => Promise<void> } }) {
+  await page.getByText(/有可用更新|Update available/i).waitFor({ timeout: 180_000 })
+}
+
+async function webHealth(url: string) {
+  const res = await fetch(`${url}/global/health?t=${Date.now()}`).catch(() => null)
+  if (!res?.ok) return ""
+  const data = (await res.json().catch(() => null)) as Record<string, unknown> | null
+  return typeof data?.version === "string" ? data.version : ""
+}
+
+async function electronReady() {
+  await waitElectronLog(/server ready/i)
+  await waitElectronWindow()
+  await sleep(5000)
+}
+
+async function waitElectronWindow() {
+  const end = Date.now() + 120_000
+  while (Date.now() < end) {
+    if (await electronWindow()) return
+    await sleep(1000)
+  }
+  throw new Error("Timed out waiting for Electron main window")
+}
+
+async function electronWindow() {
+  if (cfg.platform === "darwin") {
+    const text = await capture("osascript", ["-e", 'tell application "System Events" to if exists process "Aether Desktop" then return count windows of process "Aether Desktop"']).catch(() => "")
+    return Number(text.trim()) > 0
+  }
+  if (cfg.platform === "windows") {
+    const text = await capture("powershell", [
+      "-NoProfile",
+      "-Command",
+      "(Get-Process | Where-Object { $_.ProcessName -like '*Aether*' -and $_.MainWindowHandle -ne 0 }).Count",
+    ]).catch(() => "")
+    return Number(text.trim()) > 0
+  }
+  const text = await capture("xdotool", ["search", "--onlyvisible", "--name", "Aether"]).catch(() => "")
+  return text.trim().length > 0
+}
+
+async function waitElectronLog(pat: RegExp) {
+  const end = Date.now() + 180_000
+  while (Date.now() < end) {
+    const logs = await electronLogs()
+    for (const log of logs) {
+      const text = await fs.readFile(log, "utf8").catch(() => "")
+      await write(path.join("logs", path.basename(log)), text.slice(-300_000))
+      if (pat.test(text)) return text
+    }
+    await sleep(1000)
+  }
+  throw new Error(`Timed out waiting for Electron log pattern ${pat}`)
+}
+
+async function electronLogs() {
+  const home = os.homedir()
+  const list =
+    cfg.platform === "darwin"
+      ? [path.join(home, "Library/Logs/Aether Desktop/main.log")]
+      : cfg.platform === "windows"
+        ? [path.join(process.env.APPDATA ?? path.join(home, "AppData/Roaming"), "Aether Desktop/logs/main.log")]
+        : [
+            path.join(home, ".config/Aether Desktop/logs/main.log"),
+            path.join(home, ".config/aether-desktop/logs/main.log"),
+          ]
+  return list.filter((x) => existsSync(x))
+}
+
+async function clearElectronLogs() {
+  for (const log of await electronLogs()) {
+    await fs.rm(log, { force: true }).catch(() => undefined)
+  }
+}
+
+async function assertElectronVersion(want: string) {
+  const got = await electronVersion()
+  if (!got) throw new Error(`Could not determine Electron version; expected ${want}`)
+  if (cmp(got, want) < 0) throw new Error(`Expected Electron version ${want}, got ${got}`)
+}
+
+async function waitElectronVersion(want: string) {
+  const end = Date.now() + 180_000
+  while (Date.now() < end) {
+    const got = await electronVersion()
+    if (got && cmp(got, want) >= 0) return
+    for (const log of await electronLogs()) {
+      const text = await fs.readFile(log, "utf8").catch(() => "")
+      if (new RegExp(`app starting[\\s\\S]*${escape(want)}`, "i").test(text)) return
+    }
+    await sleep(1000)
+  }
+  throw new Error(`Timed out waiting for Electron version ${want}`)
+}
+
+async function electronVersion() {
+  if (cfg.platform === "darwin") {
+    const app = "/Applications/Aether Desktop.app/Contents/Info.plist"
+    if (!existsSync(app)) return ""
+    return (await capture("defaults", ["read", app.replace(/\.plist$/, ""), "CFBundleShortVersionString"])).trim()
+  }
+  if (cfg.platform === "linux" && cfg.format === "deb") {
+    return (await capture("dpkg-query", ["-W", "-f=${Version}", "aether-desktop"]).catch(() => "")).trim()
+  }
+  if (cfg.platform === "linux" && cfg.format === "rpm") {
+    return (await capture("rpm", ["-q", "--qf", "%{VERSION}", "aether-desktop"]).catch(() => "")).trim()
+  }
+  if (cfg.platform === "windows") {
+    const exe = await winExe()
+    if (!exe) return ""
+    return (
+      await capture("powershell", ["-NoProfile", "-Command", `(Get-Item ${ps(exe)}).VersionInfo.ProductVersion`]).catch(
+        () => "",
+      )
+    ).trim()
+  }
+  return await electronLogVersion()
+}
+
+async function electronLogVersion() {
+  for (const log of await electronLogs()) {
+    const text = await fs.readFile(log, "utf8").catch(() => "")
+    const hit = text.match(/app starting[\s\S]{0,500}?version['"]?\s*[:=]\s*['"]?([0-9][^,'"\s}]*)/i)
+    if (hit?.[1]) return hit[1]
+  }
+  return ""
+}
+
+async function driveInstaller() {
+  const end = Date.now() + 180_000
+  while (Date.now() < end) {
+    await acceptDialog().catch(() => undefined)
+    if (await winExe()) return
+    await sleep(2000)
+  }
+  throw new Error("Timed out driving Windows installer with default choices")
+}
+
+async function acceptDialog() {
+  if (cfg.platform === "darwin") {
+    await run("osascript", ["-e", 'tell application "System Events" to key code 36'])
+    return
+  }
+  if (cfg.platform === "windows") {
+    await run("powershell", [
+      "-NoProfile",
+      "-Command",
+      "Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.SendKeys]::SendWait('{ENTER}')",
+    ])
+    return
+  }
+  await run("xdotool", ["key", "Return"])
+}
+
+async function verifyReleaseLink(version: string) {
+  const url = `https://github.com/Science-Discovery/Aether/releases/tag/v${version}`
+  const end = Date.now() + 30_000
+  while (Date.now() < end) {
+    const seen = await openUrl()
+    if (seen.includes(url)) return
+    await sleep(1000)
+  }
+  throw new Error(`GitHub Releases link was not observed: ${url}`)
+}
+
+async function openUrl() {
+  if (cfg.platform === "darwin") {
+    const js = 'tell application "Safari" to if (count of windows) > 0 then return URL of current tab of front window'
+    return await capture("osascript", ["-e", js]).catch(() => "")
+  }
+  return await capture("bash", ["-lc", "ps -eo args | grep 'github.com/Science-Discovery/Aether/releases' | grep -v grep || true"])
+}
+
+async function writeWebCfg() {
+  await writeCfg(JSON.stringify({ updateBaseUrl: "https://aether.aiphys.cn/downloadbeta" }, null, 2))
+}
+
+async function writeElectronCfg() {
+  await writeCfg("{}\n")
+}
+
+async function writeCfg(text: string) {
+  const dir = path.join(os.homedir(), ".config", "aether")
+  await fs.mkdir(dir, { recursive: true })
+  await fs.writeFile(path.join(dir, "update-config.jsonc"), text)
+}
+
+function webSiteInstaller() {
+  const base = "https://aether.aiphys.cn/download/installer"
+  if (cfg.platform === "windows" && cfg.arch === "x64") return { url: `${base}/aether_windows_installer.bat`, name: "aether_windows_installer.bat" }
+  if (cfg.platform === "windows") return null
+  if (cfg.platform === "darwin" && cfg.arch === "arm64") return { url: `${base}/aether_darwin_installer.command`, name: "aether_darwin_installer.command" }
+  if (cfg.platform === "darwin" && cfg.arch === "x64") return { url: `${base}/aether_darwin_x64_installer.command`, name: "aether_darwin_x64_installer.command" }
+  if (cfg.platform === "linux" && cfg.arch === "x64") return { url: `${base}/aether_linux_installer.sh`, name: "aether_linux_installer.sh" }
+  if (cfg.platform === "linux" && cfg.arch === "arm64") return { url: `${base}/aether_linux_arm64_installer.sh`, name: "aether_linux_arm64_installer.sh" }
+  return null
+}
+
+async function webStable() {
+  return await webMeta("https://aether.aiphys.cn/download")
+}
+
+async function webBeta() {
+  return await webMeta("https://aether.aiphys.cn/downloadbeta")
+}
+
+async function webMeta(base: string) {
+  const file =
+    cfg.platform === "darwin"
+      ? `latest/mac-${cfg.arch}.yml`
+      : cfg.platform === "linux"
+        ? `latest/linux-${cfg.arch}.yml`
+        : cfg.platform === "windows" && cfg.arch === "x64"
+          ? "latest/windows-x64.yml"
+          : ""
+  if (!file) return null
+  const res = await fetch(`${base}/${file}`).catch(() => null)
+  if (!res?.ok) return null
+  return parseYml(await res.text())
+}
+
+function parseYml(text: string): Meta {
+  const meta: Meta = { version: "" }
+  let sec = ""
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim()
+    if (line.startsWith("version:")) meta.version = clean(line.slice("version:".length))
+    if (line === "package:") sec = "package"
+    if (sec === "package") {
+      if (line.startsWith("url:")) meta.package = { ...(meta.package ?? {}), url: clean(line.slice("url:".length)) }
+      if (line.startsWith("sha512:")) meta.package = { ...(meta.package ?? {}), sha512: clean(line.slice("sha512:".length)) }
+      if (line.startsWith("size:")) meta.package = { ...(meta.package ?? {}), size: Number(clean(line.slice("size:".length))) }
+    }
+  }
+  return meta.version ? meta : { version: "" }
+}
+
+function webAsset(rel: Release) {
+  const ext = cfg.platform === "darwin" ? "dmg" : "zip"
+  const stem =
+    cfg.platform === "darwin"
+      ? `aether-darwin-${cfg.arch}`
+      : cfg.platform === "linux"
+        ? `aether-linux-${cfg.arch}`
+        : cfg.platform === "windows" && cfg.arch === "x64"
+          ? "aether-windows-x64"
+        : ""
+  if (!stem) return null
+  const names = [`${stem}.${ext}`]
+  const asset = rel.assets.find((x) => names.includes(x.name)) ?? null
+  void write(
+    path.join("release", `${rel.tag_name}-${cfg.product}-${cfg.platform}-${cfg.arch}.json`),
+    JSON.stringify({ tag: rel.tag_name, want: names, hit: asset?.name ?? null, assets: rel.assets.map((x) => x.name) }, null, 2),
+  )
+  return asset
+}
+
+function electronAsset(rel: Release) {
+  const names = electronNames()
+  const asset = rel.assets.find((x) => names.includes(x.name)) ?? null
+  void write(
+    path.join("release", `${rel.tag_name}-${cfg.product}-${cfg.platform}-${cfg.arch}-${cfg.format || "default"}.json`),
+    JSON.stringify({ tag: rel.tag_name, want: names, hit: asset?.name ?? null, assets: rel.assets.map((x) => x.name) }, null, 2),
+  )
+  return asset
+}
+
+function electronNames() {
+  if (cfg.platform === "windows") return [`aether-desktop-win-${cfg.arch}.exe`, `aether-desktop-windows-${cfg.arch}.exe`]
+  if (cfg.platform === "darwin") return [`aether-desktop-mac-${cfg.arch}.dmg`]
+  if (cfg.format === "appimage") return [`aether-desktop-linux-${linuxArch()}.AppImage`]
+  if (cfg.format === "deb") return [`aether-desktop-linux-${cfg.arch === "x64" ? "amd64" : "arm64"}.deb`]
+  if (cfg.format === "rpm") return [`aether-desktop-linux-${cfg.arch === "x64" ? "x86_64" : "aarch64"}.rpm`]
+  return []
+}
+
+function linuxArch() {
+  if (cfg.arch === "x64") return "x86_64"
+  return cfg.arch
+}
+
+async function stableOrFallback() {
+  const list = await releases()
+  const rel = list.find((x) => !x.draft && !x.prerelease)
+  if (rel && electronAsset(rel)) return { fallback: false as const, release: rel }
+  const next = list.find((x) => !x.draft && x.prerelease && electronAsset(x))
+  if (!next) return { fallback: true as const, reason: "missing stable and prerelease Electron asset" }
+  const why = rel ? `stable asset missing in ${rel.tag_name}` : "stable release missing"
+  return { fallback: true as const, reason: `${why}; fallback ${next.tag_name} is installable but update case is skipped` }
+}
+
+async function pre() {
+  const rel = (await releases()).find((x) => !x.draft && x.prerelease)
+  return rel ?? null
+}
+
+async function releases() {
+  const list = (await api("/releases")) as Release[]
+  await write(
+    "release/releases.json",
+    JSON.stringify(
+      list.map((rel) => ({
+        tag: rel.tag_name,
+        draft: rel.draft,
+        prerelease: rel.prerelease,
+        assets: rel.assets.map((asset) => asset.name),
+      })),
+      null,
+      2,
+    ),
+  )
+  return list
+}
+
+async function api(url: string) {
+  const res = await fetch(`https://api.github.com/repos/Science-Discovery/Aether${url}`, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  })
+  if (!res.ok) throw new Error(`GitHub API failed ${url}: ${res.status}`)
+  return await res.json()
+}
+
+async function download(url: string, name: string) {
+  const file = path.join(tmp, name)
+  const res = await fetch(url, { redirect: "follow", headers: token && url.includes("github") ? { Authorization: `Bearer ${token}` } : {} })
+  if (!res.ok) throw new Error(`Download failed: ${url} ${res.status}`)
+  await Bun.write(file, res)
+  await write(`downloads/${name}.url.txt`, `${url}\n`)
+  return file
+}
+
+async function okUrl(url: string) {
+  const res = await fetch(url, { method: "GET", headers: { Range: "bytes=0-0" } }).catch(() => null)
+  return !!res?.ok || res?.status === 206
+}
+
+async function unpack(file: string) {
+  if (file.endsWith(".zip")) {
+    const dir = path.join(tmp, `${path.basename(file)}.out`)
+    await fs.mkdir(dir, { recursive: true })
+    if (cfg.platform === "windows") {
+      await run("powershell", ["-NoProfile", "-Command", `Expand-Archive -LiteralPath ${ps(file)} -DestinationPath ${ps(dir)} -Force`])
+      return dir
+    }
+    await run("unzip", ["-q", file, "-d", dir])
+    return dir
+  }
+  if (file.endsWith(".dmg")) return await mount(file)
+  return path.dirname(file)
+}
+
+async function mount(file: string) {
+  const dir = path.join(tmp, `${path.basename(file)}.mnt`)
+  await fs.mkdir(dir, { recursive: true })
+  await run("hdiutil", ["attach", file, "-nobrowse", "-mountpoint", dir], { timeout: 120_000 })
+  return dir
+}
+
+async function unmount(dir: string) {
+  await run("hdiutil", ["detach", dir], { ok: [0, 16] })
+}
+
+async function find(dir: string, name: string): Promise<string | null> {
+  const list = await fs.readdir(dir, { withFileTypes: true }).catch(() => [])
+  for (const item of list) {
+    const full = path.join(dir, item.name)
+    if (item.name === name || item.name.endsWith(name)) return full
+    if (item.isDirectory()) {
+      const hit = await find(full, name)
+      if (hit) return hit
+    }
+  }
+  return null
+}
+
+async function first(list: string[]) {
+  return list.find((x) => existsSync(x)) ?? null
+}
+
+async function which(name: string) {
+  const cmd = process.platform === "win32" ? "where" : "command"
+  const args = process.platform === "win32" ? [name] : ["-v", name]
+  const hit = await capture(cmd, args).catch(() => "")
+  return hit.split(/\r?\n/).find(Boolean) ?? null
+}
+
+async function winExe() {
+  if (cfg.platform !== "windows") return null
+  const roots = [
+    path.join(process.env.LOCALAPPDATA ?? "", "Programs"),
+    path.join(process.env.ProgramFiles ?? "", ""),
+    path.join(process.env["ProgramFiles(x86)"] ?? "", ""),
+  ].filter(Boolean)
+  for (const dir of roots) {
+    const hit = await find(dir, "Aether Desktop.exe")
+    if (hit) return hit
+  }
+  return null
+}
+
+function manualElectron() {
+  return cfg.platform === "darwin" || (cfg.platform === "linux" && cfg.format !== "appimage")
+}
+
+async function run(cmd: string, args: string[], opts: Cmd = {}) {
+  console.log(`$ ${cmd} ${args.join(" ")}`)
+  const proc = spawn(cmd, args, {
+    cwd: opts.cwd ?? root,
+    env: { ...process.env, ...(opts.env ?? {}) },
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+  const log = path.join(out, "commands.log")
+  const timer = opts.timeout
+    ? setTimeout(() => {
+        proc.kill("SIGTERM")
+      }, opts.timeout)
+    : null
+  proc.stdout.on("data", (x: Buffer) => {
+    process.stdout.write(x)
+    void fs.appendFile(log, x)
+  })
+  proc.stderr.on("data", (x: Buffer) => {
+    process.stderr.write(x)
+    void fs.appendFile(log, x)
+  })
+  const code = await new Promise<number>((resolve, reject) => {
+    proc.on("error", reject)
+    proc.on("close", (x) => resolve(x ?? 1))
+  })
+  if (timer) clearTimeout(timer)
+  const ok = opts.ok ?? [0]
+  if (!ok.includes(code)) throw new Error(`Command failed (${code}): ${cmd} ${args.join(" ")}`)
+}
+
+async function elevate(cmd: string, args: string[], opts: Cmd = {}) {
+  if (typeof process.getuid === "function" && process.getuid() === 0) {
+    await run(cmd, args, opts)
+    return
+  }
+  await run("sudo", [cmd, ...args], opts)
+}
+
+async function capture(cmd: string, args: string[]) {
+  const proc = spawn(cmd, args, { cwd: root, env: process.env })
+  const chunks: Buffer[] = []
+  const errs: Buffer[] = []
+  proc.stdout.on("data", (x: Buffer) => chunks.push(x))
+  proc.stderr.on("data", (x: Buffer) => errs.push(x))
+  const code = await new Promise<number>((resolve, reject) => {
+    proc.on("error", reject)
+    proc.on("close", (x) => resolve(x ?? 1))
+  })
+  if (code !== 0) throw new Error(Buffer.concat(errs).toString() || `${cmd} exited ${code}`)
+  return Buffer.concat(chunks).toString()
+}
+
+async function skip(reason: string) {
+  await note(`\nstatus: skipped\nreason: ${reason}\n`)
+  await write("result.json", JSON.stringify({ status: "skipped", cfg, reason }, null, 2))
+  console.log(`SKIP: ${reason}`)
+}
+
+async function pass(msg: string) {
+  await note(`\nstatus: passed\n${msg}\n`)
+  await write("result.json", JSON.stringify({ status: "passed", cfg, message: msg }, null, 2))
+}
+
+async function write(file: string, text: string) {
+  const dest = path.join(out, file)
+  await fs.mkdir(path.dirname(dest), { recursive: true })
+  await fs.writeFile(dest, text)
+}
+
+async function collect() {
+  for (const dir of collectDirs()) {
+    if (!existsSync(dir)) continue
+    await write(path.join("paths", safe(dir) + ".txt"), (await list(dir, 0)).join("\n"))
+  }
+  for (const log of await electronLogs()) {
+    await write(path.join("logs", path.basename(log)), await fs.readFile(log, "utf8").catch(() => ""))
+  }
+}
+
+async function screenshot() {
+  await fs.mkdir(path.join(out, "screenshots"), { recursive: true })
+  if (page) {
+    await page.screenshot({ path: path.join(out, "screenshots", "web.png"), fullPage: true }).catch(() => undefined)
+  }
+  if (cfg.platform === "darwin") {
+    await run("screencapture", ["-x", path.join(out, "screenshots", "screen.png")], { ok: [0, 1], timeout: 30_000 })
+    return
+  }
+  if (cfg.platform === "windows") {
+    await run("powershell", [
+      "-NoProfile",
+      "-Command",
+      `$p=${ps(path.join(out, "screenshots", "screen.png"))}; Add-Type -AssemblyName System.Windows.Forms; Add-Type -AssemblyName System.Drawing; $b=[System.Windows.Forms.Screen]::PrimaryScreen.Bounds; $m=New-Object System.Drawing.Bitmap $b.Width,$b.Height; $g=[System.Drawing.Graphics]::FromImage($m); $g.CopyFromScreen($b.Location,[System.Drawing.Point]::Empty,$b.Size); $m.Save($p); $g.Dispose(); $m.Dispose()`,
+    ], { timeout: 30_000 })
+    return
+  }
+  await run("import", ["-window", "root", path.join(out, "screenshots", "screen.png")], { ok: [0, 1], timeout: 30_000 })
+}
+
+function collectDirs() {
+  const home = os.homedir()
+  const dirs = [
+    path.join(home, ".config", "aether"),
+    path.join(home, ".local", "share", "aether", "update", "aether"),
+    path.join(home, ".local", "share", "applications", "aether"),
+    path.join(home, "Applications", "aether"),
+  ]
+  if (cfg.platform === "windows") {
+    dirs.push(
+      path.join(process.env.LOCALAPPDATA ?? "", "Programs", "aether"),
+      path.join(home, ".local", "share", "aether", "update", "aether"),
+      path.join(process.env.APPDATA ?? "", "Aether Desktop"),
+    )
+  }
+  if (cfg.platform === "darwin") {
+    dirs.push("/Applications/Aether Desktop.app", path.join(home, "Library", "Logs", "Aether Desktop"))
+  }
+  if (cfg.platform === "linux") {
+    dirs.push(path.join(home, ".config", "Aether Desktop"), "/opt/Aether Desktop", "/opt/aether-desktop")
+  }
+  return dirs.filter(Boolean)
+}
+
+async function list(dir: string, depth: number): Promise<string[]> {
+  if (depth > 3) return []
+  const items = await fs.readdir(dir, { withFileTypes: true }).catch(() => [])
+  const rows: string[] = []
+  for (const item of items.slice(0, 400)) {
+    const full = path.join(dir, item.name)
+    const stat = await fs.stat(full).catch(() => null)
+    rows.push(`${"  ".repeat(depth)}${item.isDirectory() ? "d" : "f"} ${full}${stat ? ` ${stat.size}` : ""}`)
+    if (item.isDirectory()) rows.push(...(await list(full, depth + 1)))
+  }
+  return rows
+}
+
+function safe(input: string) {
+  return input.replace(/^[A-Za-z]:/, "").replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^_+|_+$/g, "") || "root"
+}
+
+async function note(text: string) {
+  if (!summary) return
+  await fs.appendFile(summary, `${text}\n`)
+}
+
+function cmp(a: string, b: string) {
+  const pa = parse(a)
+  const pb = parse(b)
+  if (!pa || !pb) return 0
+  const len = Math.max(pa.nums.length, pb.nums.length)
+  for (let i = 0; i < len; i++) {
+    const x = pa.nums[i] ?? 0
+    const y = pb.nums[i] ?? 0
+    if (x < y) return -1
+    if (x > y) return 1
+  }
+  if (pa.pre === null && pb.pre !== null) return 1
+  if (pa.pre !== null && pb.pre === null) return -1
+  if (pa.pre && pb.pre) return pa.pre < pb.pre ? -1 : pa.pre > pb.pre ? 1 : 0
+  return 0
+}
+
+function parse(input: string) {
+  const raw = input.trim().replace(/^v/i, "")
+  const idx = raw.indexOf("-")
+  const rel = idx >= 0 ? raw.slice(0, idx) : raw
+  const nums = rel.split(".").map((x) => Number.parseInt(x, 10))
+  if (nums.some((x) => Number.isNaN(x))) return null
+  return { nums, pre: idx >= 0 ? raw.slice(idx + 1) : null }
+}
+
+function clean(input: string) {
+  return input.trim().replace(/^['"]|['"]$/g, "")
+}
+
+function ver(rel: Release) {
+  return rel.tag_name.replace(/^v/i, "")
+}
+
+function ps(input: string) {
+  return `'${input.replace(/'/g, "''")}'`
+}
+
+function escape(input: string) {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+function env(key: string) {
+  const val = process.env[key]?.trim()
+  if (!val) throw new Error(`Missing ${key}`)
+  return val
+}
+
+function message(cause: unknown) {
+  return cause instanceof Error ? cause.message : String(cause)
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/.github/workflows/install-update.yml
+++ b/.github/workflows/install-update.yml
@@ -1,0 +1,145 @@
+name: install-update
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  install-update:
+    name: ${{ matrix.id }}
+    runs-on: ${{ matrix.host }}
+    container: ${{ matrix.container || null }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { id: web-site-windows-x64, host: windows-2022, product: web, task: site-install, platform: windows, arch: x64 }
+          - { id: web-site-windows-arm64, host: windows-11-arm, product: web, task: site-install, platform: windows, arch: arm64 }
+          - { id: web-site-macos-arm64, host: macos-14, product: web, task: site-install, platform: darwin, arch: arm64 }
+          - { id: web-site-macos-x64, host: macos-15-intel, product: web, task: site-install, platform: darwin, arch: x64 }
+          - { id: web-site-linux-x64, host: ubuntu-24.04, product: web, task: site-install, platform: linux, arch: x64 }
+          - { id: web-site-linux-arm64, host: ubuntu-24.04-arm, product: web, task: site-install, platform: linux, arch: arm64 }
+
+          - { id: web-github-windows-x64, host: windows-2022, product: web, task: github-install, platform: windows, arch: x64 }
+          - { id: web-github-windows-arm64, host: windows-11-arm, product: web, task: github-install, platform: windows, arch: arm64 }
+          - { id: web-github-macos-arm64, host: macos-14, product: web, task: github-install, platform: darwin, arch: arm64 }
+          - { id: web-github-macos-x64, host: macos-15-intel, product: web, task: github-install, platform: darwin, arch: x64 }
+          - { id: web-github-linux-x64, host: ubuntu-24.04, product: web, task: github-install, platform: linux, arch: x64 }
+          - { id: web-github-linux-arm64, host: ubuntu-24.04-arm, product: web, task: github-install, platform: linux, arch: arm64 }
+
+          - { id: web-auto-windows-x64, host: windows-2022, product: web, task: auto-update, platform: windows, arch: x64 }
+          - { id: web-auto-windows-arm64, host: windows-11-arm, product: web, task: auto-update, platform: windows, arch: arm64 }
+          - { id: web-auto-macos-arm64, host: macos-14, product: web, task: auto-update, platform: darwin, arch: arm64 }
+          - { id: web-auto-macos-x64, host: macos-15-intel, product: web, task: auto-update, platform: darwin, arch: x64 }
+          - { id: web-auto-linux-x64, host: ubuntu-24.04, product: web, task: auto-update, platform: linux, arch: x64 }
+          - { id: web-auto-linux-arm64, host: ubuntu-24.04-arm, product: web, task: auto-update, platform: linux, arch: arm64 }
+
+          - { id: web-manual-windows-x64, host: windows-2022, product: web, task: manual-update, platform: windows, arch: x64 }
+          - { id: web-manual-windows-arm64, host: windows-11-arm, product: web, task: manual-update, platform: windows, arch: arm64 }
+          - { id: web-manual-macos-arm64, host: macos-14, product: web, task: manual-update, platform: darwin, arch: arm64 }
+          - { id: web-manual-macos-x64, host: macos-15-intel, product: web, task: manual-update, platform: darwin, arch: x64 }
+          - { id: web-manual-linux-x64, host: ubuntu-24.04, product: web, task: manual-update, platform: linux, arch: x64 }
+          - { id: web-manual-linux-arm64, host: ubuntu-24.04-arm, product: web, task: manual-update, platform: linux, arch: arm64 }
+
+          - { id: electron-github-windows-x64, host: windows-2022, product: electron, task: github-install, platform: windows, arch: x64 }
+          - { id: electron-github-windows-arm64, host: windows-11-arm, product: electron, task: github-install, platform: windows, arch: arm64 }
+          - { id: electron-github-macos-arm64, host: macos-14, product: electron, task: github-install, platform: darwin, arch: arm64 }
+          - { id: electron-github-macos-x64, host: macos-15-intel, product: electron, task: github-install, platform: darwin, arch: x64 }
+          - { id: electron-github-linux-x64-appimage, host: ubuntu-24.04, product: electron, task: github-install, platform: linux, arch: x64, format: appimage }
+          - { id: electron-github-linux-arm64-appimage, host: ubuntu-24.04-arm, product: electron, task: github-install, platform: linux, arch: arm64, format: appimage }
+          - { id: electron-github-linux-x64-deb, host: ubuntu-24.04, product: electron, task: github-install, platform: linux, arch: x64, format: deb }
+          - { id: electron-github-linux-arm64-deb, host: ubuntu-24.04-arm, product: electron, task: github-install, platform: linux, arch: arm64, format: deb }
+          - { id: electron-github-linux-x64-rpm, host: ubuntu-24.04, container: fedora:42, product: electron, task: github-install, platform: linux, arch: x64, format: rpm }
+          - { id: electron-github-linux-arm64-rpm, host: ubuntu-24.04-arm, container: fedora:42, product: electron, task: github-install, platform: linux, arch: arm64, format: rpm }
+
+          - { id: electron-auto-windows-x64, host: windows-2022, product: electron, task: auto-update, platform: windows, arch: x64 }
+          - { id: electron-auto-windows-arm64, host: windows-11-arm, product: electron, task: auto-update, platform: windows, arch: arm64 }
+          - { id: electron-auto-macos-arm64, host: macos-14, product: electron, task: auto-update, platform: darwin, arch: arm64 }
+          - { id: electron-auto-macos-x64, host: macos-15-intel, product: electron, task: auto-update, platform: darwin, arch: x64 }
+          - { id: electron-auto-linux-x64-appimage, host: ubuntu-24.04, product: electron, task: auto-update, platform: linux, arch: x64, format: appimage }
+          - { id: electron-auto-linux-arm64-appimage, host: ubuntu-24.04-arm, product: electron, task: auto-update, platform: linux, arch: arm64, format: appimage }
+          - { id: electron-auto-linux-x64-deb, host: ubuntu-24.04, product: electron, task: auto-update, platform: linux, arch: x64, format: deb }
+          - { id: electron-auto-linux-arm64-deb, host: ubuntu-24.04-arm, product: electron, task: auto-update, platform: linux, arch: arm64, format: deb }
+          - { id: electron-auto-linux-x64-rpm, host: ubuntu-24.04, container: fedora:42, product: electron, task: auto-update, platform: linux, arch: x64, format: rpm }
+          - { id: electron-auto-linux-arm64-rpm, host: ubuntu-24.04-arm, container: fedora:42, product: electron, task: auto-update, platform: linux, arch: arm64, format: rpm }
+
+          - { id: electron-manual-windows-x64, host: windows-2022, product: electron, task: manual-update, platform: windows, arch: x64 }
+          - { id: electron-manual-windows-arm64, host: windows-11-arm, product: electron, task: manual-update, platform: windows, arch: arm64 }
+          - { id: electron-manual-macos-arm64, host: macos-14, product: electron, task: manual-update, platform: darwin, arch: arm64 }
+          - { id: electron-manual-macos-x64, host: macos-15-intel, product: electron, task: manual-update, platform: darwin, arch: x64 }
+          - { id: electron-manual-linux-x64-appimage, host: ubuntu-24.04, product: electron, task: manual-update, platform: linux, arch: x64, format: appimage }
+          - { id: electron-manual-linux-arm64-appimage, host: ubuntu-24.04-arm, product: electron, task: manual-update, platform: linux, arch: arm64, format: appimage }
+          - { id: electron-manual-linux-x64-deb, host: ubuntu-24.04, product: electron, task: manual-update, platform: linux, arch: x64, format: deb }
+          - { id: electron-manual-linux-arm64-deb, host: ubuntu-24.04-arm, product: electron, task: manual-update, platform: linux, arch: arm64, format: deb }
+          - { id: electron-manual-linux-x64-rpm, host: ubuntu-24.04, container: fedora:42, product: electron, task: manual-update, platform: linux, arch: x64, format: rpm }
+          - { id: electron-manual-linux-arm64-rpm, host: ubuntu-24.04-arm, container: fedora:42, product: electron, task: manual-update, platform: linux, arch: arm64, format: rpm }
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
+      AETHER_CI_ID: ${{ matrix.id }}
+      AETHER_CI_PRODUCT: ${{ matrix.product }}
+      AETHER_CI_TASK: ${{ matrix.task }}
+      AETHER_CI_PLATFORM: ${{ matrix.platform }}
+      AETHER_CI_ARCH: ${{ matrix.arch }}
+      AETHER_CI_FORMAT: ${{ matrix.format || '' }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Install Linux GUI and package dependencies
+        if: runner.os == 'Linux' && matrix.format != 'rpm'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb xdotool xdg-utils unzip rpm imagemagick libfuse2t64 libgtk-3-0 libnotify4 libnss3 libxss1 libxtst6 libasound2t64 || \
+            sudo apt-get install -y xvfb xdotool xdg-utils unzip rpm imagemagick libfuse2 libgtk-3-0 libnotify4 libnss3 libxss1 libxtst6 libasound2
+
+      - name: Install RPM Linux GUI and package dependencies
+        if: runner.os == 'Linux' && matrix.format == 'rpm'
+        run: dnf install -y xorg-x11-server-Xvfb xdotool xdg-utils unzip ImageMagick gtk3 libnotify nss libXScrnSaver libXtst alsa-lib fuse-libs
+
+      - name: Install Playwright system dependencies
+        if: matrix.product == 'web' && runner.os == 'Linux'
+        working-directory: packages/app
+        run: bunx playwright install-deps chromium
+
+      - name: Install Playwright browser
+        if: matrix.product == 'web'
+        working-directory: packages/app
+        run: bunx playwright install chromium
+
+      - name: Run install/update matrix item
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            xvfb-run -a bun .github/scripts/install-update-ci.ts
+          else
+            bun .github/scripts/install-update-ci.ts
+          fi
+
+      - name: Upload install/update artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-update-${{ matrix.id }}-${{ github.run_attempt }}
+          if-no-files-found: ignore
+          retention-days: 14
+          path: install-update-artifacts/${{ matrix.id }}

--- a/docs/install-update/安装-更新CI测试方案-临时备忘.md
+++ b/docs/install-update/安装-更新CI测试方案-临时备忘.md
@@ -1,0 +1,271 @@
+# 安装与更新 CI 测试方案临时备忘
+
+> 临时备忘文档。基于当前讨论结果整理，供后续审阅、拆分和落地为手动触发 CI。
+
+我重新按你的定义收窄了：自动更新测试不应该绕过程序 UI，也不应该直接用 API/脚本替代“程序内弹窗”。CI 只负责像用户一样安装旧版本、启动程序、等待程序自己检查更新、处理弹窗、按弹窗给出的路径继续操作，然后验证启动结果。
+
+我复核到的关键点：
+
+- Web 自动更新：前端启动后默认会立即检查更新，发现更新后下载，下载完成后弹出应用内 toast。用户点“更新并重启”后进入更新对话框，安装完成后 `window.location.reload()` 原地刷新。
+- Electron 自动更新：启动 10 秒后检查更新。
+  - Windows、Linux AppImage：先下载，弹出原生对话框 `Update Ready`，按钮是 `Restart` / `Later`。
+  - macOS、Linux 非 AppImage：只弹出 `Update Available`，按钮是 `Open GitHub Releases` / `Later`，用户需要去 GitHub 手动下载安装。
+- Electron prerelease 开关：只要 `~/.config/aether/update-config.jsonc` 存在即可。
+- Web beta 更新源：`~/.config/aether/update-config.jsonc` 需要写 `updateBaseUrl: https://aether.aiphys.cn/downloadbeta`。
+- PR #985 合并后，Web GitHub Release 产物内的用户入口是 `install.sh` / `install.command` / `install.bat`。
+- 我现场复核了网站：公开首页有 Windows x64、macOS arm64、Linux x64、Linux arm64 网站安装入口；没有 macOS x64 网站入口。`/download/installer/aether_darwin_x64_installer.command` 和 `/download/latest/mac-x64.yml` 当前是 404；`/downloadbeta/latest/mac-x64.yml` 当前存在。
+
+## 统一规则
+
+所有 case 都是 `workflow_dispatch` 手动触发。每个矩阵格独立 job，缺产物永远 `skip`，不 fail。
+
+版本解析只用于决定 skip 和下载哪一个用户可见产物，不代替 UI 测试：
+
+- Web 网站安装源：`https://aether.aiphys.cn/download/installer/...`
+- Web 自动更新源：起点必须是网站 stable/latest；目标通过 `downloadbeta`。
+- Web GitHub 安装/手动更新目标：最新 GitHub prerelease 中对应 Web 产物。
+- Electron 自动更新起点：GitHub Releases 的最后一个 `latest` stable release；若没有 stable 或没有该平台产物，则 fallback prerelease，但该自动更新 case 直接 skip。
+- Electron 手动更新目标：最新 GitHub prerelease 中对应 Desktop 产物。
+- 任何平台/架构当前没有对应产物：该格写入 summary，标明 `skip: missing asset`。
+
+## 通用通过标准
+
+每个非 skip case 必须验证：
+
+- 用户入口可获得：网站链接、GitHub release asset、或 updater 弹窗链接。
+- 按默认方式安装，不传 `--path`，不改默认安装目录。
+- 程序能启动。
+- 能读到安装后的目标版本。
+- Web：自动更新 case 必须观察到浏览器原页面原地 reload 并显示新版本；手动更新 case 不强求原地刷新，按对应流程验证更新后页面可重新启动并显示新版本。
+- Electron：主窗口出现，sidecar 启动成功，更新后启动的是目标版本。
+- 失败时上传：安装器日志、update state/result、Electron log、截图/录屏、默认安装目录结构、GitHub/网站产物解析结果。
+
+## Web 矩阵流程
+
+### W1 Windows x64 / 网站全新安装
+
+1. 打开网站或直接访问 `/download/installer/aether_windows_installer.bat`，下载 `aether_windows_installer.bat`。
+2. 像用户一样运行 bat，不传参数。
+3. 等待默认目录 `%LOCALAPPDATA%\Programs\aether` 和 work 目录 `%USERPROFILE%\.local\share\aether\update\aether` 出现版本目录。
+4. 等待 installer 默认启动 Aether。
+5. 用浏览器连接启动后的本地页面，调用页面实际使用的 `/global/health` 或 `/global/web-update/current` 判断版本。
+6. 通过：页面可用，版本等于网站 latest manifest，快捷方式/启动入口存在。
+
+### W2 macOS arm64 / 网站全新安装
+
+1. 下载 `/download/installer/aether_darwin_installer.command`。
+2. 按网站说明授予执行权限并运行，不传参数。
+3. 默认安装到 `~/Applications/aether`，work 目录为 `~/.local/share/aether/update/aether`。
+4. 等待安装器启动 Web 端。
+5. 浏览器打开本地页面，验证健康检查和版本。
+6. 通过：页面可用，版本为 `/download/latest/mac-arm64.yml`，`~/Applications/aether/aether_<version>` 存在。
+
+### W3 macOS x64 / 网站全新安装
+
+- 当前 skip。
+- skip 条件：网站无 macOS x64 安装入口，`/download/installer/aether_darwin_x64_installer.command` 当前 404，`/download/latest/mac-x64.yml` 当前 404。
+- 未来如果公开网站补齐 x64 installer 和 manifest，则按 `W2` 同流程执行，架构改为 x64。
+
+### W4 Linux x64 / 网站全新安装
+
+1. 下载 `/download/installer/aether_linux_installer.sh`。
+2. `chmod +x` 后运行，不传参数。
+3. 默认安装到 `~/.local/share/applications/aether`，work 目录为 `~/.local/share/aether/update/aether`。
+4. 等待默认启动。
+5. 浏览器验证页面、健康检查和版本。
+6. 通过：`~/.local/share/applications/aether/aether_<version>`、desktop entry、协议 handler 存在。
+
+### W5 Linux arm64 / 网站全新安装
+
+1. 下载 `/download/installer/aether_linux_arm64_installer.sh`。
+2. `chmod +x` 后运行，不传参数。
+3. 默认路径同 Linux x64。
+4. 验证启动页面和版本。
+5. 如果网站链接或 arm64 manifest 缺失，则 skip，不 fail。
+
+### W6 Windows arm64 / 网站全新安装
+
+- 当前 skip。
+- 原因：Web 发布矩阵没有 Windows arm64 Web 产物，网站也没有 Windows arm64 installer。
+
+### W7 Web GitHub 全新安装 / Windows x64
+
+1. 解析最新 GitHub prerelease，查找 `aether-windows-x64.zip`。
+2. 缺 asset 则 skip。
+3. 下载 ZIP，按用户方式解压。
+4. 进入 `aether-windows-x64` 目录，运行 PR #985 产物内 `install.bat`，不传参数。
+5. 等待默认启动。
+6. 验证页面可用，版本等于 prerelease tag 版本，默认目录和快捷方式存在。
+
+### W8 Web GitHub 全新安装 / macOS arm64、macOS x64
+
+1. 解析最新 prerelease，分别查找 `aether-darwin-arm64.dmg`、`aether-darwin-x64.dmg`。
+2. 缺对应 asset 则 skip。
+3. 挂载 DMG，打开 `aether-darwin-<arch>`。
+4. 运行产物内 `install.command`，不传参数。
+5. 等待默认启动。
+6. 验证页面可用，版本等于 prerelease，默认 mirror 为 `~/Applications/aether`。
+7. macOS x64 只在 GitHub 流程测；网站流程仍 skip，除非公开网站补齐 x64。
+
+### W9 Web GitHub 全新安装 / Linux x64、Linux arm64
+
+1. 解析最新 prerelease，查找 `aether-linux-x64.zip` 或 `aether-linux-arm64.zip`。
+2. 缺 asset 则 skip。
+3. 解压，进入 `aether-linux-<arch>`。
+4. `chmod +x install.sh`，运行 `./install.sh`，不传参数。
+5. 等待默认启动。
+6. 验证页面、版本、desktop entry、协议 handler。
+
+### W10 Web 自动更新 / Windows x64、macOS arm64、Linux x64、Linux arm64
+
+1. 先执行对应网站全新安装流程，安装公开 stable/latest。
+2. 在默认配置目录创建 `update-config.jsonc`：
+
+```jsonc
+{
+  "updateBaseUrl": "https://aether.aiphys.cn/downloadbeta"
+}
+```
+
+3. 启动旧版本 Aether，打开浏览器页面，保持该页面不关闭。
+4. 不直接调用 update API，不打开设置页手动检查；等待启动默认检查。
+5. 预期行为：页面出现“有可用更新 / Update available” toast。
+6. CI 像用户一样点击 toast 的“更新并重启 / Update & Restart”。
+7. 预期进入更新对话框，状态经历 checking/downloading/downloaded/installing。
+8. 等待程序关闭旧版本、安装 downloadbeta 版本、重新启动。
+9. 通过：同一个浏览器页面最终原地 reload，健康检查版本变为 downloadbeta 版本，页面可继续操作。
+10. 若对应网站 stable 不存在、downloadbeta manifest 不存在、或 downloadbeta 版本不高于 stable：该平台 skip。
+
+### W11 Web 自动更新 / macOS x64、Windows arm64
+
+- macOS x64 当前 skip：没有网站 stable 起点，即使 downloadbeta 有 `mac-x64.yml`，也不能构造“从网站最新版更新”的用户场景。
+- Windows arm64 当前 skip：无 Web 产物。
+
+### W12 Web 手动更新 / 有网站起点的平台
+
+适用：Windows x64、macOS arm64、Linux x64、Linux arm64。
+
+1. 先按网站全新安装流程安装公开 stable/latest。
+2. 启动旧版本，打开浏览器页面确认旧版本可用。
+3. 像用户手动更新前的常见行为一样，关闭旧应用的浏览器页面。
+4. 下载最新 GitHub prerelease 对应 Web asset。
+5. Windows：解压 `aether-windows-x64.zip`，运行 `install.bat`。
+6. macOS arm64：挂载 `aether-darwin-arm64.dmg`，运行 `install.command`。
+7. Linux：解压 `aether-linux-<arch>.zip`，运行 `install.sh`。
+8. 全程不传 `--path` / `--no-restart`。
+9. 通过：安装脚本默认重启 Aether，浏览器可以打开更新后的 Aether 页面，页面可用且版本为 prerelease；该 case 不要求旧浏览器页面原地刷新。
+10. macOS x64 当前 skip，除非你决定新增“GitHub stable -> GitHub prerelease”的独立手动更新场景；按现在“Web 从网站最新版开始”的定义，它没有网站起点。
+
+## Electron 矩阵流程
+
+### E1 Electron GitHub 全新安装 / Windows x64、Windows arm64
+
+1. 解析最新 GitHub prerelease 的 `.exe` NSIS asset。
+2. 缺对应 arch asset 则 skip。
+3. 运行 installer，使用默认安装向导选项，不指定安装目录。
+4. 安装完成后从默认入口启动 Aether Desktop。
+5. 通过：主窗口出现，sidecar 健康，版本等于 prerelease。
+
+### E2 Electron GitHub 全新安装 / macOS arm64、macOS x64
+
+1. 解析最新 prerelease 的对应 `.dmg`。
+2. 缺 asset 则 skip。
+3. 挂载 DMG，按用户默认方式把 Aether Desktop app 放到 `/Applications`。
+4. 从 `/Applications` 启动。
+5. 通过：主窗口出现，sidecar 健康，版本等于 prerelease。
+
+### E3 Electron GitHub 全新安装 / Linux x64、Linux arm64 AppImage
+
+1. 解析最新 prerelease 的 `.AppImage`。
+2. 缺 asset 则 skip。
+3. 下载，授予执行权限，直接运行 AppImage。
+4. 通过：主窗口出现，sidecar 健康，版本等于 prerelease。
+
+### E4 Electron GitHub 全新安装 / Linux x64、Linux arm64 deb/rpm
+
+1. 解析最新 prerelease 的 `.deb` 或 `.rpm`。
+2. 缺 asset 则 skip。
+3. 用系统默认包管理方式安装：Ubuntu 用 `.deb`，RPM runner 用 `.rpm`。
+4. 从系统应用入口或包安装后的命令启动。
+5. 通过：主窗口出现，sidecar 健康，版本等于 prerelease。
+
+### E5 Electron 自动更新 / Windows x64、Windows arm64
+
+1. 解析 GitHub latest stable release 中对应 `.exe`，没有则 fallback prerelease 并 skip 自动更新。
+2. 安装 stable，使用默认安装向导。
+3. 创建 `~/.config/aether/update-config.jsonc`，内容为 `{}`。
+4. 启动 Aether Desktop。
+5. 不手动调用 updater，不点设置页；等待启动后 10 秒自动检查。
+6. 预期行为：自动下载完成后出现原生 `Update Ready` 弹窗，内容为 `Update <version> downloaded. Restart now?`，按钮 `Restart` / `Later`。
+7. CI 点击 `Restart`。
+8. 通过：应用退出并重启到 prerelease 版本，主窗口可用，sidecar 健康。
+9. 若 stable 缺失、目标 prerelease 缺失、或目标不高于 stable：skip。
+
+### E6 Electron 自动更新 / Linux x64、Linux arm64 AppImage
+
+1. 下载并运行 latest stable AppImage；没有 stable 则 fallback prerelease 并 skip。
+2. 创建 `~/.config/aether/update-config.jsonc`，内容 `{}`。
+3. 启动 AppImage。
+4. 等待自动检查和下载。
+5. 预期出现 `Update Ready` 原生弹窗。
+6. 点击 `Restart`。
+7. 通过：AppImage 更新后重启，主窗口和 sidecar 可用，版本为 prerelease。
+8. 缺 AppImage 或 updater 没有可用 metadata：skip。
+
+### E7 Electron 自动更新 / macOS arm64、macOS x64
+
+1. 安装 latest stable DMG 到 `/Applications`；没有 stable 则 fallback prerelease 并 skip 自动更新。
+2. 创建 `~/.config/aether/update-config.jsonc`，内容 `{}`。
+3. 启动 Aether Desktop，等待自动检查。
+4. 预期出现原生 `Update Available` 弹窗，内容说明 macOS 不支持自动下载安装，按钮为 `Open GitHub Releases` / `Later`。
+5. 点击 `Open GitHub Releases`。
+6. 验证系统浏览器打开 `https://github.com/Science-Discovery/Aether/releases/tag/v<version>`。
+7. 像用户一样下载该 tag 的 macOS DMG，挂载并替换 `/Applications` 中的 app。
+8. 启动新 app。
+9. 通过：弹窗和链接正确，手动安装后主窗口可用，版本为 prerelease。
+
+### E8 Electron 自动更新 / Linux deb/rpm
+
+1. 用 latest stable `.deb` 或 `.rpm` 默认安装；没有 stable 则 fallback prerelease 并 skip 自动更新。
+2. 创建 `~/.config/aether/update-config.jsonc`，内容 `{}`。
+3. 启动 Aether Desktop，等待自动检查。
+4. 预期出现 `Update Available` 原生弹窗，说明只有 AppImage 支持自动下载安装，deb/rpm 需要用包管理器升级。
+5. 点击 `Open GitHub Releases`。
+6. 验证浏览器打开目标 tag。
+7. 下载该 tag 的 `.deb` 或 `.rpm`，用默认包管理方式升级。
+8. 重新启动 Aether Desktop。
+9. 通过：弹窗和链接正确，升级后主窗口可用，版本为 prerelease。
+
+### E9 Electron 手动更新 / Windows
+
+1. 安装 latest stable `.exe`；若没有 stable，可安装 fallback prerelease 但手动更新 skip。
+2. 启动一次，确认旧版本可用。
+3. 下载最新 prerelease `.exe`。
+4. 运行 installer，使用默认安装向导。
+5. 从默认入口启动。
+6. 通过：版本变为 prerelease，主窗口和 sidecar 可用。
+
+### E10 Electron 手动更新 / macOS
+
+1. 安装 latest stable DMG 到 `/Applications`；没有 stable 则 skip。
+2. 启动旧版本确认可用。
+3. 下载最新 prerelease DMG。
+4. 按默认用户方式挂载并替换 `/Applications` app。
+5. 启动新版本。
+6. 通过：版本变为 prerelease，主窗口和 sidecar 可用。
+
+### E11 Electron 手动更新 / Linux AppImage
+
+1. 下载 latest stable AppImage，授权并运行，确认旧版本可用。
+2. 下载 latest prerelease AppImage。
+3. 按用户方式替换/运行新 AppImage，不指定自定义路径。
+4. 通过：新 AppImage 主窗口和 sidecar 可用，版本为 prerelease。
+
+### E12 Electron 手动更新 / Linux deb/rpm
+
+1. 用 latest stable `.deb` 或 `.rpm` 默认安装。
+2. 启动旧版本确认可用。
+3. 下载 latest prerelease `.deb` 或 `.rpm`。
+4. 用默认包管理方式升级。
+5. 启动新版本。
+6. 通过：版本变为 prerelease，主窗口和 sidecar 可用。

--- a/docs/install-update/安装-更新测试矩阵.md
+++ b/docs/install-update/安装-更新测试矩阵.md
@@ -1,0 +1,12 @@
+# 安装-更新测试矩阵
+
+---
+
+|                   |                        从网站从头安装                        |               从GitHub releases从头安装                |          自动更新（走程序内默认来源，无需额外设置）          | 手动更新（统一为从GitHub releases获取） |
+| :---------------: | :----------------------------------------------------------: | :----------------------------------------------------: | :----------------------------------------------------------: | :-------------------------------------: |
+|   Windows (web)   | x64: https://aether.aiphys.cn/download/installer/aether_windows_installer.bat<br />arm64: ⏸️（暂缺，可以预留好位置，但是目前是空的而且skip）<br />下载后运行安装（有一些权限或者安全提示之类的问题可能要处理） |       x64: GitHub releases<br />arm64:  ⏸️<br />        | 分不同架构（如暂缺，则这里也对应的暂缺）<br />先按照“从网站从头安装”的方式，模拟用户手头能安装的最新版本；然后再打开程序，等待自动跟新弹窗弹出来，更新到当前最新版本 |                                         |
+|    macOS (web)    | x64: ⏸️<br />Apple silicon: https://aether.aiphys.cn/download/installer/aether_darwin_installer.command<br />下载后运行安装（有一些权限或者安全提示之类的问题可能要处理） |       x64:  ⏸️<br />arm64: GitHub releases<br />        |                             同上                             |                                         |
+|    Linux (web)    | x64: https://aether.aiphys.cn/download/installer/aether_linux_installer.sh<br />arm64: https://aether.aiphys.cn/download/installer/aether_linux_arm64_installer.sh<br />下载后运行安装（有一些权限或者安全提示之类的问题可能要处理） | x64: GitHub releases<br />arm64: GitHub releases<br /> |                             同上                             |                                         |
+| Windows (Desktop) |                     x64: ⏸️<br />arm64: ⏸️                     | x64: GitHub releases<br />arm64: GitHub releases<br /> | 分不同架构<br />先按照“从GitHub releases从头安装”的方式，模拟用户手头能安装的最新版本；然后再打开程序，等待自动跟新弹窗弹出来，更新到当前最新版本 |                                         |
+|  macOS (Desktop)  |                 x64: ⏸️<br />Apple silicon: ⏸️                 | x64: GitHub releases<br />arm64: GitHub releases<br /> |                             同上                             |                                         |
+|  Linux (Desktop)  |                     x64: ⏸️<br />arm64: ⏸️                     | x64: GitHub releases<br />arm64: GitHub releases<br /> |                             同上                             |                                         |


### PR DESCRIPTION
### Issue for this PR

Closes #988

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a manually triggered `install-update` workflow for install and update validation.

The workflow covers Web and Electron install/update scenarios across supported platforms, architectures, and Linux package formats. Missing assets are treated as skipped cases instead of failures.

It also adds a Bun-based CI runner script that resolves release assets, installs with default user-facing paths, writes update config files for prerelease update checks, verifies startup/version behavior, records release parsing data, and uploads logs, directory listings, and failure screenshots.

The included temporary document records the agreed test design and matrix details.

### How did you verify your code works?

- `bun build .github/scripts/install-update-ci.ts --outfile /tmp/install-update-ci-check.js --target=bun`
- Parsed `.github/workflows/install-update.yml` with Ruby YAML loader.
- `git diff --check`
- Pre-push `bun turbo typecheck` completed successfully.

The full install/update matrix has not been run yet because it requires manual GitHub Actions execution on hosted runners.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR