### PR TITLE
feat(mobile): 微信端文件通过iLink CDN下载保存到Aether持久化目录

### DIFF
--- a/packages/opencode/src/mobile/base.ts
+++ b/packages/opencode/src/mobile/base.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, writeFile, rm, stat } from "fs/promises"
-import { isAbsolute, join, basename } from "path"
+import { isAbsolute, join, basename, extname } from "path"
 import { existsSync } from "fs"
 import z from "zod"
 import { BusEvent } from "@/bus/bus-event"
@@ -22,7 +22,8 @@ import { SessionPreference } from "@/session/preference"
 import { Question } from "@/question"
 import { Permission } from "@/permission"
 import { NotFoundError } from "@/storage/db"
-import { legacyPlatformDir, platformDir } from "@/persist/naming"
+import { legacyPlatformDir, platformDir, filesDir } from "@/persist/naming"
+import type { MediaAttachment } from "./ilink"
 
 export type MobileStatus = "idle" | "starting" | "qrcode" | "connected" | "reconnecting" | "error"
 
@@ -534,7 +535,13 @@ export abstract class MobileManagerBase {
 
   // ── Message handling ────────────────────────────────────────────────────────
 
-  async handleMessage(chatId: string, messageId: string, text: string, rootId: string): Promise<void> {
+  async handleMessage(
+    chatId: string,
+    messageId: string,
+    text: string,
+    rootId: string,
+    mediaAttachments?: MediaAttachment[],
+  ): Promise<void> {
     const scope = this.scopeKey(chatId, rootId)
     const reply = this.replyTarget(chatId, messageId)
     if (!this._initialized) {
@@ -693,7 +700,13 @@ export abstract class MobileManagerBase {
         return
       }
 
-      await this.startPrompt(scope, messageId, text, effectiveDir)
+      await this.startPrompt(
+        scope,
+        messageId,
+        text,
+        effectiveDir,
+        await this.processMediaAttachments(scope, reply, mediaAttachments, effectiveDir),
+      )
     } catch (err) {
       if (err instanceof Session.BusyError) {
         await this.replySession(
@@ -713,7 +726,13 @@ export abstract class MobileManagerBase {
     }
   }
 
-  protected async startPrompt(scope: string, messageId: string, text: string, effectiveDir: string): Promise<void> {
+  protected async startPrompt(
+    scope: string,
+    messageId: string,
+    text: string,
+    effectiveDir: string,
+    savedFilePaths: string[] = [],
+  ): Promise<void> {
     const reply = this.replyTarget(scope, messageId)
     this._activePrompt.set(scope, { sessionId: "", messageId, directory: effectiveDir })
 
@@ -731,6 +750,12 @@ export abstract class MobileManagerBase {
     console.log(`[${this.adapter.platform}] using model:`, model ?? "(default)")
 
     let promptText = text
+    if (savedFilePaths.length > 0) {
+      promptText +=
+        "\n\n[用户通过微信发送了以下文件：\n" +
+        savedFilePaths.map((p) => `- ${p}`).join("\n") +
+        "\n请根据需要读取和处理这些文件。]"
+    }
     if (this.mightWantFile(text)) {
       promptText +=
         "\n\n[系统提示：如果用户的意图是获取某个文件，请在回复中包含该文件在当前系统上的完整绝对路径。Windows 示例：E:\\\\work\\\\demo\\\\file.md；macOS/Linux 示例：/Users/demo/file.md 或 /home/demo/file.md。系统将自动把该路径对应的文件作为附件发送给用户。如果用户无需获取文件，请忽略本提示，正常回复即可。]"
@@ -835,6 +860,54 @@ export abstract class MobileManagerBase {
     } finally {
       this._activePrompt.delete(scope)
     }
+  }
+
+  protected async processMediaAttachments(
+    scope: string,
+    reply: string,
+    attachments: MediaAttachment[] | undefined,
+    effectiveDir: string,
+  ): Promise<string[]> {
+    if (!attachments || attachments.length === 0) return []
+
+    const projectID = await Instance.provide({
+      directory: effectiveDir,
+      fn: () => Instance.project.id,
+    })
+    const destDir = filesDir(projectID)
+    await mkdir(destDir, { recursive: true })
+
+    const savedPaths: string[] = []
+    for (const attachment of attachments) {
+      try {
+        const { data, fileName } = await this.downloadMediaAttachment(attachment)
+        let targetName = fileName
+        let targetPath = join(destDir, targetName)
+        let idx = 1
+        while (existsSync(targetPath)) {
+          const ext = extname(targetName)
+          const base = basename(targetName, ext)
+          targetName = `${base}_${idx}${ext}`
+          targetPath = join(destDir, targetName)
+          idx++
+        }
+        await writeFile(targetPath, data)
+        savedPaths.push(targetPath)
+        console.log(`[${this.adapter.platform}] saved media:`, targetPath)
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        console.error(`[${this.adapter.platform}] media download failed:`, msg)
+        const label = attachment.fileName || attachment.type
+        try {
+          await this.replySession(scope, reply, `⚠️ 文件下载失败: ${label}\n原因: ${msg.slice(0, 100)}`)
+        } catch {}
+      }
+    }
+    return savedPaths
+  }
+
+  protected async downloadMediaAttachment(attachment: MediaAttachment): Promise<{ data: Buffer; fileName: string }> {
+    throw new Error("downloadMediaAttachment not implemented for this platform")
   }
 
   protected enqueueMessage(chatId: string, messageId: string): boolean {

--- a/packages/opencode/src/mobile/ilink.ts
+++ b/packages/opencode/src/mobile/ilink.ts
@@ -210,11 +210,24 @@ export async function getUpdates(
 
 // ── Message parsing ────────────────────────────────────────────────────────────
 
+export interface MediaAttachment {
+  type: "image" | "voice" | "file" | "video"
+  fileName?: string
+  fileSize?: number
+  md5?: string
+  encryptQueryParam?: string
+  aesKey?: string
+  aesKeyHex?: string
+  fullUrl?: string
+  rawItem: dict
+}
+
 export interface ParsedMessage {
   conversation_id: string
   text: string
   message_id: string
   context_token: string
+  mediaAttachments: MediaAttachment[]
   raw: dict
 }
 
@@ -224,32 +237,81 @@ const ITEM_VOICE = 3
 const ITEM_FILE = 4
 const ITEM_VIDEO = 5
 
-function extractText(itemList: dict[]): string {
-  const parts: string[] = []
+function extractItemInfo(itemList: dict[]): { text: string; attachments: MediaAttachment[] } {
+  const textParts: string[] = []
+  const attachments: MediaAttachment[] = []
   for (const item of itemList) {
     const t = item.type ?? 0
     if (t === ITEM_TEXT) {
       const text = (item.text_item ?? {}).text ?? ""
-      if (text) parts.push(text)
+      if (text) textParts.push(text)
       const ref = item.ref_msg
       if (ref) {
         const refItem = ref.message_item ?? {}
         const refText = (refItem.text_item ?? {}).text ?? ""
-        if (refText) parts.push(`[引用: ${refText}]`)
+        if (refText) textParts.push(`[引用: ${refText}]`)
       }
     } else if (t === ITEM_VOICE) {
-      const vt = (item.voice_item ?? {}).text ?? ""
-      parts.push(vt || "[语音]")
+      const voice = item.voice_item ?? {}
+      const vt = voice.text ?? ""
+      textParts.push(vt || "[语音]")
+      const media = voice.media ?? {}
+      if (media.encrypt_query_param || media.full_url) {
+        attachments.push({
+          type: "voice",
+          encryptQueryParam: media.encrypt_query_param,
+          aesKey: media.aes_key,
+          fullUrl: media.full_url,
+          rawItem: item,
+        })
+      }
     } else if (t === ITEM_IMAGE) {
-      parts.push("[图片]")
+      const img = item.image_item ?? {}
+      textParts.push("[图片]")
+      const media = img.media ?? {}
+      if (media.encrypt_query_param || media.full_url) {
+        attachments.push({
+          type: "image",
+          encryptQueryParam: media.encrypt_query_param,
+          aesKey: media.aes_key,
+          aesKeyHex: img.aeskey,
+          fullUrl: media.full_url,
+          rawItem: item,
+        })
+      }
     } else if (t === ITEM_VIDEO) {
-      parts.push("[视频]")
+      const video = item.video_item ?? {}
+      textParts.push("[视频]")
+      const media = video.media ?? {}
+      if (media.encrypt_query_param || media.full_url) {
+        attachments.push({
+          type: "video",
+          encryptQueryParam: media.encrypt_query_param,
+          aesKey: media.aes_key,
+          fullUrl: media.full_url,
+          rawItem: item,
+        })
+      }
     } else if (t === ITEM_FILE) {
-      const fn = (item.file_item ?? {}).file_name ?? ""
-      parts.push(fn ? `[文件: ${fn}]` : "[文件]")
+      const file = item.file_item ?? {}
+      const fn = file.file_name ?? ""
+      textParts.push(fn ? `[文件: ${fn}]` : "[文件]")
+      const media = file.media ?? {}
+      if (media.encrypt_query_param || media.full_url) {
+        attachments.push({
+          type: "file",
+          fileName: fn || undefined,
+          fileSize: file.len ? parseInt(file.len, 10) : undefined,
+          md5: file.md5 || undefined,
+          encryptQueryParam: media.encrypt_query_param,
+          aesKey: media.aes_key,
+          fullUrl: media.full_url,
+          rawItem: item,
+        })
+      }
     }
   }
-  return parts.join(" ")
+  return { text: textParts.join(" "), attachments }
 }
 
 export function parseMessage(raw: dict): ParsedMessage | null {
@@ -257,12 +319,13 @@ export function parseMessage(raw: dict): ParsedMessage | null {
   const itemList = raw.item_list ?? []
   const fromUserId = raw.from_user_id ?? ""
   if (!itemList && !fromUserId) return null
-  const text = extractText(itemList)
+  const { text, attachments } = extractItemInfo(itemList)
   return {
     conversation_id: fromUserId,
     text,
     message_id: String(raw.message_id ?? ""),
     context_token: raw.context_token ?? "",
+    mediaAttachments: attachments,
     raw,
   }
 }
@@ -399,4 +462,92 @@ export async function sendFile(
     token,
     30000,
   )
+}
+
+// ── Download media ────────────────────────────────────────────────────────────
+
+function buildCdnDownloadUrl(encryptedQueryParam: string, cdnBaseUrl: string): string {
+  return `${cdnBaseUrl}/download?encrypted_query_param=${encodeURIComponent(encryptedQueryParam)}`
+}
+
+function parseAesKey(aesKeyBase64: string, label: string): Buffer {
+  const decoded = Buffer.from(aesKeyBase64, "base64")
+  if (decoded.length === 16) return decoded
+  if (decoded.length === 32 && /^[0-9a-fA-F]{32}$/.test(decoded.toString("ascii"))) {
+    return Buffer.from(decoded.toString("ascii"), "hex")
+  }
+  throw new Error(`${label}: aes_key must decode to 16 raw bytes or 32-char hex string, got ${decoded.length} bytes`)
+}
+
+const aesDec = (buf: Buffer, key: Buffer) => {
+  const decipher = crypto.createDecipheriv("aes-128-ecb", key, null)
+  return Buffer.concat([decipher.update(buf), decipher.final()])
+}
+
+const DOWNLOAD_TIMEOUT = 60_000
+const MAX_DOWNLOAD_SIZE = 100 * 1024 * 1024
+
+export async function downloadMedia(
+  attachment: MediaAttachment,
+  cdnBaseUrl: string = CDN_BASE_URL,
+): Promise<{ data: Buffer; fileName: string }> {
+  const label = `[wechat] download ${attachment.type}`
+
+  if (!attachment.encryptQueryParam && !attachment.fullUrl) {
+    throw new Error(`${label}: no download parameters available`)
+  }
+
+  let aesKeyBase64: string | undefined
+  if (attachment.type === "image" && attachment.aesKeyHex) {
+    aesKeyBase64 = Buffer.from(attachment.aesKeyHex, "hex").toString("base64")
+  } else {
+    aesKeyBase64 = attachment.aesKey
+  }
+
+  const url =
+    attachment.fullUrl ||
+    (attachment.encryptQueryParam ? buildCdnDownloadUrl(attachment.encryptQueryParam, cdnBaseUrl) : "")
+
+  if (!url) throw new Error(`${label}: could not construct download URL`)
+
+  console.log(`${label}: fetching url=${url.slice(0, 80)}...`)
+
+  const res = await fetch(url, { signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT) })
+  if (!res.ok) {
+    const body = await res.text().catch(() => "")
+    throw new Error(`${label}: CDN download ${res.status}: ${body.slice(0, 200)}`)
+  }
+
+  const encrypted = Buffer.from(await res.arrayBuffer())
+  if (encrypted.length > MAX_DOWNLOAD_SIZE) {
+    throw new Error(`${label}: downloaded ${encrypted.length} bytes exceeds max ${MAX_DOWNLOAD_SIZE}`)
+  }
+
+  let data: Buffer
+  if (aesKeyBase64) {
+    const key = parseAesKey(aesKeyBase64, label)
+    data = aesDec(encrypted, key)
+    console.log(`${label}: decrypted ${data.length} bytes`)
+  } else if (attachment.type === "image") {
+    data = encrypted
+    console.log(`${label}: downloaded plain image ${data.length} bytes`)
+  } else {
+    throw new Error(`${label}: aes_key required for ${attachment.type} download`)
+  }
+
+  let fileName = attachment.fileName || ""
+  if (!fileName) {
+    const ts = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19)
+    const ext =
+      attachment.type === "image"
+        ? ".png"
+        : attachment.type === "voice"
+          ? ".silk"
+          : attachment.type === "video"
+            ? ".mp4"
+            : ".bin"
+    fileName = `wechat_${attachment.type}_${ts}${ext}`
+  }
+
+  return { data, fileName }
 }

--- a/packages/opencode/src/mobile/wechat.ts
+++ b/packages/opencode/src/mobile/wechat.ts
@@ -8,7 +8,7 @@ import { legacyPlatformDir, platformDir } from "@/persist/naming"
 import { MobileManagerBase } from "./base"
 import type { MobileAdapter } from "./base"
 import * as ilink from "./ilink"
-import type { LoginStatusResult } from "./ilink"
+import type { LoginStatusResult, MediaAttachment } from "./ilink"
 
 export type WeChatStatus = "idle" | "starting" | "qrcode" | "connected" | "reconnecting" | "error"
 
@@ -422,11 +422,15 @@ class WeChatManagerImpl extends MobileManagerBase {
           await this.saveILinkState()
 
           console.log("[wechat] received:", parsed.conversation_id, parsed.text.slice(0, 50))
-          void this.handleMessage(parsed.conversation_id, parsed.message_id, parsed.text, parsed.message_id).catch(
-            (err) => {
-              console.error("[wechat] handleMessage error:", err)
-            },
-          )
+          void this.handleMessage(
+            parsed.conversation_id,
+            parsed.message_id,
+            parsed.text,
+            parsed.message_id,
+            parsed.mediaAttachments,
+          ).catch((err) => {
+            console.error("[wechat] handleMessage error:", err)
+          })
         }
 
         if (this._cursor) await this.saveILinkState()
@@ -547,6 +551,12 @@ class WeChatManagerImpl extends MobileManagerBase {
     } catch (err) {
       console.error("[wechat] sendFile error:", err, "convId:", convId, "filePath:", filePath)
     }
+  }
+
+  protected override async downloadMediaAttachment(
+    attachment: MediaAttachment,
+  ): Promise<{ data: Buffer; fileName: string }> {
+    return ilink.downloadMedia(attachment, this._ilinkCdnBaseUrl)
   }
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #1039

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

当前微信端收到文件/图片/语音/视频消息时，iLink 协议只提取文本标签（如 `[文件: xxx.pdf]`），消息中的 CDN 下载参数（`encrypt_query_param`、`aes_key`）被丢弃，Aether 无法访问文件内容。

本 PR 实现了完整的 CDN 下载流程：

1. **ilink.ts** — 新增 `MediaAttachment` 接口，重构 `extractText` → `extractItemInfo`，同时提取文本和媒体 CDN 参数（图片/语音/文件/视频各自的 `encrypt_query_param`、`aes_key`、`full_url` 等）；新增 `downloadMedia` 函数，实现 CDN URL 构造 + GET 下载 + AES-128-ECB 解密（含两种 aes_key 编码格式的解析）；`ParsedMessage` 新增 `mediaAttachments` 字段。

2. **base.ts** — `handleMessage` 新增可选参数 `mediaAttachments`；新增 `processMediaAttachments` 方法（遍历附件 → 调用 `downloadMediaAttachment` → 保存到 `filesDir(projectID)` → 文件名冲突加序号 → 失败时通知用户）；新增 `downloadMediaAttachment` 抽象方法供子类实现；`startPrompt` 新增 `savedFilePaths` 参数，将文件路径注入到 prompt 文本中供 AI 读取。

3. **wechat.ts** — `pollLoop` 将 `parsed.mediaAttachments` 传入 `handleMessage`；实现 `downloadMediaAttachment` 调用 `ilink.downloadMedia(attachment, this._ilinkCdnBaseUrl)`。

Feishu/QQ 平台不受影响，新增参数为 optional，传入 `undefined` 即可。

### How did you verify your code works?

- TypeScript 类型检查通过（`tsgo --noEmit` 无错误）
- 构建打包成功（`bun run build --single`，产物 `aether-darwin-arm64` 正常生成并 `--version` 输出正确）
- Feishu/QQ 调用 `handleMessage` 时不传 `mediaAttachments`，与现有行为完全兼容

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR