### PR TITLE
fix: enable Electron settings updater flag

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -74,6 +74,7 @@ declare global {
   interface Window {
     __OPENCODE__?: {
       updaterEnabled?: boolean
+      settingsUpdaterEnabled?: boolean
       deepLinks?: string[]
       wsl?: boolean
     }

--- a/packages/desktop-electron/src/main/index.ts
+++ b/packages/desktop-electron/src/main/index.ts
@@ -47,6 +47,7 @@ const logger = initLogging()
 const MANUAL_INSTALL_UPDATE = process.platform === "darwin" || (process.platform === "linux" && !process.env.APPIMAGE)
 const RELEASES_URL = "https://github.com/Science-Discovery/Aether/releases"
 const RENDERER_UPDATER_ENABLED = UPDATER_ENABLED && !MANUAL_INSTALL_UPDATE
+const SETTINGS_UPDATER_ENABLED = UPDATER_ENABLED
 
 logger.log("app starting", {
   version: app.getVersion(),
@@ -186,6 +187,7 @@ async function initialize() {
 
   const globals = {
     updaterEnabled: RENDERER_UPDATER_ENABLED,
+    settingsUpdaterEnabled: SETTINGS_UPDATER_ENABLED,
     deepLinks: pendingDeepLinks,
   }
 

--- a/packages/desktop-electron/src/main/menu.ts
+++ b/packages/desktop-electron/src/main/menu.ts
@@ -66,7 +66,7 @@ export function createMenu(deps: Deps) {
         {
           label: "New Window",
           accelerator: "Cmd+Shift+N",
-          click: () => createMainWindow({ updaterEnabled: false }),
+          click: () => createMainWindow({ updaterEnabled: false, settingsUpdaterEnabled: false }),
         },
         { type: "separator" },
         { role: "close" },

--- a/packages/desktop-electron/src/main/windows.ts
+++ b/packages/desktop-electron/src/main/windows.ts
@@ -6,6 +6,7 @@ import type { TitlebarTheme } from "../preload/types"
 
 type Globals = {
   updaterEnabled: boolean
+  settingsUpdaterEnabled: boolean
   deepLinks?: string[]
 }
 
@@ -143,6 +144,7 @@ function injectGlobals(win: BrowserWindow, globals: Globals) {
     const deepLinks = globals.deepLinks ?? []
     const data = {
       updaterEnabled: globals.updaterEnabled,
+      settingsUpdaterEnabled: globals.settingsUpdaterEnabled,
       deepLinks: Array.isArray(deepLinks) ? deepLinks.splice(0) : deepLinks,
     }
     void win.webContents.executeJavaScript(

--- a/packages/desktop-electron/src/renderer/env.d.ts
+++ b/packages/desktop-electron/src/renderer/env.d.ts
@@ -5,6 +5,7 @@ declare global {
     api: ElectronAPI
     __OPENCODE__?: {
       updaterEnabled?: boolean
+      settingsUpdaterEnabled?: boolean
       wsl?: boolean
       deepLinks?: string[]
     }

--- a/packages/desktop-electron/src/renderer/index.tsx
+++ b/packages/desktop-electron/src/renderer/index.tsx
@@ -20,7 +20,7 @@ import { createEffect, createResource, onCleanup, onMount, Show } from "solid-js
 import { render } from "solid-js/web"
 import pkg from "../../package.json"
 import { initI18n, t } from "./i18n"
-import { runUpdater, UPDATER_ENABLED } from "./updater"
+import { runUpdater, SETTINGS_UPDATER_ENABLED } from "./updater"
 import { webviewZoom } from "./webview-zoom"
 import "./styles.css"
 import { useTheme } from "@opencode-ai/ui/theme"
@@ -223,7 +223,7 @@ const createPlatform = (): Platform => {
 
     parseMarkdown: (markdown: string) => window.api.parseMarkdownCommand(markdown),
 
-    runUpdater: UPDATER_ENABLED() ? () => runUpdater({ alertOnFail: true }) : undefined,
+    runUpdater: SETTINGS_UPDATER_ENABLED() ? () => runUpdater({ alertOnFail: true }) : undefined,
 
     webviewZoom,
 

--- a/packages/desktop-electron/src/renderer/updater.ts
+++ b/packages/desktop-electron/src/renderer/updater.ts
@@ -1,6 +1,7 @@
 import { initI18n, t } from "./i18n"
 
 export const UPDATER_ENABLED = () => window.__OPENCODE__?.updaterEnabled ?? false
+export const SETTINGS_UPDATER_ENABLED = () => window.__OPENCODE__?.settingsUpdaterEnabled ?? false
 
 export async function runUpdater({ alertOnFail }: { alertOnFail: boolean }) {
   await initI18n()


### PR DESCRIPTION
### Issue for this PR

Refs #1015

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR separates the Electron settings update-check capability from the renderer updater capability.

The existing updaterEnabled flag still excludes platforms that require manual installation, such as macOS and Linux deb/rpm. A new settingsUpdaterEnabled flag is injected for the Settings page so all packaged Electron builds can expose the Settings "Check now" action and route it to the existing main-process updater flow.

Settings now continues to call platform.runUpdater(), which reaches window.api.runUpdater(true) and the existing checkForUpdates(true) path. On macOS this matches the menu bar Check for Updates behavior: it checks for updates and uses the current manual install prompt when needed.

Web update behavior is unchanged; the web platform does not receive or use this Electron settings updater flag.

### How did you verify your code works?

- Ran bun install --frozen-lockfile in the task worktree.
- Ran bun typecheck in packages/app.
- Ran bun typecheck in packages/desktop-electron.
- Ran git diff --cached --check before commit.
- Pushed the branch successfully; the pre-push turbo typecheck completed successfully.
- Confirmed there is no diff in web update files such as packages/app/src/entry.tsx, packages/app/src/utils/web-update.ts, packages/app/src/components/dialog-update.tsx, packages/app/src/pages/layout.tsx, or the shared Settings page component.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR