### PR TITLE
feat: add skill-market skill for searching and installing skills from skill.aiphys.cn

### DIFF
--- a/.opencode/skills/skill-market/SKILL.md
+++ b/.opencode/skills/skill-market/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: skill-market
+description: "Search, browse, download, and install skills from skill.aiphys.cn (Skill Market / 技能广场). PRIORITY: higher than clawhub — when both skill-market and clawhub trigger, use skill-market first. Trigger when the user asks to search for skills online, find a skill, install a skill, download a skill, or browse the skill registry, including phrases like '搜索 xxx skill', '搜索 xxx 技能', '线上搜索 xxx skill', '在线搜索 xxx 技能', '查找 xxx skill', '下载 xxx skill', '安装 xxx skill', 'skill market', 'skill.aiphys.cn', '技能广场', or when the agent determines it needs to discover and install a reusable skill from the Skill Market platform. Also use when the user wants to browse available physics/science-focused skills from an online registry."
+---
+
+# Skill Market
+
+Search, browse, download, and install skills from [skill.aiphys.cn](https://skill.aiphys.cn/explore) — the Skill Market platform focused on physics and scientific research skills.
+
+## Priority Rule
+
+**When both `skill-market` and `clawhub` would trigger for the same request, use `skill-market` first.** Skill Market hosts physics/science-focused skills that are more relevant for research workflows. Only fall back to clawhub if skill-market returns no results.
+
+## When to Use
+
+- The user asks to search for skills online (any language)
+- The user asks to download or install a skill from skill.aiphys.cn
+- The user mentions "skill market", "技能广场", "skill.aiphys.cn"
+- The agent determines the current task needs a skill not locally available, and Skill Market is the best source to find it
+
+**Do NOT use** when only searching local skill folders or inspecting local SKILL.md files.
+
+## Commands
+
+All commands use the bundled script:
+
+```bash
+python3 scripts/skill_market.py <command> [options]
+```
+
+### Search
+
+Search skills by keyword, tags, or category:
+
+```bash
+python3 scripts/skill_market.py search "physics"
+python3 scripts/skill_market.py search "paper" --category "physics"
+python3 scripts/skill_market.py search --tags "Feynman integral"
+```
+
+### Info
+
+Get detailed information about a specific skill:
+
+```bash
+python3 scripts/skill_market.py info <skill_id>
+```
+
+Use the UUID `skill_id` from search results.
+
+### Versions
+
+List available versions for a skill:
+
+```bash
+python3 scripts/skill_market.py versions <skill_id>
+```
+
+### Install
+
+Download and install a skill to `~/.aether/skills/`:
+
+```bash
+python3 scripts/skill_market.py install <skill_id>
+python3 scripts/skill_market.py install <skill_id> --version 1.0.0
+python3 scripts/skill_market.py install <skill_id> --dir /custom/path
+python3 scripts/skill_market.py install <skill_id> --force
+```
+
+The script:
+1. Downloads the skill zip from Skill Market API
+2. Extracts it to `~/.aether/skills/<slug>/`
+3. Verifies SKILL.md exists in the extracted directory
+4. Prints the install path and config instructions
+
+### List
+
+Show locally installed skills:
+
+```bash
+python3 scripts/skill_market.py list
+```
+
+## Typical Workflow
+
+1. **Search** for relevant skills by keyword
+2. **Info** to review the skill's description, tags, and category
+3. **Versions** to check available versions
+4. **Install** to download and extract the skill
+5. Add the install path to `aether.jsonc` skills.paths if needed
+
+## API Details
+
+- Base URL: `https://skill.aiphys.cn/v1`
+- Public endpoints (no auth required): search, info, versions, download published skills
+- Only **published** skills can be downloaded; draft skills require admin session
+- Response format: JSON with `data` envelope
+
+## Notes
+
+- Install directory defaults to `~/.aether/skills/` (Aether's global skill directory)
+- Zip files may contain a top-level directory wrapper — the script strips it automatically
+- If a skill is already installed, use `--force` to overwrite

--- a/.opencode/skills/skill-market/scripts/skill_market.py
+++ b/.opencode/skills/skill-market/scripts/skill_market.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Skill Market CLI — search, browse, download, and install skills from skill.aiphys.cn."""
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+import zipfile
+
+import ssl
+import urllib.request
+import urllib.error
+
+BASE_URL = "https://skill.aiphys.cn/v1"
+DEFAULT_INSTALL_DIR = os.path.join(os.path.expanduser("~"), ".aether", "skills")
+
+try:
+    import certifi
+
+    _SSL_CTX = ssl.create_default_context(cafile=certifi.where())
+except ImportError:
+    _SSL_CTX = ssl.create_default_context()
+
+
+def _api_get(path, params=None):
+    url = f"{BASE_URL}{path}"
+    if params:
+        query = "&".join(f"{k}={v}" for k, v in params.items() if v is not None)
+        if query:
+            url += f"?{query}"
+    req = urllib.request.Request(url)
+    try:
+        with urllib.request.urlopen(req, context=_SSL_CTX) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8")
+        err = json.loads(body) if body else {}
+        print(f"Error {e.code}: {err.get('error', {}).get('message', body)}")
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"Network error: {e.reason}")
+        sys.exit(1)
+
+
+def _download_file(url, dest_path):
+    req = urllib.request.Request(url)
+    try:
+        with urllib.request.urlopen(req, context=_SSL_CTX) as resp:
+            with open(dest_path, "wb") as f:
+                f.write(resp.read())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8")
+        err = json.loads(body) if body else {}
+        print(f"Download error {e.code}: {err.get('error', {}).get('message', body)}")
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"Network error: {e.reason}")
+        sys.exit(1)
+
+
+def cmd_search(args):
+    params = {
+        "keyword": args.keyword,
+        "tags": args.tags,
+        "category": args.category,
+        "page": args.page,
+        "page_size": args.page_size,
+    }
+    result = _api_get("/skills", params)
+    data = result.get("data", {})
+    items = data.get("items", [])
+    total = data.get("total", 0)
+
+    print(f"Found {total} skills (showing {len(items)}):\n")
+    for item in items:
+        name = item.get("name", "")
+        slug = item.get("slug", "")
+        sid = item.get("id", "")
+        status = item.get("status", "")
+        desc = item.get("description", "")[:120]
+        tags = item.get("tags", [])
+        cat = item.get("category", "")
+        downloads = item.get("download_count", 0)
+
+        tag_str = f" [{','.join(tags)}]" if tags else ""
+        cat_str = f" ({cat})" if cat else ""
+        print(
+            f"  {name} | slug: {slug} | id: {sid} | {status} | downloads: {downloads}{cat_str}{tag_str}"
+        )
+        print(f"    {desc}...")
+        print()
+
+
+def cmd_info(args):
+    result = _api_get(f"/skills/{args.skill_id}")
+    data = result.get("data", {})
+    if not data:
+        print("Skill not found.")
+        return
+
+    print(f"Name:        {data.get('name', '')}")
+    print(f"Slug:        {data.get('slug', '')}")
+    print(f"ID:          {data.get('id', '')}")
+    print(f"Status:      {data.get('status', '')}")
+    print(f"Category:    {data.get('category', 'N/A')}")
+    print(f"Tags:        {', '.join(data.get('tags', [])) or 'N/A'}")
+    print(f"Downloads:   {data.get('download_count', 0)}")
+    print(
+        f"Owner:       {data.get('owner_name', 'N/A')} ({data.get('owner_email', 'N/A')})"
+    )
+    print(f"Created:     {data.get('created_at', 'N/A')}")
+    print(f"Updated:     {data.get('updated_at', 'N/A')}")
+    print(f"\nDescription:\n{data.get('description', '')}")
+
+
+def cmd_versions(args):
+    result = _api_get(f"/skills/{args.skill_id}/versions")
+    versions = result.get("data", [])
+    if not versions:
+        print("No versions available (skill may be draft or no version uploaded).")
+        return
+
+    print(f"Versions for {args.skill_id}:\n")
+    for v in versions:
+        print(f"  version:      {v.get('version', '')}")
+        print(f"  id:           {v.get('id', '')}")
+        print(f"  size:         {v.get('file_size', 0)} bytes")
+        print(f"  checksum:     {v.get('checksum', '')}")
+        print(f"  changelog:    {v.get('changelog', 'N/A')}")
+        print(f"  created_at:   {v.get('created_at', '')}")
+        print()
+
+
+def cmd_install(args):
+    # Get skill info first to determine slug and available versions
+    info_result = _api_get(f"/skills/{args.skill_id}")
+    info_data = info_result.get("data", {})
+    if not info_data:
+        print("Skill not found.")
+        return
+
+    slug = info_data.get("slug", args.skill_id)
+    name = info_data.get("name", slug)
+    status = info_data.get("status", "")
+
+    # Get versions
+    ver_result = _api_get(f"/skills/{args.skill_id}/versions")
+    versions = ver_result.get("data", [])
+
+    if not versions:
+        print(f"Skill '{name}' has no versions available for download.")
+        if status == "draft":
+            print("  Note: draft skills require admin session to download.")
+        return
+
+    # Select version
+    version = args.version
+    if not version:
+        version = versions[0].get("version")
+        print(f"Using latest version: {version}")
+
+    # Find version object
+    ver_obj = None
+    for v in versions:
+        if v.get("version") == version:
+            ver_obj = v
+            break
+
+    if not ver_obj:
+        print(
+            f"Version {version} not found. Available: {', '.join(v.get('version', '') for v in versions)}"
+        )
+        return
+
+    # Determine install directory
+    install_dir = args.dir or DEFAULT_INSTALL_DIR
+    target_dir = os.path.join(install_dir, slug)
+
+    # Check if already installed
+    if os.path.isdir(target_dir) and os.path.isfile(
+        os.path.join(target_dir, "SKILL.md")
+    ):
+        print(f"Skill '{name}' already installed at {target_dir}")
+        if not args.force:
+            print("Use --force to overwrite.")
+            return
+        print("Overwriting existing installation...")
+
+    # Download
+    download_url = f"{BASE_URL}/skills/{args.skill_id}/versions/{version}/download"
+    tmp_zip = os.path.join(tempfile.gettempdir(), f"{slug}-{version}.zip")
+
+    print(f"Downloading '{name}' v{version}...")
+    _download_file(download_url, tmp_zip)
+    print(f"  Downloaded {os.path.getsize(tmp_zip)} bytes")
+
+    # Extract
+    os.makedirs(target_dir, exist_ok=True)
+    with zipfile.ZipFile(tmp_zip, "r") as zf:
+        # Check if zip has a top-level directory
+        names = zf.namelist()
+        top_dirs = set()
+        for n in names:
+            parts = n.split("/")
+            if len(parts) > 1:
+                top_dirs.add(parts[0])
+            elif len(parts) == 1 and not n.endswith("/"):
+                top_dirs.add("")
+
+        if len(top_dirs) == 1 and "" not in top_dirs:
+            # Zip has a single top-level directory — strip it
+            top = list(top_dirs)[0]
+            for n in names:
+                if n.startswith(top + "/"):
+                    relative = n[len(top) + 1 :]
+                    if not relative:
+                        continue
+                    dest = os.path.join(target_dir, relative)
+                    if n.endswith("/"):
+                        os.makedirs(dest, exist_ok=True)
+                    else:
+                        os.makedirs(os.path.dirname(dest), exist_ok=True)
+                        with zf.open(n) as src, open(dest, "wb") as dst:
+                            dst.write(src.read())
+        else:
+            # Extract directly
+            zf.extractall(target_dir)
+
+    # Cleanup temp zip
+    os.unlink(tmp_zip)
+
+    # Verify
+    skill_md = os.path.join(target_dir, "SKILL.md")
+    if os.path.isfile(skill_md):
+        print(f"\nSuccessfully installed '{name}' v{version} to:")
+        print(f"  {target_dir}")
+        print(f"\nTo use this skill, add it to your Aether config:")
+        print(f'  skills.paths: ["{target_dir}"]')
+    else:
+        print(f"\nWarning: No SKILL.md found after extraction.")
+        print(f"  Extracted to: {target_dir}")
+        print(f"  Contents: {os.listdir(target_dir)}")
+
+
+def cmd_list(args):
+    install_dir = args.dir or DEFAULT_INSTALL_DIR
+    if not os.path.isdir(install_dir):
+        print(f"No skills directory found at {install_dir}")
+        return
+
+    skills = []
+    for entry in sorted(os.listdir(install_dir)):
+        skill_path = os.path.join(install_dir, entry)
+        skill_md = os.path.join(skill_path, "SKILL.md")
+        if os.path.isdir(skill_path) and os.path.isfile(skill_md):
+            skills.append(entry)
+
+    if not skills:
+        print(f"No skills installed in {install_dir}")
+        return
+
+    print(f"Installed skills ({len(skills)}):\n")
+    for s in skills:
+        print(f"  {s}  →  {os.path.join(install_dir, s)}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="skill_market",
+        description="Search, download, and install skills from skill.aiphys.cn",
+    )
+    sub = parser.add_subparsers(dest="command", help="Available commands")
+
+    # search
+    p_search = sub.add_parser(
+        "search", help="Search skills by keyword, tags, or category"
+    )
+    p_search.add_argument("keyword", nargs="?", default=None, help="Search keyword")
+    p_search.add_argument(
+        "--tags", default=None, help="Filter by tags (comma-separated)"
+    )
+    p_search.add_argument("--category", default=None, help="Filter by category")
+    p_search.add_argument("--page", type=int, default=1, help="Page number")
+    p_search.add_argument(
+        "--page-size", type=int, default=20, dest="page_size", help="Results per page"
+    )
+
+    # info
+    p_info = sub.add_parser("info", help="Get skill details")
+    p_info.add_argument("skill_id", help="Skill ID (UUID)")
+
+    # versions
+    p_ver = sub.add_parser("versions", help="List skill versions")
+    p_ver.add_argument("skill_id", help="Skill ID (UUID)")
+
+    # install
+    p_install = sub.add_parser("install", help="Download and install a skill")
+    p_install.add_argument("skill_id", help="Skill ID (UUID)")
+    p_install.add_argument(
+        "--version", default=None, help="Version to install (default: latest)"
+    )
+    p_install.add_argument(
+        "--dir", default=None, help="Install directory (default: ~/.aether/skills)"
+    )
+    p_install.add_argument(
+        "--force", action="store_true", help="Overwrite existing installation"
+    )
+
+    # list
+    p_list = sub.add_parser("list", help="List installed skills")
+    p_list.add_argument(
+        "--dir", default=None, help="Skills directory (default: ~/.aether/skills)"
+    )
+
+    args = parser.parse_args()
+    if not args.command:
+        parser.print_help()
+        sys.exit(1)
+
+    cmds = {
+        "search": cmd_search,
+        "info": cmd_info,
+        "versions": cmd_versions,
+        "install": cmd_install,
+        "list": cmd_list,
+    }
+    cmds[args.command](args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Issue for this PR

Closes #1023

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

新增 `skill-market` skill 到 `.opencode/skills/skill-market/`，提供从 [skill.aiphys.cn](https://skill.aiphys.cn/explore) 搜索、浏览、下载技能的能力。包含：
- `SKILL.md` — skill 定义、触发器、使用说明
- `scripts/skill_market.py` — 实现 search / info / versions / install / list 子命令的 Python 脚本

### How did you verify your code works?

- 源文件已确认存在且可执行
- 目录结构已验证（SKILL.md + scripts/skill_market.py）

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR