### PR TITLE
feat(ci): add workflow to clean up orphan git tags

### DIFF
--- a/.github/workflows/cleanup-orphan-tags.yml
+++ b/.github/workflows/cleanup-orphan-tags.yml
@@ -1,0 +1,65 @@
+name: cleanup-orphan-tags
+run-name: "cleanup orphan tags"
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Only list orphan tags without deleting"
+        required: false
+        default: true
+        type: boolean
+      tag_prefix:
+        description: "Only consider tags starting with this prefix"
+        required: false
+        default: "v"
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    if: github.repository == 'Science-Discovery/Aether'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find and delete orphan tags
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          prefix="${{ inputs.tag_prefix }}"
+
+          gh api "repos/{owner}/{repo}/tags" --paginate \
+            -q '.[].name' | sort > all_tags.txt
+
+          gh api "repos/{owner}/{repo}/releases" --paginate \
+            -q '.[].tag_name' | sort -u > release_tags.txt
+
+          grep "^${prefix}" all_tags.txt > prefixed_tags.txt || true
+
+          comm -23 prefixed_tags.txt release_tags.txt > orphan_tags.txt
+
+          count=$(wc -l < orphan_tags.txt | tr -d ' ')
+          if [ "$count" -eq 0 ]; then
+            echo "No orphan tags found"
+            exit 0
+          fi
+
+          echo "Found $count orphan tag(s):"
+          cat orphan_tags.txt
+
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "Dry run — no tags deleted"
+            exit 0
+          fi
+
+          deleted=0
+          while IFS= read -r tag; do
+            echo "Deleting tag $tag"
+            gh api --method DELETE "repos/{owner}/{repo}/git/refs/tags/$tag" \
+              --silent || echo "::warning::Failed to delete $tag"
+            deleted=$((deleted + 1))
+          done < orphan_tags.txt
+
+          echo "Deleted $deleted orphan tag(s)"


### PR DESCRIPTION
### Issue for this PR

Closes #1006

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

新增 `.github/workflows/cleanup-orphan-tags.yml`，手动触发后查找仓库中没有对应 release（含 draft）的 tag 并删除。

- `dry_run` 输入参数默认为 true，首次运行仅列出孤儿 tag，确认后关闭 dry_run 再执行删除
- `tag_prefix` 输入参数默认为 `v`，仅匹配版本 tag，避免误删 `Features`/`aether-*` 等非版本 tag
- 删除失败仅输出 warning，不阻断流程

### How did you verify your code works?

- 通过 `gh api` 只读命令验证：远端 78 个 tag 中有 61 个无对应 release，其中 56 个以 `v` 开头，5 个为非版本 tag
- workflow 逻辑与现有 `cleanup-draft-releases.yml` 风格一致

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR