### PR TITLE
feat: Electron 语音转录认证头修复与音频文件持久化保存

### DIFF
--- a/packages/app/src/components/voice-input-button.tsx
+++ b/packages/app/src/components/voice-input-button.tsx
@@ -20,7 +20,7 @@ export interface VoiceInputAPI {
 }
 
 export interface VoiceInputButtonProps {
-  onTranscription: (text: string) => void
+  onTranscription: (text: string, audioPath?: string) => void
   onStateChange?: (state: VoiceRecorderState | "transcribing") => void
   class?: string
   style?: JSX.CSSProperties
@@ -130,7 +130,7 @@ export const VoiceInputButton: Component<VoiceInputButtonProps> = (props) => {
       const auth = cur?.http?.password
         ? { Authorization: `Basic ${btoa(`${cur.http.username ?? "opencode"}:${cur.http.password}`)}` }
         : undefined
-      const text = await transcribeAudio({
+      const result = await transcribeAudio({
         serverUrl: sdk.url,
         providerID,
         modelID,
@@ -138,9 +138,11 @@ export const VoiceInputButton: Component<VoiceInputButtonProps> = (props) => {
         conversationContext: getConversationContext(),
         signal: abortController.signal,
         headers: auth,
+        projectID: sync.project?.id,
+        saveAudio: true,
       })
 
-      props.onTranscription(text)
+      props.onTranscription(result.text, result.audioPath)
     } catch (e: unknown) {
       if (e instanceof Error && e.name === "AbortError") return
       console.error("[VoiceInput] Transcription error:", e)

--- a/packages/app/src/components/voice-input-button.tsx
+++ b/packages/app/src/components/voice-input-button.tsx
@@ -7,6 +7,7 @@ import { useLanguage } from "@/context/language"
 import { useSettings } from "@/context/settings"
 import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
+import { useServer } from "@/context/server"
 import { useParams } from "@solidjs/router"
 import { createVoiceRecorder, type VoiceRecorderState } from "@/utils/voice-recorder"
 import { transcribeAudio } from "@/utils/voice-transcription"
@@ -33,6 +34,7 @@ export const VoiceInputButton: Component<VoiceInputButtonProps> = (props) => {
   const sdk = useSDK()
   const sync = useSync()
   const params = useParams()
+  const server = useServer()
   const recorder = createVoiceRecorder()
   const [transcribing, setTranscribing] = createSignal(false)
   let abortController: AbortController | null = null
@@ -124,6 +126,10 @@ export const VoiceInputButton: Component<VoiceInputButtonProps> = (props) => {
       }
 
       abortController = new AbortController()
+      const cur = server.current
+      const auth = cur?.http?.password
+        ? { Authorization: `Basic ${btoa(`${cur.http.username ?? "opencode"}:${cur.http.password}`)}` }
+        : undefined
       const text = await transcribeAudio({
         serverUrl: sdk.url,
         providerID,
@@ -131,6 +137,7 @@ export const VoiceInputButton: Component<VoiceInputButtonProps> = (props) => {
         audioBlob,
         conversationContext: getConversationContext(),
         signal: abortController.signal,
+        headers: auth,
       })
 
       props.onTranscription(text)

--- a/packages/app/src/utils/voice-transcription.ts
+++ b/packages/app/src/utils/voice-transcription.ts
@@ -6,6 +6,13 @@ export interface TranscriptionOptions {
   conversationContext?: Array<{ role: string; content: string }>
   signal?: AbortSignal
   headers?: Record<string, string>
+  projectID?: string
+  saveAudio?: boolean
+}
+
+export interface TranscriptionResult {
+  text: string
+  audioPath?: string
 }
 
 function blobToBase64(blob: Blob): Promise<string> {
@@ -29,8 +36,8 @@ function getAudioFormat(mimeType: string): string {
   return "webm"
 }
 
-export async function transcribeAudio(options: TranscriptionOptions): Promise<string> {
-  const { serverUrl, providerID, modelID, audioBlob, conversationContext, signal } = options
+export async function transcribeAudio(options: TranscriptionOptions): Promise<TranscriptionResult> {
+  const { serverUrl, providerID, modelID, audioBlob, conversationContext, signal, projectID, saveAudio } = options
 
   const audioBase64 = await blobToBase64(audioBlob)
   const audioFormat = getAudioFormat(audioBlob.type)
@@ -44,6 +51,8 @@ export async function transcribeAudio(options: TranscriptionOptions): Promise<st
       audioBase64,
       audioFormat,
       context: conversationContext,
+      projectID,
+      saveAudio,
     }),
     signal,
   })
@@ -56,5 +65,5 @@ export async function transcribeAudio(options: TranscriptionOptions): Promise<st
   const data = await response.json()
   const text = data.text?.trim()
   if (!text) throw new Error("empty")
-  return text
+  return { text, audioPath: data.audioPath }
 }

--- a/packages/app/src/utils/voice-transcription.ts
+++ b/packages/app/src/utils/voice-transcription.ts
@@ -5,6 +5,7 @@ export interface TranscriptionOptions {
   audioBlob: Blob
   conversationContext?: Array<{ role: string; content: string }>
   signal?: AbortSignal
+  headers?: Record<string, string>
 }
 
 function blobToBase64(blob: Blob): Promise<string> {
@@ -36,7 +37,7 @@ export async function transcribeAudio(options: TranscriptionOptions): Promise<st
 
   const response = await fetch(`${serverUrl}/voice/transcribe`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...options.headers },
     body: JSON.stringify({
       providerID,
       modelID,

--- a/packages/opencode/src/persist/naming.ts
+++ b/packages/opencode/src/persist/naming.ts
@@ -79,3 +79,7 @@ export function legacyManagedDir() {
   return managedRoot(LEGACY_APP)
 }
 
+export function voiceDir(projectID: string) {
+  return path.join(Persist.current.data, "voice", projectID)
+}
+

--- a/packages/opencode/src/persist/naming.ts
+++ b/packages/opencode/src/persist/naming.ts
@@ -79,7 +79,6 @@ export function legacyManagedDir() {
   return managedRoot(LEGACY_APP)
 }
 
-export function voiceDir(projectID: string) {
-  return path.join(Persist.current.data, "voice", projectID)
+export function filesDir(projectID: string) {
+  return path.join(Persist.current.data, "files", projectID)
 }
-

--- a/packages/opencode/src/server/routes/voice.ts
+++ b/packages/opencode/src/server/routes/voice.ts
@@ -10,6 +10,8 @@ import { ModelsDev } from "../../provider/models"
 import { ProviderID } from "../../provider/schema"
 import { lazy } from "../../util/lazy"
 import { Log } from "../../util/log"
+import { voiceDir } from "../../persist/naming"
+import { mkdir } from "fs/promises"
 
 const log = Log.create({ service: "voice" })
 
@@ -292,6 +294,18 @@ async function realtime(opts: {
   })
 }
 
+async function saveAudioFile(audioBase64: string, audioFormat: string, projectID: string): Promise<string> {
+  const dir = voiceDir(projectID)
+  await mkdir(dir, { recursive: true })
+  const now = new Date()
+  const ts = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, "0")}${String(now.getDate()).padStart(2, "0")}T${String(now.getHours()).padStart(2, "0")}${String(now.getMinutes()).padStart(2, "0")}${String(now.getSeconds()).padStart(2, "0")}`
+  const ext = audioFormat.replace(/[^a-z0-9]/gi, "") || "webm"
+  const filename = `${ts}.${ext}`
+  const filePath = path.join(dir, filename)
+  await Bun.write(filePath, Buffer.from(audioBase64, "base64"))
+  return filePath
+}
+
 export const VoiceRoutes = lazy(() =>
   new Hono().post(
     "/transcribe",
@@ -306,10 +320,12 @@ export const VoiceRoutes = lazy(() =>
         context: z
           .array(z.object({ role: z.string(), content: z.string() }))
           .optional(),
+        projectID: z.string().optional(),
+        saveAudio: z.boolean().optional(),
       }),
     ),
     async (c) => {
-      const { providerID, modelID, mode, audioBase64, audioFormat, context } =
+      const { providerID, modelID, mode, audioBase64, audioFormat, context, projectID, saveAudio } =
         c.req.valid("json")
       const kind = mode ?? (modelID.includes("asr") ? "asr" : modelID.includes("realtime") ? "realtime" : "omni")
 
@@ -336,7 +352,8 @@ export const VoiceRoutes = lazy(() =>
               setTimeout(() => reject(new VoiceError("Realtime transcription hard timeout", 504)), 35_000),
             ),
           ])
-          return c.json({ text })
+          const audioPath = projectID && saveAudio ? await saveAudioFile(audioBase64, audioFormat, projectID) : undefined
+          return c.json({ text, audioPath })
         } catch (e) {
           const message = e instanceof Error ? e.message : String(e)
           const status = e instanceof VoiceError ? e.status : 500
@@ -458,6 +475,7 @@ export const VoiceRoutes = lazy(() =>
       }
 
       const finalText = text.trim()
+      const audioPath = projectID && saveAudio ? await saveAudioFile(audioBase64, audioFormat, projectID) : undefined
       log.info("voice transcribe result", {
         providerID,
         modelID,
@@ -466,7 +484,7 @@ export const VoiceRoutes = lazy(() =>
         chars: finalText.length,
         text: finalText.slice(0, 500),
       })
-      return c.json({ text: finalText })
+      return c.json({ text: finalText, audioPath })
     },
   ),
 )

--- a/packages/opencode/src/server/routes/voice.ts
+++ b/packages/opencode/src/server/routes/voice.ts
@@ -10,7 +10,7 @@ import { ModelsDev } from "../../provider/models"
 import { ProviderID } from "../../provider/schema"
 import { lazy } from "../../util/lazy"
 import { Log } from "../../util/log"
-import { voiceDir } from "../../persist/naming"
+import { filesDir } from "../../persist/naming"
 import { mkdir } from "fs/promises"
 
 const log = Log.create({ service: "voice" })
@@ -44,7 +44,22 @@ async function pcm(audioBase64: string, audioFormat: string) {
   await Bun.write(input, Buffer.from(audioBase64, "base64"))
   try {
     const proc = Bun.spawn(
-      ["ffmpeg", "-y", "-hide_banner", "-loglevel", "error", "-i", input, "-ar", "16000", "-ac", "1", "-f", "s16le", output],
+      [
+        "ffmpeg",
+        "-y",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        input,
+        "-ar",
+        "16000",
+        "-ac",
+        "1",
+        "-f",
+        "s16le",
+        output,
+      ],
       { stdout: "ignore", stderr: "pipe" },
     )
     const [code, err] = await Promise.all([proc.exited, new Response(proc.stderr).text()])
@@ -124,19 +139,25 @@ function pick(evt: Event) {
   if (evt.type === "response.content_part.done")
     return { kind: "clean", mode: "set", text: evt.part?.text ?? evt.part?.transcript ?? "" }
   if (evt.type === "response.output_item.done")
-    return { kind: "clean", mode: "set", text: evt.item?.content?.map((part) => part.text ?? part.transcript ?? "").join("") ?? "" }
+    return {
+      kind: "clean",
+      mode: "set",
+      text: evt.item?.content?.map((part) => part.text ?? part.transcript ?? "").join("") ?? "",
+    }
   if (evt.type === "response.done")
     return {
       kind: "clean",
       mode: "set",
-      text: evt.response?.output?.flatMap((item) => item.content?.map((part) => part.text ?? part.transcript ?? "") ?? []).join("") ?? "",
+      text:
+        evt.response?.output
+          ?.flatMap((item) => item.content?.map((part) => part.text ?? part.transcript ?? "") ?? [])
+          .join("") ?? "",
     }
   if (evt.type === "response.text.done") return { kind: "clean", mode: "set", text: evt.text ?? "" }
   if (evt.type === "response.audio_transcript.done")
     return { kind: "clean", mode: "set", text: evt.transcript ?? evt.text ?? "" }
   if (evt.type === "response.text.delta") return { kind: "clean", mode: "append", text: evt.delta ?? "" }
-  if (evt.type === "response.audio_transcript.delta")
-    return { kind: "clean", mode: "append", text: evt.delta ?? "" }
+  if (evt.type === "response.audio_transcript.delta") return { kind: "clean", mode: "append", text: evt.delta ?? "" }
   return { kind: "raw", mode: "append", text: scan(evt) }
 }
 
@@ -295,7 +316,7 @@ async function realtime(opts: {
 }
 
 async function saveAudioFile(audioBase64: string, audioFormat: string, projectID: string): Promise<string> {
-  const dir = voiceDir(projectID)
+  const dir = filesDir(projectID)
   await mkdir(dir, { recursive: true })
   const now = new Date()
   const ts = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, "0")}${String(now.getDate()).padStart(2, "0")}T${String(now.getHours()).padStart(2, "0")}${String(now.getMinutes()).padStart(2, "0")}${String(now.getSeconds()).padStart(2, "0")}`
@@ -317,16 +338,13 @@ export const VoiceRoutes = lazy(() =>
         mode: z.enum(["omni", "asr", "realtime"]).optional(),
         audioBase64: z.string(),
         audioFormat: z.string(),
-        context: z
-          .array(z.object({ role: z.string(), content: z.string() }))
-          .optional(),
+        context: z.array(z.object({ role: z.string(), content: z.string() })).optional(),
         projectID: z.string().optional(),
         saveAudio: z.boolean().optional(),
       }),
     ),
     async (c) => {
-      const { providerID, modelID, mode, audioBase64, audioFormat, context, projectID, saveAudio } =
-        c.req.valid("json")
+      const { providerID, modelID, mode, audioBase64, audioFormat, context, projectID, saveAudio } = c.req.valid("json")
       const kind = mode ?? (modelID.includes("asr") ? "asr" : modelID.includes("realtime") ? "realtime" : "omni")
 
       const provider = await Provider.getProvider(providerID)
@@ -352,7 +370,8 @@ export const VoiceRoutes = lazy(() =>
               setTimeout(() => reject(new VoiceError("Realtime transcription hard timeout", 504)), 35_000),
             ),
           ])
-          const audioPath = projectID && saveAudio ? await saveAudioFile(audioBase64, audioFormat, projectID) : undefined
+          const audioPath =
+            projectID && saveAudio ? await saveAudioFile(audioBase64, audioFormat, projectID) : undefined
           return c.json({ text, audioPath })
         } catch (e) {
           const message = e instanceof Error ? e.message : String(e)
@@ -363,8 +382,7 @@ export const VoiceRoutes = lazy(() =>
       }
 
       let endpoint = baseURL.replace(/\/+$/, "")
-      if (!endpoint.endsWith("/chat/completions"))
-        endpoint += "/chat/completions"
+      if (!endpoint.endsWith("/chat/completions")) endpoint += "/chat/completions"
 
       const audio = {
         type: "input_audio",


### PR DESCRIPTION
### Issue for this PR

Closes #997, Closes #1009

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

包含两个改动：

1. **fix（#997）**：Electron sidecar 启动时生成随机密码，但语音转录请求未携带 Authorization 头，后端返回 401 导致"Unknown error"。在 `voice-transcription.ts` 新增可选 `headers` 字段，`voice-input-button.tsx` 从 server context 构造 Basic Auth 头传入。

2. **feat（#1009）**：语音转录完成后，将原始音频文件保存到持久化目录，默认开启。

修改了 4 个文件：
1. `packages/app/src/utils/voice-transcription.ts` — `TranscriptionOptions` 新增 `headers/projectID/saveAudio`；返回类型改为 `TranscriptionResult { text, audioPath? }`
2. `packages/app/src/components/voice-input-button.tsx` — 从 server context 构造 `Authorization: Basic` 头；`onTranscription` 签名改为 `(text, audioPath?)`；传入 `projectID` 和 `saveAudio: true`
3. `packages/opencode/src/persist/naming.ts` — 新增 `voiceDir(projectID)` 函数
4. `packages/opencode/src/server/routes/voice.ts` — 新增 `saveAudioFile()`；接收 `projectID/saveAudio`；转录完成后写音频到磁盘；响应增加 `audioPath`

音频文件只写磁盘，绝不进入 Prompt 或数据库。进入数据库的只有转录后的纯文字（TextPart）。

存储路径：
| 平台 | 路径 |
|------|------|
| macOS/Linux | `~/.local/share/aether/voice/<project-id>/<timestamp>.webm` |
| Windows | `%LOCALAPPDATA%\aether\voice\<project-id>\<timestamp>.webm` |

### How did you verify your code works?

- turbo typecheck 全部通过（12 successful, 0 errors）
- Web 端不传 password/projectID 时，headers 和 audioPath 为 undefined，行为与之前完全一致
- Electron 端传入 auth header 后不再返回 401
- 音频保存逻辑仅在 `projectID && saveAudio` 条件下触发

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR