### PR TITLE
fix: sync SKILL_NUDGE_DEFAULT to 80 in UI, config schema, and docs

### DIFF
--- a/packages/app/src/components/settings-skills.tsx
+++ b/packages/app/src/components/settings-skills.tsx
@@ -4,7 +4,7 @@ import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { SettingsList } from "./settings-list"
 
-const SKILL_NUDGE_DEFAULT = 10
+const SKILL_NUDGE_DEFAULT = 80
 const SKILL_MAX_VERSIONS_DEFAULT = 100
 
 interface SettingsRowProps {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -779,7 +779,7 @@ export namespace Config {
       .int()
       .min(0)
       .optional()
-      .describe("LLM steps without skill_manage before background skill review triggers (default: 10, 0 to disable)"),
+      .describe("LLM steps without skill_manage before background skill review triggers (default: 80, 0 to disable)"),
     max_versions: z
       .number()
       .int()

--- a/packages/opencode/src/skill-evolution/ARCHITECTURE.md
+++ b/packages/opencode/src/skill-evolution/ARCHITECTURE.md
@@ -95,7 +95,7 @@ skill-evolution/
 ├── counter.ts          per-session 步数计数器（模块级 Map）
 │
 ├── config-reader.ts    读取 ~/.aether/skill-evolution-config.json
-│                       字段：creation_nudge_interval（默认 10）
+│                       字段：creation_nudge_interval（默认 80）
 │
 ├── review-agent.ts     后台 review session 的核心
 │                       spawnReview()      — 在 Instance(SKILL_SESSIONS_ROOT) 中
@@ -133,7 +133,7 @@ skill-evolution/
 ├── publisher.ts        发布 skill.saved Bus 事件（通知 UI 刷新）
 │
 └── constants.ts        所有魔法数字/字符串的唯一来源
-                        DEFAULT_NUDGE_INTERVAL = 10
+                        DEFAULT_NUDGE_INTERVAL = 80
                         VERSION_CAPACITY = 100
                         MAX_SCAN_FILES = 50 / MAX_FILE_SIZE = 256KB
 ```


### PR DESCRIPTION
### Issue for this PR

Closes #1001

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

PR #1002 changed `DEFAULT_NUDGE_INTERVAL` from 10 to 80 but missed 4 locations that still referenced the old default of 10:

1. `packages/app/src/components/settings-skills.tsx` — `SKILL_NUDGE_DEFAULT = 10` (root cause of the settings page still showing 10)
2. `packages/opencode/src/config/config.ts` — schema `.describe()` still said "default: 10"
3. `packages/opencode/src/skill-evolution/ARCHITECTURE.md` — two places: "默认 10" and "DEFAULT_NUDGE_INTERVAL = 10"

All four are now updated to 80.

### How did you verify your code works?

- Changes are constant literal and documentation text only, no logic changes
- The settings page default now matches `DEFAULT_NUDGE_INTERVAL` in `constants.ts`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR