### PR TITLE
docs: update README for desktop version, install flow, and new skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,19 @@
 
 ## Overview
 
-Aether is a feature-rich AI research assistant platform. It runs with a client/server architecture — the CLI starts a local HTTP server, providing a full interactive interface through the browser. Mobile access (WeChat / Feishu / QQ) is also supported. Desktop client (Electron) support is planned for the future.
+Aether is a feature-rich AI research assistant platform, running on a local client/server architecture. It offers two usage modes:
+
+- **Web Browser Version**: Starts a local HTTP server and provides a full interactive interface through the browser — more stable
+- **Electron Desktop Version**: Native desktop window with a smoother experience (may still have some instability)
+
+Both modes share the same local data and sessions. Mobile access (WeChat / Feishu / QQ) is also supported.
 
 ### Key Features
 
-- **Ready to use**: Download and double-click to launch; built-in default model settings
-- **Full coding capabilities**: Code execution, LSP code intelligence, file and terminal operations — covering the entire daily development workflow
-- **25+ AI providers**: Supports Anthropic, OpenAI, Google Gemini, AIhubmix, DeepSeek, Z.AI, Kimi, Qwen, and other mainstream platforms, plus any OpenAI-compatible API
-- **10+ built-in research Skills**: Literature review, paper writing, deep research, arXiv search, peer review, research grant writing, and more — ready to use out of the box
+- **Ready to use**: Download the installer script from the official website, or download the archive from Releases — built-in default model settings included
+- **Full coding capabilities**: Fully inherits OpenCode's coding capabilities — code execution, LSP code intelligence, file and terminal operations, covering the entire daily development workflow
+- **25+ AI providers**: Supports Anthropic, OpenAI, Google Gemini, AIhubmix, DeepSeek, Z\.AI, Kimi, Qwen, and other mainstream platforms, plus any OpenAI-compatible API
+- **20+ built-in Skills**: Literature review, paper writing, deep research, arXiv search, peer review, research grant writing, document generation, and more — ready to use out of the box
 - **Skill self-evolution**: After completing a task, the Agent automatically reviews the conversation history and solidifies successful experiences into reusable Skills (copy-on-write writes, security scanning, version snapshots), forming a continuous learning loop
 - **MCP protocol support**: Integrates Model Context Protocol — connect local or remote MCP servers to extend the toolset
 - **Knowledge base (RAG)**: Vector-index PDF and text documents, with semantic search that injects only relevant context, significantly reducing token usage
@@ -30,7 +35,7 @@ Aether is a feature-rich AI research assistant platform. It runs with a client/s
 - **Voice input**: Speech-to-text powered by multimodal models, automatically removing filler words and correcting technical terms
 - **Git integration**: View branches, commit history, diffs, and file changes in the UI
 - **Scheduled tasks**: Supports cron expressions, fixed intervals, and one-time scheduled tasks for automating research workflows
-- **Memory mechanism**: AI automatically persists user preferences and interaction experiences to `memory.instruction.md`, reused across sessions without repetition
+- **Memory mechanism**: AI automatically persists user preferences and interaction experiences to a local memory file, reused across sessions without repetition
 - **Session sharing**: Generate shareable links with real-time conversation sync
 
 ---
@@ -50,28 +55,53 @@ Download the archive for your platform from the [Releases page](https://github.c
 Extracted directory layout:
 
 ```
-aether          ← CLI binary (aether.exe on Windows)
-web/            ← Frontend static assets (must stay alongside the binary)
-Aether.vbs      ← Windows launcher
-Aether.command  ← macOS launcher
+aether              ← CLI binary (aether.exe on Windows)
+web/                ← Frontend static assets (must stay alongside the binary)
+install.sh/.command/.bat  ← Installation script (‼️ creates desktop shortcuts, app entries, etc.)
+Aether.sh / .command / .vbs  ← Launchers
+aether-icon.*       ← App icon
 ```
 
-**Windows**: Double-click `Aether.vbs` (if it errors, run `Aether.exe` first) — the browser opens automatically.
+It is recommended to run the installation script first. After installation, you can launch Aether from your system applications:
 
-**macOS**: Grant execute permission on first use, then double-click `Aether.command` to launch:
+**Windows**: Right-click `install.bat` → Run as administrator (or run it in a terminal). After installation, launch from the desktop shortcut or Start Menu.
+
+**macOS**:
+In the extracted directory:
 
 ```bash
-chmod +x Aether.command aether   # first time only
+chmod +x install.command   # first time only
+./install.command
 ```
+
+If prompted with "cannot be opened because the developer cannot be verified" or "is damaged":
+
+```bash
+xattr -cr ./install.command ./aether ./Aether.command
+```
+
+Then right-click `install.command` and select "Open" to proceed with installation. After installation, launch from `/Applications/Aether.app` or Launchpad.
 
 **Linux**:
 
 ```bash
-chmod +x aether   # first time only
-./aether web
+chmod +x install.sh   # first time only
+./install.sh
 ```
 
+After installation, launch Aether from the system application launcher. (⚠️ Note: The shell script shortcut previously created on the desktop is now deprecated.)
+
+If you prefer not to use the installation script, you can also launch directly (not recommended):
+
+**Windows**: Double-click `Aether.vbs`. If blocked by antivirus software, choose to allow it.
+
+**macOS**: Double-click `Aether.command` (requires `chmod +x` first).
+
+**Linux**: Run `./Aether.sh` or `./aether web`.
+
 After `aether web` starts, it displays local and network access URLs, and the browser opens automatically.
+
+(If you encounter other issues during installation, please check [Troubleshooting](#troubleshooting) first, or contact us via the official website.)
 
 <!-- Supported options:
 
@@ -82,19 +112,49 @@ After `aether web` starts, it displays local and network access URLs, and the br
 AETHER_IDLE_TIMEOUT=15 ./Aether.sh    # deployment idle timeout override in seconds
 ``` -->
 
-### Electron Desktop Version
+#### Electron Desktop Version
 
-Coming soon
-
-<!-- Extract (or install) and double-click to run:
+Download the installer for your platform from the [Releases page](https://github.com/Science-Discovery/Aether/releases) (make sure to select the Desktop version, not the Web version archive).
 
 | Platform | File |
 |---|---|
-| Linux | `aether-linux-x64.AppImage` / `.deb` / `.rpm` |
-| macOS | `aether-mac-arm64.dmg` (Apple Silicon) / `aether-mac-x64.dmg` |
-| Windows | `aether-win-x64.exe` installer / `win-unpacked/` portable |
+| Windows | `aether-desktop-win-x64.exe` (NSIS installer) |
+| macOS Apple Silicon | `aether-desktop-mac-arm64.dmg` |
+| macOS Intel | `aether-desktop-mac-x64.dmg` |
+| Linux | `.AppImage` / `.deb` / `.rpm` |
 
---- -->
+**Windows**: Double-click the `.exe` installer and follow the setup wizard. After installation, launch from the Start Menu or desktop shortcut. If antivirus software warns about risks, confirm the file is from the official GitHub Release and choose to keep it.
+
+**macOS**: Open the `.dmg` and drag `Aether Desktop.app` into `Applications`. If prompted that the developer cannot be verified, go to "Settings → Privacy & Security", find the message about Aether Desktop, and click "Open Anyway". If prompted "is damaged", run in Terminal:
+
+```bash
+xattr -cr /Applications/Aether\ Desktop.app
+```
+
+**Linux**:
+
+AppImage:
+
+```bash
+chmod +x ./aether-*.AppImage
+./aether-*.AppImage
+```
+
+deb:
+
+```bash
+sudo dpkg -i ./aether-desktop*.deb
+```
+
+rpm:
+
+```bash
+sudo dnf install ./aether-desktop*.rpm
+```
+
+> **Note**: The desktop version shares the same data directory (`~/.local/share/aether`) with Web/CLI — existing users can switch seamlessly. The desktop version is currently unsigned; macOS updates are manual (check and open the GitHub Release page to download), while Windows and Linux AppImage support in-app updates. Linux deb and rpm packages do not yet support automatic updates — similar to macOS, you need to manually download the latest installer and reinstall after being prompted.
+<!-- >
+> For more details, see [Desktop User Guide](docs/desktop-electron-user-guide.zh-CN.md) | [Uninstall Instructions](docs/desktop-electron-uninstall.zh-CN.md) -->
 
 ## Running from Source
 
@@ -117,6 +177,16 @@ bun run --cwd packages/app dev
 ```
 If resources fail to load after the page opens, manually add the `http://localhost:xxxx` URL shown in Terminal 1 to the server list.
 
+### Desktop Development Mode
+
+```bash
+# Terminal 1: start the API server
+bun dev serve
+
+# Terminal 2: start the desktop app
+bun run --cwd packages/desktop-electron dev
+```
+
 ---
 
 ## Configuring AI Providers
@@ -127,14 +197,16 @@ You can use the built-in free providers, or add AI providers through the setting
 
 ### Built-in Skills
 
-Aether includes 16 research-oriented Skills that auto-trigger based on their descriptions — no manual invocation needed:
+Aether includes 20+ Skills for research and daily scenarios that auto-trigger based on their descriptions — no manual invocation needed:
 
 | Category | Skill | Function |
 |---|---|---|
 | Dev Tools | `skill-creator` | Create and optimize Agent Skills |
 | | `skill-manager` | Scan, classify, and manage Skills collections |
+| | `skill-security-auditor` | AI Skill security audit and vulnerability scanning |
 | | `code-reviewer` | Code review (security, performance, best practices) |
 | | `project-signpost` | Generate project directory navigation files |
+| | `prepare-for-git-commit` | Pre-commit code checks and commit message writing |
 | Academic Research | `academic-researcher` | Literature review, paper analysis, equation derivation |
 | | `literature-review` | Multi-database systematic literature review |
 | | `peer-review` | Peer review toolkit |
@@ -143,10 +215,15 @@ Aether includes 16 research-oriented Skills that auto-trigger based on their des
 | | `arxiv-search` | Search arXiv for preprints |
 | | `read-arxiv-paper` | Read and analyze arXiv papers |
 | | `research-grants` | Write research grant proposals |
+| | `research-grants-ch` | Write Chinese research grant proposals (NSFC, China Postdoctoral Science Foundation, etc.) |
 | | `scientific-critical-thinking` | Scientific evidence quality assessment |
 | | `scientific-brainstorming` | Research hypothesis generation and interdisciplinary exploration |
 | | `response-to-referee` | Point-by-point responses to reviewer comments |
 | General | `brainstorming` | Turn ideas into designs before implementation |
+| | `clawhub` | Search and install Agent Skills from ClawHub |
+| | `docx` | Create and edit Word documents |
+| | `excel-analysis` | Analyze Excel spreadsheets |
+| | `ppt-generation` | Generate PowerPoint presentations |
 
 Academic Skills can be chained: `arxiv-search` → `read-arxiv-paper` → `literature-review` → `write-paper`
 
@@ -188,7 +265,7 @@ aether mcp debug                    # Debug MCP connections
 
 ### Mobile Access
 
-Chat with Aether from your phone via WeChat, Feishu, or QQ bots. Configure credentials for the respective platforms in the Web UI settings.
+Chat with Aether from your phone via WeChat, Feishu, or QQ bots. Configure credentials for the respective platforms in Settings (supported in both Web and Desktop versions).
 
 ---
 
@@ -220,3 +297,11 @@ aether debug config   # View current configuration
 **Frontend assets not found**: Ensure the `aether` binary and `web/` directory are in the same folder.
 
 **Model list is empty**: Check that the `OPENCODE_CONFIG` environment variable path is correct.
+
+**macOS says "cannot be opened because the developer cannot be verified"**: The app is unsigned. Right-click the app and select "Open", then go to "Settings → Privacy & Security", find the related message, and select "Open Anyway". The app will be remembered as trusted and won't prompt again. (This needs to be repeated after each update.)
+
+**macOS says "is damaged and cannot be opened"**: This is a false positive caused by macOS quarantine attributes. Run `xattr -cr /Applications/Aether\ Desktop.app` (Desktop version) or `xattr -cr ./aether ./Aether.command` (Web version) in Terminal.
+
+**Can't find the launch entry after installing the Linux Web version**: Run `install.sh` (after `chmod +x`) from the extracted directory. After installation, you'll find the Aether icon in the system application launcher. *The `Aether.sh` shortcut previously created on the desktop is now deprecated.*
+
+**Can both Desktop and Web versions be installed at the same time?**: Yes. Both share the same data and sessions. However, you should avoid running both versions simultaneously to prevent resource conflicts and instability.

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,14 +13,19 @@
 
 ## 项目简介
 
-Aether 是一个功能丰富的 AI 研究助手平台。它以客户端/服务器架构运行——CLI 在本地启动 HTTP 服务，通过浏览器提供完整的交互界面。支持移动端（微信 / 飞书 / QQ）接入。未来预计支持桌面客户端（Electron）。
+Aether 是一个功能丰富的 AI 研究助手平台，基于本地客户端/服务器架构运行。提供两种使用方式：
+
+- **Web 浏览器版**：在本地启动 HTTP 服务，通过浏览器访问完整交互界面，更稳定
+- **Electron 桌面版**：原生桌面窗口，使用体验更丝滑（可能仍有不稳定之处）
+
+两种方式共享同一套本地数据和会话。此外支持移动端（微信 / 飞书 / QQ）接入。
 
 ### 核心特性
 
-- **开箱即用**：下载安装包双击即可启动，内置默认模型配置
-- **完整编程能力**：代码运行、LSP 代码感知、文件和终端操作，覆盖日常开发全流程
+- **开箱即用**：既可从官网下载安装脚本运行安装，也可下载 releases 中的压缩包安装，内置默认模型配置
+- **完整编程能力**：完全继承 OpenCode 的编码能力，支持代码运行、LSP 代码感知、文件和终端操作，覆盖日常开发全流程
 - **25+ AI 提供商**：支持 Anthropic、OpenAI、Google Gemini、AIhubmix、DeepSeek、Z\.AI、Kimi、Qwen 等主流平台，以及任何 OpenAI 兼容接口
-- **10+ 个内置科研 Skills**：文献综述、论文写作、深度研究、arXiv 搜索、同行评审、研究基金撰写等，开箱即用
+- **20+ 个内置 Skills**：文献综述、论文写作、深度研究、arXiv 搜索、同行评审、研究基金撰写、文档生成等，开箱即用
 - **Skill 自进化**：Agent 在完成任务后自动评审对话历史，将成功经验固化为可复用的 Skill（copy-on-write 写入、安全扫描、版本快照），形成持续学习闭环
 - **MCP 协议支持**：集成 Model Context Protocol，可连接本地或远程 MCP 服务器扩展工具集
 - **知识库（RAG）**：将 PDF 和文本文档向量化索引，支持语义搜索，按相关性注入上下文，大幅节省 Token
@@ -30,7 +35,7 @@ Aether 是一个功能丰富的 AI 研究助手平台。它以客户端/服务�
 - **语音输入**：基于多模态模型的语音转文字，自动去除语气词并纠正专业术语
 - **Git 集成**：在界面中查看分支、提交历史、Diff 和文件变更等
 - **定时任务**：支持 Cron 表达式、固定间隔和一次性定时任务，可自动执行研究流程
-- **Memory 机制**：AI 自动将用户偏好和交互经验持久化到 `memory.instruction.md`，跨会话复用，无需重复说明
+- **Memory 机制**：AI 自动将用户偏好和交互经验持久化到本地记忆文件，跨会话复用，无需重复说明
 - **会话分享**：生成分享链接，实时同步对话内容
 
 ---
@@ -50,28 +55,53 @@ Aether 是一个功能丰富的 AI 研究助手平台。它以客户端/服务�
 解压后目录结构：
 
 ```
-aether          ← CLI 二进制（Windows 为 aether.exe）
-web/            ← 前端静态资源（必须与二进制同目录）
-Aether.vbs      ← Windows 启动器
-Aether.command  ← macOS 启动器
+aether              ← CLI 二进制（Windows 为 aether.exe）
+web/                ← 前端静态资源（必须与二进制同目录）
+install.sh/.command/.bat  ← 安装脚本（‼️创建桌面快捷方式、应用入口等）
+Aether.sh / .command / .vbs  ← 启动器
+aether-icon.*       ← 应用图标
 ```
 
-**Windows**：双击 `Aether.vbs`（如果报错，先运行 `Aether.exe`），浏览器自动打开界面。
+推荐先运行安装脚本，安装完成后即可从系统应用程序中启动 Aether：
 
-**macOS**：首次使用赋予执行权限后，双击 `Aether.command` 即可启动：
+**Windows**：右键 `install.bat` → 以管理员身份运行（或在终端中执行）。安装后从桌面快捷方式或开始菜单启动。
+
+**macOS**：
+在解压后的目录下：
 
 ```bash
-chmod +x Aether.command aether   # 首次需要
+chmod +x install.command   # 首次需要
+./install.command
 ```
+
+若提示"无法验证开发者"或"已损坏"：
+
+```bash
+xattr -cr ./install.command ./aether ./Aether.command
+```
+
+然后再右键点击 `install.command` 选择"打开"进行安装。安装后从 `/Applications/Aether.app` 或 Launchpad 启动。
 
 **Linux**：
 
 ```bash
-chmod +x aether   # 首次需要
-./aether web
+chmod +x install.sh   # 首次需要
+./install.sh
 ```
 
+安装后从系统启动台点击 Aether 图标启动。（⚠️注意：老版本会在桌面上创建的sh脚本已弃用）
+
+如果不通过安装脚本，也可直接运行启动器（不推荐）：
+
+**Windows**：双击 `Aether.vbs`。若被杀毒软件拦截，请选择允许运行。
+
+**macOS**：双击 `Aether.command`（需先 `chmod +x`）。
+
+**Linux**：运行 `./Aether.sh` 或 `./aether web`。
+
 `aether web` 启动后会显示本地和局域网访问地址，浏览器自动打开。
+
+（如安装过程中遇到其他问题，请先查看 [常见问题](#常见问题)，或通过官网联系）
 
 <!-- 支持以下选项：
 
@@ -82,19 +112,49 @@ chmod +x aether   # 首次需要
 AETHER_IDLE_TIMEOUT=15 ./Aether.sh    # 部署时覆盖空闲超时（秒）
 ``` -->
 
-### Electron 桌面版
+#### Electron 桌面版
 
-敬请期待
-
-<!-- 解压（或安装）后双击运行：
+从 [Releases 页面](https://github.com/Science-Discovery/Aether/releases)下载对应平台的安装包（注意选择 Desktop 版本，而非 Web 版压缩包）。
 
 | 平台 | 文件 |
 |---|---|
-| Linux | `aether-linux-x64.AppImage` / `.deb` / `.rpm` |
-| macOS | `aether-mac-arm64.dmg`（Apple Silicon）/ `aether-mac-x64.dmg` |
-| Windows | `aether-win-x64.exe` 安装程序 / `win-unpacked/` 便携版 |
+| Windows | `aether-desktop-win-x64.exe`（NSIS 安装程序） |
+| macOS Apple Silicon | `aether-desktop-mac-arm64.dmg` |
+| macOS Intel | `aether-desktop-mac-x64.dmg` |
+| Linux | `.AppImage` / `.deb` / `.rpm` |
 
---- -->
+**Windows**：双击 `.exe` 安装包，按安装向导完成。安装后从开始菜单或桌面快捷方式启动。若杀毒软件提示风险，确认文件来自官方 GitHub Release 后选择保留并继续。
+
+**macOS**：打开 `.dmg`，将 `Aether Desktop.app` 拖入 `Applications`。若提示无法验证开发者，需要在“设置--安全与隐私性”中，找到有关Aether Desktop的提示，点击选择“仍要打开”。若提示"已损坏"，在终端执行：
+
+```bash
+xattr -cr /Applications/Aether\ Desktop.app
+```
+
+**Linux**：
+
+AppImage：
+
+```bash
+chmod +x ./aether-*.AppImage
+./aether-*.AppImage
+```
+
+deb：
+
+```bash
+sudo dpkg -i ./aether-desktop*.deb
+```
+
+rpm：
+
+```bash
+sudo dnf install ./aether-desktop*.rpm
+```
+
+> **说明**：桌面版与 Web/CLI 共享同一套数据目录（`~/.local/share/aether`），已有用户可无缝切换。桌面版当前未做代码签名，macOS 更新为手动模式（检查后打开 GitHub Release 页面下载），Windows 和 Linux AppImage 支持应用内更新。Linux deb 和 rpm 包暂不支持自动更新，类似macOS，也需在弹窗提醒后手动下载最新安装包覆盖安装。
+<!-- >
+> 更多详情见 [桌面版用户指南](docs/desktop-electron-user-guide.zh-CN.md) | [卸载说明](docs/desktop-electron-uninstall.zh-CN.md) -->
 
 ## 从源码运行
 
@@ -117,6 +177,16 @@ bun run --cwd packages/app dev
 ```
 网页打开后如果发现资源加载失败，可以手动添加终端1中显示的 `http://localhost:xxxx` 到服务器列表中。
 
+### 桌面版开发模式
+
+```bash
+# 终端 1：启动 API Server
+bun dev serve
+
+# 终端 2：启动桌面端
+bun run --cwd packages/desktop-electron dev
+```
+
 ---
 
 ## 配置 AI 提供商
@@ -127,14 +197,16 @@ bun run --cwd packages/app dev
 
 ### 内置 Skills
 
-Aether 预置了 16 个面向科研场景的 Skills，通过描述自动触发，无需手动调用：
+Aether 预置了 20+ 个面向科研和日常场景的 Skills，通过描述自动触发，无需手动调用：
 
 | 类别 | Skill | 功能 |
 |---|---|---|
 | 开发工具 | `skill-creator` | 创建和优化 Agent Skills |
 | | `skill-manager` | 扫描、分类和管理 Skills 集合 |
+| | `skill-security-auditor` | AI Skill 安全审计与漏洞扫描 |
 | | `code-reviewer` | 代码审查（安全、性能、最佳实践） |
 | | `project-signpost` | 生成项目目录导航文件 |
+| | `prepare-for-git-commit` | Git commit 前的代码检查与消息编写 |
 | 学术研究 | `academic-researcher` | 文献综述、论文分析、公式推导 |
 | | `literature-review` | 多数据库系统文献综述 |
 | | `peer-review` | 同行评审工具包 |
@@ -143,10 +215,15 @@ Aether 预置了 16 个面向科研场景的 Skills，通过描述自动触发�
 | | `arxiv-search` | 搜索 arXiv 预印本 |
 | | `read-arxiv-paper` | 阅读和分析 arXiv 论文 |
 | | `research-grants` | 撰写研究基金申请书 |
+| | `research-grants-ch` | 撰写中国科研基金申请书（国自然、博后基金等） |
 | | `scientific-critical-thinking` | 科学证据质量评估 |
 | | `scientific-brainstorming` | 科研假设生成与跨学科探索 |
 | | `response-to-referee` | 逐条回复审稿人意见 |
 | 通用 | `brainstorming` | 在实现之前将想法转化为设计方案 |
+| | `clawhub` | 从 ClawHub 搜索和安装 Agent Skills |
+| | `docx` | 创建和编辑 Word 文档 |
+| | `excel-analysis` | 分析 Excel 电子表格 |
+| | `ppt-generation` | 生成 PowerPoint 演示文稿 |
 
 学术 Skills 可串联使用：`arxiv-search` → `read-arxiv-paper` → `literature-review` → `write-paper`
 
@@ -188,7 +265,7 @@ aether mcp debug                    # 调试 MCP 连接
 
 ### 移动端
 
-通过微信、飞书、QQ 机器人从手机端与 Aether 对话。在 Web 界面的设置中配置对应平台的凭证即可启用。
+通过微信、飞书、QQ 机器人从手机端与 Aether 对话。在设置中配置对应平台的凭证即可启用（Web 版和桌面版均支持）。
 
 ---
 
@@ -221,4 +298,10 @@ aether debug config   # 查看当前配置
 
 **模型列表为空**：检查环境变量 `OPENCODE_CONFIG` 路径是否正确。
 
----
+**macOS 提示"无法打开，因为无法验证开发者"**：应用未签名。右键点击应用选择"打开"，在“设置--安全与隐私性”中找到相关提示，选择“仍要打开”。之后应用会被记为信任，不再提示。（每次更新后需要重复此操作）
+
+**macOS 提示"已损坏，无法打开"**：这是 macOS 隔离属性导致的误报。在终端执行 `xattr -cr /Applications/Aether\ Desktop.app`（桌面版）或 `xattr -cr ./aether ./Aether.command`（Web 版）即可。
+
+**Linux Web 版安装后找不到启动入口**：运行解压目录中的 `install.sh`（需先 `chmod +x`），安装完成后可在系统启动台中找到 Aether 图标。*原先在桌面上的 `Aether.sh` 启动脚本已弃用*。
+
+**桌面版和 Web 版可以同时安装吗？**：可以。两者共享同一套数据和会话。但是应避免同时运行两个版本，以免竞争资源导致不稳定。

--- a/README.zht.md
+++ b/README.zht.md
@@ -13,14 +13,19 @@
 
 ## 專案簡介
 
-Aether 是一個功能豐富的 AI 研究助手平台。它以客戶端/伺服器架構運行——CLI 在本機啟動 HTTP 服務，透過瀏覽器提供完整的互動介面。支援行動端（微信 / 飛書 / QQ）接入。未來預計支援桌面客戶端（Electron）。
+Aether 是一個功能豐富的 AI 研究助手平台，基於本機客戶端/伺服器架構運行。提供兩種使用方式：
+
+- **Web 瀏覽器版**：在本機啟動 HTTP 服務，透過瀏覽器存取完整互動介面，更穩定
+- **Electron 桌面版**：原生桌面視窗，使用體驗更流暢（可能仍有不穩定之處）
+
+兩種方式共享同一套本機資料和工作階段。此外支援行動端（微信 / 飛書 / QQ）接入。
 
 ### 核心特性
 
-- **開箱即用**：下載安裝包雙擊即可啟動，內建預設模型配置
-- **完整程式設計能力**：程式碼執行、LSP 程式碼感知、檔案和終端機操作，覆蓋日常開發全流程
+- **開箱即用**：既可從官網下載安裝腳本執行安裝，也可下載 Releases 中的壓縮包安裝，內建預設模型配置
+- **完整程式設計能力**：完全繼承 OpenCode 的編碼能力，支援程式碼執行、LSP 程式碼感知、檔案和終端機操作，覆蓋日常開發全流程
 - **25+ AI 提供商**：支援 Anthropic、OpenAI、Google Gemini、AIhubmix、DeepSeek、Z\.AI、Kimi、Qwen 等主流平台，以及任何 OpenAI 相容介面
-- **10+ 個內建科研 Skills**：文獻綜述、論文寫作、深度研究、arXiv 搜尋、同行評審、研究基金撰寫等，開箱即用
+- **20+ 個內建 Skills**：文獻綜述、論文寫作、深度研究、arXiv 搜尋、同行評審、研究基金撰寫、文件產生等，開箱即用
 - **Skill 自進化**：Agent 在完成任務後自動評審對話歷史，將成功經驗固化為可複用的 Skill（copy-on-write 寫入、安全掃描、版本快照），形成持續學習閉環
 - **MCP 協定支援**：整合 Model Context Protocol，可連接本機或遠端 MCP 伺服器擴充工具集
 - **知識庫（RAG）**：將 PDF 和文字文件向量化索引，支援語義搜尋，按相關性注入上下文，大幅節省 Token
@@ -30,8 +35,8 @@ Aether 是一個功能豐富的 AI 研究助手平台。它以客戶端/伺服�
 - **語音輸入**：基於多模態模型的語音轉文字，自動去除語氣詞並糾正專業術語
 - **Git 整合**：在介面中檢視分支、提交歷史、Diff 和檔案變更等
 - **定時任務**：支援 Cron 表示式、固定間隔和一次性定時任務，可自動執行研究流程
-- **Memory 機制**：AI 自動將使用者偏好和互動經驗持久化到 `memory.instruction.md`，跨會話複用，無需重複說明
-- **會話分享**：產生分享連結，即時同步對話內容
+- **Memory 機制**：AI 自動將使用者偏好和互動經驗持久化到本機記憶檔案，跨工作階段複用，無需重複說明
+- **工作階段分享**：產生分享連結，即時同步對話內容
 
 ---
 
@@ -50,28 +55,53 @@ Aether 是一個功能豐富的 AI 研究助手平台。它以客戶端/伺服�
 解壓後目錄結構：
 
 ```
-aether          ← CLI 二進位（Windows 為 aether.exe）
-web/            ← 前端靜態資源（必須與二進位同目錄）
-Aether.vbs      ← Windows 啟動器
-Aether.command  ← macOS 啟動器
+aether              ← CLI 二進位（Windows 為 aether.exe）
+web/                ← 前端靜態資源（必須與二進位同目錄）
+install.sh/.command/.bat  ← 安裝腳本（‼️建立桌面捷徑、應用程式入口等）
+Aether.sh / .command / .vbs  ← 啟動器
+aether-icon.*       ← 應用程式圖示
 ```
 
-**Windows**：雙擊 `Aether.vbs`（如果報錯，先執行 `Aether.exe`），瀏覽器自動開啟介面。
+推薦先執行安裝腳本，安裝完成後即可從系統應用程式中啟動 Aether：
 
-**macOS**：首次使用賦予執行權限後，雙擊 `Aether.command` 即可啟動：
+**Windows**：右鍵 `install.bat` → 以系統管理員身分執行（或在終端機中執行）。安裝後從桌面捷徑或開始功能表啟動。
+
+**macOS**：
+在解壓後的目錄下：
 
 ```bash
-chmod +x Aether.command aether   # 首次需要
+chmod +x install.command   # 首次需要
+./install.command
 ```
+
+若提示「無法驗證開發者」或「已損毀」：
+
+```bash
+xattr -cr ./install.command ./aether ./Aether.command
+```
+
+然後再右鍵點擊 `install.command` 選擇「開啟」進行安裝。安裝後從 `/Applications/Aether.app` 或 Launchpad 啟動。
 
 **Linux**：
 
 ```bash
-chmod +x aether   # 首次需要
-./aether web
+chmod +x install.sh   # 首次需要
+./install.sh
 ```
 
+安裝後從系統啟動台點擊 Aether 圖示啟動。（⚠️注意：舊版本會在桌面上建立的 sh 腳本已棄用）
+
+如果不透過安裝腳本，也可直接執行啟動器（不推薦）：
+
+**Windows**：雙擊 `Aether.vbs`。若被防毒軟體攔截，請選擇允許執行。
+
+**macOS**：雙擊 `Aether.command`（需先 `chmod +x`）。
+
+**Linux**：執行 `./Aether.sh` 或 `./aether web`。
+
 `aether web` 啟動後會顯示本機和區域網路存取位址，瀏覽器自動開啟。
+
+（如安裝過程中遇到其他問題，請先檢視[常見問題](#常見問題)，或透過官網聯繫）
 
 <!-- 支援以下選項：
 
@@ -79,21 +109,52 @@ chmod +x aether   # 首次需要
 ./aether web --port 8080              # 指定連接埠
 ./aether web --hostname 0.0.0.0       # 允許區域網路存取
 ./aether web --idle-timeout 120       # 空閒逾時（秒），0 表示常駐執行
+AETHER_IDLE_TIMEOUT=15 ./Aether.sh    # 部署時覆蓋空閒逾時（秒）
 ``` -->
 
-### Electron 桌面版
+#### Electron 桌面版
 
-敬請期待
-
-<!-- 解壓（或安裝）後雙擊執行：
+從 [Releases 頁面](https://github.com/Science-Discovery/Aether/releases)下載對應平台的安裝包（注意選擇 Desktop 版本，而非 Web 版壓縮包）。
 
 | 平台 | 檔案 |
 |---|---|
-| Linux | `aether-linux-x64.AppImage` / `.deb` / `.rpm` |
-| macOS | `aether-mac-arm64.dmg`（Apple Silicon）/ `aether-mac-x64.dmg` |
-| Windows | `aether-win-x64.exe` 安裝程式 / `win-unpacked/` 便攜版 |
+| Windows | `aether-desktop-win-x64.exe`（NSIS 安裝程式） |
+| macOS Apple Silicon | `aether-desktop-mac-arm64.dmg` |
+| macOS Intel | `aether-desktop-mac-x64.dmg` |
+| Linux | `.AppImage` / `.deb` / `.rpm` |
 
---- -->
+**Windows**：雙擊 `.exe` 安裝包，按安裝精靈完成。安裝後從開始功能表或桌面捷徑啟動。若防毒軟體提示風險，確認檔案來自官方 GitHub Release 後選擇保留並繼續。
+
+**macOS**：開啟 `.dmg`，將 `Aether Desktop.app` 拖入 `Applications`。若提示無法驗證開發者，需要在「設定─安全性與隱私權」中，找到有關 Aether Desktop 的提示，點擊選擇「仍要開啟」。若提示「已損毀」，在終端機執行：
+
+```bash
+xattr -cr /Applications/Aether\ Desktop.app
+```
+
+**Linux**：
+
+AppImage：
+
+```bash
+chmod +x ./aether-*.AppImage
+./aether-*.AppImage
+```
+
+deb：
+
+```bash
+sudo dpkg -i ./aether-desktop*.deb
+```
+
+rpm：
+
+```bash
+sudo dnf install ./aether-desktop*.rpm
+```
+
+> **說明**：桌面版與 Web/CLI 共享同一套資料目錄（`~/.local/share/aether`），已有使用者可無縫切換。桌面版目前未做程式碼簽章，macOS 更新為手動模式（檢查後開啟 GitHub Release 頁面下載），Windows 和 Linux AppImage 支援應用程式內更新。Linux deb 和 rpm 包暫不支援自動更新，類似 macOS，也需在彈窗提醒後手動下載最新安裝包覆蓋安裝。
+<!-- >
+> 更多詳情見[桌面版使用者指南](docs/desktop-electron-user-guide.zh-CN.md) | [解除安裝說明](docs/desktop-electron-uninstall.zh-CN.md) -->
 
 ## 從原始碼執行
 
@@ -116,6 +177,16 @@ bun run --cwd packages/app dev
 ```
 網頁開啟後如果發現資源載入失敗，可以手動新增終端機 1 中顯示的 `http://localhost:xxxx` 到伺服器列表中。
 
+### 桌面版開發模式
+
+```bash
+# 終端機 1：啟動 API Server
+bun dev serve
+
+# 終端機 2：啟動桌面端
+bun run --cwd packages/desktop-electron dev
+```
+
 ---
 
 ## 設定 AI 提供商
@@ -126,14 +197,16 @@ bun run --cwd packages/app dev
 
 ### 內建 Skills
 
-Aether 預建了 16 個面向科研場景的 Skills，透過描述自動觸發，無需手動呼叫：
+Aether 預建了 20+ 個面向科研和日常場景的 Skills，透過描述自動觸發，無需手動呼叫：
 
 | 類別 | Skill | 功能 |
 |---|---|---|
 | 開發工具 | `skill-creator` | 建立和最佳化 Agent Skills |
 | | `skill-manager` | 掃描、分類和管理 Skills 集合 |
+| | `skill-security-auditor` | AI Skill 安全稽核與漏洞掃描 |
 | | `code-reviewer` | 程式碼審查（安全、效能、最佳實踐） |
 | | `project-signpost` | 產生專案目錄導航檔案 |
+| | `prepare-for-git-commit` | Git commit 前的程式碼檢查與訊息撰寫 |
 | 學術研究 | `academic-researcher` | 文獻綜述、論文分析、公式推導 |
 | | `literature-review` | 多資料庫系統文獻綜述 |
 | | `peer-review` | 同行評審工具包 |
@@ -142,10 +215,15 @@ Aether 預建了 16 個面向科研場景的 Skills，透過描述自動觸發�
 | | `arxiv-search` | 搜尋 arXiv 預印本 |
 | | `read-arxiv-paper` | 閱讀和分析 arXiv 論文 |
 | | `research-grants` | 撰寫研究基金申請書 |
+| | `research-grants-ch` | 撰寫中國科研基金申請書（國自然、博後基金等） |
 | | `scientific-critical-thinking` | 科學證據品質評估 |
 | | `scientific-brainstorming` | 科研假設產生與跨學科探索 |
 | | `response-to-referee` | 逐條回覆審稿人意見 |
 | 通用 | `brainstorming` | 在實作之前將想法轉化為設計方案 |
+| | `clawhub` | 從 ClawHub 搜尋和安裝 Agent Skills |
+| | `docx` | 建立和編輯 Word 文件 |
+| | `excel-analysis` | 分析 Excel 試算表 |
+| | `ppt-generation` | 產生 PowerPoint 簡報 |
 
 學術 Skills 可串聯使用：`arxiv-search` → `read-arxiv-paper` → `literature-review` → `write-paper`
 
@@ -187,7 +265,7 @@ aether mcp debug                    # 除錯 MCP 連線
 
 ### 行動端
 
-透過微信、飛書、QQ 機器人從手機端與 Aether 對話。在 Web 介面的設定中配置對應平台的憑證即可啟用。
+透過微信、飛書、QQ 機器人從手機端與 Aether 對話。在設定中配置對應平台的憑證即可啟用（Web 版和桌面版均支援）。
 
 ---
 
@@ -200,7 +278,7 @@ aether run <message>  # 非互動式執行指令
 aether models         # 列出可用模型
 aether providers      # 檢視提供商
 aether mcp            # 管理 MCP 伺服器
-aether session        # 會話管理
+aether session        # 工作階段管理
 aether stats          # 檢視使用統計
 aether upgrade        # 自更新
 aether debug config   # 檢視目前設定
@@ -219,3 +297,11 @@ aether debug config   # 檢視目前設定
 **提示找不到前端資源**：確認 `aether` 二進位和 `web/` 目錄在同一目錄下。
 
 **模型列表為空**：檢查環境變數 `OPENCODE_CONFIG` 路徑是否正確。
+
+**macOS 提示「無法開啟，因為無法驗證開發者」**：應用程式未簽章。右鍵點擊應用程式選擇「開啟」，在「設定─安全性與隱私權」中找到相關提示，選擇「仍要開啟」。之後應用程式會被記為信任，不再提示。（每次更新後需要重複此操作）
+
+**macOS 提示「已損毀，無法開啟」**：這是 macOS 隔離屬性導致的誤報。在終端機執行 `xattr -cr /Applications/Aether\ Desktop.app`（桌面版）或 `xattr -cr ./aether ./Aether.command`（Web 版）即可。
+
+**Linux Web 版安裝後找不到啟動入口**：執行解壓目錄中的 `install.sh`（需先 `chmod +x`），安裝完成後可在系統啟動台中找到 Aether 圖示。*原先在桌面上的 `Aether.sh` 啟動腳本已棄用*。
+
+**桌面版和 Web 版可以同時安裝嗎？**：可以。兩者共享同一套資料和工作階段。但是應避免同時執行兩個版本，以免競爭資源導致不穩定。


### PR DESCRIPTION
- 项目简介：补充桌面版说明，移除"未来预计支持"
- 核心特性：更新 Skills 数量为 20+
- 手动安装：优先推荐 install 脚本安装流程，补充目录结构和各平台详细说明
- Electron 桌面版：替换"敬请期待"，补充完整安装说明（含 macOS 安全提示、Linux 多格式、Windows 杀毒提示）
- Skills 表格：补充缺失的 7 个 Skill（skill-security-auditor, prepare-for-git-commit, research-grants-ch, clawhub, docx, excel-analysis, ppt-generation）
- 常见问题：新增 macOS 安全与隐私、Linux 启动入口、版本共存等 4 条
- 从源码运行：补充桌面版开发模式
- 移动端：说明 Web 版和桌面版均支持
- 三语 README 同步更新