### PR TITLE
fix: Electron 桌面端语音转录缺少认证头导致失败

### DIFF
--- a/packages/app/src/components/voice-input-button.tsx
+++ b/packages/app/src/components/voice-input-button.tsx
@@ -7,6 +7,7 @@ import { useLanguage } from "@/context/language"
 import { useSettings } from "@/context/settings"
 import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
+import { useServer } from "@/context/server"
 import { useParams } from "@solidjs/router"
 import { createVoiceRecorder, type VoiceRecorderState } from "@/utils/voice-recorder"
 import { transcribeAudio } from "@/utils/voice-transcription"
@@ -33,6 +34,7 @@ export const VoiceInputButton: Component<VoiceInputButtonProps> = (props) => {
   const sdk = useSDK()
   const sync = useSync()
   const params = useParams()
+  const server = useServer()
   const recorder = createVoiceRecorder()
   const [transcribing, setTranscribing] = createSignal(false)
   let abortController: AbortController | null = null
@@ -124,6 +126,10 @@ export const VoiceInputButton: Component<VoiceInputButtonProps> = (props) => {
       }
 
       abortController = new AbortController()
+      const cur = server.current
+      const auth = cur?.http?.password
+        ? { Authorization: `Basic ${btoa(`${cur.http.username ?? "opencode"}:${cur.http.password}`)}` }
+        : undefined
       const text = await transcribeAudio({
         serverUrl: sdk.url,
         providerID,
@@ -131,6 +137,7 @@ export const VoiceInputButton: Component<VoiceInputButtonProps> = (props) => {
         audioBlob,
         conversationContext: getConversationContext(),
         signal: abortController.signal,
+        headers: auth,
       })
 
       props.onTranscription(text)

--- a/packages/app/src/utils/voice-transcription.ts
+++ b/packages/app/src/utils/voice-transcription.ts
@@ -5,6 +5,7 @@ export interface TranscriptionOptions {
   audioBlob: Blob
   conversationContext?: Array<{ role: string; content: string }>
   signal?: AbortSignal
+  headers?: Record<string, string>
 }
 
 function blobToBase64(blob: Blob): Promise<string> {
@@ -36,7 +37,7 @@ export async function transcribeAudio(options: TranscriptionOptions): Promise<st
 
   const response = await fetch(`${serverUrl}/voice/transcribe`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...options.headers },
     body: JSON.stringify({
       providerID,
       modelID,


### PR DESCRIPTION
### Issue for this PR

Closes #997

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Electron sidecar 启动时生成随机密码，但语音转录请求未携带 Authorization 头，后端返回 401 导致"Unknown error"。

修改了 2 个文件：
1. `packages/app/src/utils/voice-transcription.ts` — `TranscriptionOptions` 新增可选 `headers` 字段，fetch 请求中展开该字段加入请求头
2. `packages/app/src/components/voice-input-button.tsx` — 从 server context 读取当前连接的 password，构造 `Authorization: Basic` 头传入转录请求

Web 端不受影响（auth 为 `undefined` 时不携带 Authorization 头，行为与之前完全一致）。

### How did you verify your code works?

- turbo typecheck 全部通过（12 successful, 0 errors）
- Web 端不传 password 时 headers 为 undefined，不改变现有行为
- Electron 端传入 auth header 后不再返回 401

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR