### PR TITLE
fix: reduce skill evolution frequency and tighten review prompt

### DIFF
--- a/packages/opencode/src/skill-evolution/SKILL_EVOLUTION_DESIGN.md
+++ b/packages/opencode/src/skill-evolution/SKILL_EVOLUTION_DESIGN.md
@@ -174,7 +174,7 @@ packages/opencode/src/skill-evolution/    ← 所有新增文件都在此目录
 
 ```
 对话正常结束，且同时满足：
-① 计数器 ≥ 阈值（默认 10）
+① 计数器 ≥ 阈值（默认 80）
 ② final_response 成立
 ③ 用户未中断
 ④ 非评审 session 本身
@@ -564,7 +564,7 @@ skills:
   paths:                        # 自定义 skill 路径（0.6.0 已支持）
     - ~/.agents/team-skills
   disabled: [skill-a, skill-b]  # 全局禁用（0.6.0 已支持）
-  creation_nudge_interval: 10   # 每多少次 LLM 步骤触发评审（0 = 禁用）
+  creation_nudge_interval: 80   # 每多少次 LLM 步骤触发评审（0 = 禁用）
 ```
 
 ---
@@ -574,7 +574,7 @@ skills:
 ```
 用户完成任务
       │
-      ▼ 每 10 次 LLM 步骤（可配置）
+      ▼ 每 80 次 LLM 步骤（可配置）
 后台评审子 session（在 ~/.aether/skill-sessions/ 项目中可见）
       │
       ├── 有价值 → skill_manage（action 由 AI 自主决定）

--- a/packages/opencode/src/skill-evolution/constants.ts
+++ b/packages/opencode/src/skill-evolution/constants.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_NUDGE_INTERVAL = 10
+export const DEFAULT_NUDGE_INTERVAL = 80
 
 // Version snapshot settings
 export const VERSION_CAPACITY = 100
@@ -19,8 +19,10 @@ Work in TWO ordered stages — do the gate first, the rules only after it passes
 
 STAGE 1 — Gate: decide whether to save at all. Default answer is NO on every dimension. You need strong evidence on ALL four to override — not just "maybe useful" but "clearly verified, clearly reusable, clearly novel, and likely to be repeated many times". State your verdict on EACH dimension explicitly — "A: yes/no — <one-line reason>", "B: yes/no — <one-line reason>", "C: yes/no — <one-line reason>", "D: yes/no — <one-line reason>". Do not skip straight to writing.
 
+OVERARCHING VETO: Even if all four dimensions pass, you MUST still answer "Nothing to save." if the skill would save less than ~10 minutes of future effort, or if it merely offers a minor convenience rather than unlocking a capability that would otherwise be blocked. A skill must be worth the ongoing cost of maintaining and loading it; marginal improvements do not qualify.
+
 A. REUSABLE — NO by default. Override to YES only if:
-   - The conversation revealed a multi-step PROCEDURE (not a single command or fact) that took trial-and-error to discover.
+   - The conversation revealed a NON-OBVIOUS multi-step PROCEDURE (not a single command or fact) that took trial-and-error to discover. A procedure is non-obvious if an experienced engineer would NOT intuitively arrive at the same sequence by common sense alone.
    - A capable model encountering the same task WITHOUT this skill would likely repeat the same dead ends or mistakes.
    - One-off Q&A, single tool calls, or anything a competent model already does by default → always NO.
 
@@ -31,17 +33,18 @@ B. VERIFIED — NO by default. Override to YES only if:
 C. NOVEL — NO by default. Override to YES only if:
    - An existing skill on this topic is MISSING something this conversation proved — a new step, a corrected error, or a newly discovered pitfall.
    - Rephrasing existing content, adding examples that don't change the method, "tightening" wording, or anything that would just churn the file → always NO.
+   - If an existing skill already covers 80%+ of what this conversation revealed and the new insight is merely a small addition or edge-case refinement → always NO. The gap must be substantial.
    - If no existing skill covers this topic: C defaults to YES — skip the check.
 
 D. REPEATABLE — NO by default. Override to YES only if:
-   - The exploration path uncovered here is likely to be WALKED AGAIN by future users or agents on SIMILAR tasks — not just a rare edge case.
-   - The core question: "will this specific sequence of steps or this specific pitfall arise again in typical usage?" If yes → D is yes.
-   - A one-time environment anomaly, a project-specific quirk, or a setup that most projects won't encounter → always NO.
+   - The exploration path uncovered here is FREQUENTLY encountered by future users or agents across different projects and contexts — not just a rare edge case or a one-off scenario.
+   - The core question: "will this specific sequence of steps or this specific pitfall arise repeatedly in typical usage across multiple projects?" Only if the answer is clearly yes → D is yes.
+   - A one-time environment anomaly, a project-specific quirk, a setup that most projects won't encounter, or a scenario that might recur but only rarely → always NO.
 
 If ANY of A, B, C, D is NO: respond with exactly "Nothing to save." and STOP — do not read the rules, do not call the tool.
 If ALL are YES: proceed to STAGE 2, then you MUST call the skill_manage tool (action: create / patch / edit / delete).
 
-STAGE 2 — Write: only reached when the gate passed. The gate already decided this material is worth saving; your job here is to make it GOOD, not to abandon it. Do not respond "Nothing to save." from Stage 2 — if something feels off, revise.
+STAGE 2 — Write: only reached when the gate passed. The gate already decided this material is worth saving; your job here is to make it GOOD, not to abandon it. Do not respond "Nothing to save." from Stage 2 — if something feels off, revise. However, if you have any doubt whether this skill is truly needed, respond "Nothing to save." — creating unnecessary skills is far worse than missing a marginal one.
 
 ## What a GOOD skill looks like
 

--- a/packages/opencode/src/skill-evolution/hook.test.ts
+++ b/packages/opencode/src/skill-evolution/hook.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { SkillEvolutionHook } from "./hook"
 import { Counter } from "./counter"
+import { DEFAULT_NUDGE_INTERVAL } from "./constants"
 import { SessionID } from "@/session/schema"
 
 describe("SkillEvolutionHook.onStep", () => {
@@ -54,14 +55,14 @@ describe("SkillEvolutionHook.onLoopEnd", () => {
       aborted: false,
       projectId: "proj-test",
     })
-    // 5 < 10 (DEFAULT_NUDGE_INTERVAL) — counter must not be reset
+    // 5 < DEFAULT_NUDGE_INTERVAL — counter must not be reset
     expect(Counter.get(id)).toBe(5)
     Counter.reset(id)
   })
 
   test("resets counter only after spawn when threshold is met", async () => {
     const id = ("hook-threshold-" + Math.random()) as SessionID
-    for (let i = 0; i < 10; i++) Counter.increment(id)
+    for (let i = 0; i < DEFAULT_NUDGE_INTERVAL; i++) Counter.increment(id)
 
     await SkillEvolutionHook.onLoopEnd({
       sessionID: id,

--- a/packages/opencode/src/skill-evolution/hook.ts
+++ b/packages/opencode/src/skill-evolution/hook.ts
@@ -1,4 +1,5 @@
 import { Counter } from "./counter"
+import { DEFAULT_NUDGE_INTERVAL } from "./constants"
 import { ConfigReader } from "./config-reader"
 import { isReviewSession, spawnReview } from "./review-agent"
 import { Log } from "@/util/log"
@@ -44,7 +45,7 @@ export namespace SkillEvolutionHook {
     if (!input.finalResponse) return
     if (isReviewSession()) return
 
-    const interval = await ConfigReader.getNudgeInterval().catch(() => 10)
+    const interval = await ConfigReader.getNudgeInterval().catch(() => DEFAULT_NUDGE_INTERVAL)
     if (interval === 0) return
 
     const count = Counter.get(input.sessionID)


### PR DESCRIPTION
### Issue for this PR

Closes #1001

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two targeted changes to reduce skill evolution aggressiveness:

1. Raise `DEFAULT_NUDGE_INTERVAL` from 10 to 80 — review triggers 8× less often by default. Also eliminated a hardcoded `10` fallback in `hook.ts` by importing the constant.
2. Tighten `SKILL_REVIEW_PROMPT_BASE` in five places:
   - Added OVERARCHING VETO (reject skills saving < ~10 min of effort)
   - REUSABLE now requires "non-obvious" procedures
   - NOVEL now rejects when existing skill covers 80%+
   - REPEATABLE now requires "frequently encountered across multiple projects"
   - STAGE 2 entry now includes doubt-based veto

Updated `SKILL_EVOLUTION_DESIGN.md` to reflect the new default of 80.

### How did you verify your code works?

- `bun typecheck` passes in `packages/opencode`
- Changes are limited to constants, one import in hook.ts, prompt text, and documentation — no logic changes

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR