### PR TITLE
docs: add LLM upstream diff reports for 2026-05-04 and 2026-06-02

### DIFF
--- a/docs/llm-upstream-diff/llm-api-chain-current-state-analysis.md
+++ b/docs/llm-upstream-diff/llm-api-chain-current-state-analysis.md
@@ -1,0 +1,249 @@
+# LLM API 链路现状分析（2026-06-02）
+
+> 本文基于 [`llm-upstream-diff-report-2026-05-04.md`](./llm-upstream-diff-report-2026-05-04.md) 与
+> [`llm-upstream-diff-report-2026-06-02.md`](./llm-upstream-diff-report-2026-06-02.md) 两份上游差异报告，
+> 把其中 `LLM-UP-001 ~ 035` 的差异点**按 LLM API 调用链路的环节重新归类**，
+> 给出当前 Aether 在每个环节上的缺陷/bug 清单，并标注哪些可以直接从上游迁移。
+>
+> 文中的「现状未覆盖」均在当前 HEAD `8a79a87dd` 用 grep 二次复核过（关键行号见下）。
+> 上一轮报告基线 HEAD 为 `750aa9945`，期间仅新增本目录的报告文档，链路代码未变。
+
+---
+
+## 0. 阅读前提：两条横亘整条链路的「结构性鸿沟」
+
+在逐环节分析之前，必须先明确两点——它们决定了**每一个差异点能否逐行 cherry-pick，还是只能按行为语义重写**：
+
+1. **架构鸿沟。** 上游已把 `session/llm.ts`、`provider/provider.ts`、`session/prompt.ts`、`compaction.ts`、`summary.ts` 全面迁到 Effect `Service`/`Layer` + `@opencode-ai/core` monorepo 拆分 + SQL/Drizzle session store，并新增 `@opencode-ai/llm` 原生运行时包。Aether 仍是 pre-Effect 的 `namespace` + 直接 bundle `@ai-sdk/*` 的形态。**绝大多数上游 patch 无法逐行套用，只能按行为语义回迁。**
+2. **AI SDK 代际差。** Aether 在 AI SDK **v5** 线（`ai 5.0.124`、`@ai-sdk/google 2.x`、`vertex 3.x`、`bedrock 3.x`、`xai 2.x`、`mistral 2.x`），上游已在 **v6**。所有「bump 某 provider SDK」类提交都被这个代际差阻塞，统一归入 v6 迁移专项。
+
+**结论：本文所有「可直接迁移」均指「行为语义可在 Aether 现有架构内复刻」，不是 git cherry-pick。**
+
+---
+
+## 1. LLM API 调用链路分环节拆解
+
+把一次 LLM 调用从入口到落库拆成 7 个环节，并把所有差异点挂到对应环节：
+
+```
+用户请求
+  │
+  ▼
+[环节 A] Provider / Model 解析 & SDK key 映射     provider.ts
+  │   选 SDK、铸 token、选 language model 接口
+  ▼
+[环节 B] 请求构造 / 消息归一化 / Transform        transform.ts
+  │   providerOptions、reasoning 选项、消息重排、字符清洗、tools
+  ▼
+[环节 C] 历史消息 → ModelMessage 转换             message-v2.ts
+  │   reasoning 跨模型处理、签名 reasoning 保留、latest 推导
+  ▼
+[环节 D] 流式传输 / Transport                     provider.ts (wrapSSE) / llm.ts
+  │   SSE 超时、header 超时、finish-reason 归一
+  ▼
+[环节 E] 重试 / 错误处理                           retry.ts / error.ts
+  │   5xx、server_is_overloaded、可重试 SSE
+  ▼
+[环节 F] 会话循环 / 压缩 / Usage 计费              prompt.ts / index.ts / compaction.ts
+  │   latest-turn 判定、双重压缩、分层定价、usage 归一
+  ▼
+[环节 G] Copilot 自维护 SDK（旁路）               provider/sdk/copilot/**
+      首 delta 解析、V2/V3 specificationVersion
+```
+
+| 环节 | 涉及差异点 |
+|------|-----------|
+| A 解析/SDK key | LLM-UP-001、022、023、024、025、026 |
+| B 请求构造/Transform | LLM-UP-002、006、008、016、019、020、029(配置)、030、031 |
+| C 历史→ModelMessage | LLM-UP-005、017 |
+| D 流式/传输 | LLM-UP-003、027、029、034(专项) |
+| E 重试/错误 | LLM-UP-004、028 |
+| F 会话/压缩/计费 | LLM-UP-009、~~018~~（误报，已撤销）、021、035(专项) |
+| G Copilot SDK | LLM-UP-012、015 |
+| 横切（依赖升级） | LLM-UP-007（OpenRouter SDK）、AI SDK v6 专项、LLM-UP-033 native runtime |
+
+---
+
+## 2. 各环节现状：缺陷 / bug 清单
+
+下面每个环节区分三类标记：
+**🐛 Bug**（会导致请求失败 / 行为错误）、**⚠️ 缺陷**（鲁棒性/正确性不足但不一定崩）、**✅ 已覆盖**（本地已实现或本地策略优先）。
+
+### 环节 A —— Provider / Model 解析 & SDK key 映射（`provider.ts`）
+
+| 项 | 类型 | 现状 | 影响 |
+|----|------|------|------|
+| LLM-UP-001 dotted providerID 取首段 | ✅ 已覆盖 | `ProviderTransform.providerOptions` 已对 OpenAI-compatible/openai/anthropic dotted providerID 取首段 | wafer.ai 等自定义 provider |
+| **LLM-UP-022 cf-ai-gateway sdkKey/variants** | ⚠️ 缺陷 | `sdkKey()` 无 `ai-gateway-provider → openaiCompatible` 映射；`variants()` 无该分支 | CF AI Gateway 用户拿到 deprecation key / 错配 reasoning 选项 |
+| **LLM-UP-023 Azure Anthropic resolve** | 🐛 Bug | `provider.ts:304-306/321-323` 旧 `chat?:responses` 二选一，无 `sdk.messages` 兜底 | Azure 托管 Anthropic 模型**无法 resolve** |
+| **LLM-UP-025 Vertex GoogleAuth scopes** | 🐛 Bug | `provider.ts:531-533` 旧无 scope 的 `getApplicationDefault()` 形态 | 部分 Vertex ADC token 铸造失败 / scope 不足 |
+| **LLM-UP-026 Vertex 大洲级 multi-region** | ⚠️ 缺陷 | 内联 vertex loader 的 `GOOGLE_VERTEX_ENDPOINT` 无 `.rep.googleapis.com` 特例 | `location=eu/us` 用户端点不解析（触发面窄） |
+
+### 环节 B —— 请求构造 / 消息归一化 / Transform（`transform.ts`）
+
+| 项 | 类型 | 现状（复核行号） | 影响 |
+|----|------|------|------|
+| LLM-UP-002 Anthropic tool-call 后 text/reasoning 重排 | ✅ 已覆盖 | `ProviderTransform.message` 已拆分 `[tool-call, text/reasoning]` | Anthropic / Vertex Anthropic |
+| LLM-UP-006 DeepSeek 空 reasoning 保留 | ✅ 已覆盖 | DeepSeek assistant 补空 reasoning + 回灌空 `reasoning_content` | DeepSeek / 国产 interleaved |
+| LLM-UP-008 Azure providerOptions/store/cache | ✅ 保留本地策略 | 当前 `providerOptions` 保留 `azure` key，不双写 openai | Azure（与上游双写策略不同，刻意保留） |
+| **LLM-UP-016 Opus 4.7+ `display:"summarized"` + 泛化检测** | 🐛 Bug | `transform.ts:414` 仅字面匹配 `opus-4-7/4.7`；全文件 `display:"summarized"` **0 命中**（已复核） | **Opus 4.7+ 收到空 thinking 块**；SAP 反序 / Vertex `@` 后缀命名变体不被识别为 adaptive |
+| **LLM-UP-019 sanitizeSurrogates** | ⚠️ 缺陷 | `transform.ts` 无 surrogate 清洗（已复核 0 命中） | 落单 UTF-16 代理项导致部分 provider 400 |
+| **LLM-UP-020 tools 按名排序** | ⚠️ 缺陷 | `llm.ts:330` `activeTools: Object.keys(tools)` 未排序（已复核） | tools 顺序抖动 → prompt cache miss |
+| **LLM-UP-024 Azure gpt-5.5 走 completions** | 🐛 Bug | `options()`（`transform.ts:890-915`）有 gpt-5 块但无 gpt-5.5/azure 短路 | Azure gpt-5.5 拿到 `reasoning_effort` → **400** |
+| **LLM-UP-030 deep-research 限定 effort** | ⚠️ 缺陷 | `transform.ts` 无 `deep-research` 字样 | OpenAI `*-deep-research` 给全 effort 菜单 → 不支持档 400（仅当上架该模型） |
+| **LLM-UP-031 直连 GPT-5 加密 reasoning include** | ⚠️ 缺陷 | `transform.ts:891-895` 直连 GPT-5 路径只设 effort/summary，无 `include:["reasoning.encrypted_content"]` | `store:false` 无状态多轮 reasoning 丢加密状态 |
+
+### 环节 C —— 历史消息 → ModelMessage 转换（`message-v2.ts`）
+
+| 项 | 类型 | 现状（复核行号） | 影响 |
+|----|------|------|------|
+| LLM-UP-005 跨模型 reasoning 转 text | ✅ 已覆盖 | `toModelMessages` 在 `differentModel` 时把非空 reasoning 转 text、丢空 reasoning | Bedrock / 切模型续聊 |
+| **LLM-UP-017 签名 reasoning 保留** | 🐛 Bug | `transform.ts:108-111` 仍 `part.text !== ""` 直接丢空 reasoning；`message-v2.ts:703-709` 无 `hasSignedReasoning` | 丢签名 reasoning → Anthropic/Bedrock 签名位移 **400** |
+
+### 环节 D —— 流式传输 / Transport（`provider.ts` wrapSSE / `llm.ts`）
+
+| 项 | 类型 | 现状 | 影响 |
+|----|------|------|------|
+| LLM-UP-003 finish=stop 含 tool call 归一为 tool-calls | ✅ 已覆盖 | `LLM.stream` middleware 已归一 | OpenAI-compatible |
+| **LLM-UP-027 可重试的 SSE 卡死** | ⚠️ 缺陷 | `wrapSSE`（`provider.ts:76`）仍抛裸 `new Error("SSE read timed out")`，无 `ResponseStreamError`、无重试映射 | 卡死 SSE 不可靠重试（与本地 SSE-timeout 层互补） |
+| LLM-UP-029 headerTimeout（也属配置环节 F/B） | ⚠️ 缺陷（默认建议关） | `config.ts:1094` 仅 `timeout`+`chunkTimeout`，无 `headerTimeout` | 响应头超时无独立 abort（默认 10s 在国内代理后可能误 abort，建议默认关） |
+| LLM-UP-034 OpenAI responses-over-WS | 专项暂缓 | 扁平 `plugin/codex.ts`，无 ws 传输 | 新实验特性，非修复 |
+
+### 环节 E —— 重试 / 错误处理（`retry.ts` / `error.ts`）
+
+| 项 | 类型 | 现状 | 影响 |
+|----|------|------|------|
+| LLM-UP-004 5xx retry | ✅ 已覆盖（措辞需收紧） | 可重试性走 `parseAPICallError`→`isRetryable`/`isOpenAiErrorRetryable`；**无字面 `statusCode>=500` 判断**（05-04 原文过度具体） | 所有 provider |
+| **LLM-UP-028 重试 `server_is_overloaded`** | ⚠️ 缺陷 | `error.ts:116` `parseStreamError` 无 `server_error` 分支；`retry.ts` 字符串启发式不匹配字面 `server_is_overloaded` | zen / opencode gateway 该错误不重试 |
+
+### 环节 F —— 会话循环 / 压缩 / Usage 计费（`prompt.ts` / `index.ts` / `compaction.ts`）
+
+| 项 | 类型 | 现状（复核行号） | 影响 |
+|----|------|------|------|
+| LLM-UP-009 usage 不重复计费 | ✅ 已覆盖 | AI SDK v6 已升 `6.0.174`，`Session.getUsage` 归一逻辑通过本地测试 | Anthropic/Bedrock/OpenRouter（真实 smoke 仍建议） |
+| ~~LLM-UP-018 双重自动压缩~~ | ✅ 不适用（误报，已实测） | 上游 bug 依赖 `tail_start_id` 的 replay-tail 重排产生非时序数组；**Aether 无 `tail_start_id`**（全仓 0 命中），`filterCompacted`（`message-v2.ts:899-915`）遇压缩边界直接 `break`，把溢出 tail **整段排除**。实测 `m1<m2<m3<m4` 场景结果为 `[m2,m3,m4]`（溢出 m1 不在数组），位置扫描正确落在 summary（`summary===true`），守卫 `prompt.ts:565` 不触发二次压缩 | 无 —— 原报告把上游 reorder 前提误套到 Aether |
+| **LLM-UP-021 分层定价 tiers[]** | ⚠️ 缺陷 | `index.ts:1883-1886` 仍二元 `experimentalOver200K`（已复核），schema 无 `tiers` | tiered pricing 模型成本不准（无 abort 风险） |
+| LLM-UP-035 session 级 usage totals | 不适用 port | 依赖上游 SQL/Drizzle store + migration，Aether 无 | 产品功能，按本地存储原生实现 |
+
+### 环节 G —— Copilot 自维护 SDK（`provider/sdk/copilot/**`，旁路 AI SDK 中间件）
+
+| 项 | 类型 | 现状 | 影响 |
+|----|------|------|------|
+| **LLM-UP-015 ① 首 delta 解析过严** | 🐛 Bug（永久 Aether-only） | `chat/openai-compatible-chat-language-model.ts:519-532` 对首个 tool-call delta 缺 `id` 严格抛 `InvalidResponseDataError` | Copilot chat 路径 tool 调用（如 `memory_list`）**中断** |
+| **LLM-UP-015 ② V2 SDK 中间件失效** | 🐛 Bug（永久 Aether-only） | SDK 仍 `specificationVersion="v2"`，v6 `streamText` 跳过 `wrapLanguageModel`，`ProviderTransform.message`/finish-reason 归一对 Copilot chat 不生效 | Copilot chat 路径绕过所有 transform 修复 |
+| LLM-UP-012 Copilot GPT-5 variants / AIU 计费 | 部分/暂缓 | 有 Copilot SDK 和测试，上游细节有差异 | 单独排期 |
+
+> **关键定性（06-02 报告确认）：** 上游 `28112fbd1..687c66248` 内**根本没有 `provider/sdk/` 目录**，整套 Copilot SDK 是 Aether vendored，上游用 stock `@ai-sdk/github-copilot`。**LLM-UP-015 永远不会由上游修复，必须 Aether 自行排期。**
+
+---
+
+## 3. 可直接从上游迁移的修改（汇总）
+
+「可直接迁移」= 行为修复、不依赖 Effect/v6、当前确实未覆盖、改动局限在 Aether 现有文件内。
+
+### 第一批 —— 行为修复，机械或小而自洽（优先）
+
+> 注：原列入第一批的 **LLM-UP-018（双重压缩）经实测确认为误报**，Aether 不存在该 bug（无 `tail_start_id` replay-tail 重排），已从下表移除，详见 §2 环节 F。
+
+| 项 | 环节 | 类型 | 动作 | 风险 | 验收 |
+|----|------|------|------|------|------|
+| **LLM-UP-016** Opus 4.7+ `display:"summarized"` | B | 🐛 用户可见 | 移植 `anthropicOpus47OrLater` 正则 + 给四个 adaptive 分支加 `display:"summarized"`（四分支都已存在） | 中 | `bun test test/provider/transform.test.ts` |
+| **LLM-UP-019** sanitizeSurrogates | B | ⚠️ | helper 拼进 `normalizeMessages`，清洗 system/user/assistant text+reasoning 与 tool-result | 低（只改非法字符串） | `bun test test/provider/transform.test.ts` |
+| **LLM-UP-020** tools 排序 | B | ⚠️ cache | `Object.entries(tools).toSorted()` 一次后复用于 `activeTools`/repair 查找 | 低（首次一次性 cache miss） | `bun test test/session/llm.test.ts` |
+| **LLM-UP-017** 签名 reasoning 保留 | C | 🐛 | `normalizeMessages` 保留带 `signature`/`redactedData` 的空 reasoning；`toModelMessages` 空 text→`" "` | 中（不改触发 400） | `bun test test/provider/transform.test.ts test/session/message-v2.test.ts` |
+
+### 第二批 —— provider 专项小修，架构无关
+
+| 项 | 环节 | 类型 | 动作 | 验收 |
+|----|------|------|------|------|
+| **LLM-UP-022** cf-ai-gateway key/variants | A | ⚠️ | 补 `sdkKey` case + `variants` 分支，复用现有 efforts 常量 | `bun test test/provider/transform.test.ts` |
+| **LLM-UP-023** Azure Anthropic resolve | A | 🐛 | 两处 azure loader 加 `messages` 兜底（`chat→responses→messages→chat→languageModel`） | `bun test test/provider/provider.test.ts` |
+| **LLM-UP-024** Azure gpt-5.5 completions | B | 🐛 | `options()` 加 `npm==="@ai-sdk/azure" && id.includes("gpt-5.5")` 早返回（只设 `reasoningSummary:"auto"`） | `bun test test/provider/transform.test.ts` |
+| **LLM-UP-025** Vertex GoogleAuth scopes | A | 🐛 | `new GoogleAuth({scopes:[".../cloud-platform"]})` + `getClient()` + `getAccessToken()` | `bun test test/provider/provider.test.ts` |
+| **LLM-UP-027** 可重试 SSE 卡死 | D | ⚠️ | 适配 Aether 命令式 retry 循环：`wrapSSE` 抛 `ResponseStreamError` + 映射可重试 | `bun test test/session/llm.test.ts test/provider/provider.test.ts` |
+| **LLM-UP-031** 直连 GPT-5 加密 include | B | ⚠️ | `options()` 一行：直连 GPT-5 也加 `include:["reasoning.encrypted_content"]`（跳过 `packages/llm` 部分） | `bun test test/provider/transform.test.ts` |
+| **LLM-UP-021** 分层定价 | F | ⚠️ | Zod cost schema 加 `tiers` + `getUsage` 选档；**务必保留** Aether 的 cache-token 调整与自有 `total` 计算 | `bun test test/session/compaction.test.ts` |
+
+### 第三批 —— 小 / 触发面窄
+
+| 项 | 环节 | 说明 |
+|----|------|------|
+| LLM-UP-026 | A | Vertex `eu`/`us` 大洲端点分支 |
+| LLM-UP-028 | E | `retry.ts` 识别 `server_is_overloaded`/`server_error` |
+| LLM-UP-029 | D/B | `headerTimeout` 配置（**建议 OpenAI 10s 默认设关或可调**，避免国内慢网关误 abort） |
+| LLM-UP-030 | B | openai/openrouter 内联块 `deep-research → medium` 守卫 |
+| LLM-UP-032 | A | NVIDIA `X-BILLING-INVOKE-ORIGIN` header（仅当支持 NVIDIA） |
+
+---
+
+## 4. 不迁移 / 禁止迁移 / keep-local
+
+### ⚠️ 反向冲突（禁止回迁）
+
+- **`2f2fcc165`/`#30127`（上游删除自动 full session diff）与 Aether `bafdfb6d2`（修好并保留自动 diff）意图相反。** 上游让 `Session.diff` 返回 `[]`、改读 `message.info.summary?.diffs`、删 `Storage` 依赖；Aether 是顺序无关指纹去重 + `setSummary`/`Storage.write`/`Bus.publish` 一起 gate。**盲目回迁会删掉 `bafdfb6d2` 修好的机制、重新引入闪烁/陈旧并打断 review 面板。`summary.ts:92-191` 仍依赖 `["session_diff", ...]`。**
+
+### 专项 / 暂缓（大型架构迁移，非单点修复）
+
+- **LLM-UP-033 native LLM runtime**（`@opencode-ai/llm`，40+ 文件新包，默认关）：不可移植，**不 cherry-pick 任何子项**。其中 `61390dbb4`（native 续传 metadata）的 bug 只存在于 native 协议实现，Aether AI SDK 路径不会触发。
+- **LLM-UP-034 OpenAI responses-over-WebSocket**：新实验特性，需引 `ws` 依赖 + 重构 plugin 目录。
+- **LLM-UP-035 session 级 usage totals**：依赖 SQL/Drizzle store + migration。
+- **AI SDK v5→v6 迁移专项**：阻塞一批 provider SDK bump（bedrock 4.x、google/vertex thought signatures、xAI PDF 等）。注意 google tool-id 回归的 **pin 约束**——未来 v6 迁移须落在 `@ai-sdk/google ≤3.0.73` / `vertex ≤4.0.128`。
+- **LLM-UP-007 OpenRouter SDK**：已随 AI SDK v6 专项升到 `@openrouter/ai-sdk-provider@2.9.0`，仍建议真实 OpenRouter/DeepSeek smoke。
+
+### keep-local（本地策略优先，上游对应改动对 Aether 是 no-op 或有害）
+
+- **LLM-UP-013 本地兼容层必须保留**：OpenAI-compatible `includeUsage`、`max_tokens→max_completion_tokens`、reasoning 回灌、**LiteLLM `_noop` dummy tool**（Aether 面向旧 LiteLLM / 国内 OpenAI-compatible 网关，上游以「LiteLLM 已服务端修复」为前提删除，Aether 不能跟）、SSE timeout、HTTP proxy。
+- **LLM-UP-008 Azure** 保留本地「不 remap 到 openai」策略。
+- **LLM-UP-010/011** models.dev 服务化、Alibaba 官方 SDK：保留本地 snapshot 与国产网关 `enable_thinking` 语义。
+- mistral medium 3.5 / GPT-5 variant helpers / Gemini thinking helpers / Opus 4.5 effort：Aether 用内联 `iife`，仅当实际上架对应子模型时**选择性**回迁。
+
+### LLM-UP-015 Copilot SDK —— 永久 Aether-only
+
+上游无 vendored SDK，永不会修。需 Aether 自行排期：
+- **短期**：放宽 chat 首 delta 解析——id 与 name 同时缺失时占位等下一帧，仅半残（仅缺其一）时仍抛。
+- **长期**：把 Copilot SDK 升到 `LanguageModelV3`，让 AI SDK v6 中间件对 Copilot chat 路径复生效。
+
+---
+
+## 5. 一页速查：bug 优先级矩阵
+
+| 严重度 | 项 | 一句话 |
+|--------|----|--------|
+| 🔴 会崩/请求失败 | LLM-UP-023 | Azure Anthropic 无法 resolve |
+| 🔴 | LLM-UP-024 | Azure gpt-5.5 → 400 |
+| 🔴 | LLM-UP-025 | Vertex ADC token 铸造失败 |
+| 🔴 | LLM-UP-017 | 签名 reasoning 丢失 → Anthropic/Bedrock 400 |
+| 🔴 | LLM-UP-015① | Copilot chat tool 调用中断（自维护） |
+| 🟠 用户可见错误 | LLM-UP-016 | Opus 4.7+ 空 thinking 块 |
+| ~~🟠 核心循环~~ | ~~LLM-UP-018~~ | ~~双重自动压缩~~ —— 经实测撤销，Aether 无此 bug |
+| 🟡 鲁棒性/正确性 | LLM-UP-019/020/021/022/026/027/028/029/030/031 | 字符清洗 / cache / 定价 / gateway / SSE 重试 / 超时 等 |
+
+---
+
+## 6. 落地建议
+
+1. **先做第一批四项**（016/017/019/020）：都不依赖 Effect/v6，016/017 是用户可见 / 会触发 400 的 reasoning 问题。每项都有现成测试入口。（原列入的 `LLM-UP-018` 经实测为误报，已撤销——Aether 无 `tail_start_id` replay-tail 重排，`filterCompacted` 直接排除溢出 tail，详见 §2 环节 F。）
+2. **第二批 provider 专项**（022~025/027/031/021）：按 provider 真实使用面排序——若 Aether 实际服务 Azure / Vertex，则 023/024/025 应提到第一梯队。
+3. **第三批默认低优**；LLM-UP-029 `headerTimeout` 落地时**默认关闭或调大**，防国内代理误 abort。
+4. **守住反向冲突** `2f2fcc165`，回迁任何 session diff 相关代码前先核对 `bafdfb6d2`。
+5. **Copilot SDK（015）与 AI SDK v6 迁移**各开独立专项，不混入上面三批。
+
+### 统一验收
+
+```bash
+cd /home/fyl/opencode/packages/opencode
+bun typecheck
+bun test test/provider/transform.test.ts
+bun test test/provider/provider.test.ts
+bun test test/session/message-v2.test.ts
+bun test test/session/llm.test.ts
+bun test test/session/retry.test.ts
+bun test test/session/compaction.test.ts
+```
+
+声称修复真实 provider 时（Opus 4.7+ adaptive / Azure Anthropic / Vertex 等需真实 smoke）：
+
+```bash
+OPENCODE_SYSTEM_TEST=1 bun run test:system:llm:p0 -- --provider deepseek
+OPENCODE_SYSTEM_TEST=1 bun run test:system:llm:p0 -- --provider alibaba-cn --input p1-reasoning --p1
+```

--- a/docs/llm-upstream-diff/llm-upstream-diff-report-2026-05-04.md
+++ b/docs/llm-upstream-diff/llm-upstream-diff-report-2026-05-04.md
@@ -1,0 +1,88 @@
+# LLM 上游差异报告 2026-05-04
+
+> **续期更新见 [`llm-upstream-diff-report-2026-06-02.md`](./llm-upstream-diff-report-2026-06-02.md)**（上游窗口 `28112fbd1..687c66248`，新增 `LLM-UP-016 ~ 035`）。本文件作为 05-04 历史快照保留，状态变化在续期报告的「对既有项的状态更新」一节说明。
+
+## 基线
+
+- 当前仓库：`/home/fyl/opencode`
+- 上游仓库：`/home/fyl/tmp/opencode`
+- 上游分支：`dev`
+- 上游时间窗口：`2026-03-26` 之后进入 `dev` 的 LLM/session/provider/config/auth/package 相关提交
+
+当前工作区已有变更未触碰：
+
+- `packages/opencode/src/provider/models-snapshot.js`
+- `packages/opencode/src/session/llm.ts`
+- `packages/opencode/test/session/llm.test.ts`
+- `docs/llm-upstream-diff-migration-plan.md`
+- `aether-site/`
+
+## 方法
+
+本轮按 `docs/llm-upstream-diff-migration-plan.md` 的第 1 步执行，只生成报告，不改运行时代码。
+
+已执行的分析：
+
+- 对比当前仓库与上游 clone 的 `packages/opencode/src/session`、`packages/opencode/src/provider`、`packages/opencode/src/config` 的 no-index diff。
+- 抽读高价值文件差异：`session/llm.ts`、`session/prompt.ts`、`session/retry.ts`、`provider/provider.ts`、`provider/transform.ts`、`provider/models.ts`。
+- 扫描并抽查上游 `2026-03-26` 之后相关 commit，重点看 bugfix、provider 兼容、reasoning、tool call、usage、AI SDK/provider SDK bump。
+- 对照当前 Aether 的本地兼容层和测试，避免把已覆盖或本地策略误判为待回迁。
+- 在当前 HEAD `b2f150759` 复核 P0/P1 项，确认多项此前标为缺失的行为已经由现有工作区改动或本地实现覆盖。
+
+## 候选项
+
+| 编号 | 优先级 | 上游 commit/PR | 变更主题 | 影响 provider/model | 当前 Aether 状态 | 建议动作 | 风险 | 测试要求 | 验收命令 |
+|------|--------|----------------|----------|---------------------|------------------|----------|------|----------|----------|
+| LLM-UP-001 | P0 | `a12333310` / `#25145` | `providerOptions` key 对 OpenAI-compatible dot provider 做 split | OpenAI-compatible custom provider，如 `wafer.ai` | 已覆盖；`ProviderTransform.providerOptions` 已对 OpenAI-compatible/openai/anthropic dot providerID 取首段 | 已验证 | 继续避免影响 xAI/Mistral/Groq 等硬编码 key | 已有 dotted providerID 断言 | `cd packages/opencode && bun test test/provider/transform.test.ts` |
+| LLM-UP-002 | P0 | `348a84969` / `#22646` | Anthropic assistant content 中 `tool-call` 后接 text/reasoning 时重排，避免 `tool_use` 未立即跟 `tool_result` | Anthropic、Google Vertex Anthropic | 已覆盖；`ProviderTransform.message` 已拆分 `[tool-call, text/reasoning]`，`message-v2.ts` 已处理 pending/running tool | 已验证 | Anthropic 历史消息顺序敏感，需避免影响非 Anthropic provider | 已有 transform 与 pending/running tool 回归测试 | `cd packages/opencode && bun test test/provider/transform.test.ts test/session/message-v2.test.ts` |
+| LLM-UP-003 | P0 | `733a3bd03` / `#14973` | provider 返回 `stop` 但 assistant 含 tool call 时继续工具循环 | OpenAI-compatible | 已覆盖；`LLM.stream` middleware 已将含 tool call 的 `stop/unknown` 归一为 `tool-calls` | 已验证 | 后续改 streaming middleware 时需保留该归一化 | 已有 fake endpoint 覆盖 finish=`stop` 且含 tool call 的继续执行 | `cd packages/opencode && bun test test/session/llm.test.ts` |
+| LLM-UP-004 | P0 | `4ca809ef4` / `#22511` | 5xx API error 即使 `isRetryable` 未置位也应 retry | 所有 provider | 已覆盖；`SessionRetry.retryable` 已对 `statusCode >= 500` 放行，并保留 context overflow 不重试 | 已验证 | 可能增加真实 5xx 重试次数，符合上游修复语义 | 已有 retryable 5xx/4xx/context overflow 断言 | `cd packages/opencode && bun test test/session/retry.test.ts` |
+| LLM-UP-005 | P0 | `29ec07700` / `#25303` | 不同模型间转换 reasoning part 时改为普通 text，修复 Bedrock reasoning 问题 | Bedrock、跨模型继续对话/切模型 | 已覆盖；`MessageV2.toModelMessages` 已在 `differentModel` 时把非空 reasoning 转 text 并丢弃空 reasoning | 已验证 | 跨模型 reasoning 转 text 只应在 `differentModel` 时生效 | 已有 different-model reasoning 转 text 断言 | `cd packages/opencode && bun test test/session/message-v2.test.ts` |
+| LLM-UP-006 | P0 | `86715fecc` / `#24180`、`923af96d2` / `#24146` | DeepSeek assistant 历史始终带 reasoning，并保留空 `reasoning_content` | DeepSeek V4 thinking、OpenAI-compatible interleaved reasoning | 已覆盖；DeepSeek assistant 会补空 reasoning，并通过 interleaved 回灌为空 `reasoning_content` | 已验证 | Aether 本地 DashScope/ZAI/Kimi/GLM 逻辑必须继续保留 | 已有 DeepSeek 非空与空 reasoning_content 断言 | `cd packages/opencode && bun test test/provider/transform.test.ts` |
+| LLM-UP-007 | P0 | `e7053c41f` / `#24435` | 升级 `@openrouter/ai-sdk-provider` 修复 DeepSeek reasoning，并跳过本地 interleaved 回灌 | OpenRouter DeepSeek | 已升级；随 AI SDK v6 专项升到 `@openrouter/ai-sdk-provider@2.9.0`，删除旧 `1.5.4` patch | 已迁移，待真实 smoke | 新 OpenRouter reasoning 需真实 provider 验证；旧 patch 不能直接套用到 2.x | 本地 typecheck/provider/transform/LLM/Copilot 测试已通过；仍建议 OpenRouter/DeepSeek smoke | `cd packages/opencode && bun typecheck`，再按系统 smoke 文档跑 OpenRouter/DeepSeek |
+| LLM-UP-008 | P0 | `9965d385d` / `#20272`、`c5deeee8c` / `#22764`、`cb18f2ef4` / `#22957`、`a740d2c66` / `#25007` | Azure providerOptions、`store`、prompt cache、reasoning defaults 对齐 OpenAI | Azure OpenAI | 大多已覆盖；当前测试已有 Azure chat/responses reasoning scrub，当前 `providerOptions` 保留 `azure` key；但与上游“双写 openai+azure”策略不同 | 已覆盖，保留本地策略 | 上游双写可能与当前测试“azure 不 remap 到 openai”冲突 | 不回迁代码；只在后续 Azure 真实失败时重评 | `cd packages/opencode && bun test test/provider/transform.test.ts` |
+| LLM-UP-009 | P0 | `280eb16e7` / `#21047`、`72c77d0e7` / `#19758` | reasoning/cache token 不重复计费，Anthropic/Bedrock AI SDK v6 usage 归一 | Anthropic、Bedrock、OpenRouter、Venice | 已重评；AI SDK 已升到 `6.0.174`，现有 `Session.getUsage` 归一逻辑通过 v6 本地测试 | 已验证 | 真实 provider usage metadata 仍建议 smoke 复核，尤其 OpenRouter/Bedrock | 保留 usage/compaction 单测；真实 provider 再跑 smoke | `cd packages/opencode && bun test test/session/compaction.test.ts test/session/compaction-flow.test.ts` |
+| LLM-UP-010 | P1 | `f8738c900` / `#25434`、`23c865608` / `#20605`、`fff98636f` / `#20929` | `models.dev` 服务化、schema 拆分、删除/弱化 snapshot | models.dev 元数据加载 | 暂不适合；当前 Aether 保留 `models-snapshot.js`，且该文件已有本地未提交改动 | 暂缓 | 容易覆盖本地 snapshot 和模型扩展；架构重构噪音大 | 不做代码回迁；后续只抽取具体模型能力字段 | 不适用 |
+| LLM-UP-011 | P1 | `7230cd268` / `#22248` | 新增 Alibaba SDK 和 cache 支持 | Alibaba/DashScope | Aether 已有本地 DashScope/OpenAI-compatible `enable_thinking` 与国产模型参数策略 | 已覆盖，保留本地策略 | 上游改为官方 SDK 可能破坏 Aether 国内网关语义 | 用现有 alibaba-cn smoke 验证 | `cd packages/opencode && OPENCODE_SYSTEM_TEST=1 bun run test:system:llm:p0 -- --provider alibaba-cn --input p1-reasoning --p1` |
+| LLM-UP-012 | P1 | `0acac216a` / `#24734`、`610c036ef` / `#22824`、Copilot SDK diff | Copilot GPT-5 variants、低 reasoning effort、Responses API 细节 | GitHub Copilot GPT-5 | 部分已有；当前有 Copilot SDK 和测试，但上游 Copilot SDK 有细节差异 | 暂缓，单独评估 Copilot | Copilot SDK 自维护成本高，不能混在 provider 通用回迁里 | 跑 `test/provider/copilot/**`，必要时补 GPT-5 variant cases | `cd packages/opencode && bun test test/provider/copilot` |
+| LLM-UP-013 | Local | diff-only | OpenAI-compatible `includeUsage`、`max_tokens` 到 `max_completion_tokens`、reasoning 回灌、LiteLLM `_noop`、SSE timeout、HTTP proxy | OpenAI-compatible、LiteLLM、国内网关 | Aether 本地能力，上游没有等价或策略不同 | 必须保留 | 回迁上游 `provider.ts`/`transform.ts` 时最容易被覆盖 | 保留现有 provider/transform/LLM smoke 测试 | `cd packages/opencode && bun test test/provider/provider.test.ts test/provider/transform.test.ts test/session/llm.test.ts` |
+| LLM-UP-014 | P2 | 多个 Effect/HttpApi/config 拆分 commit，如 `3df18dcde`、`e8471256f`、`ee7339f2c`、`93940a185` | Provider/Session/Config Effect service 化、HttpApi 化、module barrel 删除 | 架构层 | 与本轮 LLM 行为修复耦合低 | 放弃本轮回迁 | 大面积覆盖会吞掉 Aether 本地改动，且测试面过大 | 不做 | 不适用 |
+| LLM-UP-015 | P1 | local-only（`provider/sdk/copilot/**`，引入自 `d9f18e400`；触发面疑似随 `2046ce0d6` 工具工厂迁移变大） | Copilot V2 SDK 两处缺陷：① `chat/openai-compatible-chat-language-model.ts` 对首个 tool-call delta 缺 `id` 的解析过严，抛 `InvalidResponseDataError: Expected 'id' to be a string.`（OpenAI-compatible 协议允许后续 chunk 才补 id/name，是 SDK 实现的兼容缺陷）；② SDK 整体仍实现 `LanguageModelV2`，AI SDK v6 `streamText` 因 `specificationVersion: "v3"` 跳过 `wrapLanguageModel`，`ProviderTransform.message` 与 finish-reason 归一对 Copilot chat 路径不生效（已在 `session/llm.ts` 注释存档） | GitHub Copilot chat 路径（非 Responses） | 未覆盖；触发后会直接中断 tool 调用（如 `memory_list`） | 短期：放宽 chat 首 delta 解析——id/name 同时缺失时占位等下一帧，仅在半残（id 与 name 仅缺其一）时仍抛；长期：把 Copilot SDK 升到 `LanguageModelV3`，让 v6 中间件重新覆盖该路径 | 短期改动需保证不破坏现有 chat 单测；V3 迁移涉及面大、需独立专项 | 复现 chat 路径 tool-call streaming 即可触发；补 chat 适配器单测覆盖"首 delta 仅含 index"分支 | `cd packages/opencode && bun test test/provider/copilot` |
+
+## 优先回迁建议
+
+当前 HEAD 复核后，第一批 P0 行为已经由现有工作区实现或本地实现覆盖：
+
+1. `LLM-UP-001` 到 `LLM-UP-006`：标记为已覆盖并已用本地测试验证。
+2. `LLM-UP-007`：已随 AI SDK v6 专项升级迁移，仍建议真实 OpenRouter/DeepSeek smoke。
+3. `LLM-UP-008`：维持已覆盖并保留本地 Azure 策略。
+4. `LLM-UP-009`：已随 AI SDK v6 专项重评，usage/compaction 本地测试通过。
+5. `LLM-UP-010` 到 `LLM-UP-012`：P1 保持专项评估或本地策略优先，不做本轮代码回迁。
+
+`LLM-UP-007` 不建议进入第一批，因为它牵涉 `@openrouter/ai-sdk-provider`、AI SDK peer dependency、`bun.lock` 和现有 patch。应作为依赖升级专项处理。
+
+## 验收建议
+
+第一批 P0 复核后从 package 目录运行：
+
+```bash
+cd /home/fyl/opencode/packages/opencode
+bun typecheck
+bun test test/provider/transform.test.ts
+bun test test/session/message-v2.test.ts
+bun test test/session/retry.test.ts
+bun test test/session/llm.test.ts
+```
+
+若声称修复真实 provider：
+
+```bash
+cd /home/fyl/opencode/packages/opencode
+OPENCODE_SYSTEM_TEST=1 bun run test:system:llm:p0 -- --provider deepseek
+OPENCODE_SYSTEM_TEST=1 bun run test:system:llm:p0 -- --provider alibaba-cn --input p1-reasoning --p1
+OPENCODE_SYSTEM_TEST=1 bun run test:system:llm:p0 -- --provider minimax-cn
+```
+
+## 结论
+
+当前仓库与上游 `dev` 的 LLM call chain 差异主要由上游 Effect/HttpApi 架构迁移、AI SDK v6/provider SDK 升级和少量真实 provider bugfix 混合造成。本轮不应整块覆盖上游文件。

--- a/docs/llm-upstream-diff/llm-upstream-diff-report-2026-06-02.md
+++ b/docs/llm-upstream-diff/llm-upstream-diff-report-2026-06-02.md
@@ -26,7 +26,8 @@
 
 1. **架构鸿沟扩大。** 上游本窗口把 `session/llm.ts`、`provider/provider.ts`、`session/prompt.ts`、`compaction.ts`、`summary.ts` 全面迁到 Effect `Service`/`Layer` + `@opencode-ai/core` monorepo 拆分 + SQL/Drizzle session store，并新增 `@opencode-ai/llm` 原生运行时包。Aether 仍是 pre-Effect 的 `namespace` + 直接 bundle `@ai-sdk/*` 形态。**因此绝大多数上游 patch 无法逐行 cherry-pick，只能按行为语义回迁。**
 2. **AI SDK 代际差。** Aether 在 AI SDK **v5** 线（`ai 5.0.124`、`@ai-sdk/google 2.x`、`google-vertex 3.x`、`bedrock 3.x`、`xai 2.x`、`mistral 2.x`），上游已在 **v6**。所有「bump 某 provider SDK」类提交都被这个代际差阻塞，归入 v6 迁移专项。
-3. **有 5 个真正可立即回迁、且当前确实未覆盖的行为修复**（不依赖 Effect/v6）：`LLM-UP-018` 双重压缩、`LLM-UP-016` Opus 4.7+ `display:"summarized"`、`LLM-UP-019` 代理项 surrogate、`LLM-UP-020` tools 排序、`LLM-UP-017` 签名 reasoning 保留。建议作为第一批（与下文「优先回迁建议」第一批、「结论」一致）。
+3. **有 4 个真正可立即回迁、且当前确实未覆盖的行为修复**（不依赖 Effect/v6）：`LLM-UP-016` Opus 4.7+ `display:"summarized"`、`LLM-UP-017` 签名 reasoning 保留、`LLM-UP-019` 代理项 surrogate、`LLM-UP-020` tools 排序。建议作为第一批（与下文「优先回迁建议」第一批、「结论」一致）。
+   - **更正（实测复核）：** 原列为第一批 P0 的 `LLM-UP-018`（双重压缩）经实测确认为**误报**——Aether 无 `tail_start_id`、`filterCompacted` 已把溢出 tail 整段排除，不存在该 bug。**已撤销**，详见下表 `LLM-UP-018` 行。
 4. **有 1 个高风险「反向冲突」项：** 上游 `2f2fcc165`（删除自动 session diff）与 Aether 本地 `bafdfb6d2`（修好并保留自动 diff）意图相反，**禁止回迁**。05-04 快照未覆盖此冲突，本报告首次澄清。
 5. **`LLM-UP-015`（Copilot V2 SDK）确认永远不会由上游修复** —— 上游根本没有 vendored 的 `provider/sdk/` 目录，整套 Copilot SDK 是 Aether 自有，必须自行排期。
 
@@ -38,7 +39,7 @@
 |------|--------|----------------|----------|---------------------|------------------|----------|------|----------|
 | LLM-UP-016 | P0 | `05e3c4ece`/`#29769`、`b956e9a06`/`#29911`、`3070b0f4a`/`#30027`、`f4f508e65`/`#29991` | Opus 4.7+ adaptive reasoning：① `anthropicOpus47OrLater` 泛化「≥4.7/未来 major」检测，覆盖 Vertex `@` 后缀与 SAP 反序 `claude-4.7-opus`/`4.6-opus`；② 在 anthropic / vertex-anthropic / bedrock / gateway / sap-ai-core 全部 adaptive 分支强制 `display:"summarized"` | Anthropic Opus 4.7+（直连 / Bedrock / Vertex / CF Gateway / SAP AI Core） | **未覆盖**。`transform.ts:414` 仅字面匹配 `opus-4-7`/`opus-4.7`；`display:"summarized"` 全文件 0 命中（已复核）。后果：Opus 4.7+ API 默认 `omitted`，Aether 将收到**空 thinking 块**；SAP/Vertex 命名变体甚至不被识别为 adaptive | 回迁（机械）：移植 `anthropicOpus47OrLater` 正则 + 给四个 adaptive 分支加 `display:"summarized"`。四个分支 Aether 都已存在 | 中：用户可见的 reasoning 摘要丢失 + 漏检 adaptive | `cd packages/opencode && bun test test/provider/transform.test.ts` |
 | LLM-UP-017 | P1 | `233fc5b91`/`#21370`、`4e14f7951`/`#26276`（reasoning 半） | 含签名 reasoning 时保留 assistant 内容：① `normalizeMessages` 保留带 `anthropic/bedrock.signature` 或 `.redactedData` 的空 reasoning 块；② `toModelMessages` 对带签名 reasoning 的 assistant，空 text 替换为 `" "`，避免 SDK 过滤掉分隔符导致签名位移 | Anthropic / Bedrock adaptive thinking 多轮 | **未覆盖**。`transform.ts:108-111` 仍是旧 `part.text !== ""` 直接丢弃空 reasoning；`message-v2.ts:703-709` 无 `hasSignedReasoning` 逻辑 | 回迁（小、自洽）：两段一起改 | 中：丢弃签名 reasoning 会触发 Anthropic/Bedrock 签名位置 400 | `cd packages/opencode && bun test test/provider/transform.test.ts test/session/message-v2.test.ts` |
-| LLM-UP-018 | P0 | `94564f358`/`#27545` | 防 filterCompacted 重排导致的双重自动压缩：新增 `MessageV2.latest(msgs)` 按 **max MessageID** 而非数组位置推导 latest user/assistant/finished/tasks | 所有会自动压缩的 session | **未覆盖（真实潜在 bug）**。`filterCompacted`（`message-v2.ts:899-915`）做了 `reverse()` + 提前 `break`，数组非时序；而 `prompt.ts:311` 仍用 `for (let i = msgs.length-1; ...)` 位置扫描（已复核）。压缩后会把溢出尾部的旧 assistant 误判为最新轮 → 重复压缩 | 回迁行为：在 Aether 的 plain-async 循环里按 max-id 推导 latest，并补回归测试（溢出尾部 + 压缩） | 中：触及核心循环 turn 判定 | `cd packages/opencode && bun test test/session/llm.test.ts test/session/compaction.test.ts` |
+| ~~LLM-UP-018~~ | ~~P0~~ → **撤销（误报）** | `94564f358`/`#27545` | （上游）防 filterCompacted 重排导致的双重自动压缩：新增 `MessageV2.latest(msgs)` 按 max MessageID 推导 latest | 所有会自动压缩的 session | **不适用（误报，已实测）**。上游 bug 依赖 `tail_start_id` 的 replay-tail 重排把溢出 tail 拼回数组中段产生非时序数组；**Aether 无 `tail_start_id`**（全仓 0 命中），`filterCompacted`（`message-v2.ts:899-915`）遇压缩边界直接 `break`，把溢出 tail **整段排除**。实测 `m1<m2<m3<m4` 场景结果为 `[m2,m3,m4]`（溢出 m1 不在数组），位置扫描正确落在 summary（`summary===true`），守卫 `prompt.ts:565` `summary !== true` 为 false，不触发第二次压缩 | **不回迁**。原报告把上游 reorder 前提误套到 Aether——grep 只证实「prompt.ts 用位置扫描、message-v2 有 reverse()」两个事实，未验证溢出 tail 是否仍留在数组中 | 无 | `cd packages/opencode && bun test test/session/message-v2.test.ts`（可加 filterCompacted「溢出 tail 排除」回归测试锁住该行为） |
 | LLM-UP-019 | P1 | `6409aceb1`/`#25934` | `sanitizeSurrogates`：把落单 UTF-16 代理项替换为 `�`，在 `normalizeMessages` 对 system/user/assistant text+reasoning 与 tool-result 输出统一清洗 | 所有 provider | **未覆盖**。`transform.ts` 无 `sanitizeSurrogates`/surrogate 正则（已复核） | 回迁（机械）：把 helper 拼进 Aether `normalizeMessages` | 低：纯清洗，只改本就非法的字符串 | `cd packages/opencode && bun test test/provider/transform.test.ts` |
 | LLM-UP-020 | P1 | `83bb21648`/`#26370` | tools 始终按名排序：`Object.entries(tools).toSorted(...)` 后用于 `tools`/`activeTools`/`experimental_repairToolCall` 查找/预批准 | 所有 provider（对 prompt cache 敏感） | **未覆盖**。`llm.ts:330` `activeTools: Object.keys(tools)` 未排序；repair 查找也未排序（已复核） | 回迁（小、低风险）：排序一次后复用 | 低：首次部署可能一次性 cache miss，之后更稳定 | `cd packages/opencode && bun test test/session/llm.test.ts` |
 | LLM-UP-021 | P1 | `c2b1ebd9d`/`#27184` | 分层定价：把二元 `experimentalOver200K` 泛化为 `cost.tiers[]`（按 context token size 选最高匹配档），`getUsage` 选档逻辑 + `models.ts`/`provider.ts` schema | 所有发布 tiered pricing 的模型 | **未覆盖**。`index.ts:1883-1886` 仍只有二元 `experimentalOver200K`；schema 无 `tiers`/`ProviderCostTier` | 回迁行为：给 Zod cost schema 加 `tiers` + `getUsage` 选档；**务必保留** Aether 的 OpenRouter/Anthropic cache-token 调整（`index.ts:1850-1857`）与自有 `total` 计算 | 中：仅成本准确性，无 abort 风险；与 cache 调整交互需测试 | `cd packages/opencode && bun test test/session/compaction.test.ts` |
@@ -91,11 +92,12 @@
 
 **第一批（行为修复，不依赖 Effect/v6，当前确实未覆盖，已 grep 复核）：**
 
-1. `LLM-UP-018` 双重自动压缩（P0，核心循环潜在 bug）
-2. `LLM-UP-016` Opus 4.7+ `display:"summarized"` + 泛化检测（P0，用户可见 reasoning 丢失）
+1. `LLM-UP-016` Opus 4.7+ `display:"summarized"` + 泛化检测（P0，用户可见 reasoning 丢失）
+2. `LLM-UP-017` 签名 reasoning 保留（P1，与 016 同属 Anthropic adaptive 可靠性）
 3. `LLM-UP-019` surrogate 清洗（P1，机械）
 4. `LLM-UP-020` tools 排序（P1，机械，利于 cache）
-5. `LLM-UP-017` 签名 reasoning 保留（P1，与 016 同属 Anthropic adaptive 可靠性）
+
+> ~~`LLM-UP-018` 双重自动压缩~~：经实测**撤销**，Aether 无此 bug（无 `tail_start_id` replay-tail 重排，`filterCompacted` 直接排除溢出 tail）。详见上表 `LLM-UP-018` 行。
 
 **第二批（provider 专项小修，架构无关）：**
 
@@ -138,6 +140,6 @@ OPENCODE_SYSTEM_TEST=1 bun run test:system:llm:p0 -- --provider alibaba-cn --inp
 
 ## 结论
 
-本轮窗口（`28112fbd1..687c66248`，220 个相关提交）上游主线是 Effect/`@opencode-ai/core`/SQL store/native-runtime/AI SDK v6 的架构迁移，**绝大多数无法逐行回迁**。但从中剥离出 **16 个值得跟进的行为差异点（`LLM-UP-016 ~ 031`）**，其中 5 个是当前确实未覆盖、架构无关、可立即作为第一批回迁的行为修复（`016/017/018/019/020`）。
+本轮窗口（`28112fbd1..687c66248`，220 个相关提交）上游主线是 Effect/`@opencode-ai/core`/SQL store/native-runtime/AI SDK v6 的架构迁移，**绝大多数无法逐行回迁**。但从中剥离出 **16 个值得跟进的行为差异点（`LLM-UP-016 ~ 031`）**，其中 4 个是当前确实未覆盖、架构无关、可立即作为第一批回迁的行为修复（`016/017/019/020`）。`LLM-UP-018`（双重压缩）经实测确认为误报、不适用 Aether，已撤销（Aether 无 `tail_start_id` replay-tail 重排）。
 
 同时确认了一处必须守住的反向冲突（`2f2fcc165` vs `bafdfb6d2`），并把 `LLM-UP-015`（Copilot SDK）定性为永久 Aether-only 自维护项。native runtime、OpenAI WS、usage totals、AI SDK v6 与 Copilot SDK 升级仍各自开专项评估。

--- a/docs/llm-upstream-diff/llm-upstream-diff-report-2026-06-02.md
+++ b/docs/llm-upstream-diff/llm-upstream-diff-report-2026-06-02.md
@@ -1,0 +1,143 @@
+# LLM 上游差异报告 2026-06-02
+
+> 本报告是 [`llm-upstream-diff-report-2026-05-04.md`](./llm-upstream-diff-report-2026-05-04.md) 的续期更新。
+> 05-04 报告作为历史快照保留，其 `LLM-UP-001 ~ LLM-UP-015` 编号在本报告中沿用，
+> 状态有变化的在「对既有项的状态更新」一节说明；新发现的差异点从 `LLM-UP-016` 起编号。
+
+## 基线
+
+- 当前仓库：`/home/fyl/opencode`
+- 当前分支：`dev`
+- 当前 HEAD：`750aa9945`（上一轮报告基线为 `b2f150759`，该分支已并入 `dev`，期间新增提交以 memory/voice/electron/sandbox/mobile 等 Aether 自有功能为主，LLM 调用链未实质推进）
+- 上游仓库：`/home/fyl/tmp/opencode`
+- 上游分支：`dev`
+- 上游 HEAD：`687c66248`（2026-06-02）
+- 上一轮上游基线：`28112fbd1`（2026-05-04）
+- 本轮时间窗口：`28112fbd1..687c66248`，共 1443 个提交，其中触及 `session/`、`provider/`、`config/`、`auth/`、`package.json` 的相关提交 220 个
+
+## 方法
+
+- 在上游 `28112fbd1..687c66248` 窗口内筛出 LLM 行为相关提交（reasoning、provider 兼容、usage、tool call、retry/transport、SDK bump、compaction、native runtime），剔除 Effect/Zod/HttpApi/flags 等纯架构重构噪音。
+- 把候选提交按主题拆成 6 个簇并行核查：① reasoning/adaptive、② provider SDK bump + provider 专项 fix、③ streaming/transport/retry、④ native LLM runtime、⑤ session/compaction/usage、⑥ LiteLLM 移除 + Copilot。
+- 每个差异点都对照当前 Aether 实际代码（`provider/transform.ts`、`provider/provider.ts`、`session/llm.ts`、`session/prompt.ts`、`session/message-v2.ts`、`session/index.ts`、`provider/error.ts`、`session/retry.ts`、`config/config.ts` 等）确认是否已覆盖，而非假设覆盖。
+- 高优先项（`display:"summarized"`、`opus47` 检测、`sanitizeSurrogates`、tools 排序、position-based turn detection）已在当前 HEAD 用 grep 二次复核确认确实缺失。
+
+## 关键结论（先读）
+
+1. **架构鸿沟扩大。** 上游本窗口把 `session/llm.ts`、`provider/provider.ts`、`session/prompt.ts`、`compaction.ts`、`summary.ts` 全面迁到 Effect `Service`/`Layer` + `@opencode-ai/core` monorepo 拆分 + SQL/Drizzle session store，并新增 `@opencode-ai/llm` 原生运行时包。Aether 仍是 pre-Effect 的 `namespace` + 直接 bundle `@ai-sdk/*` 形态。**因此绝大多数上游 patch 无法逐行 cherry-pick，只能按行为语义回迁。**
+2. **AI SDK 代际差。** Aether 在 AI SDK **v5** 线（`ai 5.0.124`、`@ai-sdk/google 2.x`、`google-vertex 3.x`、`bedrock 3.x`、`xai 2.x`、`mistral 2.x`），上游已在 **v6**。所有「bump 某 provider SDK」类提交都被这个代际差阻塞，归入 v6 迁移专项。
+3. **有 5 个真正可立即回迁、且当前确实未覆盖的行为修复**（不依赖 Effect/v6）：`LLM-UP-018` 双重压缩、`LLM-UP-016` Opus 4.7+ `display:"summarized"`、`LLM-UP-019` 代理项 surrogate、`LLM-UP-020` tools 排序、`LLM-UP-017` 签名 reasoning 保留。建议作为第一批（与下文「优先回迁建议」第一批、「结论」一致）。
+4. **有 1 个高风险「反向冲突」项：** 上游 `2f2fcc165`（删除自动 session diff）与 Aether 本地 `bafdfb6d2`（修好并保留自动 diff）意图相反，**禁止回迁**。05-04 快照未覆盖此冲突，本报告首次澄清。
+5. **`LLM-UP-015`（Copilot V2 SDK）确认永远不会由上游修复** —— 上游根本没有 vendored 的 `provider/sdk/` 目录，整套 Copilot SDK 是 Aether 自有，必须自行排期。
+
+---
+
+## 新增候选项
+
+| 编号 | 优先级 | 上游 commit/PR | 变更主题 | 影响 provider/model | 当前 Aether 状态 | 建议动作 | 风险 | 验收命令 |
+|------|--------|----------------|----------|---------------------|------------------|----------|------|----------|
+| LLM-UP-016 | P0 | `05e3c4ece`/`#29769`、`b956e9a06`/`#29911`、`3070b0f4a`/`#30027`、`f4f508e65`/`#29991` | Opus 4.7+ adaptive reasoning：① `anthropicOpus47OrLater` 泛化「≥4.7/未来 major」检测，覆盖 Vertex `@` 后缀与 SAP 反序 `claude-4.7-opus`/`4.6-opus`；② 在 anthropic / vertex-anthropic / bedrock / gateway / sap-ai-core 全部 adaptive 分支强制 `display:"summarized"` | Anthropic Opus 4.7+（直连 / Bedrock / Vertex / CF Gateway / SAP AI Core） | **未覆盖**。`transform.ts:414` 仅字面匹配 `opus-4-7`/`opus-4.7`；`display:"summarized"` 全文件 0 命中（已复核）。后果：Opus 4.7+ API 默认 `omitted`，Aether 将收到**空 thinking 块**；SAP/Vertex 命名变体甚至不被识别为 adaptive | 回迁（机械）：移植 `anthropicOpus47OrLater` 正则 + 给四个 adaptive 分支加 `display:"summarized"`。四个分支 Aether 都已存在 | 中：用户可见的 reasoning 摘要丢失 + 漏检 adaptive | `cd packages/opencode && bun test test/provider/transform.test.ts` |
+| LLM-UP-017 | P1 | `233fc5b91`/`#21370`、`4e14f7951`/`#26276`（reasoning 半） | 含签名 reasoning 时保留 assistant 内容：① `normalizeMessages` 保留带 `anthropic/bedrock.signature` 或 `.redactedData` 的空 reasoning 块；② `toModelMessages` 对带签名 reasoning 的 assistant，空 text 替换为 `" "`，避免 SDK 过滤掉分隔符导致签名位移 | Anthropic / Bedrock adaptive thinking 多轮 | **未覆盖**。`transform.ts:108-111` 仍是旧 `part.text !== ""` 直接丢弃空 reasoning；`message-v2.ts:703-709` 无 `hasSignedReasoning` 逻辑 | 回迁（小、自洽）：两段一起改 | 中：丢弃签名 reasoning 会触发 Anthropic/Bedrock 签名位置 400 | `cd packages/opencode && bun test test/provider/transform.test.ts test/session/message-v2.test.ts` |
+| LLM-UP-018 | P0 | `94564f358`/`#27545` | 防 filterCompacted 重排导致的双重自动压缩：新增 `MessageV2.latest(msgs)` 按 **max MessageID** 而非数组位置推导 latest user/assistant/finished/tasks | 所有会自动压缩的 session | **未覆盖（真实潜在 bug）**。`filterCompacted`（`message-v2.ts:899-915`）做了 `reverse()` + 提前 `break`，数组非时序；而 `prompt.ts:311` 仍用 `for (let i = msgs.length-1; ...)` 位置扫描（已复核）。压缩后会把溢出尾部的旧 assistant 误判为最新轮 → 重复压缩 | 回迁行为：在 Aether 的 plain-async 循环里按 max-id 推导 latest，并补回归测试（溢出尾部 + 压缩） | 中：触及核心循环 turn 判定 | `cd packages/opencode && bun test test/session/llm.test.ts test/session/compaction.test.ts` |
+| LLM-UP-019 | P1 | `6409aceb1`/`#25934` | `sanitizeSurrogates`：把落单 UTF-16 代理项替换为 `�`，在 `normalizeMessages` 对 system/user/assistant text+reasoning 与 tool-result 输出统一清洗 | 所有 provider | **未覆盖**。`transform.ts` 无 `sanitizeSurrogates`/surrogate 正则（已复核） | 回迁（机械）：把 helper 拼进 Aether `normalizeMessages` | 低：纯清洗，只改本就非法的字符串 | `cd packages/opencode && bun test test/provider/transform.test.ts` |
+| LLM-UP-020 | P1 | `83bb21648`/`#26370` | tools 始终按名排序：`Object.entries(tools).toSorted(...)` 后用于 `tools`/`activeTools`/`experimental_repairToolCall` 查找/预批准 | 所有 provider（对 prompt cache 敏感） | **未覆盖**。`llm.ts:330` `activeTools: Object.keys(tools)` 未排序；repair 查找也未排序（已复核） | 回迁（小、低风险）：排序一次后复用 | 低：首次部署可能一次性 cache miss，之后更稳定 | `cd packages/opencode && bun test test/session/llm.test.ts` |
+| LLM-UP-021 | P1 | `c2b1ebd9d`/`#27184` | 分层定价：把二元 `experimentalOver200K` 泛化为 `cost.tiers[]`（按 context token size 选最高匹配档），`getUsage` 选档逻辑 + `models.ts`/`provider.ts` schema | 所有发布 tiered pricing 的模型 | **未覆盖**。`index.ts:1883-1886` 仍只有二元 `experimentalOver200K`；schema 无 `tiers`/`ProviderCostTier` | 回迁行为：给 Zod cost schema 加 `tiers` + `getUsage` 选档；**务必保留** Aether 的 OpenRouter/Anthropic cache-token 调整（`index.ts:1850-1857`）与自有 `total` 计算 | 中：仅成本准确性，无 abort 风险；与 cache 调整交互需测试 | `cd packages/opencode && bun test test/session/compaction.test.ts` |
+| LLM-UP-022 | P1 | `ca77b8f8e`/`#25573`（含 `#24432`） | cf-ai-gateway：① `sdkKey()` 加 `ai-gateway-provider → "openaiCompatible"`；② `variants()` 加 `ai-gateway-provider` 分支（openai 上游走 `openaiReasoningEfforts`，其余走 `WIDELY_SUPPORTED_EFFORTS`） | Cloudflare AI Gateway（`ai-gateway-provider`，已是 Aether 依赖 `2.3.1`） | **未覆盖**。Aether `sdkKey()` 无 `ai-gateway-provider` case；`variants()` 无该分支。属 `LLM-UP-001` 同族但**不同点**（001 是 dotted providerID 取首段；本项是 npm→key 映射 + variants） | 回迁（加性、架构无关）：补 `sdkKey` case + `variants` 分支，复用 Aether 现有 efforts 常量 | 低：不回迁则 CF gateway 用户拿到 deprecation key 或错配 reasoning 选项 | `cd packages/opencode && bun test test/provider/transform.test.ts` |
+| LLM-UP-023 | P1 | `c1f607d20`/`#25721` | `selectAzureLanguageModel`：fallback 链 `chat→responses→messages→chat→languageModel`，新增 `messages` 分支让 Anthropic SDK（暴露 `.messages`）在 Azure 下能 resolve | Azure（尤其 Azure 托管 Anthropic） | **未覆盖**。`provider.ts:304-306`、`321-323` 仍是旧 `useLanguageModel→useCompletionUrls?chat:responses`，无 `sdk.messages` 兜底 | 回迁（机械，1:1 映射到两处 azure loader） | 中：Azure+Anthropic 无法 resolve model | `cd packages/opencode && bun test test/provider/provider.test.ts` |
+| LLM-UP-024 | P1 | `967557979`/`#26222` | Azure gpt-5.5 走 completions API：`options()` 早返回——`npm==="@ai-sdk/azure" && id.includes("gpt-5.5")` 时只设 `reasoningSummary:"auto"`，避免 `reasoning_effort` 400 | Azure gpt-5.5 | **未覆盖**。`options()`（`transform.ts:890-915`）有 gpt-5 块但无 gpt-5.5 / azure 短路；gpt-5.5 on Azure 会落入通用分支拿 `reasoningEffort` 而 400 | 回迁（小、自洽）：加 azure+gpt-5.5 早返回 | 中：Azure gpt-5.5 请求失败；修复本身低风险 | `cd packages/opencode && bun test test/provider/transform.test.ts` |
+| LLM-UP-025 | P1 | `797c689ec`/`#15110` | Vertex AI 给 `GoogleAuth` 传 OAuth scopes：`new GoogleAuth({scopes:["…/cloud-platform"]})` + `getClient()` + `client.getAccessToken()` 取代旧 `getApplicationDefault()`/`credential.getAccessToken()` | Google Vertex（custom fetch token 铸造） | **未覆盖**。`provider.ts:531-533` 仍是旧无 scope 形态 | 回迁（小、架构无关，`provider.ts` 半 1:1） | 中：部分 Vertex 配置 ADC token 铸造失败/scope 不足；修复低风险 | `cd packages/opencode && bun test test/provider/provider.test.ts` |
+| LLM-UP-026 | P2 | `7a9724496`/`#28347` | Vertex 大洲级 multi-region：`location` ∈ {`eu`,`us`} 且有 project 且无 baseURL 时注入 `https://aiplatform.{loc}.rep.googleapis.com/...`（默认 `{region}-aiplatform.googleapis.com` 对大洲多区不解析） | Google Vertex（Anthropic 模型） | **未覆盖**。Aether 内联 vertex loader 的 `GOOGLE_VERTEX_ENDPOINT` 无 `.rep.googleapis.com` 特例 | 回迁（适配内联 loader）：加 `eu`/`us` 分支 | 中：仅影响 `location=eu/us` 用户，触发面窄 | `cd packages/opencode && bun test test/provider/provider.test.ts` |
+| LLM-UP-027 | P1 | `c7e1fc5e4`/`#29837`（+ `14e0b9b17` 共享半） | 可重试的 SSE 卡死：`wrapSSE` chunk-timeout 抛 `ProviderError.ResponseStreamError` 并在 `message-v2.ts` 映射为可重试 `APIError` | 任何用 SSE + `chunkTimeout` 的 provider（实践中 OpenAI 默认路径） | **未覆盖**。Aether `wrapSSE`（`provider.ts:76`）仍抛裸 `new Error("SSE read timed out")`，无 `ResponseStreamError` 类、无重试映射；卡死 SSE 不可靠重试 | 回迁（适配 Aether 命令式 retry 循环，非上游 Effect policy）。**与 `LLM-UP-013` 的 SSE-timeout 本地层互补、非冲突**——本地负责触发超时，上游让结果可重试 | 低：自洽，唯一行为变化是卡死流改为重试 | `cd packages/opencode && bun test test/session/llm.test.ts test/provider/provider.test.ts` |
+| LLM-UP-028 | P2 | `25ecf0af6`/`#25888` | 重试 `server_is_overloaded` 错误（上游在 `parseStreamError` 让其 fall through 到 `server_error`→可重试） | 流错误体含 `code:"server_is_overloaded"` 的 provider（zen / opencode gateway） | **未覆盖**。Aether `error.ts:116` 的 `parseStreamError` 是改写版、无 `server_error` 分支；`retry.ts` 的字符串启发式也不匹配字面 `server_is_overloaded`（匹配的是 `Overloaded`/`exhausted`/`unavailable`/`rate_limit`/`too_many_requests`） | 回迁（Aether 专属位置）：在 `retry.ts` `retryable()` 加 `server_is_overloaded`/`server_error` 识别 | 低 | `cd packages/opencode && bun test test/session/retry.test.ts` |
+| LLM-UP-029 | P2 | `f965db9e1`/`#29484` | 新增 `headerTimeout` provider 配置（独立于 `timeout`/`chunkTimeout`）：响应头超时则用 `HeaderTimeoutError` abort，OpenAI 默认 10s，映射为可重试 | 全 provider 可选，OpenAI 默认开 | **未覆盖**。`config.ts:1094` 仅 `timeout`+`chunkTimeout`，无 `headerTimeout`/`timeoutController`/`HeaderTimeoutError` | 回迁选项到 Aether 的 **Zod** schema（非 Effect Schema）+ timeoutController + 映射重试。**建议 OpenAI 10s 默认设为关闭或可调**，避免国内慢网关/代理（LLM-UP-013）误 abort | 中：默认 10s 在代理后可能误 abort | `cd packages/opencode && bun test test/config` |
+| LLM-UP-030 | P2 | `319498e2f`/`#26273` | OpenAI deep-research 限定 effort 为 `["medium"]` | OpenAI `*-deep-research` | **未覆盖**。`transform.ts` 无 `deep-research` 字样；会给全 effort 菜单 → 不支持档 400 | 回迁（一行级）：在 openai/openrouter 内联块加 `deep-research → medium` 守卫 | 低（仅当暴露 deep-research 模型） | `cd packages/opencode && bun test test/provider/transform.test.ts` |
+| LLM-UP-031 | P1 | `eb84f461b`/`#29000`（opencode 半） | `options()` 给 `@ai-sdk/openai` GPT-5 也加 `include:["reasoning.encrypted_content"]`（原先只在 `providerID.startsWith("opencode")` 分支有），修 `store:false` 无状态多轮 reasoning | OpenAI GPT-5（`@ai-sdk/openai` 直连） | **未覆盖（opencode 半）**。`transform.ts:891-895` 直连 GPT-5 路径只设 effort/summary，无 `include`。`packages/llm` 原生半不适用（Aether 无该包） | 回迁 `options()` 一行；跳过 `packages/llm`/`native-runtime` 部分 | 低-中：直连 GPT-5 无状态 reasoning 续传可能丢加密状态 | `cd packages/opencode && bun test test/provider/transform.test.ts` |
+| LLM-UP-032 | P3 | `d34a0194e`/`#27394` | NVIDIA endpoints 加 `X-BILLING-INVOKE-ORIGIN: OpenCode` header | NVIDIA | **未覆盖**。Aether 无 NVIDIA plugin handler，仅 provider 列表项 | 若 Aether 支持 NVIDIA 则回迁（小）；否则暂缓 | 低：仅 billing 归因，不影响请求 | 不适用 |
+| LLM-UP-033 | P2（专项/暂缓） | `dbe36851b`/`#27114`、`6618e2bce`/`#28271`、`8a321c453`、`61390dbb4`/`#28678`、`facd20739`/`#28571`、`41f6daf96`/`#28523`、`fb9d69ef6`/`#28560`、`a9c115c22` | **native LLM runtime 栈**：新增 `@opencode-ai/llm` 包绕过 AI SDK，直连 provider 协议（openai-responses/anthropic-messages/...），由 `OPENCODE_EXPERIMENTAL_NATIVE_LLM` 开关，**默认关闭**，仅 OpenAI/Anthropic/opencode API-key 模型走原生，其余回落 AI SDK | OpenAI / Anthropic API-key / OpenAI OAuth | **未覆盖且不可移植**。依赖 Effect `Service`/`Layer` 的 `llm.ts`/`provider.ts` + `@opencode-ai/core` 拆分 + 40+ 文件新包，Aether 全无。`61390dbb4`（native 续传 metadata）已评估**不值得单独 cherry-pick**——其 bug 只存在于 native 协议实现，Aether 的 AI SDK 路径不会触发 | 整体暂缓，作为大型架构迁移专项；**不 cherry-pick 任何子项**。`a9c115c22` 纯 cosmetic、不适用 | 迁移高 / 暂缓低（上游默认关，无功能损失） | 不适用 |
+| LLM-UP-034 | P2（专项/暂缓） | `62da1e768`/`#29477`、`14e0b9b17`/`#29673`（WS 半） | OpenAI responses-over-WebSocket 传输：新 `plugin/openai/{ws,ws-pool}.ts`、`OPENCODE_EXPERIMENTAL_WEBSOCKETS` flag、按 channel 分级 rollout | OpenAI / Codex responses API | **未覆盖**。Aether 是扁平 `plugin/codex.ts`，无 ws 传输 / runtime flag / ws-pool | 暂缓（新实验特性，非修复）。需引 `ws` 依赖 + 重构 plugin 目录 + 与本地 proxy 层交互 | 工作量高 / 行为风险中 | 不适用 |
+| LLM-UP-035 | P3（feature/暂缓） | `36d40fee4`/`#26644`、`3dc2c1d81`/`#27094` | session 级累计 usage totals（cost + tokens 持久化到 session 行）；usage delta 更新不 bump `time_updated` | TUI/SDK usage 展示 | **不适用为 port**。依赖上游 SQL/Drizzle session store + migration；Aether 无对应存储（`Session` 在 `index.ts`，projector 非 SQL） | 当作可选产品功能；若需要则基于 Aether 存储原生实现，不 port migration | 不适用（非 bugfix） | 不适用 |
+
+### 暂缓 / 跳过（不单列编号）
+
+- **AI SDK v5→v6 迁移专项（阻塞一批 bump）**：`d16bfe850`（bedrock 4.x）、`61e7cdfbf`（google/vertex thought signatures）、`a5ba1d075`（venice，Aether 无此依赖）、`28dbd4ab4` + `87e9e700c`（google tool-id 回归 **pin 约束**：未来 v6 迁移须落在 `@ai-sdk/google ≤3.0.73` / `vertex ≤4.0.128`）、`e00a62e46` + `6c24062d2`（gitlab，Aether 用不同 packaging）、`4487fbf52`（xAI PDF，且 Aether `message-v2` 无 per-npm 附件 gate）。这些都因 v5/v6 代际差无法单独 bump。
+- **`576480b5d`（mistral medium 3.5 variants）**：Aether `variants()` 的 `@ai-sdk/mistral` 直接 `return {}`，无 `MISTRAL_REASONING_IDS` 可扩展，上游改动对 Aether 是 no-op。keep-local。
+- **`1cf8123bc`（GPT-5 reasoning variant helpers）、`c36ab3f93`（Gemini thinking controls helpers）、`e0396b809`（Opus 4.5 `{effort}` 分支）**：Aether 用内联 `iife` 策略，已覆盖常见档位；仅当 Aether 实际上架对应子模型（gpt-5-chat / codex-v3 / versioned-pro / gemini-3 flash-image|pro-image / Opus 4.5 新 effort API）时**选择性**回迁对应小分支，否则 keep-local。
+- **`4e14f7951`（Bedrock 附件 per-mime 拆分半）**：Bedrock 图片可入 tool result、PDF 不可；仅当 Aether 服务 Bedrock 多模态 tool result 时回迁。
+- **`799996db7`（TUI provider-specific retry 对话框）**：依赖上游 Effect `Retryable.action` 机制 + Go-upsell UX，Aether `retryable()` 返回纯字符串，结构不兼容。**跳过**。
+- **`ca28dd02e`/`2d0d3d596`/`811954880`（compaction tail 保留）**：Aether 从未采用 `tail_start_id`，是「summarize + 可选 replay」模型，**不适用**。其中 `2d0d3d596` 的「summary 消息只贡献 text」一行守卫可作为廉价保险，价值低。
+- **`748fcb7eb`（孤儿中断 tool 排除）、`e76cf967e`（finalize 中断 assistant）、`75d141b57`（取消子任务 session）**：上游 Effect 循环 / Effect interrupt 专属；Aether 的 plain-async 循环 + `SessionRecovery.repairSession` + `SessionPrompt.cancel` 已覆盖或使其失效。**仅需抽查**：`repairSession` 在 abort 后是否总会盖上 `time.completed` + aborted error；父 abort 是否传播到子 task session。
+
+### ⚠️ 反向冲突（禁止回迁）
+
+- **`2f2fcc165`/`#30127`（删除自动 full session diff）与 Aether `bafdfb6d2` 意图相反。** 上游让 `Session.diff` 返回 `[]`、`summarize` 不算 diff、改读 `message.info.summary?.diffs`、删 `Storage` 依赖；而 Aether `bafdfb6d2` 是**修好并保留**自动 diff（顺序无关指纹去重、`setSummary`/`Storage.write`/`Bus.publish` 一起 gate、`invalidate` 同步、`Session.Event.Deleted` 订阅）。Aether `summary.ts:92-191` 仍读写 `["session_diff", ...]` 并算 `Snapshot.diffFull`。**盲目回迁会删掉 `bafdfb6d2` 修好的机制、重新引入闪烁/陈旧并打断 review 面板。**
+  - **05-04 快照（91 行历史版）未记录此项**：`bafdfb6d2` 与 `2f2fcc165` 仅在 `providerExecuted` 半不重叠；**`session.diff` 半是重叠且冲突的**，由本报告首次澄清。
+
+---
+
+## 对既有项（LLM-UP-001 ~ 015）的状态更新
+
+- **LLM-UP-001（OpenAI-compatible dot provider key split）**：新增 `LLM-UP-022`（cf-ai-gateway `sdkKey`/variants）是同族延伸，**不重复**——001 是 dotted providerID 取首段，022 是 `ai-gateway-provider` 这个 npm → `openaiCompatible` key 映射 + variants 分支。
+- **LLM-UP-004（5xx retry）**：措辞需收紧。`error.ts` 中**没有字面 `statusCode >= 500` 判断**；可重试性走 `parseAPICallError`→`isRetryable`/`isOpenAiErrorRetryable`（后者只额外加 404 + `e.isRetryable`）。语义大体成立但原文「已对 statusCode >= 500 放行」过度具体。另：`server_is_overloaded`（见 `LLM-UP-028`）当前**不会**被 Aether 逻辑捕获。
+- **LLM-UP-012（Copilot GPT-5 variants）**：新增可选子项 `ae92f3158`（Copilot token-based billing，`copilot_usage.total_nano_aiu`）。纯 usage/metadata、不动 SDK、不影响 tool-call 解析。**未覆盖**且依赖上游 `session/llm/ai-sdk.ts` 架构，不可直接 port；如需 AIU 计费可见性，按概念在 Aether 自有 adapter 重实现，否则暂缓。
+- **LLM-UP-013（Aether 本地兼容层）**：
+  - `reasoningSummary` npm-guard **已与上游收敛**——上游 `7f7eb2e7f` 删掉 guard，Aether `transform.ts:891-894` 本就无 guard（无条件注入），两边一致。
+  - LiteLLM `_noop` dummy tool 是**刻意 keep-local**：上游 `7f7eb2e7f` 以「LiteLLM ≥ v1.85.0-rc.2 已服务端修复」为前提删除了 LiteLLM 侧 `_noop`，但 Aether 面向常为旧 LiteLLM 或非 LiteLLM 的国内 OpenAI-compatible 网关，**必须保留**。注意 Aether `llm.ts:253-266` 的 `_noop` 是 **LiteLLM-only**，而当前上游保留的是 **Copilot-only**——两者恰好互为反向。若 Copilot chat 路径压缩时也撞「history 有 tool call 时必须带 tools」校验，可针对性给 Aether 条件补 `|| providerID.includes("github-copilot")`（与 LiteLLM 决策独立）。
+  - 上游 `c7e1fc5e4`（SSE 可重试，见 `LLM-UP-027`）建立在 Aether 本地 SSE-timeout 层**之上**，互补非冲突；`headerTimeout`（`LLM-UP-029`）是相邻但不同的超时，需单独标记。
+- **LLM-UP-015（Copilot V2 SDK 两缺陷）**：**确认永久 Aether-only**。上游 `28112fbd1..687c66248` 内 `provider/sdk/copilot/**` 无任何提交，且**上游根本没有 `provider/sdk/` 目录**——整套 Copilot SDK 是 Aether vendored，上游用 stock `@ai-sdk/github-copilot`。故首 delta `id` 严格抛错与 V2→V3 中间件失效永不会由上游修复。当前现状未变：`chat/openai-compatible-chat-language-model.ts:519-532` 仍严格抛 `InvalidResponseDataError`，`:54` 与 `responses/openai-responses-language-model.ts:132` 仍 `specificationVersion="v2"`。`memory_list` 等 chat 路径 tool 调用仍会 abort。**需 Aether 自行排期**：短期放宽首 delta 解析（id+name 同缺时占位等下帧），长期把 SDK 升到 `LanguageModelV3` 让 v6 中间件复生效。
+
+---
+
+## 优先回迁建议
+
+**第一批（行为修复，不依赖 Effect/v6，当前确实未覆盖，已 grep 复核）：**
+
+1. `LLM-UP-018` 双重自动压缩（P0，核心循环潜在 bug）
+2. `LLM-UP-016` Opus 4.7+ `display:"summarized"` + 泛化检测（P0，用户可见 reasoning 丢失）
+3. `LLM-UP-019` surrogate 清洗（P1，机械）
+4. `LLM-UP-020` tools 排序（P1，机械，利于 cache）
+5. `LLM-UP-017` 签名 reasoning 保留（P1，与 016 同属 Anthropic adaptive 可靠性）
+
+**第二批（provider 专项小修，架构无关）：**
+
+6. `LLM-UP-022` cf-ai-gateway key/variants（P1）
+7. `LLM-UP-023` Azure Anthropic resolve（P1）
+8. `LLM-UP-024` Azure gpt-5.5 completions（P1）
+9. `LLM-UP-025` Vertex GoogleAuth scopes（P1）
+10. `LLM-UP-027` 可重试 SSE 卡死（P1）
+11. `LLM-UP-031` 直连 GPT-5 加密 reasoning include（P1）
+12. `LLM-UP-021` 分层定价（P1/P2，成本准确性）
+
+**第三批（小/触发面窄）：** `LLM-UP-026`、`LLM-UP-028`、`LLM-UP-029`（默认关）、`LLM-UP-030`、`LLM-UP-032`。
+
+**专项 / 暂缓：** `LLM-UP-033`（native runtime）、`LLM-UP-034`（OpenAI WS）、`LLM-UP-035`（usage totals）、AI SDK v6 迁移、Copilot SDK（`LLM-UP-012`/`LLM-UP-015`）。
+
+**禁止回迁：** `2f2fcc165`（与 `bafdfb6d2` 反向冲突）。
+
+## 验收建议
+
+第一批落地后从 package 目录运行：
+
+```bash
+cd /home/fyl/opencode/packages/opencode
+bun typecheck
+bun test test/provider/transform.test.ts
+bun test test/session/message-v2.test.ts
+bun test test/session/llm.test.ts
+bun test test/session/retry.test.ts
+bun test test/session/compaction.test.ts
+```
+
+声称修复真实 provider 时：
+
+```bash
+cd /home/fyl/opencode/packages/opencode
+OPENCODE_SYSTEM_TEST=1 bun run test:system:llm:p0 -- --provider deepseek
+OPENCODE_SYSTEM_TEST=1 bun run test:system:llm:p0 -- --provider alibaba-cn --input p1-reasoning --p1
+# Opus 4.7+ adaptive（LLM-UP-016）、Azure Anthropic（LLM-UP-023）等需真实 provider 单独 smoke
+```
+
+## 结论
+
+本轮窗口（`28112fbd1..687c66248`，220 个相关提交）上游主线是 Effect/`@opencode-ai/core`/SQL store/native-runtime/AI SDK v6 的架构迁移，**绝大多数无法逐行回迁**。但从中剥离出 **16 个值得跟进的行为差异点（`LLM-UP-016 ~ 031`）**，其中 5 个是当前确实未覆盖、架构无关、可立即作为第一批回迁的行为修复（`016/017/018/019/020`）。
+
+同时确认了一处必须守住的反向冲突（`2f2fcc165` vs `bafdfb6d2`），并把 `LLM-UP-015`（Copilot SDK）定性为永久 Aether-only 自维护项。native runtime、OpenAI WS、usage totals、AI SDK v6 与 Copilot SDK 升级仍各自开专项评估。


### PR DESCRIPTION
### Issue for this PR

Closes #994

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds two upstream-diff tracking reports under `docs/llm-upstream-diff/`, the first deliverable of the tracking workflow proposed in #994:

- **`llm-upstream-diff-report-2026-05-04.md`** — historical snapshot, candidates `LLM-UP-001 ~ 015`, P0 items re-reviewed at HEAD `b2f150759` and marked as already covered by existing work or local-only compatibility layers.
- **`llm-upstream-diff-report-2026-06-02.md`** — renewal over upstream window `28112fbd1..687c66248` (220 LLM-relevant commits). Adds `LLM-UP-016 ~ 035`, calls out 5 architecture-independent fixes ready as a first batch (`016/017/018/019/020`), flags one reverse-conflict that must NOT be backported (upstream `2f2fcc165` vs local `bafdfb6d2`), and confirms `LLM-UP-015` (Copilot V2 SDK) as a permanent Aether-only item.

Docs only — no runtime code changes. Every "not covered" claim in the 06-02 report was grep-verified against current source.

### How did you verify your code works?

- No code paths changed.
- Re-verified the reports' factual claims with `grep` (e.g. `display:"summarized"` 0 hits, `sanitizeSurrogates` 0 hits, `transform.ts:414` literal opus-4.7 match, `index.ts:1884` still binary `experimentalOver200K`).
- Checked cross-links between the two reports resolve and the "first batch" list is consistent across sections.

### Screenshots / recordings

Not applicable (docs only).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR