### PR TITLE
fix: defer Electron settings updater capability

### DIFF
--- a/packages/desktop-electron/src/renderer/index.tsx
+++ b/packages/desktop-electron/src/renderer/index.tsx
@@ -224,7 +224,10 @@ const createPlatform = (): Platform => {
 
     parseMarkdown: (markdown: string) => window.api.parseMarkdownCommand(markdown),
 
-    runUpdater: SETTINGS_UPDATER_ENABLED() ? () => runUpdater({ alertOnFail: true }) : undefined,
+    get runUpdater() {
+      if (!SETTINGS_UPDATER_ENABLED()) return undefined
+      return () => runUpdater({ alertOnFail: true })
+    },
 
     webviewZoom,
 


### PR DESCRIPTION
### Issue for this PR

Refs #1015

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes the Electron Settings page update-check capability so it is evaluated when Settings reads platform.runUpdater instead of being frozen during renderer platform construction.

The previous Settings updater flag is injected into the renderer after the Electron window starts loading. The old renderer code read that flag once while creating the platform object, so runUpdater could stay undefined even after settingsUpdaterEnabled was injected. This change turns runUpdater into a getter that reads SETTINGS_UPDATER_ENABLED at access time and still routes manual checks through the existing runUpdater({ alertOnFail: true }) path.

The change is limited to the Electron renderer platform implementation. Web code and the shared Settings component are not modified.

### How did you verify your code works?

- Ran git diff --cached --check.
- Ran bun typecheck in packages/app.
- Ran bun typecheck in packages/desktop-electron; it failed on the existing semver declaration issue in src/main/index.ts before reaching this renderer change.
- Confirmed the staged diff only touched packages/desktop-electron/src/renderer/index.tsx.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR