### PR TITLE
fix(app): keep multimodal audio models selectable for chat

### DIFF
--- a/packages/app/src/components/dialog-select-model.tsx
+++ b/packages/app/src/components/dialog-select-model.tsx
@@ -14,7 +14,7 @@ import { DialogSelectProvider } from "./dialog-select-provider"
 import { DialogManageModels } from "./dialog-manage-models"
 import { ModelTooltip } from "./model-tooltip"
 import { useLanguage } from "@/context/language"
-import { isVoiceModel } from "@/utils/voice"
+import { isChatModel } from "@/utils/voice"
 
 const isFree = (provider: string, cost: { input: number } | undefined) =>
   provider === "opencode" && (!cost || cost.input === 0)
@@ -35,7 +35,7 @@ const ModelList: Component<{
     model
       .list()
       .filter((m) => model.visible({ modelID: m.id, providerID: m.provider.id }))
-      .filter((m) => !isVoiceModel(m))
+      .filter(isChatModel)
       .filter((m) => (props.provider ? m.provider.id === props.provider : true)),
   )
 

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -16,7 +16,7 @@ import { useModels } from "@/context/models"
 import { usePlatform } from "@/context/platform"
 import { useSettings, monoFontFamily } from "@/context/settings"
 import { playSoundById, SOUND_OPTIONS } from "@/utils/sound"
-import { isVoiceModel } from "@/utils/voice"
+import { isChatModel, isVoiceModel } from "@/utils/voice"
 import { Link } from "./link"
 import { formatServerError } from "@/utils/server-errors"
 import { SettingsList } from "./settings-list"
@@ -137,7 +137,7 @@ export const SettingsGeneral: Component = () => {
     const items = models
       .list()
       .filter((m) => models.visible({ providerID: m.provider.id, modelID: m.id }))
-      .filter((m) => !voice(m))
+      .filter(isChatModel)
       .map((m) => ({
         value: `${m.provider.id}/${m.id}`,
         label: `${m.name} (${m.provider.name})`,

--- a/packages/app/src/utils/voice.test.ts
+++ b/packages/app/src/utils/voice.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test"
+import { isChatModel, isVoiceModel, type VoiceModel } from "./voice"
+
+const base = {
+  provider: { id: "google", name: "Google" },
+}
+
+function model(input: Partial<VoiceModel>): VoiceModel {
+  return {
+    ...base,
+    id: "model",
+    name: "Model",
+    ...input,
+  }
+}
+
+describe("voice model classification", () => {
+  test("keeps multimodal chat models selectable for chat", () => {
+    const gemini = model({
+      id: "gemini-3-pro-preview",
+      name: "Gemini 3 Pro Preview",
+      capabilities: {
+        input: { audio: true },
+        output: { text: true, audio: false },
+      },
+      modalities: {
+        input: ["text", "image", "video", "audio", "pdf"],
+        output: ["text"],
+      },
+    })
+
+    expect(isVoiceModel(gemini)).toBe(true)
+    expect(isChatModel(gemini)).toBe(true)
+  })
+
+  test("keeps audio output models out of chat", () => {
+    const tts = model({
+      id: "gemini-2.5-pro-preview-tts",
+      name: "Gemini 2.5 Pro Preview TTS",
+      capabilities: {
+        input: { audio: false },
+        output: { text: false, audio: true },
+      },
+      modalities: {
+        input: ["text"],
+        output: ["audio"],
+      },
+    })
+
+    expect(isVoiceModel(tts)).toBe(true)
+    expect(isChatModel(tts)).toBe(false)
+  })
+
+  test("keeps audio-only transcription models out of chat", () => {
+    const parakeet = model({
+      id: "nvidia/parakeet-tdt-0.6b-v2",
+      name: "Parakeet TDT 0.6B v2",
+      capabilities: {
+        input: { audio: true },
+        output: { text: true, audio: false },
+      },
+      modalities: {
+        input: ["audio"],
+        output: ["text"],
+      },
+    })
+
+    expect(isVoiceModel(parakeet)).toBe(true)
+    expect(isChatModel(parakeet)).toBe(false)
+  })
+
+  test("recognizes transcription model names without modalities", () => {
+    expect(isVoiceModel(model({ id: "whisper-large-v3", name: "Whisper Large V3" }))).toBe(true)
+    expect(isVoiceModel(model({ id: "qwen2.5-omni-7b", name: "Qwen Omni" }))).toBe(true)
+  })
+})

--- a/packages/app/src/utils/voice.ts
+++ b/packages/app/src/utils/voice.ts
@@ -2,15 +2,26 @@ export type VoiceModel = {
   id: string
   name: string
   provider: { id: string; name: string }
-  capabilities?: { input: { audio: boolean } }
-  modalities?: { input: Array<string> }
+  capabilities?: {
+    input: { text?: boolean; audio?: boolean }
+    output?: { text?: boolean; audio?: boolean }
+  }
+  modalities?: { input: Array<string>; output?: Array<string> }
 }
 
 export function isVoiceModel(model: VoiceModel) {
   const text = `${model.id} ${model.name}`.toLowerCase()
-  return (
-    model.capabilities?.input.audio ||
-    model.modalities?.input.includes("audio") ||
-    /\b(asr|omni|realtime|whisper)\b|speech[-_ ]?to[-_ ]?text|transcri/.test(text)
-  )
+  const input = model.capabilities?.input.audio || model.modalities?.input.includes("audio")
+  const output = model.capabilities?.output?.audio || model.modalities?.output?.includes("audio")
+  if (input || output) return true
+  return /\b(asr|omni|realtime|whisper)\b|speech[-_ ]?to[-_ ]?text|transcri/.test(text)
+}
+
+export function isChatModel(model: VoiceModel) {
+  const input = model.capabilities?.input.text ?? model.modalities?.input.includes("text") ?? true
+  if (!input) return false
+  if (model.capabilities?.output?.text !== undefined) return model.capabilities.output.text
+  const output = model.modalities?.output
+  if (output) return output.includes("text")
+  return true
 }


### PR DESCRIPTION
### Issue for this PR

Closes #1042

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This separates voice-capable model detection from chat-selectable model detection.

Models with audio input and text output can now remain available in chat selectors, while audio-only transcription models and audio-output models are filtered out of chat selectors. The same chat filter is used in the model picker and Settings default model selectors.

### How did you verify your code works?

- `bun test --preload ./happydom.ts ./src/utils/voice.test.ts`
- `bun typecheck`
- `git push -u origin fix-voice-chat-model-filter` ran the repository pre-push `bun turbo typecheck` hook successfully.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
