### PR TITLE
fix: preserve Opus 4.7+ adaptive thinking summaries

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -406,16 +406,24 @@ export namespace ProviderTransform {
   const WIDELY_SUPPORTED_EFFORTS = ["low", "medium", "high"]
   const OPENAI_EFFORTS = ["none", "minimal", ...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
 
+  function opus47(api: string) {
+    const version = /opus-(\d+)[.-](\d+)(?:[.@-]|$)|claude-(\d+)[.-](\d+)-opus(?:[.@-]|$)/i.exec(api)
+    if (!version) return false
+    const major = Number(version[1] ?? version[3])
+    const minor = Number(version[2] ?? version[4])
+    return major > 4 || (major === 4 && minor >= 7)
+  }
+
   export function variants(model: Provider.Model): Record<string, Record<string, any>> {
     if (!model.capabilities.reasoning) return {}
 
     const id = model.id.toLowerCase()
     const api = `${id} ${model.api.id.toLowerCase()}`
-    const opus47 = ["opus-4-7", "opus-4.7"].some((v) => api.includes(v))
-    const isAnthropicAdaptive = ["opus-4-6", "opus-4.6", "opus-4-7", "opus-4.7", "sonnet-4-6", "sonnet-4.6"].some((v) =>
-      api.includes(v),
-    )
-    const adaptiveEfforts = opus47 ? ["low", "medium", "high", "xhigh", "max"] : ["low", "medium", "high", "max"]
+    const opus = opus47(api)
+    const isAnthropicAdaptive =
+      opus ||
+      ["opus-4-6", "opus-4.6", "4-6-opus", "4.6-opus", "sonnet-4-6", "sonnet-4.6"].some((v) => api.includes(v))
+    const adaptiveEfforts = opus ? ["low", "medium", "high", "xhigh", "max"] : ["low", "medium", "high", "max"]
     if (
       id.includes("deepseek") ||
       id.includes("minimax") ||
@@ -456,6 +464,7 @@ export namespace ProviderTransform {
                 {
                   thinking: {
                     type: "adaptive",
+                    ...(opus ? { display: "summarized" } : {}),
                   },
                   effort,
                 },
@@ -623,6 +632,7 @@ export namespace ProviderTransform {
               {
                 thinking: {
                   type: "adaptive",
+                  ...(opus ? { display: "summarized" } : {}),
                 },
                 effort,
               },
@@ -655,6 +665,7 @@ export namespace ProviderTransform {
                 reasoningConfig: {
                   type: "adaptive",
                   maxReasoningEffort: effort,
+                  ...(opus ? { display: "summarized" } : {}),
                 },
               },
             ]),
@@ -761,6 +772,7 @@ export namespace ProviderTransform {
                 {
                   thinking: {
                     type: "adaptive",
+                    ...(opus ? { display: "summarized" } : {}),
                   },
                   effort,
                 },

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2123,6 +2123,7 @@ describe("ProviderTransform.variants", () => {
       expect(result.xhigh).toEqual({
         thinking: {
           type: "adaptive",
+          display: "summarized",
         },
         effort: "xhigh",
       })
@@ -2551,6 +2552,28 @@ describe("ProviderTransform.variants", () => {
       expect(result.high).toEqual({
         thinking: {
           type: "adaptive",
+          display: "summarized",
+        },
+        effort: "high",
+      })
+    })
+
+    test("vertex opus 4.8 suffix models return summarized adaptive thinking options", () => {
+      const model = createMockModel({
+        id: "google-vertex-anthropic/claude-opus-4-8@default",
+        providerID: "google-vertex-anthropic",
+        api: {
+          id: "claude-opus-4-8@default",
+          url: "https://vertexai.googleapis.com",
+          npm: "@ai-sdk/google-vertex/anthropic",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+      expect(result.high).toEqual({
+        thinking: {
+          type: "adaptive",
+          display: "summarized",
         },
         effort: "high",
       })
@@ -2620,6 +2643,28 @@ describe("ProviderTransform.variants", () => {
         reasoningConfig: {
           type: "adaptive",
           maxReasoningEffort: "xhigh",
+          display: "summarized",
+        },
+      })
+    })
+
+    test("anthropic opus 4.8 returns summarized adaptive reasoning options", () => {
+      const model = createMockModel({
+        id: "bedrock/anthropic-claude-opus-4-8",
+        providerID: "bedrock",
+        api: {
+          id: "anthropic.claude-opus-4.8",
+          url: "https://bedrock.amazonaws.com",
+          npm: "@ai-sdk/amazon-bedrock",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+      expect(result.high).toEqual({
+        reasoningConfig: {
+          type: "adaptive",
+          maxReasoningEffort: "high",
+          display: "summarized",
         },
       })
     })
@@ -2833,6 +2878,27 @@ describe("ProviderTransform.variants", () => {
           type: "adaptive",
         },
         effort: "max",
+      })
+    })
+
+    test("anthropic reversed opus 4.7 models return summarized adaptive thinking variants", () => {
+      const model = createMockModel({
+        id: "sap-ai-core/anthropic--claude-4.7-opus",
+        providerID: "sap-ai-core",
+        api: {
+          id: "anthropic--claude-4.7-opus",
+          url: "https://api.ai.sap",
+          npm: "@jerome-benoit/sap-ai-provider-v2",
+        },
+      })
+      const result = ProviderTransform.variants(model)
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+      expect(result.high).toEqual({
+        thinking: {
+          type: "adaptive",
+          display: "summarized",
+        },
+        effort: "high",
       })
     })
 


### PR DESCRIPTION
### Issue for this PR

Closes #1010

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds Opus 4.7+ detection for Anthropic-style model IDs and sends `display: "summarized"` for adaptive thinking variants.

This covers Anthropic, Vertex Anthropic, Bedrock, Gateway, and SAP AI Core paths, including future Opus versions, Vertex suffix IDs, and SAP reversed IDs such as `claude-4.7-opus`.

### How did you verify your code works?

- `cd packages/opencode && bun test test/provider/transform.test.ts`
- `cd packages/opencode && bun typecheck`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR