### PR TITLE
fix: query both configured and default update channels for web auto-update

### DIFF
--- a/packages/opencode/src/server/web-update.ts
+++ b/packages/opencode/src/server/web-update.ts
@@ -276,8 +276,8 @@ function hide(args: string[], cwd: string) {
   return file
 }
 
-async function spawnAuto(os: z.infer<typeof WebUpdateOS>, script: string, work: string, cur: string) {
-  const updateBase = await getUpdateBase()
+async function spawnAuto(os: z.infer<typeof WebUpdateOS>, script: string, work: string, cur: string, base?: string) {
+  const updateBase = base ?? (await getUpdateBase())
   return await new Promise<number>((resolve, reject) => {
     const cmd = os === "windows" ? "cmd" : "bash"
     const args = os === "windows" ? ["/c", script, "auto", cur] : [script, "auto", cur]
@@ -362,6 +362,12 @@ async function getUpdateBase() {
   return cachedBaseUrl
 }
 
+async function allBases(): Promise<string[]> {
+  const primary = await getUpdateBase()
+  if (primary === WEB_UPDATE_BASE_DEFAULT) return [WEB_UPDATE_BASE_DEFAULT]
+  return [primary, WEB_UPDATE_BASE_DEFAULT]
+}
+
 function parseManifest(text: string) {
   let sec = ""
   let ver = ""
@@ -438,8 +444,8 @@ function parseManifest(text: string) {
   return { ver, pkg, sha, size, ins, note }
 }
 
-async function fetchManifest(os: z.infer<typeof WebUpdateOS>, version?: string) {
-  const url = manifestUrl(os, version)(await getUpdateBase())
+async function fetchManifestFrom(os: z.infer<typeof WebUpdateOS>, version: string | undefined, base: string) {
+  const url = manifestUrl(os, version)(base)
   const res = await fetch(url)
   if (!res.ok) {
     return { ok: false as const, url, error: `Failed to fetch version metadata: ${res.status}` }
@@ -461,7 +467,22 @@ async function fetchManifest(os: z.infer<typeof WebUpdateOS>, version?: string) 
     package_size: data.size,
     installer_url: data.ins ? abs(url, data.ins) : "",
     notes_url: data.note ? abs(url, data.note) : "",
+    base,
   }
+}
+
+async function fetchManifest(os: z.infer<typeof WebUpdateOS>, version?: string) {
+  const bases = await allBases()
+  if (bases.length === 1) return fetchManifestFrom(os, version, bases[0])
+  const results = await Promise.all(bases.map((b) => fetchManifestFrom(os, version, b).catch(() => null)))
+  const successes = results.filter((r): r is Extract<typeof r, { ok: true }> => r?.ok === true)
+  if (successes.length === 0) {
+    return results[0] ?? { ok: false as const, url: "", error: "Failed to fetch version metadata from all channels" }
+  }
+  if (!version && successes.length > 1) {
+    return successes.reduce((best, cur) => (compareVer(cur.version, best.version) > 0 ? cur : best))
+  }
+  return successes[0]
 }
 
 function packageMatch(os: string, ver: string, name: string) {
@@ -687,11 +708,11 @@ function getWorkDir(os: string): string | null {
   return path.join(home, ".local", "share", "aether", "update", "aether")
 }
 
-async function fetchInstallerScript(os: string): Promise<string | null> {
+async function fetchInstallerScript(os: string, base?: string): Promise<string | null> {
   const item = INSTALLER_SCRIPT[os]
   const name = typeof item === "function" ? item(arch()) : item
   if (!name) return null
-  const url = `${await getUpdateBase()}/installer/${name}`
+  const url = `${base ?? (await getUpdateBase())}/installer/${name}`
   const dest = path.join(tmpdir(), `aether-installer-${name}`)
   try {
     const res = await fetch(url)
@@ -878,7 +899,7 @@ export async function downloadWebUpdate(input: z.infer<typeof WebUpdateDownloadI
   }
   const dirErr = await mkdirp(workDir)
   if (dirErr) return failRes(dirErr)
-  const scriptPath = await fetchInstallerScript(os)
+  const scriptPath = await fetchInstallerScript(os, meta.ok ? meta.base : undefined)
   if (!scriptPath) return failRes(`Failed to fetch installer script for ${os}`)
   log.info("running installer auto mode", { os, script: scriptPath, version, workDir })
   try {
@@ -895,7 +916,7 @@ export async function downloadWebUpdate(input: z.infer<typeof WebUpdateDownloadI
         package_size: meta.package_size,
       }),
     )
-    const exitCode = await spawnAuto(os, scriptPath, workDir, cur)
+    const exitCode = await spawnAuto(os, scriptPath, workDir, cur, meta.ok ? meta.base : undefined)
     const chk = await verifyDownload(os, meta, workDir)
     if (!chk.ok) {
       return await failState(workDir, version, chk.error, {
@@ -1041,6 +1062,8 @@ export async function retryWebUpdateMirror(input: z.infer<typeof WebUpdateMirror
 
 export const WebUpdateTest = {
   fetchManifest,
+  fetchManifestFrom,
+  allBases,
   getWorkDir,
   manifestUrl: async (os: z.infer<typeof WebUpdateOS>, version?: string) =>
     manifestUrl(os, version)(await getUpdateBase()),

--- a/packages/opencode/test/server/web-update.test.ts
+++ b/packages/opencode/test/server/web-update.test.ts
@@ -16,6 +16,7 @@ function meta(ver: string, sha: string, size: number): Parameters<typeof WebUpda
     package_size: size,
     installer_url: `https://example.com/${ver}/update_linux.sh`,
     notes_url: `https://example.com/${ver}/notes.md`,
+    base: "https://example.com",
   }
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #1019

### Type of change

- [x] Bug fix

### What does this PR do?

修复 web 版自动更新只查询 `update-config.jsonc` 中配置 URL、忽略默认 stable 通道的问题。

实现方式（最小侵入，零 Electron 影响）：

- 新增 `allBases()`：始终包含默认 stable 通道；若用户在 `update-config.jsonc` 配置了不同的 `updateBaseUrl`，则附加该自定义通道。注意：除默认 stable URL 外，**不在代码中硬编码任何其他通道 URL**（包括 beta），所有附加通道完全由用户配置驱动。
- 拆分 `fetchManifest`：底层 `fetchManifestFrom(os, version, base)` 处理单通道查询并在成功结果中携带 `base` 字段；上层 `fetchManifest(os, version?)` 并行查询 `allBases()` 全部通道，无版本号时取版本最高者，指定版本时取首个成功响应。
- `spawnAuto` 与 `fetchInstallerScript` 增加可选 `base` 参数；`downloadWebUpdate` 将 `meta.base` 透传，确保从命中通道下载安装脚本与安装包（通过 `AETHER_UPDATE_BASE` 环境变量传递给安装脚本）。

不影响：
- Electron 桌面更新（仅检测 `update-config.jsonc` 是否存在以启用 prerelease，未读取其内容）
- 客户端 API（`WebUpdateCheckResponse` 无新字段）
- 更新脚本（已通过 `AETHER_UPDATE_BASE` 环境变量正确传递 base URL）
- 普通用户（无配置时 `allBases()` 返回单元素数组，走单通道快速路径，行为与修改前一致）

### How did you verify your code works?

- `bun typecheck`（在 `packages/opencode` 目录下）通过
- `bun test test/server/web-update.test.ts`：26 pass / 0 fail
- `bun test test/server/web-update-script.test.ts`：5 pass / 7 skip / 0 fail
- 测试侧补充：`meta()` 辅助函数的返回类型增加必填 `base` 字段以匹配新签名

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR