### PR TITLE
fix: preserve signed empty reasoning blocks

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -106,8 +106,17 @@ export namespace ProviderTransform {
           }
           if (!Array.isArray(msg.content)) return msg
           const filtered = msg.content.filter((part) => {
-            if (part.type === "text" || part.type === "reasoning") {
+            if (part.type === "text") {
               return part.text !== ""
+            }
+            if (part.type === "reasoning") {
+              return (
+                part.text !== "" ||
+                part.providerOptions?.anthropic?.signature != null ||
+                part.providerOptions?.anthropic?.redactedData != null ||
+                part.providerOptions?.bedrock?.signature != null ||
+                part.providerOptions?.bedrock?.redactedData != null
+              )
             }
             return true
           })

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -700,11 +700,20 @@ export namespace MessageV2 {
           role: "assistant",
           parts: [],
         }
+        const signed = msg.parts.some((part) => {
+          if (part.type !== "reasoning") return false
+          return (
+            part.metadata?.anthropic?.signature != null ||
+            part.metadata?.anthropic?.redactedData != null ||
+            part.metadata?.bedrock?.signature != null ||
+            part.metadata?.bedrock?.redactedData != null
+          )
+        })
         for (const part of msg.parts) {
           if (part.type === "text")
             assistantMessage.parts.push({
               type: "text",
-              text: part.text,
+              text: part.text === "" && signed ? " " : part.text,
               ...(differentModel ? {} : { providerMetadata: part.metadata }),
             })
           if (part.type === "step-start")

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1204,6 +1204,67 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
     expect(result[0].content[0]).toEqual({ type: "text", text: "Answer" })
   })
 
+  test("preserves empty reasoning parts with Anthropic signatures", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "reasoning",
+            text: "",
+            providerOptions: { anthropic: { signature: "sig" } },
+          },
+          { type: "text", text: "Answer" },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, anthropicModel, {})
+
+    expect(result).toHaveLength(1)
+    expect(result[0].content).toHaveLength(2)
+    expect(result[0].content[0]).toEqual({
+      type: "reasoning",
+      text: "",
+      providerOptions: { anthropic: { signature: "sig" } },
+    })
+  })
+
+  test("preserves empty reasoning parts with Bedrock redacted data", () => {
+    const bedrockModel = {
+      ...anthropicModel,
+      id: "amazon-bedrock/anthropic.claude-opus-4-6",
+      providerID: "amazon-bedrock",
+      api: {
+        id: "anthropic.claude-opus-4-6",
+        url: "https://bedrock-runtime.us-east-1.amazonaws.com",
+        npm: "@ai-sdk/amazon-bedrock",
+      },
+    }
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "reasoning",
+            text: "",
+            providerOptions: { bedrock: { redactedData: "data" } },
+          },
+        ],
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, bedrockModel, {})
+
+    expect(result).toHaveLength(1)
+    expect(result[0].content).toHaveLength(1)
+    expect(result[0].content[0]).toEqual({
+      type: "reasoning",
+      text: "",
+      providerOptions: { bedrock: { redactedData: "data" } },
+    })
+  })
+
   test("removes entire message when all parts are empty", () => {
     const msgs = [
       { role: "user", content: "Hello" },

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -681,6 +681,56 @@ describe("session.message-v2.toModelMessage", () => {
     ])
   })
 
+  test("preserves empty text separators when assistant has signed reasoning", () => {
+    const assistantID = "m-assistant"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: assistantInfo(assistantID, "m-parent"),
+        parts: [
+          {
+            ...basePart(assistantID, "p1"),
+            type: "reasoning",
+            text: "",
+            time: { start: 0 },
+            metadata: { anthropic: { signature: "sig-1" } },
+          },
+          {
+            ...basePart(assistantID, "p2"),
+            type: "text",
+            text: "",
+          },
+          {
+            ...basePart(assistantID, "p3"),
+            type: "reasoning",
+            text: "",
+            time: { start: 1 },
+            metadata: { bedrock: { redactedData: "data-1" } },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    expect(MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "reasoning",
+            text: "",
+            providerOptions: { anthropic: { signature: "sig-1" } },
+          },
+          { type: "text", text: " " },
+          {
+            type: "reasoning",
+            text: "",
+            providerOptions: { bedrock: { redactedData: "data-1" } },
+          },
+        ],
+      },
+    ])
+  })
+
   test("drops messages that only contain step-start parts", () => {
     const assistantID = "m-assistant"
 


### PR DESCRIPTION
### Issue for this PR

Closes #1012

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Preserves empty Anthropic/Bedrock reasoning parts when they carry `signature` or `redactedData`, so extended thinking blocks are not dropped before follow-up provider requests.

It also keeps empty assistant text separators as a single space when the message contains signed reasoning, preventing adjacent reasoning blocks from being merged in a way that can invalidate their signatures.

### How did you verify your code works?

- `bun typecheck`
- `bun test test/provider/transform.test.ts test/session/message-v2.test.ts`: 161 pass / 0 fail

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR