### PR TITLE
feat(curator): 用连续空闲巡检次数替代日历天数来归档 skill

### DIFF
--- a/packages/opencode/src/skill-evolution/REVIEW_CONTEXT_DESIGN.md
+++ b/packages/opencode/src/skill-evolution/REVIEW_CONTEXT_DESIGN.md
@@ -1,0 +1,228 @@
+# Skill 进化评审 — 强化「发给评审 AI 的上下文」设计文档
+
+> 状态：**设计草案 v1**，待团队对齐后进入实现（实现走 TDD）。
+> 读者：团队开发者 + 组会评审 + 照本实现的人（含 yolo 沙盒会话——它没有讨论上下文，本文档即唯一说明书）。
+> 出处：2026-06-15 与用户复盘"评审 AI 到底收到哪些信息"（见 [`/home/zheng/code/transcribe/发给AI的信息清单.md`](../../../../../transcribe/发给AI的信息清单.md) 的实况盘点 + 真实 DB 例子）发现两处缺口：①评审 AI 看不到"已有哪些 skill"，落实不了导师 #3「优先改现成、别动不动新建」；②对话历史里工具调用**只有名字没有参数和输出**，而基础指令的 B 维度又要求 AI"指出一条成功的工具输出"，自相矛盾。
+> 关联：本目录 [`review-agent.ts`](./review-agent.ts)（评审 prompt 构建）、[`constants.ts`](./constants.ts)（`SKILL_REVIEW_PROMPT_BASE` 基础指令）。本文档**只改"喂给评审 AI 的输入上下文"这一块**，gate 判定逻辑、写作规则等全部沿用，不重述。
+
+---
+
+## 目录
+
+- [设计原则](#设计原则)
+- [解决了什么问题](#解决了什么问题)
+- [现状 → 改后](#现状--改后)
+- [对旧文件的修改](#对旧文件的修改)
+- [核心机制详解](#核心机制详解)
+  - [1. 给评审 AI 喂"已有 skill 清单"](#1-给评审-ai-喂已有-skill-清单)
+  - [2. 对话历史补"工具参数 + 输出（截断）"](#2-对话历史补工具参数--输出截断)
+- [格式样例](#格式样例)
+- [核心不变量](#核心不变量)
+- [决策记录](#决策记录)
+- [开放问题](#开放问题)
+- [关键文件速查](#关键文件速查)
+- [复用组件核实（实现前必读）](#复用组件核实实现前必读)
+- [命题清单](#命题清单)
+- [测试与红绿里程碑](#测试与红绿里程碑)
+- [范围说明](#范围说明)
+- [用户体验](#用户体验)
+
+---
+
+## 设计原则
+
+1. **只补输入、不动判定**：本次只把"已有 skill 清单"和"工具参数+输出"加进发给评审 AI 的 prompt，**不改** gate 四维度逻辑、不改写作规则、不改创建/覆盖行为。让 AI 在"看得更全"的基础上自己判，判据本身不动。
+2. **截断防爆炸**：会话里存的工具输出**已被普通会话的 `Truncate.output` 封顶到 ≤50KB**（[truncate.ts:17-18](../tool/truncate.ts#L17)，超出部分甩文件、只留预览），但 50KB/条对评审仍太松。本次在其上**再收紧一道**：评审 prompt 里每条 output 只留 ~300 字、input 只留 ~200 字（**纯字符截断**，不甩文件——评审是一次性的，不需要再去 Grep 完整文件）。补证据是为了让 B 维度可判，不是把整段历史搬进来。
+3. **最小改动、贴现有结构**：只改 [`review-agent.ts`](./review-agent.ts) 一个文件——升级 `collectCategories`、改消息映射、改 `serializeHistory`；复用现有 `buildReviewPrompt` 装配顺序，不新建文件、不改存储。
+4. **best-effort、永不挡评审**：拿不到某条 skill 的 frontmatter / 某条工具输出时，跳过该条，绝不让评审构建报错。
+
+---
+
+## 解决了什么问题
+
+### 顾虑 A：评审 AI 看不到"已有哪些 skill"（落实导师 #3）
+- 现状：[`collectCategories`](./review-agent.ts#L125) 扫了所有 skill，**只抠 `category` 字段**去重成标签（如 `GitHub`/`Research`），prompt 里只给"有哪些类别"。**没有 skill 的名字、没有 description**。
+- 后果：导师 #3「优先改现成、别动不动新建」**无从落地**——AI 根本不知道现成有哪些 skill、各干嘛，自然倾向新建。
+- 真实佐证：[`发给AI的信息清单.md`](../../../../../transcribe/发给AI的信息清单.md) 第八节捞的真实 prompt，末尾就只有 `Available skill categories: GitHub/Testing/Skills/Research`。
+
+### 顾虑 B：判"已验证"却看不到证据（修自相矛盾）
+- 现状：[`serializeHistory`](./review-agent.ts#L101) 渲染工具调用时**只有 `name` + `id`**；消息映射 [`review-agent.ts:221-229`](./review-agent.ts#L221) 把 part 的 `state`/`output`（工具的输入参数、返回结果）直接丢掉。
+- 后果：[`constants.ts`](./constants.ts) 的基础指令 B 维度明文要求 AI "point to at least one tool-call output that SUCCEEDED" ——**指令要的证据，材料里根本不存在**。AI 只能靠猜，B 维度形同虚设。
+- 真实佐证：同上第八节，4 次 `webfetch` 在 prompt 里只剩 `<tool_call name="webfetch" id="..."/>`，查询词和返回全无。
+
+> 数据本来就有：工具输出存在源会话的 part 里（`state.output`，实测可取），构建 prompt 那一刻 `rawMessages` 手里就有，是映射那步丢了。所以"补回来"只是不丢，不是去别处捞。
+
+### 本次【不】解决（留给后续，见[范围说明](#范围说明)）
+- 创建时"别静默覆盖同名 + 相似时拦一道"的系统侧闸（`skill-manage-tool.ts` 的 `handleCreate` 不查重直接覆盖）——另一处文件、另一个主题，单独做。
+- 导师 #6「创建两次才启用」——更大的功能，单独设计。
+- ID（#7）/ 每 skill 套 git（#8）/ 判好坏（#10/#14）——导师明确降级或 `.versions` 已覆盖，本次不碰。
+
+---
+
+## 现状 → 改后
+
+| 维度 | 现状 | 改后 |
+|---|---|---|
+| 评审 AI 知道的"已有 skill" | 只有分类标签（`category`） | **完整清单：每个 skill 的 name + description + category** |
+| 工具调用在历史里 | 只有 `name` + `id` | **加上输入参数 + 输出（各自截断到上限）** |
+| B 维度可判性 | 无证据，形同虚设 | 有（截断的）成功输出可指认 |
+| 改动文件 | — | 仅 [`review-agent.ts`](./review-agent.ts) |
+
+---
+
+## 对旧文件的修改
+
+> 每处标注 **侵入式**（改了旧行为，有回归风险）还是 **增量式**（只加内容、旧路径不变）。
+
+| 旧文件:位置 | 改什么 | 性质 | 依据 |
+|---|---|:---:|---|
+| `review-agent.ts` **新增** `collectSkillInventory` + `serializeSkillInventory` | 只扫子项目进化区，收集每个 skill 的 `name`+`description`+`category`，渲染成"已有 skill 清单"段 | **增量式**（新函数，旧 `collectCategories` 不动） | D1/D5 |
+| [`review-agent.ts :: collectCategories`](./review-agent.ts#L125) | **保留不动**（分类标签仍服务基础指令里"按列表给 skill 归类"的 `category` 字段要求，D4） | 不改 | D1 |
+| [`review-agent.ts :: buildReviewPrompt`](./review-agent.ts#L152) | 在分类标签段之后**追加**一段"已有 skill 清单" | **增量式**（加一段，原段落不动） | D1 |
+| [`review-agent.ts` 消息映射 `:221-229`](./review-agent.ts#L221) | 保留 part 的工具 `input`/`output`（不再只取 type/text/tool/callID） | **增量式**（多带字段） | D2 |
+| [`review-agent.ts :: serializeHistory`](./review-agent.ts#L101) | 工具节点渲染出"输入参数 + 输出"，各按上限截断 | **侵入式**（XML 节点内容变） | D2/D3 |
+
+---
+
+## 核心机制详解
+
+### 1. 给评审 AI 喂"已有 skill 清单"
+
+- **新增** `collectSkillInventory(folderName)`，**只扫当前子项目进化区**一个目录：`Spawner.skillEvolutionDir(folderName)` → `~/.local/share/aether/skill-evolution/<项目ID>/skills/`。**不扫**全局、**不扫**共享区（D5）。
+- 每个 skill：`name` 取目录名，`description`/`category` 用项目标准解析器 [`ConfigMarkdown.parse`](../config/markdown.ts#L71)（gray-matter）从 SKILL.md 取 `md.data`——**只读 `---` 块**，不会误抓正文里的 `key:` 行（D6）。
+- `serializeSkillInventory` 把清单渲染成一段，在基础指令的分类标签段**之后追加**（不替换分类标签——后者仍服务 `category` 字段指令，D4）。格式见[下文](#格式样例)。
+- best-effort：读不到/解析不了的 skill 跳过；目录不存在 → 空清单（渲染成 "(none yet)"）。
+
+### 2. 对话历史补"工具参数 + 输出（截断）"
+
+- 消息映射保留每个工具 part 的 `state.input`（调用参数）和 `state.output`（返回结果）。
+- `serializeHistory` 渲染工具节点时带上二者，**纯字符截断**：output 留前 ~300 字、input 留前 ~200 字，超出加 `…[truncated N chars]` 标注（不甩文件，D3/Q1）。
+- 仅渲染有意义的工具结果；拿不到 output 的（如还在跑、被压缩）按"无输出"渲染，不报错。
+
+---
+
+## 格式样例
+
+**改后的"已有 skill 清单"段（替换原 `Available skill categories`）**：
+
+```
+Existing skills in this project (prefer EDITING one of these over creating a near-duplicate):
+  - ai-qft-survey [Research]: Survey the frontier of AI + quantum field theory…
+  - ai-architecture-research [Research]: Investigate AI system architecture papers…
+```
+（只列当前子项目进化区的 skill；全局/共享区的不列。）
+
+**改后的工具节点（对话历史里）**：
+
+```xml
+<tool_call name="webfetch" id="call_FKR...">
+  <input>{"url":"https://arxiv.org/list/hep-th/recent"}</input>
+  <output>Status 200. Recent submissions in hep-th: … …[truncated 8421 chars]</output>
+</tool_call>
+```
+
+---
+
+## 核心不变量
+
+1. **只补输入、判定不变** — gate 四维度、写作规则、创建/覆盖行为一行不动（D1/D2 只动 prompt 装配）。
+2. **输出有界** — 每条工具输出/参数渲染长度 ≤ 上限；prompt 不会因单条巨型输出而爆炸（D3）。
+3. **best-effort** — 任一 skill frontmatter 或工具输出取不到 → 跳过该条，构建不报错（设计原则 4）。
+4. **范围不变** — skill 清单扫的还是原来那 3 个目录，不新增扫描面（机制 1）。
+
+---
+
+## 决策记录
+
+> 本文档自有编号 D1…，与 IDLE/SESSION_USAGE 的 D 编号互不干扰。
+
+- **D1：在分类标签段之外【新增】一段"完整 skill 清单（name+description+category）"，不替换分类标签。** 原因：只给 category 落实不了 #3；给名字+描述 AI 才知道"现成有啥、改哪个"。分类标签**保留**——基础指令仍要 AI"按这个列表给新 skill 归类"，二者用途不同。属增量式（加一段 + 加新函数，旧路径不动）。**实现已落地，见 `review-agent.ts` 的 `collectSkillInventory`/`serializeSkillInventory`。**
+- **D2：对话历史补工具的 input+output。** 原因：B 维度要证据、材料里却没有，是自相矛盾的真 bug；数据本就在 part 里，只是映射丢了。
+- **D3：工具输出/参数用「纯字符截断」，不复用 `Truncate.output` 的甩文件那套。** 现成的 `Truncate.output` 会把超长内容甩到磁盘文件、再给模型留一句"用 Grep/Read 看完整文件"——那段提示每条约 40~60 token，对一次性评审是纯浪费（评审不会去读那个文件）。纯字符截断只加一个 ~5 token 的 `…[truncated]` 标记，同样预览长度下更省 token。**已与用户对齐。**
+- **D4：只改 `review-agent.ts` 一个文件，不动 `constants.ts` 的基础指令文本。** 原因：基础指令的 B 维度本身没错，错在没给它证据；补上证据即可，不必改指令。
+- **D6：`collectSkillInventory` 用 `ConfigMarkdown.parse`（gray-matter）解析 frontmatter，不手搓正则。** 原因：code-review 发现手搓的 `^key:$/m` 正则会扫到正文行（frontmatter 缺该字段时把正文 `category:` 当成 skill 类别），且是项目里第 4 个 frontmatter 解析器。复用 `ConfigMarkdown.parse`（skill/index.ts 也用它）既只读 `---` 块根治该 bug，又消除重复。**已修，对应红绿测试 "does not read a `category:` line from the body"。**
+- **D5：skill 清单只扫"当前子项目进化区"，不扫全局/共享区。** 原因：评审是针对这个项目、要防的是"在这个项目里又造一个雷同的"，比对对象就该是这个项目自己进化区里已有的 skill；全局区是用户手搓的、共享区是另一作用域，混进来既无关又拉长清单。**已与用户对齐。**
+
+---
+
+## 开放问题
+
+- ~~**Q1：工具输出/参数各截断到多少字？**~~ **已定**：output 留 ~300 字、input 留 ~200 字，纯字符截断（放 `review-agent.ts` 模块常量，YAGNI 不进 config）。理由：评审只需判"这步成没成功"，预览越短越省 token（省 token 的主要杠杆是预览长度，不是截断方式）。
+- **Q2：skill 清单是否需要总长上限？** 若某子项目 skill 很多，清单也会变长。暂定不设上限（当前每项目 skill 数很少）；若日后变多再加。**待定。**
+- **Q3：要不要把"被用户关掉自进化"的 skill 也列进清单（只列、标注只读）？** 现在锁警告段已单独列了它们；清单段是否重复列、还是引用。倾向：清单段全列、锁警告段保留"禁止改"语义，二者不互斥。**待定。**
+- **Q4（与系统提示的关系）**：`SystemPrompt.skills` 可能已在系统提示里列了可用 skill（[发给AI的信息清单.md 第七节](../../../../../transcribe/发给AI的信息清单.md) 的待验证项）。若已列，本次的清单段会与之**部分重复**。处理：本次仍在用户消息里显式列（确保 gate 一定看得到、且能加"prefer editing"的措辞），重复是可接受的冗余；要不要去重待那个实验结论出来再定。**待验证后定。**
+
+---
+
+## 关键文件速查
+
+| 文件 | 作用 |
+|---|---|
+| [`review-agent.ts`](./review-agent.ts) | 评审 prompt 构建（本次唯一改动文件） |
+| [`constants.ts`](./constants.ts) | `SKILL_REVIEW_PROMPT_BASE` 基础指令（本次不改，仅引用 B 维度） |
+| [`review-agent.test.ts`](./review-agent.test.ts) | 现有测试（`serializeHistory`、prompt 装配已有用例，本次扩充） |
+
+---
+
+## 复用组件核实（实现前必读）
+
+- **X1：工具输出确实存在 part 里，且已被 `Truncate.output` 封顶到 ≤50KB。** 实测 part 的 `data.state.output` 有内容（一次 skill 加载样本 ~20KB，未超 50KB 故整条留着）；普通会话写 part 前先过 [`Truncate.output`](../tool/truncate.ts#L141)（[prompt.ts:977](../session/prompt.ts#L977)），所以读到的就是 ≤50KB 的版本 → 我们在其上再纯字符收紧到 ~300 字（D3）。构建时 `rawMessages` 可取 → D2 可行。
+- **X2：新增的 `collectSkillInventory` 只扫子项目进化区** `Spawner.skillEvolutionDir(folderName)`，取 `name`(目录名)+`description`+`category`；`collectCategories`（扫 3 个目录、只取 category）原样保留服务 category 字段（机制 1 / D5）。
+- **X3：现有测试入口在 `review-agent.test.ts`。** `serializeHistory` 与"do not create 重复 skill"已有用例（约 line 80），新用例接着加。
+
+---
+
+## 命题清单
+
+### PA. skill 清单
+- A1. 改后 prompt 含每个已有 skill 的 name + description + category，而非仅 category。
+- A2. 清单只覆盖当前子项目进化区的 skill（不含全局、不含共享区）。
+- A3. 某 skill 的 frontmatter 解析失败 → 跳过该条，prompt 仍正常生成（不抛错）。
+
+### PB. 工具参数 + 输出
+- B1. 改后对话历史里的工具节点含 input 与 output。
+- B2. 单条 output 超上限 → 被截断且带 `…[truncated]` 标注；长度 ≤ 上限。
+- B3. 工具 part 无 output（如未完成）→ 渲染为"无输出"，不抛错。
+
+### PH. 边界与失败用例（测试必须覆盖）
+- H1. 三个目录都为空 / 无任何 skill → 清单段为"(no existing skills)"，不抛错。
+- H2. output 为空字符串 / 超大字符串两个边界，截断逻辑都正确。
+- H3. 一条消息里多个 tool_call，全部带上各自 input/output。
+
+---
+
+## 测试与红绿里程碑
+
+> 走 TDD：每个里程碑先写红测试（证明现状缺它）、再实现到绿。先红后绿两次输出都要留。
+
+### ⚠️ 假绿陷阱
+- 测"行为不测实现"：断言 **prompt 文本里出现了 description / output 内容**，不要断言"调了某函数"。
+- 必须有一条**先红**：在改 `collectCategories`/`serializeHistory` 之前跑，证明现在 prompt 里**没有** description、**没有** 工具 output（否则测试恒绿，没测到东西）。
+
+### 红绿总览（按依赖排序）
+1. **里程碑1（skill 清单）**：红——断言 `buildReviewPrompt` 输出含某已有 skill 的 description，现状失败；绿——升级 `collectCategories` 后通过。
+2. **里程碑2（工具输出）**：红——构造一条带 `output` 的工具消息，断言 `serializeHistory` 输出含该 output 片段，现状失败；绿——改映射+渲染后通过。
+3. **里程碑3（截断）**：红——超长 output 断言被截断到上限且带标注，现状（无截断逻辑）失败；绿——加截断后通过。
+4. **里程碑4（边界）**：H1/H2/H3 各一条。
+
+### 收尾验证
+- 跑 `review-agent.test.ts` 全绿。
+- 跑一次真实评审（可选），人眼看新 prompt 里清单段与工具 output 都在、且 output 被截断。
+
+---
+
+## 范围说明
+
+**本次做**：只在发给评审 AI 的 prompt 里——①补"已有 skill 清单（完整 frontmatter）"②补"工具参数+输出（截断）"。仅改 `review-agent.ts`。
+
+**本次不做**（留给后续独立工作）：
+- 创建时"别静默覆盖同名 + 相似时拦"的系统侧闸（`skill-manage-tool.ts`）。
+- 导师 #6「创建两次才启用」。
+- ID（#7）、每 skill 套 git（#8）、判 skill 好坏 / 进会话看 transcript（#10/#14）——导师降级或 `.versions` 已覆盖。
+
+---
+
+## 用户体验
+
+- 对你来说的变化：skill 自进化**少重复造**——评审 AI 现在看得见"现成有哪些 skill、各干嘛"，更可能去**改现成的**而不是又建一个雷同的；并且它判"这个方法验证过没有"时**有真凭据可看**（联网/命令的实际输出），而不是凭空猜。
+- 没有界面变化；这是后台评审质量的改善。判定标准（什么该存什么不该存）不变，只是判得更有依据。

--- a/packages/opencode/src/skill-evolution/curator/IDLE_SCANS_DESIGN.md
+++ b/packages/opencode/src/skill-evolution/curator/IDLE_SCANS_DESIGN.md
@@ -1,0 +1,404 @@
+# Aether Curator 归档判据改造 — 从「按天数」到「连续空闲巡检数」设计文档
+
+> 状态：**设计草案 v1**，待团队对齐后进入实现（实现走 TDD）。
+> 读者：团队开发者 + 组会评审。
+> 出处：2026-06-12 组会，导师对 curator 当前的「90 天没用就归档」提意见，要求改用「相对使用次数」（转写 `20260612_1432_speakers.txt` 行90/行93）。
+> 关联：本目录 [`CURATOR_DESIGN.md`](./CURATOR_DESIGN.md)（curator 整体设计）。本文档**只改归档判据这一处**，其余（范围、拉模式、归档不删、触发门控）全部沿用，不重述。
+
+把 curator（skill 自动归档机制）决定「该不该归档」的尺子，从「**现实世界过了多少天没用**」换成「**连续多少次巡检都没被用过**」（`idle_scans`）。**调度间隔（7 天跑一次巡检）保持不动**——导师担心的是「判据」绑死时间，不是「调度」。判据里不再有任何日历日期，因此改错系统时间不会成片误删；且每个 skill 只跟自己比、被用一次清零，不存在「排名垫底被删光」的死亡螺旋。
+
+---
+
+## 目录
+
+- [设计原则](#设计原则)
+- [解决了导师的什么顾虑](#解决了导师的什么顾虑)
+- [与现状（CURATOR_DESIGN.md）的差异](#与现状curator_designmd的差异)
+- [为什么不用「相对排名砍末位」](#为什么不用相对排名砍末位)
+- [数据结构](#数据结构)
+- [核心机制详解](#核心机制详解)
+  - [1. 判据：连续空闲巡检数](#1-判据连续空闲巡检数)
+  - [2. 兼容：旧账本缺字段建基线](#2-兼容旧账本缺字段建基线)
+- [核心不变量](#核心不变量)
+- [决策记录](#决策记录)
+- [开放问题](#开放问题)
+- [关键文件速查](#关键文件速查)
+- [命题清单](#命题清单)
+- [测试与红绿里程碑](#测试与红绿里程碑)
+- [范围说明](#范围说明)
+- [用户体验](#用户体验)
+
+---
+
+## 设计原则
+
+1. **判据去时间化，但调度不动**：归档「判据」（该不该归档）改成数巡检次数，零日历依赖；归档「调度」（多久跑一次）仍是 7 天间隔。两者是两件事，导师的顾虑只指向前者。
+2. **每个 skill 只跟自己比**：判据是「这个 skill 自己连续几次没被碰」，不跟别的 skill 比排名 → 不会死亡螺旋（D11）。
+3. **最小改动、贴 Hermes 结构**：在现有 `applyAutomaticTransitions` 框架内换掉判据那段，不引入「使用率（次数÷总会话数）」那种要加分母、改动外溢的重方案（D10）。
+4. **改动局限 `curator/` 目录**：要改的字段全部只被 `curator/` 内部引用，外部零调用点（已 grep 核实，见 X1）。
+5. **不误伤存量**：线上已有账本无新字段，首次巡检当基线、不判归档（D13）。
+
+### 对旧文件的修改
+
+> 每处标注 **侵入式**（改了旧行为，有回归风险）还是 **增量式**（只加新调用）。
+
+| 旧文件:位置 | 改什么 | 性质 | 依据 |
+|---|---|:---:|---|
+| [`curator.ts :: applyAutomaticTransitions`](./curator.ts#L146) | 把 `daysSince`（按天）那段判据换成 `idle_scans`（按巡检次数）| **侵入式**（改归档行为，但正是本次目标）| D10 |
+| [`constants.ts`](./constants.ts#L5) | `staleAfterDays`/`archiveAfterDays` → `staleAfterIdleScans`/`archiveAfterIdleScans`；`intervalHours` 不动 | **侵入式**（字段改名，仅 curator 内引用）| D10 |
+| [`usage.ts :: UsageRecord`](./usage.ts#L13) | 加 `use_count_at_last_scan`、`idle_scans` 两字段 + `emptyRecord` 初始化 | **增量式**（加字段，旧字段不动）| D12 |
+
+> **不动**：`bumpUse`（计数写入）、`archiveSkill`/`restoreSkill`（归档/恢复）、孤儿自愈、pinned 跳过、`shouldRunNow`（7 天门控）、`skill_manage`（仍零触点）——全部沿用 `CURATOR_DESIGN.md`。
+
+---
+
+## 解决了导师的什么顾虑
+
+导师围绕 curator / skill 进化的顾虑**一共四条**。**本分支（归档判据改造）只解决前两条；顾虑 3、4 本分支不覆盖，属第二块「记会话」工作**（见[范围说明](#范围说明)）。下面分开列，避免误以为本版改动一并解决了它们。
+
+### 本分支解决的（顾虑 1、2）
+
+| # | 导师的顾虑 | 出处 | 本方案怎么解决 |
+|---|---|---|---|
+| **顾虑 1** | **硬时间标签不公平**：有人一月用一次、有人一天用十几次，统一卡「N 天没用」对低频用户不公 | 转写 行90 | 判据改成「这个 skill **自己**连续几次巡检没被碰」，与使用频率高低无关，一视同仁；且巡检本身要「用了 app 才触发」，用得少 → 巡检少 → skill 不会无辜变老 |
+| **顾虑 2** | **绝对时间不安全**：电脑系统时间设错（年份拉到 2027）会一次性误删一大片 | 转写 行93（导师真正在意的灾难）| 判据里**没有日历日期**。系统时间跳一下，最多多触发一次巡检、让 `idle_scans` +1，**绝不成片误删** |
+
+**判定标准**：导师给的解法原话是「改用相对使用次数，比较**安全**」——他要的是安全，不是要个复杂算法。**只要这两条解掉，本分支就达标**，不必上「使用率」那套重方案。
+
+### 本分支【不】解决、留给第二块「记会话」的（顾虑 3、4）
+
+> ⚠️ 这两条本分支不碰。列在此处是为把导师的完整意图记全、并说清「为什么 idle_scans 治不了它们」。
+
+| # | 导师的顾虑 | 出处 | 为什么本分支治不了 / 真正的解药 |
+|---|---|---|---|
+| **顾虑 3** | **「触发灵敏但啥也没干」的烂 skill 反被保留**：一个差劲 skill 只要触发特别灵敏、被一直调用，就显得「很重要」、被提权、再也不删 → 进化方向跑偏成「更多地展示自己」而非「把事做好」。被调用多 ≠ 该留；调用后啥也没做成 → 该删 | 转写 行100、行101 | **idle_scans 治不了**：这种 skill 一直被触发 → `use_count` 一直涨 → `idle_scans` 永远是 0 → **永不归档**，照样赖着。解药是「记会话 + 回看它当初有没有真起作用」，靠删/降权而非靠「没用」淘汰 |
+| **顾虑 4** | **没法回溯评估**：想改进/进化一个 skill 时，得回去看它当初在那十次会话里表现好不好；不重跑、只看当初的会话过程就能判断它有没有真起作用。没有「在哪被用过」的记录，这一步无从谈起——「没有数据，skill 进化无从谈起」 | 转写 行99、行102、行111、行110 | **本分支没产出这份数据**。解药 = 第二块工作：每次用 skill 记下 project id + session id + 时间，供日后回溯。导师强调「先把使用历史记全，再往后做」 |
+
+**判定标准（顾虑 3、4）**：达标 = **能记录并回溯「每个 skill 在哪个会话被用过」**，从而判断它当初有没有真起作用——这是第二块「记会话」的目标，不在本分支。
+
+---
+
+## 与现状（CURATOR_DESIGN.md）的差异
+
+| | 现状（已发布 / CURATOR_DESIGN.md）| 本方案 |
+|---|---|---|
+| 归档判据 | `now - max(last_used_at, 文件mtime) ≥ archiveAfterDays(90 天)` | `idle_scans ≥ archiveAfterIdleScans` |
+| stale 判据 | 同上 ≥ staleAfterDays(30 天) | `idle_scans ≥ staleAfterIdleScans` |
+| 「被用过」怎么判 | 看活动锚点时间是否新 | 本轮 `use_count` 是否比上轮巡检时大 |
+| 「编辑文件」算活动吗 | **算**（mtime 新 → 不归档）| **默认不算**（只认被加载/使用，见 Q-A）|
+| 调度间隔 | 7 天（`intervalHours`）| **不变** |
+| 时间安全性 | ❌ 改错系统时间会成片误删 | ✅ 不受系统时间影响 |
+
+---
+
+## 为什么不用「相对排名砍末位」
+
+一个直觉的「相对使用次数」实现是「每次巡检删掉使用次数排末位的 skill」——**这个方案错的，不能用**：
+
+- 相对排名**永远有个末位**。只要规则是「砍末位」，哪怕一批 skill 全都有用、都常被调用，也会每轮砍掉垫底的，最后只剩使用最多的那一个 → **有用的 skill 也被删光**（死亡螺旋）。
+- 根因：「排名」是比出来的、没有下限；判据必须让每个 skill **凭自己的使用情况**活，而不是跟别人比高低。
+
+`idle_scans` 正是「只跟自己比」：被用一次就清零，**只要还在用就永不归档**（D11）。
+
+---
+
+## 数据结构
+
+### UsageRecord — 单个 skill 的记录（落盘 `curator/usage.json`，key = `<projectId>/<name>`）
+
+```ts
+interface UsageRecord {
+  projectId: string
+  name: string
+  location: string
+  use_count: number              // 沿用：被加载使用的累计次数（bumpUse 累加）
+  use_count_at_last_scan: number // 【新增】上一次巡检时的 use_count，用于比「这轮有没有新增使用」
+  idle_scans: number             // 【新增】连续多少次巡检没被用过；被用一次清零
+  last_used_at: string | null    // 沿用：保留作信息/后续 session 工作用，不再参与归档判据
+  state: "active" | "stale" | "archived"
+  pinned: boolean
+  archived_at: string | null
+}
+```
+
+**逐字段解释**（▲=本次新增，其余沿用 `CURATOR_DESIGN.md`）：
+
+| 字段 | 是什么 | 例子 | 改/不改 |
+|---|---|---|:---:|
+| `projectId` | 这个 skill 属于哪个项目（项目的 hex 哈希 id） | `"a3f91c8e..."` | 不改 |
+| `name` | skill 的名字（SKILL.md frontmatter 里的 `name`） | `"qft-helper"` | 不改 |
+| `location` | skill 文件夹的绝对路径，归档/恢复时靠它定位往哪搬 | `".../skill-evolution/a3f91c8e/skills/qft-helper"` | 不改 |
+| `use_count` | 被加载使用的**累计**次数（每次 agent 加载它，`bumpUse` +1） | `7`（一共被用过 7 次） | 不改 |
+| ▲ `use_count_at_last_scan` | **上一次巡检时** `use_count` 的快照，下一轮拿它跟当前 `use_count` 比，看「这轮有没有新增使用」 | `7`（上轮也是 7 → 说明这轮没被用过） | 新增 |
+| ▲ `idle_scans` | **连续**多少次巡检都没被用过的计数；被用一次就清零 | `2`（连着 2 次巡检没人用它） | 新增 |
+| `last_used_at` | 最后一次被加载的时间（UTC ISO）；从未用过为 `null`。**本方案保留作信息，但不再参与归档判据** | `"2026-05-01T08:30:00.000Z"` | 不改（降级为纯信息） |
+| `state` | 当前生命周期状态：`active`（活跃）/ `stale`（冷落，仅标记）/ `archived`（已归档搬走） | `"active"` | 不改 |
+| `pinned` | 钉住：为 true 则跳过全部自动流转，永不被归档（只读，无设置入口） | `false` | 不改 |
+| `archived_at` | 被归档的时间；未归档为 `null` | `null` | 不改 |
+
+**一条完整记录的例子**（`qft-helper` 已连着 2 次巡检没被用，还在活跃、离 stale(4 次) 还差 2 次）：
+
+```json
+"a3f91c8e/qft-helper": {
+  "projectId": "a3f91c8e",
+  "name": "qft-helper",
+  "location": "/home/zheng/.local/share/aether/skill-evolution/a3f91c8e/skills/qft-helper",
+  "use_count": 7,
+  "use_count_at_last_scan": 7,
+  "idle_scans": 2,
+  "last_used_at": "2026-05-01T08:30:00.000Z",
+  "state": "active",
+  "pinned": false,
+  "archived_at": null
+}
+```
+
+> 读法：`use_count(7) == use_count_at_last_scan(7)` → 上一轮到这一轮没新增使用 → 这轮 `idle_scans` 会从 2 累加到 3。若哪轮 `use_count` 涨到 8 → `idle_scans` 立刻清零回 0。
+
+### CuratorConfig — 字段改名（[`constants.ts`](./constants.ts#L1)）
+
+```ts
+interface CuratorConfig {
+  enabled: boolean
+  intervalHours: number          // 沿用：两次巡检最小间隔（默认 168 = 7 天），不动
+  staleAfterIdleScans: number    // 【改名自 staleAfterDays】连续几次空闲巡检标 stale
+  archiveAfterIdleScans: number  // 【改名自 archiveAfterDays】连续几次空闲巡检归档
+}
+```
+
+可调参数（**已定：选项 A**，Q-B）：
+
+| 参数 | 含义 | **取值（选项 A）** |
+|---|---|---|
+| `intervalHours` | 巡检最小间隔 | 168（7 天，不动） |
+| `staleAfterIdleScans` | 连续几次空闲 → 标 stale（仅贴标签，不搬文件） | **4**（≈30 天） |
+| `archiveAfterIdleScans` | 连续几次空闲 → 归档（搬到 archive/，加载器扫不到，可恢复） | **12**（≈90 天） |
+
+> 选 A 是为了让行为变化最小、沿用旧 30/90 天的节奏感。（备选 B `stale=2 / archive=4` 更激进、约 1 个月就归档，本次不采用。）
+
+### stale 和 archive 的区别（两道关卡）
+
+同一条「衰老」路上**先到 stale、再到 archive**，动作完全不同：
+
+| | 到 `staleAfterIdleScans`(4≈30天) | 到 `archiveAfterIdleScans`(12≈90天) |
+|---|---|---|
+| 干什么 | 账本里**贴个「冷落」标签** `state="stale"` | **把 skill 文件夹搬到** `<projectId>/archive/` |
+| 文件 | 原地没动 | 搬走（可恢复，非删） |
+| 还能加载用吗 | 能，照常进系统提示词 | 不能，加载器扫不到 |
+| 自动复活 | 能（再被用一次退回 active） | 不会自动（手动 `restoreSkill` 恢复） |
+
+> stale = 黄牌警告（只标记、不动文件、还能用）；archive = 真请出场（搬走、不再加载、可恢复）。stale 是 archive 前的缓冲带。按 `CURATOR_DESIGN.md` Q3，stale 目前除「能复活」外无其它后果（不隐藏、不降权）。
+
+---
+
+## 核心机制详解
+
+### 1. 判据：连续空闲巡检数
+
+`applyAutomaticTransitions()` 在 7 天门控通过后跑，对每个 in-scope skill：
+
+```
+① 账本没这条 → 补一条（建基线：use_count_at_last_scan=当前 use_count，idle_scans=0），本轮不判归档（见 §2）
+② pinned==true → 跳过
+③ 本轮 use_count > use_count_at_last_scan ?
+     是（这轮被用过） → idle_scans = 0；若是 stale → 复活成 active
+     否（这轮没用）   → idle_scans += 1
+                        idle_scans ≥ archiveAfterIdleScans 且 非archived → archiveSkill()，state=archived
+                        idle_scans ≥ staleAfterIdleScans  且 active     → state=stale
+④ use_count_at_last_scan = 当前 use_count   （为下一轮留基线）
+对账本里每条：location 目录已不存在 → 孤儿自愈（沿用，不变）
+写 lastRunAt=now、runCount+1
+```
+
+- 「被用过」= `use_count`（被加载时由 `bumpUse` 累加）比上一轮巡检时大。
+- `now` 参数保留——归档时间戳 `archived_at` 仍要用它，只是不再拿它算「过了几天」。
+
+#### 「90 天」那块旧代码怎么处理（改前 → 改后）
+
+旧代码里「90」只活在**一处**：判断「过了多少天该归档」那行。处理 = 整段按天算的逻辑替换成按次数算，`90/30` 两个常量改名成次数。
+
+**改前**（[`curator.ts:146-158`](./curator.ts#L146)，现线上跑的）：
+```ts
+const lastUsedMs = rec.last_used_at ? new Date(rec.last_used_at).getTime() : -Infinity
+const daysSince = (now.getTime() - Math.max(lastUsedMs, s.mtimeMs)) / DAY   // ← 算「过了几天」
+
+if (daysSince >= config.archiveAfterDays && rec.state !== "archived") {     // ← archiveAfterDays = 90
+  if (await Usage.archiveSkill(root, s.key, now)) counts.archived++
+} else if (daysSince >= config.staleAfterDays && rec.state === "active") {  // ← staleAfterDays = 30
+  await Usage.setState(root, s.key, "stale", now); counts.marked_stale++
+} else if (daysSince < config.staleAfterDays && rec.state === "stale") {
+  await Usage.setState(root, s.key, "active", now); counts.reactivated++
+}
+```
+
+**改后**（换成数次数；伪代码，落地时按现有 setState/archiveSkill 接口）：
+```ts
+const used = rec.use_count > (rec.use_count_at_last_scan ?? rec.use_count)  // ← 这轮被用过没
+if (used) {
+  rec.idle_scans = 0                                       // 被用 → 清零；若 stale 则复活
+  if (rec.state === "stale") { /* setState active */ counts.reactivated++ }
+} else {
+  rec.idle_scans = (rec.idle_scans ?? 0) + 1               // 没用 → 攒一次
+  if (rec.idle_scans >= config.archiveAfterIdleScans && rec.state !== "archived") {  // ← 12
+    /* archiveSkill */ counts.archived++
+  } else if (rec.idle_scans >= config.staleAfterIdleScans && rec.state === "active") {  // ← 4
+    /* setState stale */ counts.marked_stale++
+  }
+}
+rec.use_count_at_last_scan = rec.use_count                 // 留给下一轮当基线
+```
+
+三处被「处理」掉：
+- ① `daysSince`（算过了几天）整段删除——**这就是「90 天」的本体**。
+- ② `Math.max(lastUsedMs, s.mtimeMs)` 删除——`last_used_at`（上次使用时间）与 `s.mtimeMs`（文件改动时间）**不再参与归档决定**（`last_used_at` 字段保留作信息，见数据结构表）。
+- ③ `DAY` 常量（[`curator.ts:122`](./curator.ts#L122)）删除；`archiveAfterDays:90`/`staleAfterDays:30` 改名为 `archiveAfterIdleScans:12`/`staleAfterIdleScans:4`（含义从「天」变「巡检次数」）。
+
+### 2. 兼容：旧账本缺字段建基线
+
+线上已有账本里的记录没有 `use_count_at_last_scan`/`idle_scans`。首次巡检读到这种记录：把缺失的 `use_count_at_last_scan` 视为「当前 use_count」、`idle_scans` 视为 0（建基线），**这一轮不判归档**。从第二轮起才正常累加。→ 升级不会因为缺字段误删任何人（D13）。
+
+---
+
+## 核心不变量
+
+> 在 `CURATOR_DESIGN.md` 8 条不变量基础上，新增/调整：
+
+1. **归档判据零日历依赖** — 只看 `idle_scans`，改系统时间不影响判据（顾虑 2）。
+2. **被用一次即清零，永不死亡螺旋** — 还在用的 skill 不会被归档，与别的 skill 用得多频繁无关（顾虑 1 / D11）。
+3. **idle_scans 每次巡检最多 +1** — 系统时间跳变最多多触发一次巡检，单 skill 计数最多 +1，不成片。
+4. **缺字段建基线、不误删** — 旧账本首次巡检只立基线（D13）。
+5. **调度仍是 7 天间隔** — `shouldRunNow` 逻辑与 `intervalHours` 完全不动。
+
+> 沿用 `CURATOR_DESIGN.md` 不变量：归档可恢复、pinned 跳过、首次推迟、计数最优努力、原子写入、`skill_manage` 零触点。
+
+---
+
+## 决策记录
+
+> 编号接续 `CURATOR_DESIGN.md`（其到 D8），本文档新增 D10–D13。
+
+- **D10：判据改 `idle_scans`（连续空闲巡检数），不用「使用率」。** 「使用率 = 次数 ÷ 总会话数」要引入会话总数当分母、改动外溢、偏离 Hermes 结构；`idle_scans` 在现有框架内最小改动，同样解掉两条顾虑。**待用户拍板。**
+- **D11：判据「只跟自己比」，不做相对排名。** 排名砍末位会死亡螺旋（删光有用 skill）；`idle_scans` 被用即清零，每个 skill 凭自己存活。
+- **D12：`UsageRecord` 加 `use_count_at_last_scan` + `idle_scans` 两字段，不动旧字段。** 增量式；`last_used_at` 保留作信息但不再参与判据。
+- **D13：旧账本缺字段 → 首次巡检建基线、不判归档。** 升级兼容，防误删存量。
+- **D-A（待定）：「编辑 SKILL.md」是否算活动？** 现状算（mtime 新→不归档）。本方案默认**不算**，只认被加载/使用——导师要砍的正是「触发灵敏但啥也没干」的 skill，「光改不用」属此类。保留则需多存「上次见到的文件 mtime」字段、编辑过一并清零 `idle_scans`。**见 Q-A。**
+
+---
+
+## 开放问题
+
+- **Q-A：「编辑 skill」算不算活动？** 默认**不算**（只认使用，D-A）。风险低：新建/在改的 skill `idle_scans` 从 0 起，要连熬好几周不被加载才归档，正常开发期都会加载它。要保留「编辑也算」则多加一字段。**待用户拍板。**
+- ~~**Q-B：两个阈值取值？**~~ **已定：选项 A `stale=4 / archive=12`（≈30/90 天，行为变化最小）。** 备选 B（更激进、≈1 个月归档）不采用。
+- **Q-C：`idle_scans` 巡检节奏受「用 app 才触发」影响。** 用得越少，巡检越稀疏，归档越慢——这正是顾虑 1 想要的「对低频用户公平」，**视为特性，不做修正**。
+
+> 实现按 YAGNI：只改判据这一处，核心逻辑走 TDD 先红后绿。
+
+---
+
+## 关键文件速查
+
+| 文件 | 本次职责 | 性质 |
+|------|------|:---:|
+| [`curator/curator.ts`](./curator.ts#L146) | `applyAutomaticTransitions` 判据段：`daysSince` → `idle_scans` 算法 | ⚠️ 侵入改 |
+| [`curator/constants.ts`](./constants.ts#L1) | 配置字段改名：`*AfterDays` → `*AfterIdleScans`；`intervalHours` 不动 | ⚠️ 侵入改 |
+| [`curator/usage.ts`](./usage.ts#L13) | `UsageRecord` 加两字段 + `emptyRecord` 初始化 | ⚠️ 增量改 |
+| [`curator/curator.test.ts`](./curator.test.ts) | 按天造场景的用例改成「连跑 N 次巡检」/ 预置 `idle_scans`；`shouldRunNow` 那批不动 | ⚠️ 改测试 |
+| [`curator/usage.test.ts`](./usage.test.ts) | 核对新字段默认值不破坏旧用例 | ♻️ 核对 |
+| [`CURATOR_DESIGN.md`](./CURATOR_DESIGN.md) | 同步更新判据描述 | 📄 文档 |
+| `bumpUse` / `archiveSkill` / `restoreSkill` / 孤儿自愈 / `shouldRunNow` | **不碰** | — |
+
+---
+
+## 复用组件核实（实现前必读）
+
+- **X1：要改的字段外部零调用点。** `grep staleAfterDays\|archiveAfterDays` 与 `UsageRecord` 引用均只落在 `curator/` 内（constants/curator/usage + 两测试），无任何外部 caller → 改名/加字段不破坏外部。
+- **X2：配置块是死配置，改名安全。** [`hook.ts:57`](../hook.ts#L57) 调 `maybeRun` 时只传 `{ ...DEFAULT_CURATOR_CONFIG, enabled }`，**不读** `~/.config/aether/aether.jsonc` 里的 `curator` 块（其中的 `intervalHours`/`*AfterDays` 从不被读）→ 字段改名不影响任何运行时配置读取。
+- **X3：`bumpUse` 写 `use_count` 的路径不变。** 判据改造只读 `use_count`，不改其写入时机（仍在 skill 加载工具里 +1），故计数侧零改动。
+
+---
+
+## 命题清单
+
+> 把全文压成可判定真假的断言，分组、组内按重要度递减。
+
+### PA. 定位与边界
+- PA1. 只改「归档判据」一处；调度（7 天间隔）、归档/恢复、孤儿自愈、pinned、`skill_manage` 零触点全部沿用。
+- PA2. 判据里无任何日历日期；仅依赖 `idle_scans`（顾虑 2）。
+- PA3. 要改字段外部零调用点，改动局限 `curator/`（X1）。
+
+### PB. 判据算法
+- PB1. 本轮 `use_count > use_count_at_last_scan` → `idle_scans=0`；否则 `idle_scans+1`。
+- PB2. `idle_scans ≥ archiveAfterIdleScans` 且非 archived → `archiveSkill` + state=archived。
+- PB3. `idle_scans ≥ staleAfterIdleScans` 且 active → state=stale。
+- PB4. 本轮被用过且当前 stale → 复活 active（`idle_scans` 同时清零）。
+- PB5. 每轮末 `use_count_at_last_scan = 当前 use_count`（留下一轮基线）。
+- PB6. pinned → 跳过全部流转（沿用）。
+
+### PC. 安全与兼容
+- PC1. 系统时间跳变 → 单 skill `idle_scans` 最多 +1，不成片误删（顾虑 2 / 不变量 3）。
+- PC2. 被用一次即清零 → 还在用的 skill 永不归档，无死亡螺旋（顾虑 1 / D11）。
+- PC3. 旧账本缺 `use_count_at_last_scan`/`idle_scans` → 首次巡检建基线、不判归档（D13）。
+- PC4. 「编辑文件」默认不算活动（D-A / Q-A）。
+
+### PD. 数据结构
+- PD1. `UsageRecord` 含 `use_count_at_last_scan`、`idle_scans`（D12）。
+- PD2. `CuratorConfig` 字段为 `staleAfterIdleScans`/`archiveAfterIdleScans`；`intervalHours` 保留（D10）。
+
+### PH. 边界与失败用例（测试必须覆盖）
+- PH1. 连续未用满 N 次才归档：连跑 N-1 次不归档、第 N 次归档（核心接缝）。
+- PH2. 中途被用：第 k 轮 use_count 增长 → `idle_scans` 清零、不归档。
+- PH3. pinned：`idle_scans` 爆表仍 active。
+- PH4. 旧账本缺字段：首次巡检不归档、只建基线。
+- PH5. 跨项目同名：两项目各有 `foo`，各算各的 `idle_scans`。
+
+---
+
+## 测试与红绿里程碑
+
+> 核心逻辑走 TDD（先红后绿、婴儿步）。**每个里程碑独立走红→绿**，交付展示两次跑测输出（红：实现没写时失败；绿：写完通过）。从 `packages/opencode` 目录内跑。
+
+### ⚠️ 假绿陷阱与依赖顺序
+
+- **N1（连续 N 次才归档）是核心接缝、先停点、最该先看到红**——它真连跑 N 次 `applyAutomaticTransitions`、不手填中间 `idle_scans`，证明「上一轮写 `use_count_at_last_scan` → 下一轮读它判增长」这条写读接力跑得通。旧实现按天数判，连跑 N 次也不会归档（mtime 不变）→ 自然红。
+- **N3（pinned）/ N4（缺字段不误删）有假绿陷阱**：若归档完全不工作，「断言没被归档」会恰好成立而假绿 → 必须排在 N1 之后，红来自「普通的会被归档、而 pinned/缺字段的没被」的对比。
+
+### 红绿总览（按依赖排序）
+
+| 次序 | 里程碑 | 红（先写失败测试）| 绿（实现）| 命题/边界 | 接缝 |
+|---|---|---|---|---|:---:|
+| **N1** | **连续 N 次才归档（核心，先停点）** | 一个 skill，连跑 `archiveAfterIdleScans` 次巡检、期间 use_count 不增长 → 前 N-1 次未归档、第 N 次移进 `<projectId>/archive/`、archived | `idle_scans` 累加 + 阈值归档 | PB1/PB2/PH1 | ★★写读接力 |
+| N2 | 中途被用清零 | 攒到 N-1 次后，把该 skill 的 use_count +1，再跑一次 → `idle_scans` 归 0、未归档 | use_count 比较清零 | PB1/PB4/PH2 | ★写读接力 |
+| N3 | 标 stale | 连跑 `staleAfterIdleScans` 次未用 → state=stale、文件还在（未到归档阈值）| 阈值标 stale | PB3 | |
+| N4 | stale 复活 | stale 后被用一次 → 退回 active | PB4 复活分支 | PB4 | |
+| N5 | pinned 跳过（排 N1 后）| 写账本 pinned:true、`idle_scans` 预置超阈值 → 跑 → 仍 active | pinned 跳过 | PB6/PH3 | 防假绿 |
+| N6 | 旧账本缺字段不误删（排 N1 后）| 写账本一条无 `idle_scans`/`use_count_at_last_scan` 的旧记录 → 首次跑 → 仍 active、字段被补基线 | 缺字段建基线 | PC3/PH4 | 防假绿 |
+| N7 | 跨项目同名各算各 | proj1/foo 攒满阈值、proj2/foo idle_scans=0 → 跑 → 仅 proj1/foo 归档 | 复合键独立累加 | PH5 | |
+
+> 顺序：N1 先停点（接缝跑通）。N2 验「清零」防死亡螺旋。N3/N4 验三态流转。N5/N6 强制排 N1 后防假绿。N7 验复合键。
+> **改测试要点**：现有 `curator.test.ts` 里靠 `mtimeAgoMs`（如 M11 的 100*DAY）制造「该归档」的用例要改写——归档不再由 mtime 触发，而由「连跑多次 / 预置 `idle_scans`」触发；`shouldRunNow` 那批（M6–M9）测调度间隔，与本次无关，**保持不动**。
+
+### 收尾验证（实现完成后）
+
+- `bun --cwd packages/opencode typecheck`，贴结果。
+- 从 `packages/opencode` 跑 `curator.test.ts` + `usage.test.ts`，贴 N1/N6 的「红→绿」两次输出。
+- `skill_manage` 一行不改；`bumpUse` 写入路径不改，无需额外回归。
+
+---
+
+## 范围说明
+
+本分支（`feat/curator-relative-usage`）**只做归档判据改造**（解决顾虑 1、2）。组会还要求的另外两项是**后续独立工作**，不在本分支：
+
+1. **记会话**（承接顾虑 3、4）：每次用 skill 记下 project id + session id + 时间，供 skill 进化回溯「它当初有没有真起作用」，进而识别并淘汰「触发灵敏但啥也没干」的烂 skill（转写 行99/102/111；行113）。这是顾虑 3、4 的真正解药——靠「回看表现 + 删/降权」，而非靠本分支的「没用就归档」。
+2. **给 skill 发 ID**（git commit 时分配），解决靠名字重名问题（转写 行103/行105；导师注明「暂时不关键」）。
+
+---
+
+## 用户体验
+
+| | 体验 |
+|---|---|
+| **改造前（已发布）** | 归档按「现实过了 90 天」算。后果：① 电脑时间设错（年份拉错）可能一次性误删一大片 skill；② 一月才用一次的低频用户，skill 容易被按日历误判成「没用」。|
+| **改造后** | 归档按「连续多少次巡检没被用过」算。对你来说：① **再也不会因为系统时间设错而被成片误删**；② 你用得少、巡检就少，**冷门但你偶尔要用的 skill 不会被无辜清掉**；③ 真正连着一个多月（默认）你用 app 都没碰过的 skill，才会被悄悄挪进可恢复的归档区。|
+
+**边界（诚实说清）**：仍**无界面、无通知**，后台静默发生；用户可直接感知的只有「技能列表保持干净、且不再出现莫名其妙的误删」。

--- a/packages/opencode/src/skill-evolution/curator/SESSION_USAGE_DESIGN.md
+++ b/packages/opencode/src/skill-evolution/curator/SESSION_USAGE_DESIGN.md
@@ -1,0 +1,417 @@
+# Aether Curator 记会话 — 给每次 skill 使用记下「近期使用坐标」设计文档
+
+> 状态：**设计定稿 v2**，可进入实现（实现走 TDD）。
+> 读者：团队开发者 + 组会评审 + 照本实现的人（含 yolo 沙盒会话——它没有设计讨论的上下文，本文档即唯一说明书）。
+> 出处：2026-06-12 组会，导师要求「先把使用历史记全，再往后做 skill 进化」——每次用 skill 要能回溯它在**哪个项目、哪次会话、什么时候**被用过，供日后判断「它当初有没有真起作用」（转写 `20260612_1432_speakers.txt` 行94/99/102/109/110/189）。
+> 关联：本目录 [`CURATOR_DESIGN.md`](./CURATOR_DESIGN.md)（curator 整体设计）、[`IDLE_SCANS_DESIGN.md`](./IDLE_SCANS_DESIGN.md)（归档判据改造，已实现）。本文档**只加「记近期使用坐标」这一块**，归档判据等全部沿用，不重述。
+>
+> **v2 相对 v1 的关键修订**（实地查 DB + 组会复核后）：①查实**会话 DB 已自动记录每次 skill 调用**（session id + 时间 + skill 名），故 `recent_uses` 从「主数据源」降级为**近期窗口缓存/索引**，DB 才是全量权威源；②`recent_uses` 的上限不是缺陷，是**有意的「近期窗口」**（只看近期、防旧成绩稀释现状）；③v1 的「Q-S 会话能否检索」风险**已查实解决**；④确定**不加**评估字段（`disposition`/`reviewed_at`），留给后续；⑤`bumpUse` 保持 `await`（实测 0.3ms，不 fire-and-forget）。
+
+给 `bumpUse`（每次 skill 被加载时记一次使用的函数）补上「坐标」：除了把累计次数 `use_count` +1，再往该 skill 的账本记录里**追加一条事件** `{ session_id, at }`（哪次会话、什么时候）。项目 id 因为账本本来就按项目分键，无需每条重复。事件列表只保留**最近 N 条**（滑动窗口，满了挤掉最老的）——这既省 token，又让评估只看「近期表现」，不被久远的旧成绩干扰。**本分支只负责「把近期使用坐标攒成一个现成索引」——不改归档行为、不判断 skill 有没有用、不删任何东西**，那些是后续工作。
+
+---
+
+## 目录
+
+- [一个关键前提：会话 DB 已自动记录 skill 调用](#一个关键前提会话-db-已自动记录-skill-调用)
+- [设计原则](#设计原则)
+- [解决了导师的什么顾虑](#解决了导师的什么顾虑)
+- [数据结构](#数据结构)
+- [核心机制详解](#核心机制详解)
+  - [1. bumpUse 追加事件 + 滑动窗口截断](#1-bumpuse-追加事件--滑动窗口截断)
+  - [2. session id 从哪来](#2-session-id-从哪来)
+  - [3. 兼容：旧账本缺字段](#3-兼容旧账本缺字段)
+- [为什么保持 await、不 fire-and-forget](#为什么保持-await不-fire-and-forget)
+- [核心不变量](#核心不变量)
+- [决策记录](#决策记录)
+- [开放问题](#开放问题)
+- [关键文件速查](#关键文件速查)
+- [复用组件核实](#复用组件核实实现前必读)
+- [命题清单](#命题清单)
+- [测试与红绿里程碑](#测试与红绿里程碑)
+- [范围说明](#范围说明)
+- [用户体验](#用户体验)
+
+---
+
+## 一个关键前提：会话 DB 已自动记录 skill 调用
+
+> 这是 v2 的地基。**先看清这层，才能理解 `recent_uses` 为什么只是「缓存」而非「唯一真相」。**
+
+实地查过磁盘上的真实数据库，确认以下事实（非推测）：
+
+- **会话存储是 SQLite，每个项目一个库**：`~/.local/share/aether/local/aether-<projectId>.db`，**文件名里的 hash 就是 project id**。
+- **每次 skill 调用都已落库**：库里 `part` 表（存会话每一片内容的表）有 `tool='skill'` 的行，`data`（JSON 字段）里带齐 `session_id`、`time_created`（时间）、`state.input.name`（**加载的哪个 skill**）、`state.status`。真实样本：`ai-qft-survey` · 会话 `ses_148db4…` · `2026-06-12 01:25` · completed。
+- **能按 session id 取回整段会话**：`MessageV2.page(sessionID)` 等函数（[message-v2.ts](../../session/message-v2.ts)）现成可用。
+- **一个 skill 的使用，锁在它自己那一个项目库里**：项目专属 skill 的发现逻辑（[skill/index.ts:144](../../skill/index.ts#L144)）只扫「当前项目」的 skill 目录，**跨项目互不可见**；实测 `ai-qft-survey` 被用 20 次、20 次全在自己项目库。所谓「shared 共享 skill」当前**未启用**（`skillEvolutionShared()` 从未被生产代码调用，存储层显式跳过 `shared/`，见 [db.ts:96](../../storage/db.ts#L96)）。→ 给定一个 skill，它的全部使用都在**一个**确定的库里，机械检索很便宜。
+
+**两条推论，决定本设计的形状**：
+
+1. **`recent_uses` 是「便利索引/近期缓存」，不是唯一数据源**：使用坐标的**权威全量记录在会话 DB**。账本里这份是为了「curator 自带一份现成的近期窗口、不必每次去开会话 DB」。**真要全量历史，回 DB 查**。
+2. **后续「判好坏」的检索必须机械**：将来评估某 skill 时，从账本拿到它的 projectId → 开那一个项目库 → 机械（确定性代码）查出使用位置 + 拼出上下文窗口 → 喂给 AI 判断。**不让 AI 自己钻 DB 乱找**（这一点比组会转写 行115「AI 自己 grab 搜索」更严，是有意收紧）。本分支不实现「判好坏」，但 `recent_uses` 是它的索引入口。
+
+---
+
+## 设计原则
+
+1. **只记不判**：本分支只把「近期使用坐标」攒成索引，**不**用它做任何归档/淘汰决定。判断「有没有真起作用」是后续独立工作（D14、[范围说明](#范围说明)）。
+2. **缓存而非真相源**：`recent_uses` 是近期窗口缓存，会话 DB 才是全量权威源（D19）。允许它与 DB 轻微不一致（best-effort 写失败、cap 丢老记录），代价可接受。
+3. **上限是特性不是缺陷**：只留最近 N 条 = 有意的「近期窗口」——省 token、且评估只看近期表现，不被久远旧成绩抬高/拉低判断（D17）。
+4. **最小改动、贴现有结构**：在 `bumpUse` 里加一段「追加事件」，复用现有账本读写（`load`/`save`）、范围过滤（`resolveScope`）、原子写入；不新建文件、不引入新存储。
+5. **best-effort、永不挡加载、保持 await**：沿用 `bumpUse` 现有契约——记账失败只吞，绝不影响 skill 加载；实测一次仅 0.3ms，保持 `await` 不改 fire-and-forget（D20 / [为什么保持 await](#为什么保持-await不-fire-and-forget)）。
+
+### 对旧文件的修改
+
+> 每处标注 **侵入式**（改了旧行为，有回归风险）还是 **增量式**（只加新字段/新调用）。
+
+| 旧文件:位置 | 改什么 | 性质 | 依据 |
+|---|---|:---:|---|
+| [`usage.ts :: UsageRecord`](./usage.ts#L13) | 加 `recent_uses: UseEvent[]` 一个字段 + `emptyRecord` 初始化成 `[]` | **增量式**（加字段，旧字段不动）| D15 |
+| [`usage.ts :: bumpUse`](./usage.ts#L229) | 签名加可选 `sessionId?`；函数体里追加事件 + 截断到 N | **增量式**（旧 2 参调用仍合法）| D15/D17 |
+| [`usage.ts :: load`](./usage.ts#L74) | 读老记录时把缺失的 `recent_uses` 补成 `[]`（防御） | **增量式** | D18 |
+| [`tool/skill.ts`](../../tool/skill.ts#L69) | `bumpUse(...)` 调用补传 `ctx.sessionID`（保持 `await`） | **增量式**（多传一个已有的值）| D16/D20 |
+
+> **不动**：归档判据（`idle_scans`，见 IDLE_SCANS_DESIGN）、`use_count` 累加时机、`last_used_at`、`archiveSkill`/`restoreSkill`、孤儿自愈、pinned、`shouldRunNow`、`skill_manage`、`constants.ts`（N 是代码常量见 Q-N）——全部沿用。
+> **不加**：评估字段 `disposition`/`reviewed_at`（D14/D21，留给后续「判好坏」）。
+
+---
+
+## 解决了导师的什么顾虑
+
+导师围绕 curator / skill 进化共四条顾虑（完整列表见 [`IDLE_SCANS_DESIGN.md`](./IDLE_SCANS_DESIGN.md#解决了导师的什么顾虑)）。其中 **顾虑 3、4** 上一分支留给「记会话」。本分支是「记会话」的**第一步：铺数据索引**。
+
+### 本分支提供前提的（顾虑 4 的「有数据/能定位」那一半）
+
+| # | 导师的顾虑 | 出处 | 本分支做到哪 |
+|---|---|---|---|
+| **顾虑 4** | **没法回溯评估**：想改进/进化一个 skill 时，得回去看它当初在那些会话里表现好不好；「没有数据，skill 进化无从谈起」 | 转写 行99/102/110/111 | **本分支产出近期使用索引**：每次使用记下 `{ session_id, at }`，账本键带 `projectId` → 凑齐「project id + session id + 时间」，**能直接定位到该去 DB 翻哪几次会话**。注意：只产出「近期指针」，不产出「判断」 |
+
+> **Q-S（v1 标的风险）已查实解决**：会话确实持久化、skill 调用确实落库、可按 session id 取回（见[关键前提](#一个关键前提会话-db-已自动记录-skill-调用)）。不再是风险。
+
+### 本分支【不】解决、仍留给后续的
+
+| # | 顾虑 / 工作 | 为什么本分支治不了 / 真正的解药 |
+|---|---|---|
+| **顾虑 3** | 「触发灵敏但啥也没干」的烂 skill 反被保留 | 光记坐标**不会淘汰任何 skill**。要治它，得在坐标之上再做：① **机械**检索 DB、拼出每次使用的上下文窗口；② 喂 AI 判断正面/负面；③ 据判断删/降权。这三步本分支都没有 |
+| **「判好坏」本身** | 拿坐标翻回会话、判断 skill 当初有没有起作用 | 本分支只存「近期指针」，不存会话内容、不做自动判断。把指针兑现成「上下文」、再判好坏，是后续工作（D14）。导师明确说「评估是后边的事，先记录，没必要每次都评，代价大」（行189）|
+
+**判定标准（本分支达标）**：账本里**每次在范围内的 skill 加载，都落下一条带 `session_id`+`at` 的事件**，列表按上限保留最近 N 条，且能 `load` 回来、跨「写→读」接力验证。**不要求**本分支能判断 skill 好坏或淘汰任何 skill。
+
+---
+
+## 数据结构
+
+### UseEvent — 一条使用事件（新增）
+
+```ts
+interface UseEvent {
+  session_id: string  // 这次使用发生在哪次会话（来自 ctx.sessionID）
+  at: string          // 使用时刻（UTC ISO 8601 字符串）
+}
+```
+
+> 不含 `projectId`：账本按 `<projectId>/<name>` 分键，一条记录天然只属于一个项目，项目 id 由键隐含（D16）。
+> 不含会话内容：只存「指针」，过程靠 id 去 DB 回查（D16）。
+
+### UsageRecord — 单个 skill 的记录（落盘 `curator/usage.json`，key = `<projectId>/<name>`）
+
+```ts
+interface UsageRecord {
+  projectId: string
+  name: string
+  location: string
+  use_count: number              // 沿用：累计被加载次数（不封顶，只增）
+  use_count_at_last_scan: number // 沿用（归档判据用）
+  idle_scans: number             // 沿用（归档判据用）
+  last_used_at: string | null    // 沿用：最近一次使用时间（单个值）
+  recent_uses: UseEvent[]        // 【新增】最近 N 次使用的坐标，按时间先后排，满 N 挤掉最老的
+  state: "active" | "stale" | "archived"
+  pinned: boolean
+  archived_at: string | null
+}
+```
+
+**新增字段解释**（▲=本次新增）：
+
+| 字段 | 是什么 | 例子 | 改/不改 |
+|---|---|---|:---:|
+| ▲ `recent_uses` | 最近 `MAX_RECENT_USES`（默认 50，见 Q-N）次使用的坐标列表（**近期窗口缓存**，DB 是权威全量源）。每次 `bumpUse` 往尾部追加一条 `{ session_id, at }`，长度超 N 就从头部丢最老的 | 见下方 JSON | 新增 |
+
+> 三者分工（别混）：`use_count` = **总量**（用了多少次，不封顶）；`recent_uses` = **最近明细**（最近几次在哪个会话/啥时候，有上限）；`last_used_at` = **最近一次的时间**（就一个值）。
+
+**一条完整记录的例子**（`ai-qft-survey` 累计用 8 次，近期窗口留着最近几条）：
+
+```json
+"cd18fbc2…/ai-qft-survey": {
+  "projectId": "cd18fbc2…",
+  "name": "ai-qft-survey",
+  "location": "/home/zheng/.local/share/aether/skill-evolution/cd18fbc2…/skills/ai-qft-survey",
+  "use_count": 8,
+  "use_count_at_last_scan": 7,
+  "idle_scans": 0,
+  "last_used_at": "2026-06-12T01:25:00.000Z",
+  "recent_uses": [
+    { "session_id": "ses_8c1f…", "at": "2026-06-08T14:02:00.000Z" },
+    { "session_id": "ses_8c1f…", "at": "2026-06-08T14:40:00.000Z" },
+    { "session_id": "ses_148db4…", "at": "2026-06-12T01:25:00.000Z" }
+  ],
+  "state": "active",
+  "pinned": false,
+  "archived_at": null
+}
+```
+
+> 读法：同一 `session_id`（`ses_8c1f…`）出现两条 → 这个 skill 在那次会话里被加载了 2 次（每次加载都记，D17）。回溯时按 `session_id` 去那个项目的会话 DB 翻过程。
+
+### 常量（[`usage.ts`](./usage.ts)）
+
+```ts
+const MAX_RECENT_USES = 50  // recent_uses 列表上限；超过从头部丢最老（Q-N 待定值）
+```
+
+> 放在 `usage.ts` 模块内、**不**进 `CuratorConfig`：这是存储细节、不是用户该调的归档旋钮（YAGNI）。
+
+---
+
+## 核心机制详解
+
+### 1. bumpUse 追加事件 + 滑动窗口截断
+
+`bumpUse` 在 skill 被加载时调用（[`skill.ts:69`](../../tool/skill.ts#L69)）。改造后流程：
+
+```
+① resolveScope(location) → 不在 <projectId>/skills/<name> 范围内则直接 return（沿用）
+② load 账本，取/建该 skill 的记录 rec（沿用）
+③ rec.use_count += 1                                  （沿用）
+④ rec.last_used_at = now.toISOString()                （沿用）
+⑤ 【新增】若有 sessionId：
+     rec.recent_uses.push({ session_id: sessionId, at: now.toISOString() })
+     若 rec.recent_uses.length > MAX_RECENT_USES：
+        从头部 splice 掉多出来的（保留最近 N 条）
+⑥ save 账本（原子写，沿用）
+   —— 整段 try/catch 包住，失败只吞，不挡加载（沿用 X3）
+```
+
+**改前**（[`usage.ts:229-242`](./usage.ts#L229)）：
+```ts
+export async function bumpUse(root: string, location: string, now: Date = new Date()): Promise<void> {
+  const scope = resolveScope(root, location)
+  if (!scope) return
+  try {
+    const data = await load(root)
+    const rec = data[scope.key] ?? emptyRecord(scope)
+    rec.use_count += 1
+    rec.last_used_at = now.toISOString()
+    data[scope.key] = rec
+    await save(root, data)
+  } catch {}
+}
+```
+
+**改后**（伪代码，落地按现有风格）：
+```ts
+export async function bumpUse(
+  root: string, location: string, sessionId?: string, now: Date = new Date(),
+): Promise<void> {
+  const scope = resolveScope(root, location)
+  if (!scope) return
+  try {
+    const data = await load(root)
+    const rec = data[scope.key] ?? emptyRecord(scope)
+    rec.use_count += 1
+    rec.last_used_at = now.toISOString()
+    if (sessionId) {                                   // ← 新增：有会话 id 才记坐标（PB1）
+      rec.recent_uses.push({ session_id: sessionId, at: now.toISOString() })
+      if (rec.recent_uses.length > MAX_RECENT_USES)
+        rec.recent_uses.splice(0, rec.recent_uses.length - MAX_RECENT_USES)
+    }
+    data[scope.key] = rec
+    await save(root, data)
+  } catch {}
+}
+```
+
+- **`sessionId` 为何可选**：生产路径（skill.ts）永远传 `ctx.sessionID`，必有值；可选只是为了不冲掉现有 7 处 2 参测试调用（X1）。无 session id 时只 +1、不记坐标（不写半条没用的事件）。
+- **截断用 `splice(0, len-N)`**：一次性把头部多余的全切掉，保留尾部最近 N 条。
+
+### 2. session id 从哪来
+
+skill 加载工具 `SkillTool.execute(params, ctx)` 的上下文对象 `ctx`（工具运行时环境，类型见 [`tool.ts:17-27`](../../tool/tool.ts#L17)）上带 **`ctx.sessionID`**（当前会话 id，类型 `SessionID`，本质是个带品牌的字符串）。当前 [`skill.ts:69`](../../tool/skill.ts#L69) 调 `bumpUse` 时没传它，改造 = 把它传进去：
+
+```ts
+// 改前
+await Usage.bumpUse(Spawner.skillEvolutionRoot(), skill.location)
+// 改后
+await Usage.bumpUse(Spawner.skillEvolutionRoot(), skill.location, ctx.sessionID)
+```
+
+> `projectId` 不用从 ctx 取——账本靠 `resolveScope` 从 skill 路径 `<root>/<projectId>/skills/<name>` 解析出来，已经有了（X2）。
+
+### 3. 兼容：旧账本缺字段
+
+线上已有账本里的记录没有 `recent_uses`。两处兜底：
+- `load`（[`usage.ts:74`](./usage.ts#L74)）读到老记录时，把缺失的 `recent_uses` 补成 `[]`，保证后续 `.push` 不炸。
+- `emptyRecord`（[`usage.ts:58`](./usage.ts#L58)）新建记录时初始化 `recent_uses: []`。
+
+→ 升级到本版不会因为老记录缺字段而报错或误删（D18）。
+
+---
+
+## 为什么保持 await、不 fire-and-forget
+
+> 这是一个被问到、用实测拍板的决定。结论：**保持 `await`。**
+
+- **实测开销极小**：账本 `usage.json` 仅 ~1.8KB；一轮「读+解析+写回+原子 rename」实测 **0.337 ms/次**。多记 `recent_uses` 仅加几百字节，量级不变（仍亚毫秒）。
+- **不是瓶颈**：`bumpUse` 的 `await` 位于 [skill.ts:69](../../tool/skill.ts#L69)——在 `ctx.ask`（权限弹窗，可能等用户）之后、`ripgrep`（扫 skill 目录文件）之前。这两样才是大头；0.3ms 在它们面前忽略不计，更别提整体夹在一次大模型往返（以秒计）中。
+- **fire-and-forget 反而引入风险**：`bumpUse` 是读-改-写。不 await 的并发写会**互相覆盖**（丢 `use_count`/丢事件）；curator 已知有一个并发竞态，裸 fire-and-forget 会加重它；还有「写没落盘就被读」。拿这些风险换看不见的 0.3ms，不划算（D20）。
+- **真嫌慢的正解**（目前不需要、YAGNI）：串行化写队列（调用方不等、底层保证不打架），而非裸 fire-and-forget。
+
+---
+
+## 核心不变量
+
+> 在前两份设计文档不变量基础上，新增：
+
+1. **只记不判** — `recent_uses` 不参与任何归档/淘汰决定；归档仍只看 `idle_scans`（D14）。
+2. **缓存非真相源** — 会话 DB 是 skill 使用的权威全量记录；`recent_uses` 是近期窗口缓存，允许轻微不一致（D19）。
+3. **每次在范围内加载都落一条坐标** — 生产路径有 `sessionId` → 必追加（顾虑 4 数据完整性）。
+4. **事件列表有界** — `recent_uses.length ≤ MAX_RECENT_USES`，超出丢最老（D17）。
+5. **坐标只存指针不存内容** — 事件里只有 `session_id`+`at`（D16）。
+6. **缺字段不炸不误删** — 老账本缺 `recent_uses` 当 `[]` 处理（D18）。
+7. **不挡加载、保持 await** — best-effort 吞错；0.3ms 不优化成 fire-and-forget（D20）。
+
+> 沿用前两份文档不变量：归档判据零日历依赖、被用即清零无死亡螺旋、归档可恢复、pinned 跳过、原子写入、`skill_manage` 零触点。
+
+---
+
+## 决策记录
+
+> 编号接续 `IDLE_SCANS_DESIGN.md`（其到 D13 + D-A），本文档新增 D14–D21。
+
+- **D14：本分支只「记坐标」，不做「判好坏 / 淘汰」。** 判断没有现成判据、且依赖先有数据；记录是低风险增量，判断是高风险侵入，分步走。**已与用户对齐。**
+- **D15：`UsageRecord` 加 `recent_uses: UseEvent[]`；`bumpUse` 加可选 `sessionId?`。** 增量式，旧字段/旧 2 参调用不动。
+- **D16：每条事件只存 `session_id`+`at`，不存 `projectId`、不存会话内容。** projectId 由账本键隐含；会话过程靠 id 去 DB 回查。
+- **D17：粒度＝「每次加载记一条」，列表截断到最近 `MAX_RECENT_USES` 条（滑动窗口）。** **已对齐**：上限是有意的「近期窗口」——省 token + 评估只看近期、不被久远旧成绩干扰（用户提出的好处）。同会话多次加载 → 多条同 `session_id` 事件。
+- **D18：旧账本缺 `recent_uses` → 当 `[]` 处理（`load` + `emptyRecord` 兜底）。** 升级兼容，防报错/误删。
+- **D19：`recent_uses` 是近期窗口缓存，会话 DB 是权威全量源。** 查实 DB 已自动记录每次 skill 调用（[关键前提](#一个关键前提会话-db-已自动记录-skill-调用)）。账本这份为「现成索引/省得每次开 DB」，真要全量历史回 DB。
+- **D20：`bumpUse` 保持 `await`，不改 fire-and-forget。** 实测 0.3ms、非瓶颈；fire-and-forget 引入并发丢更新风险，不值（[为什么保持 await](#为什么保持-await不-fire-and-forget)）。
+- **D21：本分支不加评估字段（`disposition`/`reviewed_at`）。** 评估是后续工作（导师行189「评估是后边的事」），现在加 = 空占位（YAGNI）。**已与用户对齐**——顺导师「别一次性解决完、先记录」的增量风格。
+
+---
+
+## 开放问题
+
+- **Q-N：`MAX_RECENT_USES` 取多少？** 暂定 **50**、放 `usage.ts` 模块常量（不进 `CuratorConfig`，YAGNI）。50 够覆盖「最近一批会话」做近期评估，且账本不臃肿。**待用户最终拍板数值。**
+- **Q-M：要不要连 `message_id` 一起记？** 默认**不记**（YAGNI）。导师用「时间」就能定位到会话里具体哪条 user message（行113）；`ctx.messageID` 现成可取，日后若回溯需精确到「会话里第几步」再加。
+- ~~**Q-S：session id 能否定位回会话？**~~ **已查实解决**：能（DB 持久化、skill 调用落库、按 id 可取回）。
+
+> 实现按 YAGNI：只加「记坐标」这一处，核心逻辑走 TDD 先红后绿。
+
+---
+
+## 关键文件速查
+
+| 文件 | 本次职责 | 性质 |
+|------|------|:---:|
+| [`curator/usage.ts`](./usage.ts#L13) | `UsageRecord` 加 `recent_uses` + `UseEvent` 类型；`bumpUse` 加 `sessionId?` + 追加/截断；`emptyRecord`/`load` 兜底 `[]`；`MAX_RECENT_USES` 常量 | ⚠️ 增量改 |
+| [`tool/skill.ts`](../../tool/skill.ts#L69) | `bumpUse(...)` 补传 `ctx.sessionID`（保持 `await`） | ⚠️ 增量改 |
+| [`curator/usage.test.ts`](./usage.test.ts) | 加「追加事件 / 滑动窗口截断 / 缺字段兜底 / 无 sessionId」用例；现有用例补断言 `recent_uses` 默认 `[]` | ⚠️ 改测试 |
+| [`curator/constants.ts`](./constants.ts) | **不动**（N 是代码常量，非配置项） | — |
+| 归档判据 / `idle_scans` / `archiveSkill` / 孤儿自愈 / `shouldRunNow` / `skill_manage` | **不碰** | — |
+
+---
+
+## 复用组件核实（实现前必读）
+
+- **X1：`bumpUse` 调用点全部已知。** grep `bumpUse`：生产代码仅 [`skill.ts:69`](../../tool/skill.ts#L69) 一处；其余 7 处在 `usage.test.ts`/`curator.test.ts`，均为 2 参 `bumpUse(root, loc)` 形式 → `sessionId` 设为**可选第 3 参**，旧调用零破坏。
+- **X2：`projectId` 已由 `resolveScope` 提供。** 不需要从 ctx 另取项目 id（D16）。
+- **X3：`bumpUse` 的 best-effort 契约不变。** 仍整段 `try/catch` 吞错，记坐标失败绝不影响 skill 加载；保持 `await`（D20）。
+- **X4（已查实）：会话 DB 可按 id 检索、已记 skill 调用。** SQLite 每项目一库 `aether-<projectId>.db`，`part` 表 `data` JSON 含 `tool='skill'` + session_id + 时间 + skill 名；按 `session_id` 可取回（[关键前提](#一个关键前提会话-db-已自动记录-skill-调用)）。
+
+---
+
+## 命题清单
+
+> 把全文压成可判定真假的断言，分组、组内按重要度递减。
+
+### PA. 定位与边界
+- PA1. 本分支只往账本追加「近期使用坐标」，**不**改归档/淘汰任何行为（D14）。
+- PA2. `recent_uses` 是近期窗口缓存，会话 DB 是权威全量源；二者可轻微不一致（D19）。
+- PA3. 每次在范围内的 skill 加载（生产路径必带 `sessionId`）→ `recent_uses` 追加一条 `{ session_id, at }`（顾虑 4）。
+
+### PB. 写入机制
+- PB1. `bumpUse` 有 `sessionId` → push 一条事件；无则只 `use_count+1`、不记坐标。
+- PB2. `recent_uses.length > MAX_RECENT_USES` → 从头部丢最老的，长度恒 ≤ N（D17）。
+- PB3. 同一 `session_id` 多次加载 → 多条同 id 事件（每次加载记一条，不去重）。
+- PB4. `use_count`/`last_used_at`/`idle_scans` 写入时机与值完全不变。
+- PB5. `bumpUse` 保持 `await`（D20）。
+
+### PC. 兼容
+- PC1. 老账本记录缺 `recent_uses` → `load` 当 `[]`，`.push` 不炸（D18）。
+- PC2. `emptyRecord` 新建记录 `recent_uses` 初始为 `[]`。
+- PC3. 旧 2 参 `bumpUse(root, loc)` 调用仍合法（X1）。
+
+### PD. 数据结构
+- PD1. `UsageRecord` 含 `recent_uses: UseEvent[]`；`UseEvent = { session_id, at }`（D15）。
+- PD2. 不含评估字段 `disposition`/`reviewed_at`（D21）。
+
+### PH. 边界与失败用例（测试必须覆盖）
+- PH1. **写→读接力**：连调 `bumpUse` 两次（带不同 session id）→ `load` 回来 `recent_uses` 有 2 条、id/时间对得上（核心接缝）。
+- PH2. **滑动窗口**：调 `bumpUse` N+1 次 → `recent_uses` 恰好 N 条、头部最老被挤掉、尾部最新。
+- PH3. **缺字段兜底**：手写无 `recent_uses` 的老记录 → `bumpUse` 一次 → 不炸、`recent_uses` 变 1 条。
+- PH4. **范围外不记**：非 `<projectId>/skills/` 下 → 不产生任何记录/事件。
+- PH5. **无 sessionId**：`bumpUse(root, loc)` 不传 session → `use_count+1` 但 `recent_uses` 仍空。
+
+---
+
+## 测试与红绿里程碑
+
+> 核心逻辑走 TDD（先红后绿、婴儿步）。**每个里程碑独立走红→绿**，交付展示两次跑测输出（红：实现没写时失败；绿：写完通过）。从 `packages/opencode` 目录内跑 `usage.test.ts`。
+
+### ⚠️ 假绿陷阱与依赖顺序
+
+- **S1（写→读接力）是核心接缝、最该先看到红**：真的连调 `bumpUse` 两次再 `load` 回来断言 `recent_uses` 明细——验证「写进事件 → 读得出事件」这条接缝。旧实现没 `recent_uses` 字段，`load` 回来 `undefined` → 断言「有 2 条」自然红。**禁止手填 recent_uses 再只测读**——必须让写和读在测里接力跑（CLAUDE.md 写读接缝铁律）。
+- **S2（滑动窗口）有假绿陷阱**：断言要写**恰好 == N** 且**头部最老那条已不在、尾部是最新那条**，双向钉死；写成「长度 ≥ N」会恒真假绿。
+
+### 红绿总览（按依赖排序）
+
+| 次序 | 里程碑 | 红（先写失败测试）| 绿（实现）| 命题/边界 | 接缝 |
+|---|---|---|---|---|:---:|
+| **S1** | **写→读接力（核心，先停点）** | `bumpUse(root, loc, "ses_A")`、`bumpUse(root, loc, "ses_B")` → `load` → `recent_uses` 恰 2 条、`session_id` 依次 A/B、`at` 非空 | push 事件 | PA3/PB1/PH1 | ★★写读接力 |
+| S2 | 滑动窗口截断 | `bumpUse` 跑 `MAX_RECENT_USES+1` 次 → `recent_uses` 恰 N 条、头部最老被挤掉、尾部最新还在 | splice 截断 | PB2/PH2 | ★ |
+| S3 | 同会话多次记多条 | 同一 session id 连调 2 次 → 2 条同 id 事件（不去重）| 不去重 | PB3 | |
+| S4 | 缺字段兜底 | 手写无 `recent_uses` 的老记录入账本 → `bumpUse` 一次 → 不抛、`recent_uses` 变 1 条 | load/emptyRecord 兜 `[]` | PC1/PH3 | 防崩 |
+| S5 | 无 sessionId 不记坐标（防回归）| `bumpUse(root, loc)` 不传 session → `use_count==1` 且 `recent_uses` 为空 | 可选参数分支 | PB1/PH5 | 防回归 |
+| S6 | 范围外不记 | 非 `skills/` 下 skill → load 无记录、无事件 | 沿用 resolveScope | PH4 | |
+
+> 顺序：S1 先停点（接缝跑通）。S2 验有界。S3 验粒度。S4/S5 防崩/防回归。S6 沿用既有边界。
+
+### 收尾验证（实现完成后）
+
+- `bun --cwd packages/opencode typecheck`，贴结果。
+- 从 `packages/opencode` 跑 `usage.test.ts`，贴 **S1 / S2** 的「红→绿」两次输出。
+- 现有 `curator.test.ts`（归档判据那批）不受影响，回归跑一遍确认全绿。
+- 归档判据 / `idle_scans` / `skill_manage` 一行不改。
+
+---
+
+## 范围说明
+
+本块（「记会话」）承接组会顾虑 3、4，**但本分支只做其中第一步**：
+
+1. **【本分支】记近期坐标**：每次用 skill 把 `session id + 时间` 攒进账本 `recent_uses`（近期窗口缓存/索引）。只攒索引，不判好坏、不淘汰。
+2. **【后续】机械检索 + 拼上下文**：评估某 skill 时，从账本拿 projectId → 开那一个项目库 `aether-<projectId>.db` → **机械（确定性代码）**查出使用位置 + 拼出每处上下文窗口。**不让 AI 自己钻 DB**（已验证：`part`+`message` 两表一条 SQL 就能把一次 skill 调用前后的会话过程按顺序拉出来）。
+3. **【后续】AI 判好坏 + 据判断删/降权**：把机械拼好的上下文喂 AI，判断「这个被频繁调的 skill 是正面还是负面」→ 留/降权/归档（顾虑 3）。评估专门批量做，不每次都做（导师行189）。
+
+> 另：组会还提到「给 skill 发 ID（git commit 时分配），解决靠名字重名」（导师注「暂时不关键」），与本块无关，不在此。
+
+---
+
+## 用户体验
+
+| | 体验 |
+|---|---|
+| **本分支前** | 账本只知道每个 skill「一共用过几次、最近一次什么时候」，**不知道**它具体在哪些会话里被用过；想回头评估某个 skill 当初有没有真帮上忙，curator 手里没有现成的「去翻哪几次会话」的索引。|
+| **本分支后** | 账本额外记下每个 skill「最近若干次分别在哪次会话、什么时候被用」。对你来说：**为日后「回看某个 skill 近期表现好不好、该不该留」备好了一份现成的近期索引**——评估时只看近期、省 token，也不会被它很久以前的旧表现误导。|
+
+**边界（诚实说清）**：① 本分支**纯后台记录，界面无任何变化、无新功能**——你现在看不到、也用不到这些坐标，它只是被悄悄存进账本当索引。② 本分支**不会自动判断或删除任何 skill**——「烂 skill 反被保留」要等后续「机械检索 + AI 判好坏 + 删/降权」做完才治得了。③ 这份 `recent_uses` 是**近期窗口缓存**，全量权威记录在会话 DB；真要完整历史，回 DB 查。

--- a/packages/opencode/src/skill-evolution/curator/constants.ts
+++ b/packages/opencode/src/skill-evolution/curator/constants.ts
@@ -1,17 +1,21 @@
 export interface CuratorConfig {
   enabled: boolean
-  /** Minimum hours between curator runs. */
+  /** Minimum hours between curator runs (scheduling — unchanged). */
   intervalHours: number
-  /** Days of inactivity before a skill is marked stale. */
-  staleAfterDays: number
-  /** Days of inactivity before a skill is archived. */
-  archiveAfterDays: number
+  /** Consecutive idle scans (no use between scans) before a skill is marked stale. */
+  staleAfterIdleScans: number
+  /** Consecutive idle scans before a skill is archived. */
+  archiveAfterIdleScans: number
 }
 
-/** Defaults match Hermes (curator/core.py): 7 days / 30 days / 90 days. */
+/**
+ * Defaults: scan every 7 days (interval unchanged), 4 idle scans → stale (≈30 days),
+ * 12 idle scans → archive (≈90 days). The archive criterion no longer uses calendar
+ * dates — see IDLE_SCANS_DESIGN.md (option A).
+ */
 export const DEFAULT_CURATOR_CONFIG: CuratorConfig = {
   enabled: true,
   intervalHours: 24 * 7,
-  staleAfterDays: 30,
-  archiveAfterDays: 90,
+  staleAfterIdleScans: 4,
+  archiveAfterIdleScans: 12,
 }

--- a/packages/opencode/src/skill-evolution/curator/curator.test.ts
+++ b/packages/opencode/src/skill-evolution/curator/curator.test.ts
@@ -55,6 +55,7 @@ function record(projectId: string, name: string, location: string, over: Partial
     use_count_at_last_scan: 0,
     idle_scans: 0,
     last_used_at: null,
+    recent_uses: [],
     state: "active",
     pinned: false,
     archived_at: null,

--- a/packages/opencode/src/skill-evolution/curator/curator.test.ts
+++ b/packages/opencode/src/skill-evolution/curator/curator.test.ts
@@ -52,6 +52,8 @@ function record(projectId: string, name: string, location: string, over: Partial
     name,
     location,
     use_count: 0,
+    use_count_at_last_scan: 0,
+    idle_scans: 0,
     last_used_at: null,
     state: "active",
     pinned: false,
@@ -137,13 +139,22 @@ describe("Curator.applyAutomaticTransitions", () => {
     }
   })
 
-  // M11: 到期归档 (核心接缝, 先停点) — mtime 100 天前 → 移进 archive、archived
-  test("archives a skill inactive past archiveAfterDays", async () => {
+  // N1: 连续 N 次空闲才归档 (核心接缝, 先停点) — 真连跑多次巡检、use_count 不增长 → 第 N 次移进 archive。
+  // 证明「上一轮写 use_count_at_last_scan → 下一轮读它判增长」这条写读接力跑得通 (不手填中间 idle_scans)。
+  test("archives a skill after archiveAfterIdleScans consecutive idle scans", async () => {
     const tmp = await makeTmp()
     try {
-      const dir = await makeSkill(tmp.path, "proj1", "foo", 100 * DAY)
+      const dir = await makeSkill(tmp.path, "proj1", "foo", 0)
+      const ARCHIVE = DEFAULT_CURATOR_CONFIG.archiveAfterIdleScans // 12
+      // 第 1 次巡检只建基线 (不判)，之后每次没被用 idle_scans+1。前 ARCHIVE 次 (含建基线) 都不该归档。
+      for (let i = 0; i < ARCHIVE; i++) {
+        await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
+        expect(await exists(dir)).toBe(true)
+        const mid = await Usage.load(tmp.path)
+        expect(mid["proj1/foo"]!.state).not.toBe("archived")
+      }
+      // 第 ARCHIVE+1 次：idle_scans 达阈值 → 归档
       await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
-
       expect(await exists(dir)).toBe(false)
       expect(await exists(path.join(tmp.path, "proj1", "archive", "foo", "SKILL.md"))).toBe(true)
       const data = await Usage.load(tmp.path)
@@ -155,45 +166,109 @@ describe("Curator.applyAutomaticTransitions", () => {
 })
 
 describe("Curator.applyAutomaticTransitions — transitions & edges", () => {
-  // M12: 标 stale — 40 天没动 → stale (未归档)
-  test("marks a skill stale after staleAfterDays", async () => {
+  // N2: 中途被用清零 — 攒了几次空闲后真被用一次 (bumpUse 写 use_count) → idle_scans 归 0、未归档。
+  // 写(bumpUse 增 use_count)读(applyAutomaticTransitions 判增长)在测验里接力跑, 不手填中间值。
+  test("resets idle_scans to 0 when used midway (no archive)", async () => {
     const tmp = await makeTmp()
     try {
-      const dir = await makeSkill(tmp.path, "proj1", "foo", 40 * DAY)
+      const dir = await makeSkill(tmp.path, "proj1", "foo", 0)
+      const loc = path.join(dir, "SKILL.md")
+      // 攒几次空闲 (1 次建基线 + 2 次累加 → idle_scans=2)
+      for (let i = 0; i < 3; i++) await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
+      expect((await Usage.load(tmp.path))["proj1/foo"]!.idle_scans).toBeGreaterThan(0)
+
+      await Usage.bumpUse(tmp.path, loc) // 真被用一次
       await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
+
       const data = await Usage.load(tmp.path)
-      expect(data["proj1/foo"]!.state).toBe("stale")
-      expect(await exists(dir)).toBe(true) // not archived
+      expect(data["proj1/foo"]!.idle_scans).toBe(0)
+      expect(data["proj1/foo"]!.state).toBe("active")
+      expect(await exists(dir)).toBe(true)
     } finally {
       await tmp.cleanup()
     }
   })
 
-  // M13: 复活 — stale 的 skill 又被用 (last_used_at=now) → 退回 active
-  test("reactivates a stale skill that was used recently", async () => {
+  // N3: 标 stale — 连跑 staleAfterIdleScans 次未用 → stale (未到归档阈值, 文件还在)
+  test("marks a skill stale after staleAfterIdleScans idle scans", async () => {
     const tmp = await makeTmp()
     try {
-      const dir = await makeSkill(tmp.path, "proj1", "foo", 40 * DAY)
+      const dir = await makeSkill(tmp.path, "proj1", "foo", 0)
+      const STALE = DEFAULT_CURATOR_CONFIG.staleAfterIdleScans // 4
+      // 1 次建基线 + STALE 次累加 → idle_scans 达 STALE
+      for (let i = 0; i <= STALE; i++) await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/foo"]!.state).toBe("stale")
+      expect(await exists(dir)).toBe(true) // 未归档
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // N4: stale 复活 — stale 后真被用一次 (bumpUse 增 use_count) → 退回 active、idle_scans 清零
+  test("reactivates a stale skill that was used since last scan", async () => {
+    const tmp = await makeTmp()
+    try {
+      const dir = await makeSkill(tmp.path, "proj1", "foo", 0)
+      const loc = path.join(dir, "SKILL.md")
+      // 预置: 已 stale, 上轮基线 use_count_at_last_scan=2, idle_scans=5
       await writeLedger(tmp.path, {
-        "proj1/foo": record("proj1", "foo", dir, { state: "stale", last_used_at: NOW.toISOString() }),
+        "proj1/foo": record("proj1", "foo", dir, {
+          state: "stale",
+          use_count: 2,
+          use_count_at_last_scan: 2,
+          idle_scans: 5,
+        }),
+      })
+      await Usage.bumpUse(tmp.path, loc) // 真被用一次: use_count 2→3
+      await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
+
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/foo"]!.state).toBe("active") // 复活
+      expect(data["proj1/foo"]!.idle_scans).toBe(0) // 清零
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // N5: pinned 跳过 (排 N1 后, 防假绿) — idle_scans 预置超阈值 → pinned 仍 active、不归档
+  test("skips pinned skills even when idle_scans is over the threshold", async () => {
+    const tmp = await makeTmp()
+    try {
+      const dir = await makeSkill(tmp.path, "proj1", "foo", 0)
+      await writeLedger(tmp.path, { "proj1/foo": record("proj1", "foo", dir, { pinned: true, idle_scans: 99 }) })
+      await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/foo"]!.state).toBe("active")
+      expect(await exists(dir)).toBe(true)
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // N6: 旧账本缺字段不误删 (排 N1 后, 防假绿) — 无 idle_scans/use_count_at_last_scan 的旧记录 → 首次跑只建基线
+  test("does not archive a legacy record missing the new fields (seeds baseline)", async () => {
+    const tmp = await makeTmp()
+    try {
+      const dir = await makeSkill(tmp.path, "proj1", "foo", 0)
+      // 旧账本: 故意省掉两个新字段 (绕过 record() 工厂, 模拟升级前落盘的记录)
+      await writeLedger(tmp.path, {
+        "proj1/foo": {
+          projectId: "proj1",
+          name: "foo",
+          location: dir,
+          use_count: 3,
+          last_used_at: null,
+          state: "active",
+          pinned: false,
+          archived_at: null,
+        } as unknown as UsageRecord,
       })
       await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
       const data = await Usage.load(tmp.path)
-      expect(data["proj1/foo"]!.state).toBe("active")
-    } finally {
-      await tmp.cleanup()
-    }
-  })
-
-  // M14: pinned 跳过 (排 M11 后, 防假绿) — pinned 且 100 天没动 → 仍 active
-  test("skips pinned skills (never archives them)", async () => {
-    const tmp = await makeTmp()
-    try {
-      const dir = await makeSkill(tmp.path, "proj1", "foo", 100 * DAY)
-      await writeLedger(tmp.path, { "proj1/foo": record("proj1", "foo", dir, { pinned: true }) })
-      await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
-      const data = await Usage.load(tmp.path)
-      expect(data["proj1/foo"]!.state).toBe("active")
+      expect(data["proj1/foo"]!.state).toBe("active") // 没被误删
+      expect(data["proj1/foo"]!.idle_scans).toBe(0) // 补了基线
+      expect(data["proj1/foo"]!.use_count_at_last_scan).toBe(3) // 基线=当前 use_count
       expect(await exists(dir)).toBe(true)
     } finally {
       await tmp.cleanup()
@@ -252,12 +327,19 @@ describe("Curator.applyAutomaticTransitions — transitions & edges", () => {
     }
   })
 
-  // M17: 跨项目同名 — 归档 proj1/foo 不影响 proj2/foo (复合键)
+  // N7: 跨项目同名各算各 — proj1/foo 攒满阈值、proj2/foo idle_scans=0 → 仅 proj1/foo 归档 (复合键独立累加)
   test("handles same-name skills in different projects independently", async () => {
     const tmp = await makeTmp()
     try {
-      const dir1 = await makeSkill(tmp.path, "proj1", "foo", 100 * DAY) // → archive
-      const dir2 = await makeSkill(tmp.path, "proj2", "foo", 0) // fresh → keep
+      const dir1 = await makeSkill(tmp.path, "proj1", "foo", 0)
+      const dir2 = await makeSkill(tmp.path, "proj2", "foo", 0)
+      // proj1/foo 预置到差一步归档 (跑一次 → 12 → archive), proj2/foo 全新
+      await writeLedger(tmp.path, {
+        "proj1/foo": record("proj1", "foo", dir1, {
+          idle_scans: DEFAULT_CURATOR_CONFIG.archiveAfterIdleScans - 1,
+        }),
+        "proj2/foo": record("proj2", "foo", dir2, { idle_scans: 0 }),
+      })
       await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
 
       const data = await Usage.load(tmp.path)
@@ -269,6 +351,24 @@ describe("Curator.applyAutomaticTransitions — transitions & edges", () => {
       await tmp.cleanup()
     }
   })
+
+  // N8: 系统时间跳变不成片误删 (顾虑2) — now 从 2026 跳到 2099, idle_scans 仍只 +1, 不归档。
+  // 判据里零日历依赖: 旧版"按天算"会 (2099-2026)≈26512 天 ≫ 90 天 → 立刻误删; 新版只 +1。
+  test("a system-clock jump does not mass-archive (criterion ignores the calendar)", async () => {
+    const tmp = await makeTmp()
+    try {
+      const dir = await makeSkill(tmp.path, "proj1", "foo", 0)
+      await Curator.applyAutomaticTransitions(tmp.path, { now: NOW }) // 建基线
+      const FUTURE = new Date("2099-01-01T00:00:00.000Z")
+      await Curator.applyAutomaticTransitions(tmp.path, { now: FUTURE }) // 系统时间跳到 2099
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/foo"]!.idle_scans).toBe(1) // 只 +1, 没被时间跳变放大
+      expect(data["proj1/foo"]!.state).toBe("active") // 没归档
+      expect(await exists(dir)).toBe(true)
+    } finally {
+      await tmp.cleanup()
+    }
+  })
 })
 
 describe("Curator.maybeRun", () => {
@@ -276,7 +376,11 @@ describe("Curator.maybeRun", () => {
   test("runs a pass and advances state when due", async () => {
     const tmp = await makeTmp()
     try {
-      const dir = await makeSkill(tmp.path, "proj1", "foo", 100 * DAY)
+      const dir = await makeSkill(tmp.path, "proj1", "foo", 0)
+      // 预置到差一步归档 → 这一次到期的巡检把它归档
+      await writeLedger(tmp.path, {
+        "proj1/foo": record("proj1", "foo", dir, { idle_scans: DEFAULT_CURATOR_CONFIG.archiveAfterIdleScans - 1 }),
+      })
       await Curator.saveState(tmp.path, { lastRunAt: ago(8 * DAY), paused: false, runCount: 1 })
 
       const counts = await Curator.maybeRun(tmp.path, { now: NOW })
@@ -341,7 +445,10 @@ describe("Curator on/off switch wiring (config → getCuratorEnabled → maybeRu
     const tmp = await makeTmp()
     const spy = spyOn(Config, "get").mockResolvedValue({ skills: {} } as any)
     try {
-      const dir = await makeSkill(tmp.path, "proj1", "foo", 100 * DAY)
+      const dir = await makeSkill(tmp.path, "proj1", "foo", 0)
+      await writeLedger(tmp.path, {
+        "proj1/foo": record("proj1", "foo", dir, { idle_scans: DEFAULT_CURATOR_CONFIG.archiveAfterIdleScans - 1 }),
+      })
       await Curator.saveState(tmp.path, { lastRunAt: ago(8 * DAY), paused: false, runCount: 1 })
 
       const enabled = await ConfigReader.getCuratorEnabled()

--- a/packages/opencode/src/skill-evolution/curator/curator.ts
+++ b/packages/opencode/src/skill-evolution/curator/curator.ts
@@ -89,8 +89,8 @@ export namespace Curator {
   /** Enumerate in-scope skills on disk: `<root>/<projectId>/skills/<name>/SKILL.md`. */
   async function scanSkills(
     root: string,
-  ): Promise<{ key: string; projectId: string; name: string; location: string; mtimeMs: number }[]> {
-    const out: { key: string; projectId: string; name: string; location: string; mtimeMs: number }[] = []
+  ): Promise<{ key: string; projectId: string; name: string; location: string }[]> {
+    const out: { key: string; projectId: string; name: string; location: string }[] = []
     const projects = await fs.readdir(root, { withFileTypes: true }).catch(() => [])
     for (const pe of projects) {
       if (!pe.isDirectory() || pe.name === "curator" || pe.name.startsWith(".")) continue
@@ -99,9 +99,13 @@ export namespace Curator {
       for (const se of skillDirs) {
         if (!se.isDirectory()) continue
         const location = path.join(skillsDir, se.name)
-        const stat = await fs.stat(path.join(location, "SKILL.md")).catch(() => null)
-        if (!stat) continue
-        out.push({ key: `${pe.name}/${se.name}`, projectId: pe.name, name: se.name, location, mtimeMs: stat.mtimeMs })
+        // SKILL.md must exist for the dir to count as a skill (mtime no longer used).
+        const exists = await fs.access(path.join(location, "SKILL.md")).then(
+          () => true,
+          () => false,
+        )
+        if (!exists) continue
+        out.push({ key: `${pe.name}/${se.name}`, projectId: pe.name, name: se.name, location })
       }
     }
     return out
@@ -109,9 +113,10 @@ export namespace Curator {
 
   /**
    * Pure-logic lifecycle pass (no AI). Scans every in-scope skill, seeds missing
-   * records, drives active→stale→archived by activity, reactivates revived
-   * skills, and prunes orphan records. Activity anchor = max(last_used_at,
-   * SKILL.md mtime). Pinned skills are skipped. Returns a change counter.
+   * records, drives active→stale→archived by consecutive idle scans (scans with no
+   * new use), reactivates skills used since the last scan, and prunes orphan
+   * records. The criterion has zero calendar dependency — changing the system clock
+   * can't mass-archive. Pinned skills are skipped. Returns a change counter.
    */
   export async function applyAutomaticTransitions(
     root: string,
@@ -119,7 +124,6 @@ export namespace Curator {
   ): Promise<TransitionCounts> {
     const now = opts.now ?? new Date()
     const config = opts.config ?? DEFAULT_CURATOR_CONFIG
-    const DAY = 24 * 3600_000
     const counts: TransitionCounts = {
       checked: 0,
       seeded: 0,
@@ -135,27 +139,44 @@ export namespace Curator {
 
       const before = await Usage.load(root)
       if (!before[s.key]) {
+        // First sight: seed a baseline record and DEFER judgment this scan (§2).
         await Usage.seedIfMissing(root, s.location)
         counts.seeded++
+        continue
       }
 
       const data = await Usage.load(root)
       const rec = data[s.key]
       if (!rec || rec.pinned) continue
 
-      // Activity anchor = newest of (last load, last file change).
-      const lastUsedMs = rec.last_used_at ? new Date(rec.last_used_at).getTime() : -Infinity
-      const daysSince = (now.getTime() - Math.max(lastUsedMs, s.mtimeMs)) / DAY
-
-      if (daysSince >= config.archiveAfterDays && rec.state !== "archived") {
-        if (await Usage.archiveSkill(root, s.key, now)) counts.archived++
-      } else if (daysSince >= config.staleAfterDays && rec.state === "active") {
-        await Usage.setState(root, s.key, "stale", now)
-        counts.marked_stale++
-      } else if (daysSince < config.staleAfterDays && rec.state === "stale") {
-        await Usage.setState(root, s.key, "active", now)
-        counts.reactivated++
+      // Legacy ledger missing the new fields → establish a baseline this scan, defer
+      // judgment (D13: an upgrade must never archive anyone for lacking fields).
+      if (typeof rec.use_count_at_last_scan !== "number" || typeof rec.idle_scans !== "number") {
+        await Usage.recordScanResult(root, s.key, { idle_scans: 0, use_count_at_last_scan: rec.use_count })
+        continue
       }
+
+      // Used since last scan = use_count grew. The criterion has zero calendar
+      // dependency — last_used_at and SKILL.md mtime no longer decide archiving.
+      const used = rec.use_count > rec.use_count_at_last_scan
+      let idleScans: number
+      if (used) {
+        idleScans = 0 // reset the moment a use is seen → no death spiral
+        if (rec.state === "stale") {
+          await Usage.setState(root, s.key, "active", now)
+          counts.reactivated++
+        }
+      } else {
+        idleScans = rec.idle_scans + 1
+        if (idleScans >= config.archiveAfterIdleScans && rec.state !== "archived") {
+          if (await Usage.archiveSkill(root, s.key, now)) counts.archived++
+        } else if (idleScans >= config.staleAfterIdleScans && rec.state === "active") {
+          await Usage.setState(root, s.key, "stale", now)
+          counts.marked_stale++
+        }
+      }
+      // Leave the baseline for next scan's comparison.
+      await Usage.recordScanResult(root, s.key, { idle_scans: idleScans, use_count_at_last_scan: rec.use_count })
     }
 
     // Orphan cleanup: a non-archived record whose skill directory is gone.

--- a/packages/opencode/src/skill-evolution/curator/usage.test.ts
+++ b/packages/opencode/src/skill-evolution/curator/usage.test.ts
@@ -41,6 +41,9 @@ describe("Usage.bumpUse", () => {
       expect(rec!.last_used_at).not.toBeNull()
       expect(rec!.projectId).toBe("proj1")
       expect(rec!.name).toBe("foo")
+      // 新字段默认值: 首次 upsert 出来的记录带零基线 (PD1)
+      expect(rec!.idle_scans).toBe(0)
+      expect(rec!.use_count_at_last_scan).toBe(0)
     } finally {
       await tmp.cleanup()
     }

--- a/packages/opencode/src/skill-evolution/curator/usage.test.ts
+++ b/packages/opencode/src/skill-evolution/curator/usage.test.ts
@@ -49,6 +49,129 @@ describe("Usage.bumpUse", () => {
     }
   })
 
+  // S1 (核心接缝): 写→读接力 — 连调两次带不同 session id，load 回来事件明细对得上
+  test("appends a recent_uses event per call (write→read seam)", async () => {
+    const tmp = await makeTmp()
+    try {
+      const loc = await makeSkill(tmp.path, "proj1", "foo")
+      await Usage.bumpUse(tmp.path, loc, "ses_A", new Date("2026-06-08T14:02:00.000Z"))
+      await Usage.bumpUse(tmp.path, loc, "ses_B", new Date("2026-06-12T01:25:00.000Z"))
+
+      const data = await Usage.load(tmp.path)
+      const rec = data["proj1/foo"]
+      expect(rec).toBeDefined()
+      expect(rec!.recent_uses).toHaveLength(2)
+      expect(rec!.recent_uses[0]).toEqual({ session_id: "ses_A", at: "2026-06-08T14:02:00.000Z" })
+      expect(rec!.recent_uses[1]).toEqual({ session_id: "ses_B", at: "2026-06-12T01:25:00.000Z" })
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // S2 (有界 + 假绿陷阱): N+1 次 → 恰 N 条、头部最老被挤掉、尾部最新还在
+  test("slides the window to keep only the most recent MAX_RECENT_USES events", async () => {
+    const tmp = await makeTmp()
+    try {
+      const loc = await makeSkill(tmp.path, "proj1", "foo")
+      const n = Usage.MAX_RECENT_USES
+      for (let i = 0; i <= n; i++) {
+        // i 从 0 到 n，共 n+1 次；session id 编号便于辨认头尾
+        await Usage.bumpUse(tmp.path, loc, `ses_${i}`)
+      }
+
+      const data = await Usage.load(tmp.path)
+      const rec = data["proj1/foo"]!
+      expect(rec.recent_uses).toHaveLength(n) // 恰好 N，不是 ≥N
+      expect(rec.recent_uses[0]!.session_id).toBe("ses_1") // 最老的 ses_0 被挤掉
+      expect(rec.recent_uses[n - 1]!.session_id).toBe(`ses_${n}`) // 尾部是最新
+      expect(rec.use_count).toBe(n + 1) // use_count 不封顶
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // S3: 同一 session id 多次加载 → 多条同 id 事件 (不去重)
+  test("records one event per load even within the same session", async () => {
+    const tmp = await makeTmp()
+    try {
+      const loc = await makeSkill(tmp.path, "proj1", "foo")
+      await Usage.bumpUse(tmp.path, loc, "ses_same")
+      await Usage.bumpUse(tmp.path, loc, "ses_same")
+
+      const data = await Usage.load(tmp.path)
+      const rec = data["proj1/foo"]!
+      expect(rec.recent_uses).toHaveLength(2)
+      expect(rec.recent_uses.map((e) => e.session_id)).toEqual(["ses_same", "ses_same"])
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // S4: 缺字段兜底 — 老账本记录无 recent_uses → bumpUse 不抛、变 1 条
+  test("backfills recent_uses for legacy records missing the field", async () => {
+    const tmp = await makeTmp()
+    try {
+      const loc = await makeSkill(tmp.path, "proj1", "foo")
+      // 手写一条没有 recent_uses 的老记录
+      const dir = path.join(tmp.path, "curator")
+      await fs.mkdir(dir, { recursive: true })
+      const legacy = {
+        "proj1/foo": {
+          projectId: "proj1",
+          name: "foo",
+          location: path.dirname(loc),
+          use_count: 5,
+          use_count_at_last_scan: 5,
+          idle_scans: 0,
+          last_used_at: "2026-06-01T00:00:00.000Z",
+          state: "active",
+          pinned: false,
+          archived_at: null,
+        },
+      }
+      await fs.writeFile(path.join(dir, "usage.json"), JSON.stringify(legacy), "utf-8")
+
+      await Usage.bumpUse(tmp.path, loc, "ses_new")
+
+      const data = await Usage.load(tmp.path)
+      const rec = data["proj1/foo"]!
+      expect(rec.use_count).toBe(6)
+      expect(rec.recent_uses).toHaveLength(1)
+      expect(rec.recent_uses[0]!.session_id).toBe("ses_new")
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // S5 (防回归): 不传 sessionId → use_count+1 但不记坐标
+  test("increments use_count without recording a coordinate when sessionId is absent", async () => {
+    const tmp = await makeTmp()
+    try {
+      const loc = await makeSkill(tmp.path, "proj1", "foo")
+      await Usage.bumpUse(tmp.path, loc)
+
+      const data = await Usage.load(tmp.path)
+      const rec = data["proj1/foo"]!
+      expect(rec.use_count).toBe(1)
+      expect(rec.recent_uses).toEqual([])
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // 新记录默认 recent_uses 为 []
+  test("a freshly upserted record has an empty recent_uses array", async () => {
+    const tmp = await makeTmp()
+    try {
+      const loc = await makeSkill(tmp.path, "proj1", "foo")
+      await Usage.bumpUse(tmp.path, loc)
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/foo"]!.recent_uses).toEqual([])
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
   // M2: 范围过滤 — 不在 <projectId>/skills/ 下的 skill 不记账
   test("does not record out-of-scope skills", async () => {
     const tmp = await makeTmp()
@@ -143,6 +266,36 @@ describe("Usage.load", () => {
 
       const data = await Usage.load(tmp.path)
       expect(data).toEqual({})
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // load() heals legacy records on its own — even when bumpUse never runs
+  // (recordScanResult/setState rely on load returning a well-formed record).
+  test("backfills missing recent_uses to [] for legacy records on load", async () => {
+    const tmp = await makeTmp()
+    try {
+      const dir = path.join(tmp.path, "curator")
+      await fs.mkdir(dir, { recursive: true })
+      const legacy = {
+        "proj1/foo": {
+          projectId: "proj1",
+          name: "foo",
+          location: "/some/where",
+          use_count: 3,
+          use_count_at_last_scan: 3,
+          idle_scans: 0,
+          last_used_at: null,
+          state: "active",
+          pinned: false,
+          archived_at: null,
+        },
+      }
+      await fs.writeFile(path.join(dir, "usage.json"), JSON.stringify(legacy), "utf-8")
+
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/foo"]!.recent_uses).toEqual([])
     } finally {
       await tmp.cleanup()
     }

--- a/packages/opencode/src/skill-evolution/curator/usage.ts
+++ b/packages/opencode/src/skill-evolution/curator/usage.ts
@@ -16,6 +16,11 @@ export interface UsageRecord {
   /** Absolute path to the skill directory (lets archive/restore locate it). */
   location: string
   use_count: number
+  /** Snapshot of use_count at the previous scan; compared against use_count to tell if used since. */
+  use_count_at_last_scan: number
+  /** Consecutive scans with no new use; reset to 0 the moment a use is seen. */
+  idle_scans: number
+  /** Last load time. Kept as info only — no longer part of the archive criterion. */
   last_used_at: string | null
   state: "active" | "stale" | "archived"
   /** Skip auto-transitions. Read-only in this version (no setter, see Q2). */
@@ -56,6 +61,8 @@ export namespace Usage {
       name: scope.name,
       location: scope.skillDir,
       use_count: 0,
+      use_count_at_last_scan: 0,
+      idle_scans: 0,
       last_used_at: null,
       state: "active",
       pinned: false,
@@ -165,6 +172,24 @@ export namespace Usage {
     rec.state = state
     if (state === "archived") rec.archived_at = now.toISOString()
     if (state === "active") rec.archived_at = null
+    data[key] = rec
+    await save(root, data)
+  }
+
+  /**
+   * Persist a scan pass's bookkeeping on a record: the idle_scans counter and the
+   * use_count baseline for next scan's comparison. No-op if the record is missing.
+   */
+  export async function recordScanResult(
+    root: string,
+    key: string,
+    fields: { idle_scans: number; use_count_at_last_scan: number },
+  ): Promise<void> {
+    const data = await load(root)
+    const rec = data[key]
+    if (!rec) return
+    rec.idle_scans = fields.idle_scans
+    rec.use_count_at_last_scan = fields.use_count_at_last_scan
     data[key] = rec
     await save(root, data)
   }

--- a/packages/opencode/src/skill-evolution/curator/usage.ts
+++ b/packages/opencode/src/skill-evolution/curator/usage.ts
@@ -3,6 +3,19 @@ import os from "os"
 import path from "path"
 
 /**
+ * A single skill-use coordinate. Pointer only — the full session lives in the
+ * session DB and is fetched back by `session_id` when evaluation is needed.
+ * No `projectId`: the ledger key already scopes a record to one project. See
+ * SESSION_USAGE_DESIGN.md D16.
+ */
+export interface UseEvent {
+  /** Which session this use happened in (from ctx.sessionID). */
+  session_id: string
+  /** When it happened (UTC ISO 8601). */
+  at: string
+}
+
+/**
  * Per-skill usage record. Stored in the curator ledger
  * (`<root>/curator/usage.json`), keyed by `"<projectId>/<name>"`.
  *
@@ -22,6 +35,14 @@ export interface UsageRecord {
   idle_scans: number
   /** Last load time. Kept as info only — no longer part of the archive criterion. */
   last_used_at: string | null
+  /**
+   * Recent-window cache of the last MAX_RECENT_USES use coordinates, oldest
+   * first. NOT the source of truth — the session DB holds the authoritative full
+   * history; this is a convenience index so the curator carries a ready recent
+   * window. Each bumpUse with a sessionId appends one; over the cap the oldest
+   * are dropped from the front. See SESSION_USAGE_DESIGN.md D17/D19.
+   */
+  recent_uses: UseEvent[]
   state: "active" | "stale" | "archived"
   /** Skip auto-transitions. Read-only in this version (no setter, see Q2). */
   pinned: boolean
@@ -29,6 +50,13 @@ export interface UsageRecord {
 }
 
 export namespace Usage {
+  /**
+   * Cap on `recent_uses` length; over it, the oldest events are dropped. A
+   * storage detail, not a user-tunable archive knob, so it lives here and not in
+   * CuratorConfig (YAGNI). See SESSION_USAGE_DESIGN.md Q-N.
+   */
+  export const MAX_RECENT_USES = 50
+
   function curatorDir(root: string): string {
     return path.join(root, "curator")
   }
@@ -64,6 +92,7 @@ export namespace Usage {
       use_count_at_last_scan: 0,
       idle_scans: 0,
       last_used_at: null,
+      recent_uses: [],
       state: "active",
       pinned: false,
       archived_at: null,
@@ -79,7 +108,12 @@ export namespace Usage {
       if (!data || typeof data !== "object" || Array.isArray(data)) return {}
       const clean: Record<string, UsageRecord> = {}
       for (const [k, v] of Object.entries(data)) {
-        if (v && typeof v === "object") clean[k] = v as UsageRecord
+        if (v && typeof v === "object") {
+          const rec = v as UsageRecord
+          // Legacy records predate recent_uses; backfill so .push never throws.
+          if (!Array.isArray(rec.recent_uses)) rec.recent_uses = []
+          clean[k] = rec
+        }
       }
       return clean
     } catch {
@@ -226,7 +260,12 @@ export namespace Usage {
     return true
   }
 
-  export async function bumpUse(root: string, location: string, now: Date = new Date()): Promise<void> {
+  export async function bumpUse(
+    root: string,
+    location: string,
+    sessionId?: string,
+    now: Date = new Date(),
+  ): Promise<void> {
     const scope = resolveScope(root, location)
     if (!scope) return
     try {
@@ -234,6 +273,12 @@ export namespace Usage {
       const rec = data[scope.key] ?? emptyRecord(scope)
       rec.use_count += 1
       rec.last_used_at = now.toISOString()
+      if (sessionId) {
+        // Append this use's coordinate; trim the oldest over the recent window.
+        rec.recent_uses.push({ session_id: sessionId, at: now.toISOString() })
+        if (rec.recent_uses.length > MAX_RECENT_USES)
+          rec.recent_uses.splice(0, rec.recent_uses.length - MAX_RECENT_USES)
+      }
       data[scope.key] = rec
       await save(root, data)
     } catch {

--- a/packages/opencode/src/skill-evolution/review-agent.test.ts
+++ b/packages/opencode/src/skill-evolution/review-agent.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from "bun:test"
-import { serializeHistory, buildReviewPrompt, isReviewSession } from "./review-agent"
-import type { MessageSnapshot } from "./review-agent"
+import fs from "fs/promises"
+import path from "path"
+import { Spawner } from "./spawner"
+import {
+  serializeHistory,
+  buildReviewPrompt,
+  isReviewSession,
+  serializeSkillInventory,
+  collectSkillInventory,
+} from "./review-agent"
+import type { MessageSnapshot, SkillSummary } from "./review-agent"
 
 describe("serializeHistory", () => {
   test("produces XML block from message snapshots", () => {
@@ -86,6 +95,136 @@ describe("buildReviewPrompt", () => {
     ]
     const prompt = await buildReviewPrompt(messages, "test-project-abc", [])
     expect(prompt.toLowerCase()).not.toContain("do not modify")
+  })
+})
+
+describe("serializeSkillInventory", () => {
+  test("lists each skill's name, category and description with edit-first guidance", () => {
+    const skills: SkillSummary[] = [
+      { name: "ai-qft-survey", description: "Survey AI + QFT progress", category: "Research" },
+      { name: "review-pr", description: "Review a PR diff", category: "GitHub" },
+    ]
+    const out = serializeSkillInventory(skills)
+    expect(out).toContain("ai-qft-survey")
+    expect(out).toContain("Survey AI + QFT progress")
+    expect(out).toContain("review-pr")
+    expect(out).toContain("Review a PR diff")
+    // #3: nudge the reviewer toward editing an existing skill over making a near-duplicate
+    expect(out.toLowerCase()).toContain("prefer editing")
+  })
+
+  test("empty list yields a no-skills sentinel, no throw (boundary)", () => {
+    const out = serializeSkillInventory([])
+    expect(out.toLowerCase()).toContain("none")
+  })
+})
+
+describe("collectSkillInventory", () => {
+  test("reads name+description+category from the sub-project's SKILL.md (write→read seam)", async () => {
+    const folderName = "test-inventory-scan-fixture"
+    const base = Spawner.skillEvolutionBase(folderName)
+    const skillDir = path.join(Spawner.skillEvolutionDir(folderName), "my-skill")
+    await fs.rm(base, { recursive: true, force: true })
+    await fs.mkdir(skillDir, { recursive: true })
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      `---\nname: "my-skill"\ndescription: "Does a specific thing"\ncategory: "Testing"\n---\n\nbody`,
+    )
+    try {
+      const inv = await collectSkillInventory(folderName)
+      const found = inv.find((s) => s.name === "my-skill")
+      expect(found).toBeDefined()
+      expect(found!.description).toBe("Does a specific thing")
+      expect(found!.category).toBe("Testing")
+    } finally {
+      await fs.rm(base, { recursive: true, force: true })
+    }
+  })
+
+  test("missing dir yields empty list, no throw (boundary)", async () => {
+    const inv = await collectSkillInventory("nonexistent-folder-xyz-12345")
+    expect(inv).toEqual([])
+  })
+
+  test("does not read a `category:` line from the body when frontmatter omits it (frontmatter-scoped)", async () => {
+    const folderName = "test-inventory-bodyleak-fixture"
+    const base = Spawner.skillEvolutionBase(folderName)
+    const skillDir = path.join(Spawner.skillEvolutionDir(folderName), "leaky-skill")
+    await fs.rm(base, { recursive: true, force: true })
+    await fs.mkdir(skillDir, { recursive: true })
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      `---\nname: "leaky-skill"\ndescription: "real description"\n---\n\nSome body text.\ncategory: from-body\n`,
+    )
+    try {
+      const inv = await collectSkillInventory(folderName)
+      const found = inv.find((s) => s.name === "leaky-skill")
+      expect(found).toBeDefined()
+      expect(found!.description).toBe("real description")
+      // The `category:` line lives in the body, not the frontmatter — it must NOT leak in.
+      expect(found!.category).toBeUndefined()
+    } finally {
+      await fs.rm(base, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("serializeHistory tool input/output", () => {
+  test("includes tool input and output", () => {
+    const messages: MessageSnapshot[] = [
+      {
+        role: "assistant",
+        parts: [
+          {
+            type: "tool",
+            tool: "webfetch",
+            callID: "c1",
+            state: { status: "completed", input: { url: "https://example.com" }, output: "Status 200 OK body" },
+          },
+        ],
+      },
+    ]
+    const xml = serializeHistory(messages)
+    expect(xml).toContain("https://example.com")
+    expect(xml).toContain("Status 200 OK body")
+  })
+
+  test("truncates long output and marks it; full blob absent (truncation)", () => {
+    const big = "x".repeat(5000)
+    const messages: MessageSnapshot[] = [
+      {
+        role: "assistant",
+        parts: [{ type: "tool", tool: "bash", callID: "c2", state: { status: "completed", output: big } }],
+      },
+    ]
+    const xml = serializeHistory(messages)
+    expect(xml).toContain("truncated")
+    expect(xml).not.toContain(big)
+  })
+
+  test("tool part without state renders no input/output, no throw (boundary)", () => {
+    const messages: MessageSnapshot[] = [
+      { role: "assistant", parts: [{ type: "tool", tool: "bash", callID: "c3" }] },
+    ]
+    const xml = serializeHistory(messages)
+    expect(xml).toContain('name="bash"')
+    expect(xml).not.toContain("<input>")
+    expect(xml).not.toContain("<output>")
+  })
+
+  test("renders output for every tool_call in one message (boundary)", () => {
+    const messages: MessageSnapshot[] = [
+      {
+        role: "assistant",
+        parts: [
+          { type: "tool", tool: "webfetch", callID: "a", state: { output: "first-result" } },
+          { type: "tool", tool: "webfetch", callID: "b", state: { output: "second-result" } },
+        ],
+      },
+    ]
+    const xml = serializeHistory(messages)
+    expect(xml).toContain("first-result")
+    expect(xml).toContain("second-result")
   })
 })
 

--- a/packages/opencode/src/skill-evolution/review-agent.ts
+++ b/packages/opencode/src/skill-evolution/review-agent.ts
@@ -5,6 +5,7 @@ import { Instance } from "@/project/instance"
 import { Spawner } from "./spawner"
 import { SKILL_REVIEW_PROMPT_BASE } from "./constants"
 import { Filesystem } from "@/util/filesystem"
+import { ConfigMarkdown } from "@/config/markdown"
 import { Log } from "@/util/log"
 import { Database } from "@/storage/db"
 import { ProjectIdentity } from "@/project/identity"
@@ -96,7 +97,25 @@ export interface MessageSnapshot {
 }
 
 /**
+ * Char caps for tool input/output rendered into the review history. The reviewer
+ * only needs to see that a step ran and roughly what came back (so the B/VERIFIED
+ * gate has evidence to point at) — not the full payload. Stored outputs are
+ * already ≤50KB (normal-conversation Truncate.output); we tighten further here.
+ * See REVIEW_CONTEXT_DESIGN.md D3/Q1.
+ */
+const MAX_TOOL_OUTPUT_CHARS = 300
+const MAX_TOOL_INPUT_CHARS = 200
+
+/** Pure char truncation: keep the head, mark how much was dropped. */
+function truncateForReview(s: string, max: number): string {
+  if (s.length <= max) return s
+  return s.slice(0, max) + `…[truncated ${s.length - max} chars]`
+}
+
+/**
  * Serialize a conversation history snapshot into an XML block for the review prompt.
+ * Tool calls carry their (truncated) input + output so the B/VERIFIED gate can
+ * point at a real successful output — see REVIEW_CONTEXT_DESIGN.md D2.
  */
 export function serializeHistory(messages: ReadonlyArray<MessageSnapshot>): string {
   const lines: string[] = ["<conversation_history>"]
@@ -106,7 +125,22 @@ export function serializeHistory(messages: ReadonlyArray<MessageSnapshot>): stri
       if (part.type === "text" && part.text) {
         lines.push(`    <text>${escapeXml(part.text)}</text>`)
       } else if (part.type === "tool") {
-        lines.push(`    <tool_call name="${escapeXml(part.tool ?? "")}" id="${part.callID ?? ""}"/>`)
+        const state = part.state as { input?: unknown; output?: unknown } | undefined
+        const hasInput = state?.input !== undefined && state.input !== null
+        const inputStr = hasInput
+          ? truncateForReview(JSON.stringify(state!.input), MAX_TOOL_INPUT_CHARS)
+          : ""
+        const outputStr =
+          typeof state?.output === "string" ? truncateForReview(state.output, MAX_TOOL_OUTPUT_CHARS) : ""
+        const open = `    <tool_call name="${escapeXml(part.tool ?? "")}" id="${part.callID ?? ""}"`
+        if (!inputStr && !outputStr) {
+          lines.push(`${open}/>`)
+        } else {
+          lines.push(`${open}>`)
+          if (inputStr) lines.push(`      <input>${escapeXml(inputStr)}</input>`)
+          if (outputStr) lines.push(`      <output>${escapeXml(outputStr)}</output>`)
+          lines.push(`    </tool_call>`)
+        }
       }
     }
     lines.push("  </message>")
@@ -146,6 +180,57 @@ async function collectCategories(folderName: string): Promise<string[]> {
   return Array.from(categories)
 }
 
+/** One existing skill's identity, for the "what already exists" inventory. */
+export interface SkillSummary {
+  name: string
+  description: string
+  category?: string
+}
+
+/**
+ * Read the CURRENT sub-project's evolved skills (name + description + category
+ * from each SKILL.md). Sub-project scope only — not global, not shared — so the
+ * reviewer compares against the skills it could actually duplicate. See
+ * REVIEW_CONTEXT_DESIGN.md D5. Uses the project's canonical frontmatter parser
+ * (`ConfigMarkdown.parse`, gray-matter) so only the `---` block is read — never
+ * stray `key:` lines in the markdown body. best-effort: skills whose SKILL.md is
+ * unreadable or has invalid frontmatter are skipped.
+ */
+export async function collectSkillInventory(folderName: string): Promise<SkillSummary[]> {
+  const dir = Spawner.skillEvolutionDir(folderName)
+  const out: SkillSummary[] = []
+  const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => [])
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    try {
+      const md = await ConfigMarkdown.parse(path.join(dir, entry.name, "SKILL.md"))
+      const data = (md.data ?? {}) as { description?: unknown; category?: unknown }
+      out.push({
+        name: entry.name,
+        description: typeof data.description === "string" ? data.description : "",
+        category: typeof data.category === "string" ? data.category : undefined,
+      })
+    } catch {
+      // Skip skills whose SKILL.md is unreadable or has invalid frontmatter
+    }
+  }
+  return out
+}
+
+/** Render the sub-project skill inventory block for the review prompt. */
+export function serializeSkillInventory(skills: ReadonlyArray<SkillSummary>): string {
+  if (skills.length === 0) return "Existing skills in this project: (none yet)"
+  const lines = [
+    "Existing skills in this project (prefer EDITING one of these over creating a near-duplicate):",
+  ]
+  for (const s of skills) {
+    const cat = s.category ? ` [${s.category}]` : ""
+    const desc = s.description ? `: ${s.description}` : ""
+    lines.push(`  - ${s.name}${cat}${desc}`)
+  }
+  return lines.join("\n")
+}
+
 /**
  * Build the full review prompt for the background agent.
  */
@@ -159,7 +244,8 @@ export async function buildReviewPrompt(
     categories.length > 0
       ? categories.map((c) => `  - ${c}`).join("\n") + "\n"
       : "  (no existing categories yet)\n"
-  const sections = [serializeHistory(messages), "", SKILL_REVIEW_PROMPT_BASE + categoryHint]
+  const inventoryBlock = serializeSkillInventory(await collectSkillInventory(folderName))
+  const sections = [serializeHistory(messages), "", SKILL_REVIEW_PROMPT_BASE + categoryHint, "", inventoryBlock]
   const warning = buildEvolutionLockWarning(evolutionDisabledSkillNames)
   if (warning) sections.push("", warning)
   return sections.join("\n")
@@ -225,6 +311,9 @@ export async function spawnReview(input: {
         text: "text" in p ? (p as any).text : undefined,
         tool: "tool" in p ? (p as any).tool : undefined,
         callID: "callID" in p ? (p as any).callID : undefined,
+        // Carry tool input/output so serializeHistory can show the reviewer real
+        // evidence (truncated). See REVIEW_CONTEXT_DESIGN.md D2.
+        state: "state" in p ? (p as any).state : undefined,
       })),
     }))
 

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -66,7 +66,7 @@ export const SkillTool = Tool.define("skill", async (ctx) => {
 
       // Curator: record that this skill was loaded. Best-effort, in-scope-only,
       // never throws — must not affect skill loading.
-      await Usage.bumpUse(Spawner.skillEvolutionRoot(), skill.location)
+      await Usage.bumpUse(Spawner.skillEvolutionRoot(), skill.location, ctx.sessionID)
 
       const dir = path.dirname(skill.location)
       const base = pathToFileURL(dir).href


### PR DESCRIPTION
### Issue for this PR

Closes #1058

### Type of change

- [x] New feature

### What does this PR do?

这是 #1048（最小版 curator）的后续，集中改 skill-evolution / curator 这一块。三处改动：

**1. 归档判据：日历天数 → 连续空闲巡检次数（核心）**

旧版按「距上次使用多少天」判断 stale / 归档，锚点是 `last_used_at` 和 `SKILL.md` 的 mtime。问题是日历锚点不稳：系统时钟跳变或恢复旧备份会让所有 skill 一夜变成「90 天没动」，一次巡检成片误删；mtime 还会被 `git checkout`、文件同步 touch 掉。

改法：每条记录新增 `idle_scans`（连续多少次巡检没新使用）和 `use_count_at_last_scan`（上轮巡检时的 `use_count` 快照）。每次巡检比较当前 `use_count` 和快照——涨了说明被用过、`idle_scans` 清 0；没涨就 +1。累计到 `staleAfterIdleScans`(默认 4) 标 stale，`archiveAfterIdleScans`(默认 12) 归档。在每周一次的巡检节奏下约等于原来的 30 / 90 天，但完全不看日历，所以改系统时间不会误删。`stale` 的 skill 一旦 `use_count` 再涨就自动复活回 `active`。

**2. 升级兼容：缺字段不误删**

旧账本（升级前落盘的 `usage.json`）没有这两个新字段。巡检遇到这种记录时，只补一条基线（`idle_scans=0`、`use_count_at_last_scan=当前 use_count`）然后跳过本轮判断——升级绝不会因为「记录缺字段」把谁误归档。`load()` 也会顺手把缺失的 `recent_uses` 补成 `[]`，保证后续 `.push` 不抛。

**3. 顺带两个小改动**

- `recent_uses`：每次 skill 被加载时，除了 `use_count+1`，再记一条使用坐标（session id + 时间戳），保留最近 50 条（`MAX_RECENT_USES`，超了从头部丢最老的）。这是给以后的巡检留一个「能回查真实会话」的索引，权威全量历史仍在 session DB。
- 评审 agent：把「当前子项目已有哪些 skill」（name + description + category，用 gray-matter 只读 frontmatter）的清单，连同截断后的工具输入/输出，一起喂给评审 agent，引导它优先改已有 skill 而不是造近似重复的新 skill。

另外仓库里有三份设计文档（`IDLE_SCANS_DESIGN.md` / `SESSION_USAGE_DESIGN.md` / `REVIEW_CONTEXT_DESIGN.md`），是上面这些决策的取舍记录，纯文档、不影响运行。

### How did you verify your code works?

对 curator 和 review-agent 两个测试套件跑 `bun test`，**52 个全过**，typecheck 在 push 时也跑过。新增 / 改写的关键用例（都按「先红后绿」写，能复现旧行为的失败）：

- **时钟跳变**：基线建好后把 now 从 2026 跳到 2099，`idle_scans` 只 +1、不归档（旧版按天算会 ≈26512 天 ≫ 90 立刻误删）。
- **真连跑多轮归档**：连续跑满 `archiveAfterIdleScans` 次未用才归档，写读接力（上轮写快照→下轮读它判增长）真在测里跑通，不手填中间值。
- **中途被用清零**：攒了几次空闲后真调一次 `bumpUse`，`idle_scans` 归 0、不归档。
- **升级兼容**：故意构造缺新字段的旧记录，首轮只建基线、`state` 仍 `active`、文件还在。
- **复活**：`stale` 的 skill 被真正用一次后回到 `active` 且 `idle_scans=0`。
- **边界**：pinned 跳过、跨项目同名各算各、`recent_uses` 滑动窗口恰好留 N 条不去重。

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
