### PR TITLE
test(provider): add fixture-backed new model coverage

### DIFF
--- a/docs/llm-upstream-diff/llm-api-chain-current-state-analysis.md
+++ b/docs/llm-upstream-diff/llm-api-chain-current-state-analysis.md
@@ -5,8 +5,9 @@
 > 把其中 `LLM-UP-001 ~ 035` 的差异点**按 LLM API 调用链路的环节重新归类**，
 > 给出当前 Aether 在每个环节上的缺陷/bug 清单，并标注哪些可以直接从上游迁移。
 >
-> 文中的「现状未覆盖」均在当前 HEAD `8a79a87dd` 用 grep 二次复核过（关键行号见下）。
-> 上一轮报告基线 HEAD 为 `750aa9945`，期间仅新增本目录的报告文档，链路代码未变。
+> 文中的「现状未覆盖」最初在 HEAD `8a79a87dd` 用 grep 二次复核过（关键行号见下）。
+> 2026-06-10 补充复核时，`ProviderTransform` 中部分 reasoning 修复已经落地；本次同时补充
+> `packages/opencode/test/tool/fixtures/models-api.json` 相对上游模型集合滞后的测试覆盖风险。
 
 ---
 
@@ -18,6 +19,24 @@
 2. **AI SDK 代际差。** Aether 在 AI SDK **v5** 线（`ai 5.0.124`、`@ai-sdk/google 2.x`、`vertex 3.x`、`bedrock 3.x`、`xai 2.x`、`mistral 2.x`），上游已在 **v6**。所有「bump 某 provider SDK」类提交都被这个代际差阻塞，统一归入 v6 迁移专项。
 
 **结论：本文所有「可直接迁移」均指「行为语义可在 Aether 现有架构内复刻」，不是 git cherry-pick。**
+
+### 0.1 测试 fixture 的模型集合滞后
+
+`packages/opencode/test/tool/fixtures/models-api.json` 不是完全没有新模型：本地 fixture 已有 `gpt-5.2`、
+`claude-opus-4-5`、`gemini-3-flash`、`deepseek-v3.2`、`qwen3` 等条目。本次已补入 direct provider
+的 `deepseek-v4-flash`、`deepseek-v4-pro`、`gemini-3.1-pro-preview`、`gemini-3.1-flash-lite-preview`
+样本，但它仍明显滞后于 `~/tmp/opencode` 的 fixture，至少缺少以下会触发现有硬编码分支的新模型样本：
+
+| 缺口 | 本地 fixture | 上游 fixture | 风险 |
+|------|--------------|--------------|------|
+| DeepSeek v4 聚合 provider | direct `deepseek` 已命中 `deepseek-v4-flash` / `deepseek-v4-pro`；Vercel/OpenRouter 等聚合路径未补 | 已含 `deepseek-v4-flash`、`deepseek-v4-pro` 及多 provider 路径 | direct provider 已有 fixture-backed 覆盖；聚合 provider 的 slug/providerOptions 路径仍缺真实 metadata 回归样本 |
+| Gemini 3.1 聚合 provider | direct `google` 已命中 `gemini-3.1-pro-preview` / `gemini-3.1-flash-lite-preview`；Vercel/OpenRouter 等聚合路径未补 | 已含 `gemini-3.1-pro-preview`、`gemini-3.1-flash-lite(-preview)`、`google/gemini-3.1-*` | direct Google thinking level / smallOptions 已有 fixture-backed 覆盖；Gateway/OpenRouter 映射仍缺真实 metadata 回归样本 |
+
+当前 `test/session/llm.test.ts` 虽会读取这个 fixture，但实际只用到少数代表模型（如 `alibaba/qwen-plus`、
+`openai/gpt-5.2`、`anthropic/claude-3-5-sonnet-20241022`、`google/gemini-2.5-flash`）。因此即使
+fixture 里有部分新模型，也不能证明 `provider.ts` / `transform.ts` 对新模型命名的硬编码判断已经被真实
+models.dev metadata 测到。本次新增 direct DeepSeek v4 / Google Gemini 3.1 的 fixture-backed transform
+覆盖；provider/gateway 聚合路径仍待补齐。
 
 ---
 
@@ -61,6 +80,7 @@
 | F 会话/压缩/计费 | LLM-UP-009、~~018~~（误报，已撤销）、021、035(专项) |
 | G Copilot SDK | LLM-UP-012、015 |
 | 横切（依赖升级） | LLM-UP-007（OpenRouter SDK）、AI SDK v6 专项、LLM-UP-033 native runtime |
+| 横切（测试数据/fixture） | `models-api.json` 缺 DeepSeek v4 / Gemini 3.1 等聚合 provider 新模型样本 |
 
 ---
 
@@ -86,7 +106,7 @@
 | LLM-UP-002 Anthropic tool-call 后 text/reasoning 重排 | ✅ 已覆盖 | `ProviderTransform.message` 已拆分 `[tool-call, text/reasoning]` | Anthropic / Vertex Anthropic |
 | LLM-UP-006 DeepSeek 空 reasoning 保留 | ✅ 已覆盖 | DeepSeek assistant 补空 reasoning + 回灌空 `reasoning_content` | DeepSeek / 国产 interleaved |
 | LLM-UP-008 Azure providerOptions/store/cache | ✅ 保留本地策略 | 当前 `providerOptions` 保留 `azure` key，不双写 openai | Azure（与上游双写策略不同，刻意保留） |
-| **LLM-UP-016 Opus 4.7+ `display:"summarized"` + 泛化检测** | 🐛 Bug | `transform.ts:414` 仅字面匹配 `opus-4-7/4.7`；全文件 `display:"summarized"` **0 命中**（已复核） | **Opus 4.7+ 收到空 thinking 块**；SAP 反序 / Vertex `@` 后缀命名变体不被识别为 adaptive |
+| LLM-UP-016 Opus 4.7+ `display:"summarized"` + 泛化检测 | ✅ 已覆盖（需真实 smoke） | 当前 `opus47()` 已支持 `opus-4.7`、`opus-4-7`、`claude-4.7-opus`、Vertex `@` 后缀；Anthropic/Gateway/Bedrock/SAP adaptive 分支已写 `display:"summarized"` | 仍建议对 Opus 4.7+ 真实 provider smoke，确认 API 返回非空 thinking summary |
 | **LLM-UP-019 sanitizeSurrogates** | ⚠️ 缺陷 | `transform.ts` 无 surrogate 清洗（已复核 0 命中） | 落单 UTF-16 代理项导致部分 provider 400 |
 | **LLM-UP-020 tools 按名排序** | ⚠️ 缺陷 | `llm.ts:330` `activeTools: Object.keys(tools)` 未排序（已复核） | tools 顺序抖动 → prompt cache miss |
 | **LLM-UP-024 Azure gpt-5.5 走 completions** | 🐛 Bug | `options()`（`transform.ts:890-915`）有 gpt-5 块但无 gpt-5.5/azure 短路 | Azure gpt-5.5 拿到 `reasoning_effort` → **400** |
@@ -98,7 +118,7 @@
 | 项 | 类型 | 现状（复核行号） | 影响 |
 |----|------|------|------|
 | LLM-UP-005 跨模型 reasoning 转 text | ✅ 已覆盖 | `toModelMessages` 在 `differentModel` 时把非空 reasoning 转 text、丢空 reasoning | Bedrock / 切模型续聊 |
-| **LLM-UP-017 签名 reasoning 保留** | 🐛 Bug | `transform.ts:108-111` 仍 `part.text !== ""` 直接丢空 reasoning；`message-v2.ts:703-709` 无 `hasSignedReasoning` | 丢签名 reasoning → Anthropic/Bedrock 签名位移 **400** |
+| LLM-UP-017 签名 reasoning 保留 | ✅ 已覆盖 | `normalizeMessages` 已保留带 `anthropic/bedrock.signature` 或 `.redactedData` 的空 reasoning；`message-v2.ts` 已对带签名 reasoning 的空 text 写 `" "` | 仍需保留回归测试，避免后续清理空内容时破坏签名位置 |
 
 ### 环节 D —— 流式传输 / Transport（`provider.ts` wrapSSE / `llm.ts`）
 
@@ -135,22 +155,31 @@
 
 > **关键定性（06-02 报告确认）：** 上游 `28112fbd1..687c66248` 内**根本没有 `provider/sdk/` 目录**，整套 Copilot SDK 是 Aether vendored，上游用 stock `@ai-sdk/github-copilot`。**LLM-UP-015 永远不会由上游修复，必须 Aether 自行排期。**
 
+### 环节 H —— 测试 fixture / 新模型回归覆盖（`models-api.json`）
+
+| 项 | 类型 | 现状 | 影响 |
+|----|------|------|------|
+| DeepSeek v4 聚合 provider 缺口 | ⚠️ 缺陷 | direct `deepseek` 已补 `deepseek-v4-flash` / `deepseek-v4-pro`；上游 fixture 还包含这些模型的多种聚合 provider 变体 | DeepSeek v4 direct provider reasoning/interleaved 已有 fixture-backed 覆盖；聚合 provider slug/providerOptions 路径仍缺真实 metadata 回归样本 |
+| Gemini 3.1 聚合 provider 缺口 | ⚠️ 缺陷 | direct `google` 已补 `gemini-3.1-pro-preview` / `gemini-3.1-flash-lite-preview`；上游 fixture 还包含 OpenRouter、Vercel 等路径 | `gemini-3.1` thinking level、Google direct smallOptions 已有 fixture-backed 覆盖；Gateway/OpenRouter 映射仍缺真实 metadata 样本 |
+| fixture 使用面仍偏窄 | ⚠️ 缺陷 | `transform.test.ts` 已读取新增 direct DeepSeek v4 / Gemini 3.1 样本；`session/llm.test.ts` 仍集中在 `qwen-plus`、`gpt-5.2`、`claude-3-5-sonnet`、`gemini-2.5-flash` | `provider.ts` 中按模型名硬编码的 `gpt-5.*`、Copilot Responses/Chat 分流，以及聚合 provider 映射仍无法靠 fixture 全面回归 |
+
 ---
 
 ## 3. 可直接从上游迁移的修改（汇总）
 
 「可直接迁移」= 行为修复、不依赖 Effect/v6、当前确实未覆盖、改动局限在 Aether 现有文件内。
 
-### 第一批 —— 行为修复，机械或小而自洽（优先）
+### 第一批 —— 剩余行为修复，机械或小而自洽（优先）
 
-> 注：原列入第一批的 **LLM-UP-018（双重压缩）经实测确认为误报**，Aether 不存在该 bug（无 `tail_start_id` replay-tail 重排），已从下表移除，详见 §2 环节 F。
+> 注：原列入第一批的 **LLM-UP-016/017 已在当前代码覆盖**，`LLM-UP-018` 经实测确认为误报。
+> 剩余第一批重点是字符清洗和 tools 排序；同时补 fixture 新模型样本，避免新模型命名继续绕过测试。
+> 本次已先补 direct DeepSeek v4 / Google Gemini 3.1 样本，聚合 provider 路径仍需后续补齐。
 
 | 项 | 环节 | 类型 | 动作 | 风险 | 验收 |
 |----|------|------|------|------|------|
-| **LLM-UP-016** Opus 4.7+ `display:"summarized"` | B | 🐛 用户可见 | 移植 `anthropicOpus47OrLater` 正则 + 给四个 adaptive 分支加 `display:"summarized"`（四分支都已存在） | 中 | `bun test test/provider/transform.test.ts` |
 | **LLM-UP-019** sanitizeSurrogates | B | ⚠️ | helper 拼进 `normalizeMessages`，清洗 system/user/assistant text+reasoning 与 tool-result | 低（只改非法字符串） | `bun test test/provider/transform.test.ts` |
 | **LLM-UP-020** tools 排序 | B | ⚠️ cache | `Object.entries(tools).toSorted()` 一次后复用于 `activeTools`/repair 查找 | 低（首次一次性 cache miss） | `bun test test/session/llm.test.ts` |
-| **LLM-UP-017** 签名 reasoning 保留 | C | 🐛 | `normalizeMessages` 保留带 `signature`/`redactedData` 的空 reasoning；`toModelMessages` 空 text→`" "` | 中（不改触发 400） | `bun test test/provider/transform.test.ts test/session/message-v2.test.ts` |
+| **fixture 新模型样本** | H | ⚠️ coverage | 已补 direct DeepSeek v4 与 Google Gemini 3.1 代表模型；后续从上游 fixture 补 Vercel/OpenRouter 等聚合 provider 代表模型 | 低 | `bun test test/provider/transform.test.ts test/session/llm.test.ts` |
 
 ### 第二批 —— provider 专项小修，架构无关
 
@@ -212,21 +241,22 @@
 | 🔴 会崩/请求失败 | LLM-UP-023 | Azure Anthropic 无法 resolve |
 | 🔴 | LLM-UP-024 | Azure gpt-5.5 → 400 |
 | 🔴 | LLM-UP-025 | Vertex ADC token 铸造失败 |
-| 🔴 | LLM-UP-017 | 签名 reasoning 丢失 → Anthropic/Bedrock 400 |
+| ✅ 已覆盖但需防回归 | LLM-UP-017 | 签名 reasoning 保留已落地，需保留测试 |
 | 🔴 | LLM-UP-015① | Copilot chat tool 调用中断（自维护） |
-| 🟠 用户可见错误 | LLM-UP-016 | Opus 4.7+ 空 thinking 块 |
+| ✅ 已覆盖但需真实 smoke | LLM-UP-016 | Opus 4.7+ adaptive 配置已落地，需真实 provider 验证 |
 | ~~🟠 核心循环~~ | ~~LLM-UP-018~~ | ~~双重自动压缩~~ —— 经实测撤销，Aether 无此 bug |
-| 🟡 鲁棒性/正确性 | LLM-UP-019/020/021/022/026/027/028/029/030/031 | 字符清洗 / cache / 定价 / gateway / SSE 重试 / 超时 等 |
+| 🟡 鲁棒性/正确性 | LLM-UP-019/020/021/022/026/027/028/029/030/031 + fixture 缺口 | 字符清洗 / cache / 定价 / gateway / SSE 重试 / 超时 / 新模型覆盖 等 |
 
 ---
 
 ## 6. 落地建议
 
-1. **先做第一批四项**（016/017/019/020）：都不依赖 Effect/v6，016/017 是用户可见 / 会触发 400 的 reasoning 问题。每项都有现成测试入口。（原列入的 `LLM-UP-018` 经实测为误报，已撤销——Aether 无 `tail_start_id` replay-tail 重排，`filterCompacted` 直接排除溢出 tail，详见 §2 环节 F。）
+1. **先做剩余第一批**：`LLM-UP-019/020` 加上 fixture 新模型样本。direct DeepSeek v4 / Google Gemini 3.1 已补，后续继续补聚合 provider 路径；`LLM-UP-016/017` 当前已覆盖，但应保留/补强真实模型命名回归；`LLM-UP-018` 经实测为误报，已撤销。
 2. **第二批 provider 专项**（022~025/027/031/021）：按 provider 真实使用面排序——若 Aether 实际服务 Azure / Vertex，则 023/024/025 应提到第一梯队。
 3. **第三批默认低优**；LLM-UP-029 `headerTimeout` 落地时**默认关闭或调大**，防国内代理误 abort。
-4. **守住反向冲突** `2f2fcc165`，回迁任何 session diff 相关代码前先核对 `bafdfb6d2`。
-5. **Copilot SDK（015）与 AI SDK v6 迁移**各开独立专项，不混入上面三批。
+4. **更新 fixture 时不要整文件盲拷贝**：优先用脚本/结构化 JSON 合并上游新增 provider/model 条目，至少覆盖 `deepseek-v4-flash`、`deepseek-v4-pro`、`gemini-3.1-pro-preview`、`gemini-3.1-flash-lite(-preview)`，并补断言说明这些样本触发了哪些 hardcoded 分支。
+5. **守住反向冲突** `2f2fcc165`，回迁任何 session diff 相关代码前先核对 `bafdfb6d2`。
+6. **Copilot SDK（015）与 AI SDK v6 迁移**各开独立专项，不混入上面三批。
 
 ### 统一验收
 

--- a/docs/llm-upstream-diff/llm-upstream-diff-report-2026-06-02.md
+++ b/docs/llm-upstream-diff/llm-upstream-diff-report-2026-06-02.md
@@ -20,16 +20,19 @@
 - 在上游 `28112fbd1..687c66248` 窗口内筛出 LLM 行为相关提交（reasoning、provider 兼容、usage、tool call、retry/transport、SDK bump、compaction、native runtime），剔除 Effect/Zod/HttpApi/flags 等纯架构重构噪音。
 - 把候选提交按主题拆成 6 个簇并行核查：① reasoning/adaptive、② provider SDK bump + provider 专项 fix、③ streaming/transport/retry、④ native LLM runtime、⑤ session/compaction/usage、⑥ LiteLLM 移除 + Copilot。
 - 每个差异点都对照当前 Aether 实际代码（`provider/transform.ts`、`provider/provider.ts`、`session/llm.ts`、`session/prompt.ts`、`session/message-v2.ts`、`session/index.ts`、`provider/error.ts`、`session/retry.ts`、`config/config.ts` 等）确认是否已覆盖，而非假设覆盖。
-- 高优先项（`display:"summarized"`、`opus47` 检测、`sanitizeSurrogates`、tools 排序、position-based turn detection）已在当前 HEAD 用 grep 二次复核确认确实缺失。
+- 高优先项（`display:"summarized"`、`opus47` 检测、`sanitizeSurrogates`、tools 排序、position-based turn detection）最初在当前 HEAD 用 grep 二次复核确认。
+  2026-06-10 追加复核发现：`display:"summarized"`、Opus 4.7+ 泛化检测、签名 reasoning 保留已经落地；`sanitizeSurrogates` 与 tools 排序仍缺失。
+- `packages/opencode/test/tool/fixtures/models-api.json` 未整文件展开，只用 `rg`/`jq` 定向核查模型命名。结论是：本次已补 direct DeepSeek v4 / Google Gemini 3.1 样本，但相对上游仍缺这些模型的聚合 provider 关键样本。
 
 ## 关键结论（先读）
 
 1. **架构鸿沟扩大。** 上游本窗口把 `session/llm.ts`、`provider/provider.ts`、`session/prompt.ts`、`compaction.ts`、`summary.ts` 全面迁到 Effect `Service`/`Layer` + `@opencode-ai/core` monorepo 拆分 + SQL/Drizzle session store，并新增 `@opencode-ai/llm` 原生运行时包。Aether 仍是 pre-Effect 的 `namespace` + 直接 bundle `@ai-sdk/*` 形态。**因此绝大多数上游 patch 无法逐行 cherry-pick，只能按行为语义回迁。**
 2. **AI SDK 代际差。** Aether 在 AI SDK **v5** 线（`ai 5.0.124`、`@ai-sdk/google 2.x`、`google-vertex 3.x`、`bedrock 3.x`、`xai 2.x`、`mistral 2.x`），上游已在 **v6**。所有「bump 某 provider SDK」类提交都被这个代际差阻塞，归入 v6 迁移专项。
-3. **有 4 个真正可立即回迁、且当前确实未覆盖的行为修复**（不依赖 Effect/v6）：`LLM-UP-016` Opus 4.7+ `display:"summarized"`、`LLM-UP-017` 签名 reasoning 保留、`LLM-UP-019` 代理项 surrogate、`LLM-UP-020` tools 排序。建议作为第一批（与下文「优先回迁建议」第一批、「结论」一致）。
+3. **当前第一批剩余未覆盖项收敛为 2 个行为修复 + 1 个测试数据缺口**（不依赖 Effect/v6）：`LLM-UP-019` 代理项 surrogate、`LLM-UP-020` tools 排序，以及 `models-api.json` 聚合 provider 新模型样本补齐。`LLM-UP-016` Opus 4.7+ `display:"summarized"` 与 `LLM-UP-017` 签名 reasoning 保留在 2026-06-10 复核时已覆盖，应保留测试和真实 provider smoke。
    - **更正（实测复核）：** 原列为第一批 P0 的 `LLM-UP-018`（双重压缩）经实测确认为**误报**——Aether 无 `tail_start_id`、`filterCompacted` 已把溢出 tail 整段排除，不存在该 bug。**已撤销**，详见下表 `LLM-UP-018` 行。
 4. **有 1 个高风险「反向冲突」项：** 上游 `2f2fcc165`（删除自动 session diff）与 Aether 本地 `bafdfb6d2`（修好并保留自动 diff）意图相反，**禁止回迁**。05-04 快照未覆盖此冲突，本报告首次澄清。
 5. **`LLM-UP-015`（Copilot V2 SDK）确认永远不会由上游修复** —— 上游根本没有 vendored 的 `provider/sdk/` 目录，整套 Copilot SDK 是 Aether 自有，必须自行排期。
+6. **测试 fixture 仍落后于上游模型集合。** 本地 fixture 有 `gpt-5.2`、`claude-opus-4-5`、`gemini-3-flash`、`deepseek-v3.2`、`qwen3` 等条目，本次已补 direct `deepseek-v4-flash`、`deepseek-v4-pro`、`gemini-3.1-pro-preview`、`gemini-3.1-flash-lite-preview`；但上游 fixture 还包含这些模型的多 provider 变体。这会让 `provider.ts`/`transform.ts` 中按模型名硬编码的聚合 provider 分支缺少真实 metadata 回归。
 
 ---
 
@@ -37,8 +40,8 @@
 
 | 编号 | 优先级 | 上游 commit/PR | 变更主题 | 影响 provider/model | 当前 Aether 状态 | 建议动作 | 风险 | 验收命令 |
 |------|--------|----------------|----------|---------------------|------------------|----------|------|----------|
-| LLM-UP-016 | P0 | `05e3c4ece`/`#29769`、`b956e9a06`/`#29911`、`3070b0f4a`/`#30027`、`f4f508e65`/`#29991` | Opus 4.7+ adaptive reasoning：① `anthropicOpus47OrLater` 泛化「≥4.7/未来 major」检测，覆盖 Vertex `@` 后缀与 SAP 反序 `claude-4.7-opus`/`4.6-opus`；② 在 anthropic / vertex-anthropic / bedrock / gateway / sap-ai-core 全部 adaptive 分支强制 `display:"summarized"` | Anthropic Opus 4.7+（直连 / Bedrock / Vertex / CF Gateway / SAP AI Core） | **未覆盖**。`transform.ts:414` 仅字面匹配 `opus-4-7`/`opus-4.7`；`display:"summarized"` 全文件 0 命中（已复核）。后果：Opus 4.7+ API 默认 `omitted`，Aether 将收到**空 thinking 块**；SAP/Vertex 命名变体甚至不被识别为 adaptive | 回迁（机械）：移植 `anthropicOpus47OrLater` 正则 + 给四个 adaptive 分支加 `display:"summarized"`。四个分支 Aether 都已存在 | 中：用户可见的 reasoning 摘要丢失 + 漏检 adaptive | `cd packages/opencode && bun test test/provider/transform.test.ts` |
-| LLM-UP-017 | P1 | `233fc5b91`/`#21370`、`4e14f7951`/`#26276`（reasoning 半） | 含签名 reasoning 时保留 assistant 内容：① `normalizeMessages` 保留带 `anthropic/bedrock.signature` 或 `.redactedData` 的空 reasoning 块；② `toModelMessages` 对带签名 reasoning 的 assistant，空 text 替换为 `" "`，避免 SDK 过滤掉分隔符导致签名位移 | Anthropic / Bedrock adaptive thinking 多轮 | **未覆盖**。`transform.ts:108-111` 仍是旧 `part.text !== ""` 直接丢弃空 reasoning；`message-v2.ts:703-709` 无 `hasSignedReasoning` 逻辑 | 回迁（小、自洽）：两段一起改 | 中：丢弃签名 reasoning 会触发 Anthropic/Bedrock 签名位置 400 | `cd packages/opencode && bun test test/provider/transform.test.ts test/session/message-v2.test.ts` |
+| LLM-UP-016 | P0 → 已覆盖/需 smoke | `05e3c4ece`/`#29769`、`b956e9a06`/`#29911`、`3070b0f4a`/`#30027`、`f4f508e65`/`#29991` | Opus 4.7+ adaptive reasoning：① `anthropicOpus47OrLater` 泛化「≥4.7/未来 major」检测，覆盖 Vertex `@` 后缀与 SAP 反序 `claude-4.7-opus`/`4.6-opus`；② 在 anthropic / vertex-anthropic / bedrock / gateway / sap-ai-core 全部 adaptive 分支强制 `display:"summarized"` | Anthropic Opus 4.7+（直连 / Bedrock / Vertex / CF Gateway / SAP AI Core） | **已覆盖（2026-06-10 复核）**。当前 `transform.ts` 有 `opus47()` 正则、`display:"summarized"`，并有 Opus 4.7/4.8、Vertex `@`、Bedrock、SAP 等单测 | 不再列入待回迁；保留测试，真实 Opus 4.7+ provider 单独 smoke | 中：真实 API 行为仍需 smoke 确认 summary 非空 | `cd packages/opencode && bun test test/provider/transform.test.ts` |
+| LLM-UP-017 | P1 → 已覆盖/需防回归 | `233fc5b91`/`#21370`、`4e14f7951`/`#26276`（reasoning 半） | 含签名 reasoning 时保留 assistant 内容：① `normalizeMessages` 保留带 `anthropic/bedrock.signature` 或 `.redactedData` 的空 reasoning 块；② `toModelMessages` 对带签名 reasoning 的 assistant，空 text 替换为 `" "`，避免 SDK 过滤掉分隔符导致签名位移 | Anthropic / Bedrock adaptive thinking 多轮 | **已覆盖（2026-06-10 复核）**。`normalizeMessages` 已保留 signed empty reasoning；`message-v2.ts` 已有 signed 检测并把空 text 写成 `" "` | 不再列入待回迁；保留 transform/message-v2 回归测试 | 中：后续清理空内容时容易回归 | `cd packages/opencode && bun test test/provider/transform.test.ts test/session/message-v2.test.ts` |
 | ~~LLM-UP-018~~ | ~~P0~~ → **撤销（误报）** | `94564f358`/`#27545` | （上游）防 filterCompacted 重排导致的双重自动压缩：新增 `MessageV2.latest(msgs)` 按 max MessageID 推导 latest | 所有会自动压缩的 session | **不适用（误报，已实测）**。上游 bug 依赖 `tail_start_id` 的 replay-tail 重排把溢出 tail 拼回数组中段产生非时序数组；**Aether 无 `tail_start_id`**（全仓 0 命中），`filterCompacted`（`message-v2.ts:899-915`）遇压缩边界直接 `break`，把溢出 tail **整段排除**。实测 `m1<m2<m3<m4` 场景结果为 `[m2,m3,m4]`（溢出 m1 不在数组），位置扫描正确落在 summary（`summary===true`），守卫 `prompt.ts:565` `summary !== true` 为 false，不触发第二次压缩 | **不回迁**。原报告把上游 reorder 前提误套到 Aether——grep 只证实「prompt.ts 用位置扫描、message-v2 有 reverse()」两个事实，未验证溢出 tail 是否仍留在数组中 | 无 | `cd packages/opencode && bun test test/session/message-v2.test.ts`（可加 filterCompacted「溢出 tail 排除」回归测试锁住该行为） |
 | LLM-UP-019 | P1 | `6409aceb1`/`#25934` | `sanitizeSurrogates`：把落单 UTF-16 代理项替换为 `�`，在 `normalizeMessages` 对 system/user/assistant text+reasoning 与 tool-result 输出统一清洗 | 所有 provider | **未覆盖**。`transform.ts` 无 `sanitizeSurrogates`/surrogate 正则（已复核） | 回迁（机械）：把 helper 拼进 Aether `normalizeMessages` | 低：纯清洗，只改本就非法的字符串 | `cd packages/opencode && bun test test/provider/transform.test.ts` |
 | LLM-UP-020 | P1 | `83bb21648`/`#26370` | tools 始终按名排序：`Object.entries(tools).toSorted(...)` 后用于 `tools`/`activeTools`/`experimental_repairToolCall` 查找/预批准 | 所有 provider（对 prompt cache 敏感） | **未覆盖**。`llm.ts:330` `activeTools: Object.keys(tools)` 未排序；repair 查找也未排序（已复核） | 回迁（小、低风险）：排序一次后复用 | 低：首次部署可能一次性 cache miss，之后更稳定 | `cd packages/opencode && bun test test/session/llm.test.ts` |
@@ -57,6 +60,14 @@
 | LLM-UP-033 | P2（专项/暂缓） | `dbe36851b`/`#27114`、`6618e2bce`/`#28271`、`8a321c453`、`61390dbb4`/`#28678`、`facd20739`/`#28571`、`41f6daf96`/`#28523`、`fb9d69ef6`/`#28560`、`a9c115c22` | **native LLM runtime 栈**：新增 `@opencode-ai/llm` 包绕过 AI SDK，直连 provider 协议（openai-responses/anthropic-messages/...），由 `OPENCODE_EXPERIMENTAL_NATIVE_LLM` 开关，**默认关闭**，仅 OpenAI/Anthropic/opencode API-key 模型走原生，其余回落 AI SDK | OpenAI / Anthropic API-key / OpenAI OAuth | **未覆盖且不可移植**。依赖 Effect `Service`/`Layer` 的 `llm.ts`/`provider.ts` + `@opencode-ai/core` 拆分 + 40+ 文件新包，Aether 全无。`61390dbb4`（native 续传 metadata）已评估**不值得单独 cherry-pick**——其 bug 只存在于 native 协议实现，Aether 的 AI SDK 路径不会触发 | 整体暂缓，作为大型架构迁移专项；**不 cherry-pick 任何子项**。`a9c115c22` 纯 cosmetic、不适用 | 迁移高 / 暂缓低（上游默认关，无功能损失） | 不适用 |
 | LLM-UP-034 | P2（专项/暂缓） | `62da1e768`/`#29477`、`14e0b9b17`/`#29673`（WS 半） | OpenAI responses-over-WebSocket 传输：新 `plugin/openai/{ws,ws-pool}.ts`、`OPENCODE_EXPERIMENTAL_WEBSOCKETS` flag、按 channel 分级 rollout | OpenAI / Codex responses API | **未覆盖**。Aether 是扁平 `plugin/codex.ts`，无 ws 传输 / runtime flag / ws-pool | 暂缓（新实验特性，非修复）。需引 `ws` 依赖 + 重构 plugin 目录 + 与本地 proxy 层交互 | 工作量高 / 行为风险中 | 不适用 |
 | LLM-UP-035 | P3（feature/暂缓） | `36d40fee4`/`#26644`、`3dc2c1d81`/`#27094` | session 级累计 usage totals（cost + tokens 持久化到 session 行）；usage delta 更新不 bump `time_updated` | TUI/SDK usage 展示 | **不适用为 port**。依赖上游 SQL/Drizzle session store + migration；Aether 无对应存储（`Session` 在 `index.ts`，projector 非 SQL） | 当作可选产品功能；若需要则基于 Aether 存储原生实现，不 port migration | 不适用（非 bugfix） | 不适用 |
+
+### Fixture / 测试数据缺口（2026-06-10 补充）
+
+| 项 | 当前 Aether 状态 | 上游观察 | 建议动作 |
+|----|------------------|----------|----------|
+| DeepSeek v4 聚合 provider 样本缺失 | direct `deepseek` 已补 `deepseek-v4-flash` / `deepseek-v4-pro` 并有 fixture-backed transform 覆盖；Vercel/OpenRouter 等聚合路径未补 | `~/tmp/opencode` fixture 已包含 `deepseek-v4-flash`、`deepseek-v4-pro`，并覆盖 OpenRouter、Vercel、Fireworks、SiliconFlow、NVIDIA 等多种 provider 路径 | 后续从上游结构化合并聚合 provider 代表条目，覆盖 providerOptions/slug 行为 |
+| Gemini 3.1 聚合 provider 样本缺失 | direct `google` 已补 `gemini-3.1-pro-preview` / `gemini-3.1-flash-lite-preview` 并有 fixture-backed transform 覆盖；Vercel/OpenRouter 等聚合路径未补 | 上游 fixture 已包含 `gemini-3.1-pro-preview`、`gemini-3.1-flash-lite(-preview)`、`google/gemini-3.1-*` | 后续补 Vercel/OpenRouter 路径样本，覆盖 providerOptions 映射 |
+| fixture 使用面仍偏窄 | `transform.test.ts` 已读取 direct DeepSeek v4 / Gemini 3.1 样本；`session/llm.test.ts` 读取 fixture，但主要样本仍是 `qwen-plus`、`gpt-5.2`、`claude-3-5-sonnet`、`gemini-2.5-flash` | 上游测试已有 `gemini-3.1-*` 的 transform 断言 | 继续新增基于 fixture 的 smoke-style 单测，避免仅用手写 mock model 覆盖模型命名分支 |
 
 ### 暂缓 / 跳过（不单列编号）
 
@@ -92,22 +103,23 @@
 
 **第一批（行为修复，不依赖 Effect/v6，当前确实未覆盖，已 grep 复核）：**
 
-1. `LLM-UP-016` Opus 4.7+ `display:"summarized"` + 泛化检测（P0，用户可见 reasoning 丢失）
-2. `LLM-UP-017` 签名 reasoning 保留（P1，与 016 同属 Anthropic adaptive 可靠性）
-3. `LLM-UP-019` surrogate 清洗（P1，机械）
-4. `LLM-UP-020` tools 排序（P1，机械，利于 cache）
+1. `LLM-UP-019` surrogate 清洗（P1，机械）
+2. `LLM-UP-020` tools 排序（P1，机械，利于 cache）
+3. `models-api.json` 继续补 DeepSeek v4 / Gemini 3.1 聚合 provider 代表模型，并让测试真实消费这些 fixture 样本
+
+`LLM-UP-016` 与 `LLM-UP-017` 当前已覆盖，不再列入待回迁；保留为防回归和真实 smoke 项。
 
 > ~~`LLM-UP-018` 双重自动压缩~~：经实测**撤销**，Aether 无此 bug（无 `tail_start_id` replay-tail 重排，`filterCompacted` 直接排除溢出 tail）。详见上表 `LLM-UP-018` 行。
 
 **第二批（provider 专项小修，架构无关）：**
 
-6. `LLM-UP-022` cf-ai-gateway key/variants（P1）
-7. `LLM-UP-023` Azure Anthropic resolve（P1）
-8. `LLM-UP-024` Azure gpt-5.5 completions（P1）
-9. `LLM-UP-025` Vertex GoogleAuth scopes（P1）
-10. `LLM-UP-027` 可重试 SSE 卡死（P1）
-11. `LLM-UP-031` 直连 GPT-5 加密 reasoning include（P1）
-12. `LLM-UP-021` 分层定价（P1/P2，成本准确性）
+4. `LLM-UP-022` cf-ai-gateway key/variants（P1）
+5. `LLM-UP-023` Azure Anthropic resolve（P1）
+6. `LLM-UP-024` Azure gpt-5.5 completions（P1）
+7. `LLM-UP-025` Vertex GoogleAuth scopes（P1）
+8. `LLM-UP-027` 可重试 SSE 卡死（P1）
+9. `LLM-UP-031` 直连 GPT-5 加密 reasoning include（P1）
+10. `LLM-UP-021` 分层定价（P1/P2，成本准确性）
 
 **第三批（小/触发面窄）：** `LLM-UP-026`、`LLM-UP-028`、`LLM-UP-029`（默认关）、`LLM-UP-030`、`LLM-UP-032`。
 
@@ -135,11 +147,11 @@ bun test test/session/compaction.test.ts
 cd /home/fyl/opencode/packages/opencode
 OPENCODE_SYSTEM_TEST=1 bun run test:system:llm:p0 -- --provider deepseek
 OPENCODE_SYSTEM_TEST=1 bun run test:system:llm:p0 -- --provider alibaba-cn --input p1-reasoning --p1
-# Opus 4.7+ adaptive（LLM-UP-016）、Azure Anthropic（LLM-UP-023）等需真实 provider 单独 smoke
+# Opus 4.7+ adaptive（LLM-UP-016，已覆盖但需真实验证）、Azure Anthropic（LLM-UP-023）等需真实 provider 单独 smoke
 ```
 
 ## 结论
 
-本轮窗口（`28112fbd1..687c66248`，220 个相关提交）上游主线是 Effect/`@opencode-ai/core`/SQL store/native-runtime/AI SDK v6 的架构迁移，**绝大多数无法逐行回迁**。但从中剥离出 **16 个值得跟进的行为差异点（`LLM-UP-016 ~ 031`）**，其中 4 个是当前确实未覆盖、架构无关、可立即作为第一批回迁的行为修复（`016/017/019/020`）。`LLM-UP-018`（双重压缩）经实测确认为误报、不适用 Aether，已撤销（Aether 无 `tail_start_id` replay-tail 重排）。
+本轮窗口（`28112fbd1..687c66248`，220 个相关提交）上游主线是 Effect/`@opencode-ai/core`/SQL store/native-runtime/AI SDK v6 的架构迁移，**绝大多数无法逐行回迁**。但从中剥离出 **16 个值得跟进的行为差异点（`LLM-UP-016 ~ 031`）**。2026-06-10 复核后，`016/017` 已覆盖，当前第一批剩余未覆盖项是 `019/020`；fixture 已补 direct DeepSeek v4 / Google Gemini 3.1，仍需补齐这些模型的聚合 provider 样本。`LLM-UP-018`（双重压缩）经实测确认为误报、不适用 Aether，已撤销（Aether 无 `tail_start_id` replay-tail 重排）。
 
 同时确认了一处必须守住的反向冲突（`2f2fcc165` vs `bafdfb6d2`），并把 `LLM-UP-015`（Copilot SDK）定性为永久 Aether-only 自维护项。native runtime、OpenAI WS、usage totals、AI SDK v6 与 Copilot SDK 升级仍各自开专项评估。

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1,8 +1,23 @@
 import { describe, expect, test } from "bun:test"
+import type { ModelMessage } from "ai"
+import { Provider } from "../../src/provider/provider"
 import { ProviderTransform } from "../../src/provider/transform"
+import type { ModelsDev } from "../../src/provider/models"
 import { ModelID, ProviderID } from "../../src/provider/schema"
 
 const OUTPUT_TOKEN_MAX = 32000
+
+async function sample(pid: string, id: string) {
+  const data = (await Bun.file(new URL("../tool/fixtures/models-api.json", import.meta.url)).json()) as Record<
+    string,
+    ModelsDev.Provider
+  >
+  const provider = data[pid]
+  if (!provider) throw new Error(`Missing fixture provider: ${pid}`)
+  const model = Provider.fromModelsDevProvider(provider).models[id]
+  if (!model) throw new Error(`Missing fixture model: ${pid}/${id}`)
+  return model
+}
 
 describe("ProviderTransform.options - setCacheKey", () => {
   const sessionID = "test-session-123"
@@ -893,6 +908,30 @@ describe("ProviderTransform.schema - gemini non-object properties removal", () =
 })
 
 describe("ProviderTransform.message - DeepSeek reasoning content", () => {
+  test("fixture deepseek v4 models preserve interleaved reasoning metadata", async () => {
+    const flash = await sample("deepseek", "deepseek-v4-flash")
+    const pro = await sample("deepseek", "deepseek-v4-pro")
+
+    expect(ProviderTransform.variants(flash)).toEqual({})
+    expect(ProviderTransform.variants(pro)).toEqual({})
+    expect(flash.capabilities.interleaved).toEqual({ field: "reasoning_content" })
+    expect(pro.capabilities.interleaved).toEqual({ field: "reasoning_content" })
+
+    const msgs: ModelMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "v4 thinking" },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ]
+    const result = ProviderTransform.message(msgs, flash, {})
+
+    expect(result[0].content).toEqual([{ type: "text", text: "answer" }])
+    expect(result[0].providerOptions?.openaiCompatible?.reasoning_content).toBe("v4 thinking")
+  })
+
   test("DeepSeek with tool calls includes reasoning_content in providerOptions", () => {
     const msgs = [
       {
@@ -2801,6 +2840,44 @@ describe("ProviderTransform.variants", () => {
           includeThoughts: true,
           thinkingLevel: "high",
         },
+      })
+    })
+
+    test("fixture gemini-3.1 pro preview uses high thinking defaults", async () => {
+      const model = await sample("google", "gemini-3.1-pro-preview")
+      expect(model.api.npm).toBe("@ai-sdk/google")
+      expect(model.capabilities.reasoning).toBe(true)
+      expect(Object.keys(model.variants ?? {})).toEqual(["low", "medium", "high"])
+      expect(
+        ProviderTransform.options({
+          model,
+          sessionID: "test-session-123",
+          providerOptions: {},
+        }).thinkingConfig,
+      ).toEqual({
+        includeThoughts: true,
+        thinkingLevel: "high",
+      })
+    })
+
+    test("fixture gemini-3.1 flash lite preview uses small thinkingLevel", async () => {
+      const model = await sample("google", "gemini-3.1-flash-lite-preview")
+      expect(model.api.npm).toBe("@ai-sdk/google")
+      expect(Object.keys(model.variants ?? {})).toEqual(["low", "medium", "high"])
+      expect(ProviderTransform.smallOptions(model)).toEqual({
+        thinkingConfig: {
+          thinkingLevel: "minimal",
+        },
+      })
+      expect(
+        ProviderTransform.options({
+          model,
+          sessionID: "test-session-123",
+          providerOptions: {},
+        }).thinkingConfig,
+      ).toEqual({
+        includeThoughts: true,
+        thinkingLevel: "high",
       })
     })
   })

--- a/packages/opencode/test/tool/fixtures/models-api.json
+++ b/packages/opencode/test/tool/fixtures/models-api.json
@@ -9830,6 +9830,42 @@
         "open_weights": false,
         "cost": { "input": 0.28, "output": 0.42, "cache_read": 0.028 },
         "limit": { "context": 128000, "output": 128000 }
+      },
+      "deepseek-v4-flash": {
+        "id": "deepseek-v4-flash",
+        "name": "DeepSeek V4 Flash",
+        "family": "deepseek-flash",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": { "field": "reasoning_content" },
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-04-24",
+        "modalities": { "input": ["text"], "output": ["text"] },
+        "open_weights": true,
+        "limit": { "context": 1000000, "output": 384000 },
+        "cost": { "input": 0.14, "output": 0.28, "cache_read": 0.028 }
+      },
+      "deepseek-v4-pro": {
+        "id": "deepseek-v4-pro",
+        "name": "DeepSeek V4 Pro",
+        "family": "deepseek-thinking",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": { "field": "reasoning_content" },
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-04-24",
+        "modalities": { "input": ["text"], "output": ["text"] },
+        "open_weights": true,
+        "limit": { "context": 1000000, "output": 384000 },
+        "cost": { "input": 1.74, "output": 3.48, "cache_read": 0.145 }
       }
     }
   },
@@ -21833,6 +21869,23 @@
         },
         "limit": { "context": 1048576, "output": 65536 }
       },
+      "gemini-3.1-flash-lite-preview": {
+        "id": "gemini-3.1-flash-lite-preview",
+        "name": "Gemini 3.1 Flash Lite Preview",
+        "family": "gemini-flash-lite",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-03-03",
+        "last_updated": "2026-03-03",
+        "modalities": { "input": ["text", "image", "video", "audio", "pdf"], "output": ["text"] },
+        "open_weights": false,
+        "limit": { "context": 1048576, "output": 65536 },
+        "cost": { "input": 0.25, "output": 1.5, "cache_read": 0.025, "input_audio": 0.5 }
+      },
       "gemini-2.5-flash-image": {
         "id": "gemini-2.5-flash-image",
         "name": "Gemini 2.5 Flash Image",
@@ -21904,6 +21957,36 @@
           "context_over_200k": { "input": 4, "output": 18, "cache_read": 0.4 }
         },
         "limit": { "context": 1000000, "output": 64000 }
+      },
+      "gemini-3.1-pro-preview": {
+        "id": "gemini-3.1-pro-preview",
+        "name": "Gemini 3.1 Pro Preview",
+        "family": "gemini-pro",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-02-19",
+        "last_updated": "2026-02-19",
+        "modalities": { "input": ["text", "image", "video", "audio", "pdf"], "output": ["text"] },
+        "open_weights": false,
+        "limit": { "context": 1048576, "output": 65536 },
+        "cost": {
+          "input": 2,
+          "output": 12,
+          "cache_read": 0.2,
+          "tiers": [
+            {
+              "input": 4,
+              "output": 18,
+              "cache_read": 0.4,
+              "tier": { "type": "context", "size": 200000 }
+            }
+          ],
+          "context_over_200k": { "input": 4, "output": 18, "cache_read": 0.4 }
+        }
       },
       "gemini-2.5-flash": {
         "id": "gemini-2.5-flash",


### PR DESCRIPTION
### Issue for this PR

Closes #1044

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds fixture-backed coverage for newer reasoning-capable models from models.dev so provider transform behavior is tested against real metadata instead of only hand-written mocks.

The change:
- adds direct-provider fixture entries for `deepseek-v4-flash`, `deepseek-v4-pro`, `gemini-3.1-pro-preview`, and `gemini-3.1-flash-lite-preview`
- adds transform tests that exercise the `models.dev -> Provider -> ProviderTransform` path
- verifies DeepSeek v4 interleaved reasoning metadata is preserved through transform
- verifies Gemini 3.1 thinking defaults and small-model options are derived correctly from fixture metadata
- updates the LLM upstream diff docs to reflect that Opus 4.7 summarized thinking and signed reasoning preservation are already covered, while fixture gaps for aggregated-provider variants still remain

### How did you verify your code works?

- `cd packages/opencode && bun test test/provider/transform.test.ts`
- `cd packages/opencode && bun typecheck`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR