### PR TITLE
fix: remove legacy Linux web launcher

### DIFF
--- a/Update/aether_linux_installer.sh
+++ b/Update/aether_linux_installer.sh
@@ -484,7 +484,7 @@ desktop_hint() {
     [ -n "$home" ] || home="$HOME"
   fi
 
-  local launch="$home/Desktop/Aether.sh"
+  local launch="$home/Desktop/aether.desktop"
   if [ -f "$launch" ]; then
     echo "[init] Desktop launcher: $launch"
     return 0

--- a/Update/aether_linux_installer.sh
+++ b/Update/aether_linux_installer.sh
@@ -484,13 +484,13 @@ desktop_hint() {
     [ -n "$home" ] || home="$HOME"
   fi
 
-  local launch="$home/Desktop/aether.desktop"
+  local launch="$home/.local/share/applications/aether.desktop"
   if [ -f "$launch" ]; then
-    echo "[init] Desktop launcher: $launch"
+    echo "[init] Application launcher: $launch"
     return 0
   fi
-  echo "[init] NOTE: Desktop launcher not found: $launch"
-  echo "[init] The local installer should create it; check Desktop permissions if missing."
+  echo "[init] NOTE: Application launcher not found: $launch"
+  echo "[init] The local installer should create it; check application menu integration if missing."
 }
 
 normalize_work() {

--- a/Update/aether_linux_installer_beta.sh
+++ b/Update/aether_linux_installer_beta.sh
@@ -484,7 +484,7 @@ desktop_hint() {
     [ -n "$home" ] || home="$HOME"
   fi
 
-  local launch="$home/Desktop/Aether.sh"
+  local launch="$home/Desktop/aether.desktop"
   if [ -f "$launch" ]; then
     echo "[init] Desktop launcher: $launch"
     return 0

--- a/Update/aether_linux_installer_beta.sh
+++ b/Update/aether_linux_installer_beta.sh
@@ -484,13 +484,13 @@ desktop_hint() {
     [ -n "$home" ] || home="$HOME"
   fi
 
-  local launch="$home/Desktop/aether.desktop"
+  local launch="$home/.local/share/applications/aether.desktop"
   if [ -f "$launch" ]; then
-    echo "[init] Desktop launcher: $launch"
+    echo "[init] Application launcher: $launch"
     return 0
   fi
-  echo "[init] NOTE: Desktop launcher not found: $launch"
-  echo "[init] The local installer should create it; check Desktop permissions if missing."
+  echo "[init] NOTE: Application launcher not found: $launch"
+  echo "[init] The local installer should create it; check application menu integration if missing."
 }
 
 normalize_work() {

--- a/Update/aether_linux_installer_devtest.sh
+++ b/Update/aether_linux_installer_devtest.sh
@@ -483,13 +483,13 @@ desktop_hint() {
     [ -n "$home" ] || home="$HOME"
   fi
 
-  local launch="$home/Desktop/aether.desktop"
+  local launch="$home/.local/share/applications/aether.desktop"
   if [ -f "$launch" ]; then
-    echo "[init] Desktop launcher: $launch"
+    echo "[init] Application launcher: $launch"
     return 0
   fi
-  echo "[init] NOTE: Desktop launcher not found: $launch"
-  echo "[init] The local installer should create it; check Desktop permissions if missing."
+  echo "[init] NOTE: Application launcher not found: $launch"
+  echo "[init] The local installer should create it; check application menu integration if missing."
 }
 
 normalize_work() {

--- a/Update/aether_linux_installer_devtest.sh
+++ b/Update/aether_linux_installer_devtest.sh
@@ -483,7 +483,7 @@ desktop_hint() {
     [ -n "$home" ] || home="$HOME"
   fi
 
-  local launch="$home/Desktop/Aether.sh"
+  local launch="$home/Desktop/aether.desktop"
   if [ -f "$launch" ]; then
     echo "[init] Desktop launcher: $launch"
     return 0

--- a/Update/install.sh
+++ b/Update/install.sh
@@ -820,9 +820,9 @@ if [ -n "$mirror_prune" ] && [ "$mirror_prune" -gt 0 ]; then
   echo "Mirror cleanup: removed $mirror_prune older version directories."
 fi
 if [ -n "$launch" ]; then
-  echo "[install] Desktop launcher: $launch"
+  echo "[install] Application launcher: $launch"
 else
-  echo "[install] Warning: failed to create Desktop launcher."
+  echo "[install] Warning: failed to create application launcher."
 fi
 if [ -n "${copy_note:-}" ]; then
   echo "$copy_note"

--- a/Update/install.sh
+++ b/Update/install.sh
@@ -593,8 +593,10 @@ EOF
   fi
   desk="$home/Desktop"
   mkdir -p "$desk" || return 1
-  cp "$apps/aether.desktop" "$desk/aether.desktop" 2>/dev/null || true
-  chmod +x "$desk/aether.desktop" 2>/dev/null || true
+  if cp "$apps/aether.desktop" "$desk/aether.desktop" 2>/dev/null; then
+    chmod +x "$desk/aether.desktop" 2>/dev/null || true
+    rm -f "$desk/Aether.sh" 2>/dev/null || true
+  fi
   printf "%s" "$apps/aether.desktop"
 }
 

--- a/Update/install.sh
+++ b/Update/install.sh
@@ -593,10 +593,7 @@ EOF
   fi
   desk="$home/Desktop"
   mkdir -p "$desk" || return 1
-  if cp "$apps/aether.desktop" "$desk/aether.desktop" 2>/dev/null; then
-    chmod +x "$desk/aether.desktop" 2>/dev/null || true
-    rm -f "$desk/Aether.sh" 2>/dev/null || true
-  fi
+  rm -f "$desk/Aether.sh" 2>/dev/null || true
   printf "%s" "$apps/aether.desktop"
 }
 

--- a/Update/update_linux.sh
+++ b/Update/update_linux.sh
@@ -910,10 +910,10 @@ launch="$(write_launch "$start_target" || true)"
 debug_log "LAUNCH | launch=${launch:-none}"
 register_protocol "$start_target"
 if [ -n "$launch" ]; then
-  echo "[install] Desktop launcher: $launch"
-  echo "[install] To start Aether, click the Aether icon on your desktop or in your application menu."
+  echo "[install] Application launcher: $launch"
+  echo "[install] To start Aether, click the Aether icon in your application menu."
 else
-  echo "[install] Warning: failed to create Desktop launcher."
+  echo "[install] Warning: failed to create application launcher."
   echo "[install] To start Aether, open $start_target and run Aether.sh."
 fi
 

--- a/Update/update_linux.sh
+++ b/Update/update_linux.sh
@@ -552,14 +552,8 @@ EOF
 
   local desk="$home/Desktop"
   mkdir -p "$desk" || return 1
-  if [ -f "$apps/aether.desktop" ]; then
-    if cp "$apps/aether.desktop" "$desk/aether.desktop" 2>/dev/null; then
-      chmod +x "$desk/aether.desktop" || true
-      debug_log "LAUNCH | copied desktop entry to $desk/aether.desktop"
-      rm -f "$desk/Aether.sh" 2>/dev/null || true
-      debug_log "LAUNCH | removed legacy launcher $desk/Aether.sh if present"
-    fi
-  fi
+  rm -f "$desk/Aether.sh" 2>/dev/null || true
+  debug_log "LAUNCH | removed legacy launcher $desk/Aether.sh if present"
 
   printf "%s" "$apps/aether.desktop"
 }

--- a/Update/update_linux.sh
+++ b/Update/update_linux.sh
@@ -553,9 +553,12 @@ EOF
   local desk="$home/Desktop"
   mkdir -p "$desk" || return 1
   if [ -f "$apps/aether.desktop" ]; then
-    cp "$apps/aether.desktop" "$desk/aether.desktop" 2>/dev/null || true
-    chmod +x "$desk/aether.desktop" || true
-    debug_log "LAUNCH | copied desktop entry to $desk/aether.desktop"
+    if cp "$apps/aether.desktop" "$desk/aether.desktop" 2>/dev/null; then
+      chmod +x "$desk/aether.desktop" || true
+      debug_log "LAUNCH | copied desktop entry to $desk/aether.desktop"
+      rm -f "$desk/Aether.sh" 2>/dev/null || true
+      debug_log "LAUNCH | removed legacy launcher $desk/Aether.sh if present"
+    fi
   fi
 
   printf "%s" "$apps/aether.desktop"

--- a/packages/opencode/test/server/web-update-script.test.ts
+++ b/packages/opencode/test/server/web-update-script.test.ts
@@ -253,8 +253,7 @@ describe("web update scripts", () => {
       expect(desktop).toContain("Name=Aether")
       expect(desktop).toContain(path.join(work, "aether_1.2.7", "Aether.sh"))
       expect(await Bun.file(path.join(home, "Desktop", "Aether.sh")).exists()).toBe(false)
-      const desk = await Bun.file(path.join(home, "Desktop", "aether.desktop")).text()
-      expect(desk).toContain(path.join(work, "aether_1.2.7", "Aether.sh"))
+      expect(await Bun.file(path.join(home, "Desktop", "aether.desktop")).exists()).toBe(false)
     },
     { timeout: 30000 },
   )

--- a/packages/opencode/test/server/web-update-script.test.ts
+++ b/packages/opencode/test/server/web-update-script.test.ts
@@ -231,8 +231,10 @@ describe("web update scripts", () => {
 
       await fs.mkdir(dl, { recursive: true })
       await fs.mkdir(home, { recursive: true })
+      await fs.mkdir(path.join(home, "Desktop"), { recursive: true })
       await ver(cur, "1.2.6")
       await app(src, "linux")
+      await Bun.write(path.join(home, "Desktop", "Aether.sh"), "#!/usr/bin/env bash\nexit 0\n")
       zip(src, out)
       await cp(path.join(update, "update_linux.sh"), script)
 
@@ -250,6 +252,9 @@ describe("web update scripts", () => {
       expect(desktop).toContain("Type=Application")
       expect(desktop).toContain("Name=Aether")
       expect(desktop).toContain(path.join(work, "aether_1.2.7", "Aether.sh"))
+      expect(await Bun.file(path.join(home, "Desktop", "Aether.sh")).exists()).toBe(false)
+      const desk = await Bun.file(path.join(home, "Desktop", "aether.desktop")).text()
+      expect(desk).toContain(path.join(work, "aether_1.2.7", "Aether.sh"))
     },
     { timeout: 30000 },
   )


### PR DESCRIPTION
### Issue for this PR

Closes #1004

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Removes the legacy Linux `~/Desktop/Aether.sh` launcher after successfully writing the current `~/Desktop/aether.desktop` launcher during web install/update flows.

This prevents older desktop scripts from continuing to launch stale Linux web app versions after an automatic update. It also updates Linux installer hints to refer to `aether.desktop` instead of the removed legacy script.

### How did you verify your code works?

- `bun typecheck`
- `bun test test/server/web-update-script.test.ts`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
