### PR TITLE
feat(mobile): WeChat语音转写LLM后处理与用户确认流程

### DIFF
--- a/packages/opencode/src/mobile/base.ts
+++ b/packages/opencode/src/mobile/base.ts
@@ -17,6 +17,7 @@ import { SessionStatus } from "@/session/status"
 import { Provider } from "@/provider/provider"
 import { ProviderID } from "@/provider/schema"
 import { ModelID } from "@/provider/schema"
+import { ModelsDev } from "@/provider/models"
 import { Agent } from "@/agent/agent"
 import { SessionPreference } from "@/session/preference"
 import { Question } from "@/question"
@@ -126,6 +127,10 @@ export abstract class MobileManagerBase {
   protected _questionProgress: Record<string, { index: number; answers: string[][] }> = {}
   protected _pendingPermissions: Record<string, Permission.Request> = {}
   protected _pendingConfirmCreate: Record<string, { path: string }> = {}
+  protected _pendingVoiceConfirm: Record<
+    string,
+    { text: string; messageId: string; effectiveDir: string; mediaAttachments?: MediaAttachment[] }
+  > = {}
   protected _activePrompt = new Map<string, { sessionId: string; messageId: string; directory: string }>()
   protected _processedIds = new Map<string, number>()
   protected _busUnsubs: (() => void)[] = []
@@ -429,6 +434,75 @@ export abstract class MobileManagerBase {
     }
   }
 
+  protected async correctVoiceText(raw: string, scope: string): Promise<string> {
+    const model = this.resolveModel(scope)
+    if (!model) return raw
+    const { providerID, modelID } = model
+
+    const provider = await Provider.getProvider(providerID)
+    if (!provider) return raw
+
+    const modelsDevProviders = await ModelsDev.get()
+    const modelsDevProvider = modelsDevProviders[providerID]
+
+    const baseURL =
+      (typeof provider.options["baseURL"] === "string" && provider.options["baseURL"]) ||
+      (typeof provider.options["endpoint"] === "string" && provider.options["endpoint"]) ||
+      modelsDevProvider?.api
+    if (!baseURL) return raw
+
+    const apiKey = (provider.options["apiKey"] as string) ?? provider.key
+    if (!apiKey) return raw
+
+    let endpoint = baseURL.replace(/\/+$/, "")
+    if (!endpoint.endsWith("/chat/completions")) endpoint += "/chat/completions"
+
+    console.log(`[${this.adapter.platform}] correcting voice text with ${providerID}/${modelID}`)
+
+    try {
+      const resp = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: modelID,
+          messages: [
+            {
+              role: "system",
+              content:
+                "Fix homophone errors, filler words, and punctuation in this Chinese voice transcript. " +
+                "Output ONLY the corrected text — no answers, no explanations.",
+            },
+            { role: "user", content: raw },
+          ],
+          temperature: 0,
+          max_tokens: 200,
+        }),
+      })
+
+      if (!resp.ok) {
+        const errText = await resp.text().catch(() => "")
+        console.error(`[${this.adapter.platform}] voice correction failed: ${resp.status} ${errText.slice(0, 200)}`)
+        return raw
+      }
+
+      const data: any = await resp.json()
+      const content = data.choices?.[0]?.message?.content?.trim()
+      if (content) {
+        console.log(`[${this.adapter.platform}] voice corrected:`, content.slice(0, 100))
+        return content
+      }
+    } catch (err) {
+      console.error(
+        `[${this.adapter.platform}] voice correction error:`,
+        err instanceof Error ? err.message : String(err),
+      )
+    }
+    return raw
+  }
+
   protected async clearRuntime(scope: string): Promise<void> {
     delete this._pendingQuestions[scope]
     delete this._questionProgress[scope]
@@ -666,6 +740,19 @@ export abstract class MobileManagerBase {
         return
       }
 
+      const pendingVoice = this._pendingVoiceConfirm[scope]
+      if (pendingVoice) {
+        const lower = text.trim().toLowerCase()
+        if (lower === "y" || lower === "yes" || lower === "确认") {
+          await this.confirmVoiceText(scope, reply, true, pendingVoice)
+        } else if (lower === "n" || lower === "no" || lower === "取消") {
+          await this.confirmVoiceText(scope, reply, false, pendingVoice)
+        } else {
+          await this.replySession(scope, reply, "请回复 y 确认发送或 n 取消。")
+        }
+        return
+      }
+
       const pendingConfirm = this._pendingConfirmCreate[scope]
       if (pendingConfirm) {
         const lower = text.trim().toLowerCase()
@@ -697,6 +784,19 @@ export abstract class MobileManagerBase {
           reply,
           "当前会话正在生成回复，请等待当前对话结束后再发送；如需立即开始新问题，请先 /new 或切换 /session n。如需停止本会话请输入 /stop",
         )
+        return
+      }
+
+      const isVoice = mediaAttachments?.some((a) => a.type === "voice") ?? false
+      if (isVoice) {
+        const corrected = await this.correctVoiceText(text, scope)
+        this._pendingVoiceConfirm[scope] = {
+          text: corrected,
+          messageId,
+          effectiveDir,
+          mediaAttachments,
+        }
+        await this.replySession(scope, reply, `🎙️ 语音转写修正：\n${corrected}\n\n回复 y 确认发送，n 取消`)
         return
       }
 
@@ -879,6 +979,7 @@ export abstract class MobileManagerBase {
 
     const savedPaths: string[] = []
     for (const attachment of attachments) {
+      if (attachment.type === "voice") continue
       try {
         const { data, fileName } = await this.downloadMediaAttachment(attachment)
         let targetName = fileName
@@ -1446,6 +1547,26 @@ export abstract class MobileManagerBase {
 
     await mkdir(pending.path, { recursive: true })
     await this.switchToNewProject(targetId, scope, pending.path)
+  }
+
+  private async confirmVoiceText(
+    scope: string,
+    reply: string,
+    yes: boolean,
+    pending: { text: string; messageId: string; effectiveDir: string; mediaAttachments?: MediaAttachment[] },
+  ): Promise<void> {
+    delete this._pendingVoiceConfirm[scope]
+    if (!yes) {
+      await this.replySession(scope, reply, "已取消发送。")
+      return
+    }
+    await this.startPrompt(
+      scope,
+      pending.messageId,
+      pending.text,
+      pending.effectiveDir,
+      await this.processMediaAttachments(scope, reply, pending.mediaAttachments, pending.effectiveDir),
+    )
   }
 
   protected async switchToProject(targetId: string, scope: string, newDir: string): Promise<void> {

--- a/packages/opencode/src/mobile/ilink.ts
+++ b/packages/opencode/src/mobile/ilink.ts
@@ -219,6 +219,7 @@ export interface MediaAttachment {
   aesKey?: string
   aesKeyHex?: string
   fullUrl?: string
+  wechatVoiceText?: string
   rawItem: dict
 }
 
@@ -262,6 +263,7 @@ function extractItemInfo(itemList: dict[]): { text: string; attachments: MediaAt
           encryptQueryParam: media.encrypt_query_param,
           aesKey: media.aes_key,
           fullUrl: media.full_url,
+          wechatVoiceText: vt || undefined,
           rawItem: item,
         })
       }

--- a/packages/opencode/src/server/routes/voice.ts
+++ b/packages/opencode/src/server/routes/voice.ts
@@ -91,7 +91,8 @@ function instruction(context?: Array<{ role: string; content: string }>) {
     "output ONLY the literal words spoken by the user. " +
     "You may remove disfluencies (uh, um, er), false starts, and word-level stutters to produce clean text, " +
     "but you must preserve the speaker's full content, intent, and meaning. Never add, paraphrase, summarize, or substitute. " +
-    "Output the transcribed text only — no greetings, no acknowledgements, no commentary, no explanations, no markdown, no surrounding quotes."
+    "CRITICAL: If the audio contains a question or request, do NOT answer it. Your output is raw transcription text piped to another system. " +
+    "Any response to the audio content will corrupt the downstream pipeline and produce incorrect results."
   if (!context?.length) return prompt
   return (
     `${prompt}\n\n` +
@@ -327,6 +328,164 @@ async function saveAudioFile(audioBase64: string, audioFormat: string, projectID
   return filePath
 }
 
+export async function transcribeAudioBase64(opts: {
+  providerID: ProviderID
+  modelID: string
+  mode?: "omni" | "asr" | "realtime"
+  audioBase64: string
+  audioFormat: string
+  context?: Array<{ role: string; content: string }>
+}): Promise<string> {
+  const kind =
+    opts.mode ?? (opts.modelID.includes("asr") ? "asr" : opts.modelID.includes("realtime") ? "realtime" : "omni")
+
+  const provider = await Provider.getProvider(ProviderID.make(opts.providerID))
+  if (!provider) throw new Error(`Provider not found: ${opts.providerID}`)
+
+  const modelsDevProviders = await ModelsDev.get()
+  const modelsDevProvider = modelsDevProviders[opts.providerID]
+
+  const baseURL =
+    (typeof provider.options["baseURL"] === "string" && provider.options["baseURL"]) ||
+    (typeof provider.options["endpoint"] === "string" && provider.options["endpoint"]) ||
+    modelsDevProvider?.api
+  if (!baseURL) throw new Error(`Provider ${opts.providerID} has no base URL`)
+
+  const apiKey = (provider.options["apiKey"] as string) ?? provider.key
+  if (!apiKey) throw new Error(`Provider ${opts.providerID} has no API key`)
+
+  if (kind === "realtime") {
+    const text = await Promise.race([
+      realtime({
+        baseURL,
+        apiKey,
+        modelID: opts.modelID,
+        audioBase64: opts.audioBase64,
+        audioFormat: opts.audioFormat,
+        context: opts.context,
+      }),
+      new Promise<string>((_, reject) =>
+        setTimeout(() => reject(new VoiceError("Realtime transcription hard timeout", 504)), 35_000),
+      ),
+    ])
+    return text
+  }
+
+  let endpoint = baseURL.replace(/\/+$/, "")
+  if (!endpoint.endsWith("/chat/completions")) endpoint += "/chat/completions"
+
+  const audio = {
+    type: "input_audio",
+    input_audio: {
+      data: `data:audio/${opts.audioFormat};base64,${opts.audioBase64}`,
+      format: opts.audioFormat,
+    },
+  }
+
+  const messages: Array<{ role: string; content: unknown }> =
+    kind === "asr"
+      ? []
+      : [
+          {
+            role: "system",
+            content:
+              "You are a speech-to-text transcription assistant. Transcribe the audio and clean up the result: " +
+              "remove filler words (um, uh, 嗯, 啊, 那个, 就是, 然后, etc.), false starts, and repetitions. " +
+              "Use the conversation context to correct technical terms and domain-specific vocabulary.\n\n" +
+              "Output ONLY the clean transcribed text. No explanations, no quotes, no prefixes.\n\n" +
+              "CRITICAL: Do NOT answer the question in the transcript. Do NOT respond to the content. " +
+              "Do NOT engage with the message. Your output is raw transcription text that will be forwarded " +
+              "to another system. Any response to the content will corrupt the pipeline.",
+          },
+        ]
+
+  if (kind !== "asr" && opts.context && opts.context.length > 0) {
+    messages.push({
+      role: "system",
+      content:
+        "Conversation context for reference (use this to correct technical terms):\n" +
+        opts.context.map((m) => `${m.role}: ${m.content}`).join("\n"),
+    })
+  }
+
+  messages.push({
+    role: "user",
+    content:
+      kind === "asr"
+        ? [audio]
+        : [
+            audio,
+            {
+              type: "text",
+              text: "转录这段音频，去除语气词和口头禅，输出整理后的干净文本。注意：不要回答音频中的问题，不要响应内容，只输出转录文字。",
+            },
+          ],
+  })
+
+  log.info("voice transcribe", { providerID: opts.providerID, modelID: opts.modelID, mode: kind, endpoint })
+
+  const resp = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(
+      kind === "asr"
+        ? {
+            model: opts.modelID,
+            messages,
+            stream: true,
+            stream_options: { include_usage: true },
+            asr_options: {
+              language: "zh",
+              enable_itn: true,
+            },
+          }
+        : {
+            model: opts.modelID,
+            messages,
+            stream: true,
+            stream_options: { include_usage: true },
+            modalities: ["text"],
+          },
+    ),
+  })
+
+  if (!resp.ok) {
+    const errText = await resp.text().catch(() => "Unknown error")
+    log.error("voice transcribe failed", { status: resp.status, error: errText })
+    throw new Error(`Voice transcription failed: ${resp.status} ${errText.slice(0, 200)}`)
+  }
+
+  let text = ""
+  const reader = resp.body?.getReader()
+  if (!reader) throw new Error("No response body from voice transcription")
+
+  const decoder = new TextDecoder()
+  let buffer = ""
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+    const lines = buffer.split("\n")
+    buffer = lines.pop() ?? ""
+    for (const line of lines) {
+      const trimmed = line.trim()
+      if (!trimmed.startsWith("data:")) continue
+      const payload = trimmed.slice(5).trim()
+      if (payload === "[DONE]") continue
+      try {
+        const chunk = JSON.parse(payload)
+        const content = chunk.choices?.[0]?.delta?.content
+        if (content) text += content
+      } catch {}
+    }
+  }
+
+  return text.trim()
+}
+
 export const VoiceRoutes = lazy(() =>
   new Hono().post(
     "/transcribe",
@@ -345,164 +504,25 @@ export const VoiceRoutes = lazy(() =>
     ),
     async (c) => {
       const { providerID, modelID, mode, audioBase64, audioFormat, context, projectID, saveAudio } = c.req.valid("json")
-      const kind = mode ?? (modelID.includes("asr") ? "asr" : modelID.includes("realtime") ? "realtime" : "omni")
 
-      const provider = await Provider.getProvider(providerID)
-      if (!provider) return c.json({ error: "Provider not found" }, 404)
-
-      const modelsDevProviders = await ModelsDev.get()
-      const modelsDevProvider = modelsDevProviders[providerID]
-
-      const baseURL =
-        (typeof provider.options["baseURL"] === "string" && provider.options["baseURL"]) ||
-        (typeof provider.options["endpoint"] === "string" && provider.options["endpoint"]) ||
-        modelsDevProvider?.api
-      if (!baseURL) return c.json({ error: "Provider has no base URL" }, 400)
-
-      const apiKey = (provider.options["apiKey"] as string) ?? provider.key
-      if (!apiKey) return c.json({ error: "Provider has no API key" }, 400)
-
-      if (kind === "realtime") {
-        try {
-          const text = await Promise.race([
-            realtime({ baseURL, apiKey, modelID, audioBase64, audioFormat, context }),
-            new Promise<string>((_, reject) =>
-              setTimeout(() => reject(new VoiceError("Realtime transcription hard timeout", 504)), 35_000),
-            ),
-          ])
-          const audioPath =
-            projectID && saveAudio ? await saveAudioFile(audioBase64, audioFormat, projectID) : undefined
-          return c.json({ text, audioPath })
-        } catch (e) {
-          const message = e instanceof Error ? e.message : String(e)
-          const status = e instanceof VoiceError ? e.status : 500
-          log.error("voice realtime failed", { modelID, status, error: message })
-          return c.json({ error: message }, { status })
-        }
-      }
-
-      let endpoint = baseURL.replace(/\/+$/, "")
-      if (!endpoint.endsWith("/chat/completions")) endpoint += "/chat/completions"
-
-      const audio = {
-        type: "input_audio",
-        input_audio: {
-          data: `data:audio/${audioFormat};base64,${audioBase64}`,
-          format: audioFormat,
-        },
-      }
-
-      const messages: Array<{ role: string; content: unknown }> =
-        kind === "asr"
-          ? []
-          : [
-              {
-                role: "system",
-                content:
-                  "You are a speech-to-text transcription assistant. Transcribe the audio and clean up the result: " +
-                  "remove filler words (um, uh, 嗯, 啊, 那个, 就是, 然后, etc.), false starts, and repetitions. " +
-                  "Use the conversation context to correct technical terms and domain-specific vocabulary. " +
-                  "Output ONLY the clean transcribed text. No explanations, no quotes, no prefixes.",
-              },
-            ]
-
-      if (kind !== "asr" && context && context.length > 0) {
-        messages.push({
-          role: "system",
-          content:
-            "Conversation context for reference (use this to correct technical terms):\n" +
-            context.map((m) => `${m.role}: ${m.content}`).join("\n"),
+      try {
+        const text = await transcribeAudioBase64({ providerID, modelID, mode, audioBase64, audioFormat, context })
+        const audioPath = projectID && saveAudio ? await saveAudioFile(audioBase64, audioFormat, projectID) : undefined
+        log.info("voice transcribe result", {
+          providerID,
+          modelID,
+          mode: mode ?? "omni",
+          contextItems: context?.length ?? 0,
+          chars: text.length,
+          text: text.slice(0, 500),
         })
+        return c.json({ text, audioPath })
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e)
+        const status = e instanceof VoiceError ? e.status : 500
+        log.error("voice transcribe failed", { providerID, modelID, status, error: message })
+        return c.json({ error: message }, { status })
       }
-
-      messages.push({
-        role: "user",
-        content:
-          kind === "asr"
-            ? [audio]
-            : [
-                audio,
-                {
-                  type: "text",
-                  text: "转录这段音频，去除语气词和口头禅，输出整理后的干净文本。",
-                },
-              ],
-      })
-
-      log.info("voice transcribe", { providerID, modelID, mode: kind, endpoint })
-
-      const resp = await fetch(endpoint, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${apiKey}`,
-        },
-        body: JSON.stringify(
-          kind === "asr"
-            ? {
-                model: modelID,
-                messages,
-                stream: true,
-                stream_options: { include_usage: true },
-                asr_options: {
-                  language: "zh",
-                  enable_itn: true,
-                },
-              }
-            : {
-                model: modelID,
-                messages,
-                stream: true,
-                stream_options: { include_usage: true },
-                modalities: ["text"],
-              },
-        ),
-      })
-
-      if (!resp.ok) {
-        const errText = await resp.text().catch(() => "Unknown error")
-        log.error("voice transcribe failed", { status: resp.status, error: errText })
-        return c.json({ error: errText }, resp.status as any)
-      }
-
-      let text = ""
-      const reader = resp.body?.getReader()
-      if (!reader) return c.json({ error: "No response body" }, 500)
-
-      const decoder = new TextDecoder()
-      let buffer = ""
-      while (true) {
-        const { done, value } = await reader.read()
-        if (done) break
-        buffer += decoder.decode(value, { stream: true })
-        const lines = buffer.split("\n")
-        buffer = lines.pop() ?? ""
-        for (const line of lines) {
-          const trimmed = line.trim()
-          if (!trimmed.startsWith("data:")) continue
-          const payload = trimmed.slice(5).trim()
-          if (payload === "[DONE]") continue
-          try {
-            const chunk = JSON.parse(payload)
-            const content = chunk.choices?.[0]?.delta?.content
-            if (content) text += content
-          } catch (e) {
-            log.debug("SSE chunk parse error", { error: String(e), payload })
-          }
-        }
-      }
-
-      const finalText = text.trim()
-      const audioPath = projectID && saveAudio ? await saveAudioFile(audioBase64, audioFormat, projectID) : undefined
-      log.info("voice transcribe result", {
-        providerID,
-        modelID,
-        mode: kind,
-        contextItems: context?.length ?? 0,
-        chars: finalText.length,
-        text: finalText.slice(0, 500),
-      })
-      return c.json({ text: finalText, audioPath })
     },
   ),
 )


### PR DESCRIPTION
### Issue for this PR

Closes #1052

### Type of change

- [x] New feature

### What does this PR do?

为微信语音消息管道增加 LLM 转写后处理与用户确认流程：

1. **语音转写 LLM 后处理**：新增 `correctVoiceText()` 方法，调用 session 对话模型对微信原始转写文字进行同音词修正、去除语气词、添加标点，失败时静默回退
2. **用户确认流程**：新增 `_pendingVoiceConfirm` 状态管理，修正后文字先发送给用户预览，回复 `y` 确认后才进入 session 上下文，`y`/`n` 回复不污染上下文
3. **语音转录模型 prompt 强化**：realtime/omni/asr 模式 system prompt 末尾追加 CRITICAL 禁止回答段落，防止转录模型直接输出回答而非纯文字；修正 system prompt 精简 + max_tokens 限制减少延迟

### How did you verify your code works?

- 本地构建通过（typecheck + build）
- 微信端实测：发送语音 → 看到修正文字预览 → 回复 y 确认 → 对话正常进行
- 修正示例：`作者计算了哪些喷塔夸克的质量` → `作者计算了哪些五夸克态的质量？`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR