### PR TITLE
feat(curator): 记录近期使用坐标 + 评审 agent 补 skill 清单与工具 I/O

### DIFF
--- a/packages/opencode/src/skill-evolution/REVIEW_CONTEXT_DESIGN.md
+++ b/packages/opencode/src/skill-evolution/REVIEW_CONTEXT_DESIGN.md
@@ -1,0 +1,228 @@
+# Skill 进化评审 — 强化「发给评审 AI 的上下文」设计文档
+
+> 状态：**设计草案 v1**，待团队对齐后进入实现（实现走 TDD）。
+> 读者：团队开发者 + 组会评审 + 照本实现的人（含 yolo 沙盒会话——它没有讨论上下文，本文档即唯一说明书）。
+> 出处：2026-06-15 与用户复盘"评审 AI 到底收到哪些信息"（见 [`/home/zheng/code/transcribe/发给AI的信息清单.md`](../../../../../transcribe/发给AI的信息清单.md) 的实况盘点 + 真实 DB 例子）发现两处缺口：①评审 AI 看不到"已有哪些 skill"，落实不了导师 #3「优先改现成、别动不动新建」；②对话历史里工具调用**只有名字没有参数和输出**，而基础指令的 B 维度又要求 AI"指出一条成功的工具输出"，自相矛盾。
+> 关联：本目录 [`review-agent.ts`](./review-agent.ts)（评审 prompt 构建）、[`constants.ts`](./constants.ts)（`SKILL_REVIEW_PROMPT_BASE` 基础指令）。本文档**只改"喂给评审 AI 的输入上下文"这一块**，gate 判定逻辑、写作规则等全部沿用，不重述。
+
+---
+
+## 目录
+
+- [设计原则](#设计原则)
+- [解决了什么问题](#解决了什么问题)
+- [现状 → 改后](#现状--改后)
+- [对旧文件的修改](#对旧文件的修改)
+- [核心机制详解](#核心机制详解)
+  - [1. 给评审 AI 喂"已有 skill 清单"](#1-给评审-ai-喂已有-skill-清单)
+  - [2. 对话历史补"工具参数 + 输出（截断）"](#2-对话历史补工具参数--输出截断)
+- [格式样例](#格式样例)
+- [核心不变量](#核心不变量)
+- [决策记录](#决策记录)
+- [开放问题](#开放问题)
+- [关键文件速查](#关键文件速查)
+- [复用组件核实（实现前必读）](#复用组件核实实现前必读)
+- [命题清单](#命题清单)
+- [测试与红绿里程碑](#测试与红绿里程碑)
+- [范围说明](#范围说明)
+- [用户体验](#用户体验)
+
+---
+
+## 设计原则
+
+1. **只补输入、不动判定**：本次只把"已有 skill 清单"和"工具参数+输出"加进发给评审 AI 的 prompt，**不改** gate 四维度逻辑、不改写作规则、不改创建/覆盖行为。让 AI 在"看得更全"的基础上自己判，判据本身不动。
+2. **截断防爆炸**：会话里存的工具输出**已被普通会话的 `Truncate.output` 封顶到 ≤50KB**（[truncate.ts:17-18](../tool/truncate.ts#L17)，超出部分甩文件、只留预览），但 50KB/条对评审仍太松。本次在其上**再收紧一道**：评审 prompt 里每条 output 只留 ~300 字、input 只留 ~200 字（**纯字符截断**，不甩文件——评审是一次性的，不需要再去 Grep 完整文件）。补证据是为了让 B 维度可判，不是把整段历史搬进来。
+3. **最小改动、贴现有结构**：只改 [`review-agent.ts`](./review-agent.ts) 一个文件——升级 `collectCategories`、改消息映射、改 `serializeHistory`；复用现有 `buildReviewPrompt` 装配顺序，不新建文件、不改存储。
+4. **best-effort、永不挡评审**：拿不到某条 skill 的 frontmatter / 某条工具输出时，跳过该条，绝不让评审构建报错。
+
+---
+
+## 解决了什么问题
+
+### 顾虑 A：评审 AI 看不到"已有哪些 skill"（落实导师 #3）
+- 现状：[`collectCategories`](./review-agent.ts#L125) 扫了所有 skill，**只抠 `category` 字段**去重成标签（如 `GitHub`/`Research`），prompt 里只给"有哪些类别"。**没有 skill 的名字、没有 description**。
+- 后果：导师 #3「优先改现成、别动不动新建」**无从落地**——AI 根本不知道现成有哪些 skill、各干嘛，自然倾向新建。
+- 真实佐证：[`发给AI的信息清单.md`](../../../../../transcribe/发给AI的信息清单.md) 第八节捞的真实 prompt，末尾就只有 `Available skill categories: GitHub/Testing/Skills/Research`。
+
+### 顾虑 B：判"已验证"却看不到证据（修自相矛盾）
+- 现状：[`serializeHistory`](./review-agent.ts#L101) 渲染工具调用时**只有 `name` + `id`**；消息映射 [`review-agent.ts:221-229`](./review-agent.ts#L221) 把 part 的 `state`/`output`（工具的输入参数、返回结果）直接丢掉。
+- 后果：[`constants.ts`](./constants.ts) 的基础指令 B 维度明文要求 AI "point to at least one tool-call output that SUCCEEDED" ——**指令要的证据，材料里根本不存在**。AI 只能靠猜，B 维度形同虚设。
+- 真实佐证：同上第八节，4 次 `webfetch` 在 prompt 里只剩 `<tool_call name="webfetch" id="..."/>`，查询词和返回全无。
+
+> 数据本来就有：工具输出存在源会话的 part 里（`state.output`，实测可取），构建 prompt 那一刻 `rawMessages` 手里就有，是映射那步丢了。所以"补回来"只是不丢，不是去别处捞。
+
+### 本次【不】解决（留给后续，见[范围说明](#范围说明)）
+- 创建时"别静默覆盖同名 + 相似时拦一道"的系统侧闸（`skill-manage-tool.ts` 的 `handleCreate` 不查重直接覆盖）——另一处文件、另一个主题，单独做。
+- 导师 #6「创建两次才启用」——更大的功能，单独设计。
+- ID（#7）/ 每 skill 套 git（#8）/ 判好坏（#10/#14）——导师明确降级或 `.versions` 已覆盖，本次不碰。
+
+---
+
+## 现状 → 改后
+
+| 维度 | 现状 | 改后 |
+|---|---|---|
+| 评审 AI 知道的"已有 skill" | 只有分类标签（`category`） | **完整清单：每个 skill 的 name + description + category** |
+| 工具调用在历史里 | 只有 `name` + `id` | **加上输入参数 + 输出（各自截断到上限）** |
+| B 维度可判性 | 无证据，形同虚设 | 有（截断的）成功输出可指认 |
+| 改动文件 | — | 仅 [`review-agent.ts`](./review-agent.ts) |
+
+---
+
+## 对旧文件的修改
+
+> 每处标注 **侵入式**（改了旧行为，有回归风险）还是 **增量式**（只加内容、旧路径不变）。
+
+| 旧文件:位置 | 改什么 | 性质 | 依据 |
+|---|---|:---:|---|
+| `review-agent.ts` **新增** `collectSkillInventory` + `serializeSkillInventory` | 只扫子项目进化区，收集每个 skill 的 `name`+`description`+`category`，渲染成"已有 skill 清单"段 | **增量式**（新函数，旧 `collectCategories` 不动） | D1/D5 |
+| [`review-agent.ts :: collectCategories`](./review-agent.ts#L125) | **保留不动**（分类标签仍服务基础指令里"按列表给 skill 归类"的 `category` 字段要求，D4） | 不改 | D1 |
+| [`review-agent.ts :: buildReviewPrompt`](./review-agent.ts#L152) | 在分类标签段之后**追加**一段"已有 skill 清单" | **增量式**（加一段，原段落不动） | D1 |
+| [`review-agent.ts` 消息映射 `:221-229`](./review-agent.ts#L221) | 保留 part 的工具 `input`/`output`（不再只取 type/text/tool/callID） | **增量式**（多带字段） | D2 |
+| [`review-agent.ts :: serializeHistory`](./review-agent.ts#L101) | 工具节点渲染出"输入参数 + 输出"，各按上限截断 | **侵入式**（XML 节点内容变） | D2/D3 |
+
+---
+
+## 核心机制详解
+
+### 1. 给评审 AI 喂"已有 skill 清单"
+
+- **新增** `collectSkillInventory(folderName)`，**只扫当前子项目进化区**一个目录：`Spawner.skillEvolutionDir(folderName)` → `~/.local/share/aether/skill-evolution/<项目ID>/skills/`。**不扫**全局、**不扫**共享区（D5）。
+- 每个 skill：`name` 取目录名，`description`/`category` 用项目标准解析器 [`ConfigMarkdown.parse`](../config/markdown.ts#L71)（gray-matter）从 SKILL.md 取 `md.data`——**只读 `---` 块**，不会误抓正文里的 `key:` 行（D6）。
+- `serializeSkillInventory` 把清单渲染成一段，在基础指令的分类标签段**之后追加**（不替换分类标签——后者仍服务 `category` 字段指令，D4）。格式见[下文](#格式样例)。
+- best-effort：读不到/解析不了的 skill 跳过；目录不存在 → 空清单（渲染成 "(none yet)"）。
+
+### 2. 对话历史补"工具参数 + 输出（截断）"
+
+- 消息映射保留每个工具 part 的 `state.input`（调用参数）和 `state.output`（返回结果）。
+- `serializeHistory` 渲染工具节点时带上二者，**纯字符截断**：output 留前 ~300 字、input 留前 ~200 字，超出加 `…[truncated N chars]` 标注（不甩文件，D3/Q1）。
+- 仅渲染有意义的工具结果；拿不到 output 的（如还在跑、被压缩）按"无输出"渲染，不报错。
+
+---
+
+## 格式样例
+
+**改后的"已有 skill 清单"段（替换原 `Available skill categories`）**：
+
+```
+Existing skills in this project (prefer EDITING one of these over creating a near-duplicate):
+  - ai-qft-survey [Research]: Survey the frontier of AI + quantum field theory…
+  - ai-architecture-research [Research]: Investigate AI system architecture papers…
+```
+（只列当前子项目进化区的 skill；全局/共享区的不列。）
+
+**改后的工具节点（对话历史里）**：
+
+```xml
+<tool_call name="webfetch" id="call_FKR...">
+  <input>{"url":"https://arxiv.org/list/hep-th/recent"}</input>
+  <output>Status 200. Recent submissions in hep-th: … …[truncated 8421 chars]</output>
+</tool_call>
+```
+
+---
+
+## 核心不变量
+
+1. **只补输入、判定不变** — gate 四维度、写作规则、创建/覆盖行为一行不动（D1/D2 只动 prompt 装配）。
+2. **输出有界** — 每条工具输出/参数渲染长度 ≤ 上限；prompt 不会因单条巨型输出而爆炸（D3）。
+3. **best-effort** — 任一 skill frontmatter 或工具输出取不到 → 跳过该条，构建不报错（设计原则 4）。
+4. **范围不变** — skill 清单扫的还是原来那 3 个目录，不新增扫描面（机制 1）。
+
+---
+
+## 决策记录
+
+> 本文档自有编号 D1…，与 IDLE/SESSION_USAGE 的 D 编号互不干扰。
+
+- **D1：在分类标签段之外【新增】一段"完整 skill 清单（name+description+category）"，不替换分类标签。** 原因：只给 category 落实不了 #3；给名字+描述 AI 才知道"现成有啥、改哪个"。分类标签**保留**——基础指令仍要 AI"按这个列表给新 skill 归类"，二者用途不同。属增量式（加一段 + 加新函数，旧路径不动）。**实现已落地，见 `review-agent.ts` 的 `collectSkillInventory`/`serializeSkillInventory`。**
+- **D2：对话历史补工具的 input+output。** 原因：B 维度要证据、材料里却没有，是自相矛盾的真 bug；数据本就在 part 里，只是映射丢了。
+- **D3：工具输出/参数用「纯字符截断」，不复用 `Truncate.output` 的甩文件那套。** 现成的 `Truncate.output` 会把超长内容甩到磁盘文件、再给模型留一句"用 Grep/Read 看完整文件"——那段提示每条约 40~60 token，对一次性评审是纯浪费（评审不会去读那个文件）。纯字符截断只加一个 ~5 token 的 `…[truncated]` 标记，同样预览长度下更省 token。**已与用户对齐。**
+- **D4：只改 `review-agent.ts` 一个文件，不动 `constants.ts` 的基础指令文本。** 原因：基础指令的 B 维度本身没错，错在没给它证据；补上证据即可，不必改指令。
+- **D6：`collectSkillInventory` 用 `ConfigMarkdown.parse`（gray-matter）解析 frontmatter，不手搓正则。** 原因：code-review 发现手搓的 `^key:$/m` 正则会扫到正文行（frontmatter 缺该字段时把正文 `category:` 当成 skill 类别），且是项目里第 4 个 frontmatter 解析器。复用 `ConfigMarkdown.parse`（skill/index.ts 也用它）既只读 `---` 块根治该 bug，又消除重复。**已修，对应红绿测试 "does not read a `category:` line from the body"。**
+- **D5：skill 清单只扫"当前子项目进化区"，不扫全局/共享区。** 原因：评审是针对这个项目、要防的是"在这个项目里又造一个雷同的"，比对对象就该是这个项目自己进化区里已有的 skill；全局区是用户手搓的、共享区是另一作用域，混进来既无关又拉长清单。**已与用户对齐。**
+
+---
+
+## 开放问题
+
+- ~~**Q1：工具输出/参数各截断到多少字？**~~ **已定**：output 留 ~300 字、input 留 ~200 字，纯字符截断（放 `review-agent.ts` 模块常量，YAGNI 不进 config）。理由：评审只需判"这步成没成功"，预览越短越省 token（省 token 的主要杠杆是预览长度，不是截断方式）。
+- **Q2：skill 清单是否需要总长上限？** 若某子项目 skill 很多，清单也会变长。暂定不设上限（当前每项目 skill 数很少）；若日后变多再加。**待定。**
+- **Q3：要不要把"被用户关掉自进化"的 skill 也列进清单（只列、标注只读）？** 现在锁警告段已单独列了它们；清单段是否重复列、还是引用。倾向：清单段全列、锁警告段保留"禁止改"语义，二者不互斥。**待定。**
+- **Q4（与系统提示的关系）**：`SystemPrompt.skills` 可能已在系统提示里列了可用 skill（[发给AI的信息清单.md 第七节](../../../../../transcribe/发给AI的信息清单.md) 的待验证项）。若已列，本次的清单段会与之**部分重复**。处理：本次仍在用户消息里显式列（确保 gate 一定看得到、且能加"prefer editing"的措辞），重复是可接受的冗余；要不要去重待那个实验结论出来再定。**待验证后定。**
+
+---
+
+## 关键文件速查
+
+| 文件 | 作用 |
+|---|---|
+| [`review-agent.ts`](./review-agent.ts) | 评审 prompt 构建（本次唯一改动文件） |
+| [`constants.ts`](./constants.ts) | `SKILL_REVIEW_PROMPT_BASE` 基础指令（本次不改，仅引用 B 维度） |
+| [`review-agent.test.ts`](./review-agent.test.ts) | 现有测试（`serializeHistory`、prompt 装配已有用例，本次扩充） |
+
+---
+
+## 复用组件核实（实现前必读）
+
+- **X1：工具输出确实存在 part 里，且已被 `Truncate.output` 封顶到 ≤50KB。** 实测 part 的 `data.state.output` 有内容（一次 skill 加载样本 ~20KB，未超 50KB 故整条留着）；普通会话写 part 前先过 [`Truncate.output`](../tool/truncate.ts#L141)（[prompt.ts:977](../session/prompt.ts#L977)），所以读到的就是 ≤50KB 的版本 → 我们在其上再纯字符收紧到 ~300 字（D3）。构建时 `rawMessages` 可取 → D2 可行。
+- **X2：新增的 `collectSkillInventory` 只扫子项目进化区** `Spawner.skillEvolutionDir(folderName)`，取 `name`(目录名)+`description`+`category`；`collectCategories`（扫 3 个目录、只取 category）原样保留服务 category 字段（机制 1 / D5）。
+- **X3：现有测试入口在 `review-agent.test.ts`。** `serializeHistory` 与"do not create 重复 skill"已有用例（约 line 80），新用例接着加。
+
+---
+
+## 命题清单
+
+### PA. skill 清单
+- A1. 改后 prompt 含每个已有 skill 的 name + description + category，而非仅 category。
+- A2. 清单只覆盖当前子项目进化区的 skill（不含全局、不含共享区）。
+- A3. 某 skill 的 frontmatter 解析失败 → 跳过该条，prompt 仍正常生成（不抛错）。
+
+### PB. 工具参数 + 输出
+- B1. 改后对话历史里的工具节点含 input 与 output。
+- B2. 单条 output 超上限 → 被截断且带 `…[truncated]` 标注；长度 ≤ 上限。
+- B3. 工具 part 无 output（如未完成）→ 渲染为"无输出"，不抛错。
+
+### PH. 边界与失败用例（测试必须覆盖）
+- H1. 三个目录都为空 / 无任何 skill → 清单段为"(no existing skills)"，不抛错。
+- H2. output 为空字符串 / 超大字符串两个边界，截断逻辑都正确。
+- H3. 一条消息里多个 tool_call，全部带上各自 input/output。
+
+---
+
+## 测试与红绿里程碑
+
+> 走 TDD：每个里程碑先写红测试（证明现状缺它）、再实现到绿。先红后绿两次输出都要留。
+
+### ⚠️ 假绿陷阱
+- 测"行为不测实现"：断言 **prompt 文本里出现了 description / output 内容**，不要断言"调了某函数"。
+- 必须有一条**先红**：在改 `collectCategories`/`serializeHistory` 之前跑，证明现在 prompt 里**没有** description、**没有** 工具 output（否则测试恒绿，没测到东西）。
+
+### 红绿总览（按依赖排序）
+1. **里程碑1（skill 清单）**：红——断言 `buildReviewPrompt` 输出含某已有 skill 的 description，现状失败；绿——升级 `collectCategories` 后通过。
+2. **里程碑2（工具输出）**：红——构造一条带 `output` 的工具消息，断言 `serializeHistory` 输出含该 output 片段，现状失败；绿——改映射+渲染后通过。
+3. **里程碑3（截断）**：红——超长 output 断言被截断到上限且带标注，现状（无截断逻辑）失败；绿——加截断后通过。
+4. **里程碑4（边界）**：H1/H2/H3 各一条。
+
+### 收尾验证
+- 跑 `review-agent.test.ts` 全绿。
+- 跑一次真实评审（可选），人眼看新 prompt 里清单段与工具 output 都在、且 output 被截断。
+
+---
+
+## 范围说明
+
+**本次做**：只在发给评审 AI 的 prompt 里——①补"已有 skill 清单（完整 frontmatter）"②补"工具参数+输出（截断）"。仅改 `review-agent.ts`。
+
+**本次不做**（留给后续独立工作）：
+- 创建时"别静默覆盖同名 + 相似时拦"的系统侧闸（`skill-manage-tool.ts`）。
+- 导师 #6「创建两次才启用」。
+- ID（#7）、每 skill 套 git（#8）、判 skill 好坏 / 进会话看 transcript（#10/#14）——导师降级或 `.versions` 已覆盖。
+
+---
+
+## 用户体验
+
+- 对你来说的变化：skill 自进化**少重复造**——评审 AI 现在看得见"现成有哪些 skill、各干嘛"，更可能去**改现成的**而不是又建一个雷同的；并且它判"这个方法验证过没有"时**有真凭据可看**（联网/命令的实际输出），而不是凭空猜。
+- 没有界面变化；这是后台评审质量的改善。判定标准（什么该存什么不该存）不变，只是判得更有依据。

--- a/packages/opencode/src/skill-evolution/curator/SESSION_USAGE_DESIGN.md
+++ b/packages/opencode/src/skill-evolution/curator/SESSION_USAGE_DESIGN.md
@@ -1,0 +1,417 @@
+# Aether Curator 记会话 — 给每次 skill 使用记下「近期使用坐标」设计文档
+
+> 状态：**设计定稿 v2**，可进入实现（实现走 TDD）。
+> 读者：团队开发者 + 组会评审 + 照本实现的人（含 yolo 沙盒会话——它没有设计讨论的上下文，本文档即唯一说明书）。
+> 出处：2026-06-12 组会，导师要求「先把使用历史记全，再往后做 skill 进化」——每次用 skill 要能回溯它在**哪个项目、哪次会话、什么时候**被用过，供日后判断「它当初有没有真起作用」（转写 `20260612_1432_speakers.txt` 行94/99/102/109/110/189）。
+> 关联：本目录 [`CURATOR_DESIGN.md`](./CURATOR_DESIGN.md)（curator 整体设计）、[`IDLE_SCANS_DESIGN.md`](./IDLE_SCANS_DESIGN.md)（归档判据改造，已实现）。本文档**只加「记近期使用坐标」这一块**，归档判据等全部沿用，不重述。
+>
+> **v2 相对 v1 的关键修订**（实地查 DB + 组会复核后）：①查实**会话 DB 已自动记录每次 skill 调用**（session id + 时间 + skill 名），故 `recent_uses` 从「主数据源」降级为**近期窗口缓存/索引**，DB 才是全量权威源；②`recent_uses` 的上限不是缺陷，是**有意的「近期窗口」**（只看近期、防旧成绩稀释现状）；③v1 的「Q-S 会话能否检索」风险**已查实解决**；④确定**不加**评估字段（`disposition`/`reviewed_at`），留给后续；⑤`bumpUse` 保持 `await`（实测 0.3ms，不 fire-and-forget）。
+
+给 `bumpUse`（每次 skill 被加载时记一次使用的函数）补上「坐标」：除了把累计次数 `use_count` +1，再往该 skill 的账本记录里**追加一条事件** `{ session_id, at }`（哪次会话、什么时候）。项目 id 因为账本本来就按项目分键，无需每条重复。事件列表只保留**最近 N 条**（滑动窗口，满了挤掉最老的）——这既省 token，又让评估只看「近期表现」，不被久远的旧成绩干扰。**本分支只负责「把近期使用坐标攒成一个现成索引」——不改归档行为、不判断 skill 有没有用、不删任何东西**，那些是后续工作。
+
+---
+
+## 目录
+
+- [一个关键前提：会话 DB 已自动记录 skill 调用](#一个关键前提会话-db-已自动记录-skill-调用)
+- [设计原则](#设计原则)
+- [解决了导师的什么顾虑](#解决了导师的什么顾虑)
+- [数据结构](#数据结构)
+- [核心机制详解](#核心机制详解)
+  - [1. bumpUse 追加事件 + 滑动窗口截断](#1-bumpuse-追加事件--滑动窗口截断)
+  - [2. session id 从哪来](#2-session-id-从哪来)
+  - [3. 兼容：旧账本缺字段](#3-兼容旧账本缺字段)
+- [为什么保持 await、不 fire-and-forget](#为什么保持-await不-fire-and-forget)
+- [核心不变量](#核心不变量)
+- [决策记录](#决策记录)
+- [开放问题](#开放问题)
+- [关键文件速查](#关键文件速查)
+- [复用组件核实](#复用组件核实实现前必读)
+- [命题清单](#命题清单)
+- [测试与红绿里程碑](#测试与红绿里程碑)
+- [范围说明](#范围说明)
+- [用户体验](#用户体验)
+
+---
+
+## 一个关键前提：会话 DB 已自动记录 skill 调用
+
+> 这是 v2 的地基。**先看清这层，才能理解 `recent_uses` 为什么只是「缓存」而非「唯一真相」。**
+
+实地查过磁盘上的真实数据库，确认以下事实（非推测）：
+
+- **会话存储是 SQLite，每个项目一个库**：`~/.local/share/aether/local/aether-<projectId>.db`，**文件名里的 hash 就是 project id**。
+- **每次 skill 调用都已落库**：库里 `part` 表（存会话每一片内容的表）有 `tool='skill'` 的行，`data`（JSON 字段）里带齐 `session_id`、`time_created`（时间）、`state.input.name`（**加载的哪个 skill**）、`state.status`。真实样本：`ai-qft-survey` · 会话 `ses_148db4…` · `2026-06-12 01:25` · completed。
+- **能按 session id 取回整段会话**：`MessageV2.page(sessionID)` 等函数（[message-v2.ts](../../session/message-v2.ts)）现成可用。
+- **一个 skill 的使用，锁在它自己那一个项目库里**：项目专属 skill 的发现逻辑（[skill/index.ts:144](../../skill/index.ts#L144)）只扫「当前项目」的 skill 目录，**跨项目互不可见**；实测 `ai-qft-survey` 被用 20 次、20 次全在自己项目库。所谓「shared 共享 skill」当前**未启用**（`skillEvolutionShared()` 从未被生产代码调用，存储层显式跳过 `shared/`，见 [db.ts:96](../../storage/db.ts#L96)）。→ 给定一个 skill，它的全部使用都在**一个**确定的库里，机械检索很便宜。
+
+**两条推论，决定本设计的形状**：
+
+1. **`recent_uses` 是「便利索引/近期缓存」，不是唯一数据源**：使用坐标的**权威全量记录在会话 DB**。账本里这份是为了「curator 自带一份现成的近期窗口、不必每次去开会话 DB」。**真要全量历史，回 DB 查**。
+2. **后续「判好坏」的检索必须机械**：将来评估某 skill 时，从账本拿到它的 projectId → 开那一个项目库 → 机械（确定性代码）查出使用位置 + 拼出上下文窗口 → 喂给 AI 判断。**不让 AI 自己钻 DB 乱找**（这一点比组会转写 行115「AI 自己 grab 搜索」更严，是有意收紧）。本分支不实现「判好坏」，但 `recent_uses` 是它的索引入口。
+
+---
+
+## 设计原则
+
+1. **只记不判**：本分支只把「近期使用坐标」攒成索引，**不**用它做任何归档/淘汰决定。判断「有没有真起作用」是后续独立工作（D14、[范围说明](#范围说明)）。
+2. **缓存而非真相源**：`recent_uses` 是近期窗口缓存，会话 DB 才是全量权威源（D19）。允许它与 DB 轻微不一致（best-effort 写失败、cap 丢老记录），代价可接受。
+3. **上限是特性不是缺陷**：只留最近 N 条 = 有意的「近期窗口」——省 token、且评估只看近期表现，不被久远旧成绩抬高/拉低判断（D17）。
+4. **最小改动、贴现有结构**：在 `bumpUse` 里加一段「追加事件」，复用现有账本读写（`load`/`save`）、范围过滤（`resolveScope`）、原子写入；不新建文件、不引入新存储。
+5. **best-effort、永不挡加载、保持 await**：沿用 `bumpUse` 现有契约——记账失败只吞，绝不影响 skill 加载；实测一次仅 0.3ms，保持 `await` 不改 fire-and-forget（D20 / [为什么保持 await](#为什么保持-await不-fire-and-forget)）。
+
+### 对旧文件的修改
+
+> 每处标注 **侵入式**（改了旧行为，有回归风险）还是 **增量式**（只加新字段/新调用）。
+
+| 旧文件:位置 | 改什么 | 性质 | 依据 |
+|---|---|:---:|---|
+| [`usage.ts :: UsageRecord`](./usage.ts#L13) | 加 `recent_uses: UseEvent[]` 一个字段 + `emptyRecord` 初始化成 `[]` | **增量式**（加字段，旧字段不动）| D15 |
+| [`usage.ts :: bumpUse`](./usage.ts#L229) | 签名加可选 `sessionId?`；函数体里追加事件 + 截断到 N | **增量式**（旧 2 参调用仍合法）| D15/D17 |
+| [`usage.ts :: load`](./usage.ts#L74) | 读老记录时把缺失的 `recent_uses` 补成 `[]`（防御） | **增量式** | D18 |
+| [`tool/skill.ts`](../../tool/skill.ts#L69) | `bumpUse(...)` 调用补传 `ctx.sessionID`（保持 `await`） | **增量式**（多传一个已有的值）| D16/D20 |
+
+> **不动**：归档判据（`idle_scans`，见 IDLE_SCANS_DESIGN）、`use_count` 累加时机、`last_used_at`、`archiveSkill`/`restoreSkill`、孤儿自愈、pinned、`shouldRunNow`、`skill_manage`、`constants.ts`（N 是代码常量见 Q-N）——全部沿用。
+> **不加**：评估字段 `disposition`/`reviewed_at`（D14/D21，留给后续「判好坏」）。
+
+---
+
+## 解决了导师的什么顾虑
+
+导师围绕 curator / skill 进化共四条顾虑（完整列表见 [`IDLE_SCANS_DESIGN.md`](./IDLE_SCANS_DESIGN.md#解决了导师的什么顾虑)）。其中 **顾虑 3、4** 上一分支留给「记会话」。本分支是「记会话」的**第一步：铺数据索引**。
+
+### 本分支提供前提的（顾虑 4 的「有数据/能定位」那一半）
+
+| # | 导师的顾虑 | 出处 | 本分支做到哪 |
+|---|---|---|---|
+| **顾虑 4** | **没法回溯评估**：想改进/进化一个 skill 时，得回去看它当初在那些会话里表现好不好；「没有数据，skill 进化无从谈起」 | 转写 行99/102/110/111 | **本分支产出近期使用索引**：每次使用记下 `{ session_id, at }`，账本键带 `projectId` → 凑齐「project id + session id + 时间」，**能直接定位到该去 DB 翻哪几次会话**。注意：只产出「近期指针」，不产出「判断」 |
+
+> **Q-S（v1 标的风险）已查实解决**：会话确实持久化、skill 调用确实落库、可按 session id 取回（见[关键前提](#一个关键前提会话-db-已自动记录-skill-调用)）。不再是风险。
+
+### 本分支【不】解决、仍留给后续的
+
+| # | 顾虑 / 工作 | 为什么本分支治不了 / 真正的解药 |
+|---|---|---|
+| **顾虑 3** | 「触发灵敏但啥也没干」的烂 skill 反被保留 | 光记坐标**不会淘汰任何 skill**。要治它，得在坐标之上再做：① **机械**检索 DB、拼出每次使用的上下文窗口；② 喂 AI 判断正面/负面；③ 据判断删/降权。这三步本分支都没有 |
+| **「判好坏」本身** | 拿坐标翻回会话、判断 skill 当初有没有起作用 | 本分支只存「近期指针」，不存会话内容、不做自动判断。把指针兑现成「上下文」、再判好坏，是后续工作（D14）。导师明确说「评估是后边的事，先记录，没必要每次都评，代价大」（行189）|
+
+**判定标准（本分支达标）**：账本里**每次在范围内的 skill 加载，都落下一条带 `session_id`+`at` 的事件**，列表按上限保留最近 N 条，且能 `load` 回来、跨「写→读」接力验证。**不要求**本分支能判断 skill 好坏或淘汰任何 skill。
+
+---
+
+## 数据结构
+
+### UseEvent — 一条使用事件（新增）
+
+```ts
+interface UseEvent {
+  session_id: string  // 这次使用发生在哪次会话（来自 ctx.sessionID）
+  at: string          // 使用时刻（UTC ISO 8601 字符串）
+}
+```
+
+> 不含 `projectId`：账本按 `<projectId>/<name>` 分键，一条记录天然只属于一个项目，项目 id 由键隐含（D16）。
+> 不含会话内容：只存「指针」，过程靠 id 去 DB 回查（D16）。
+
+### UsageRecord — 单个 skill 的记录（落盘 `curator/usage.json`，key = `<projectId>/<name>`）
+
+```ts
+interface UsageRecord {
+  projectId: string
+  name: string
+  location: string
+  use_count: number              // 沿用：累计被加载次数（不封顶，只增）
+  use_count_at_last_scan: number // 沿用（归档判据用）
+  idle_scans: number             // 沿用（归档判据用）
+  last_used_at: string | null    // 沿用：最近一次使用时间（单个值）
+  recent_uses: UseEvent[]        // 【新增】最近 N 次使用的坐标，按时间先后排，满 N 挤掉最老的
+  state: "active" | "stale" | "archived"
+  pinned: boolean
+  archived_at: string | null
+}
+```
+
+**新增字段解释**（▲=本次新增）：
+
+| 字段 | 是什么 | 例子 | 改/不改 |
+|---|---|---|:---:|
+| ▲ `recent_uses` | 最近 `MAX_RECENT_USES`（默认 50，见 Q-N）次使用的坐标列表（**近期窗口缓存**，DB 是权威全量源）。每次 `bumpUse` 往尾部追加一条 `{ session_id, at }`，长度超 N 就从头部丢最老的 | 见下方 JSON | 新增 |
+
+> 三者分工（别混）：`use_count` = **总量**（用了多少次，不封顶）；`recent_uses` = **最近明细**（最近几次在哪个会话/啥时候，有上限）；`last_used_at` = **最近一次的时间**（就一个值）。
+
+**一条完整记录的例子**（`ai-qft-survey` 累计用 8 次，近期窗口留着最近几条）：
+
+```json
+"cd18fbc2…/ai-qft-survey": {
+  "projectId": "cd18fbc2…",
+  "name": "ai-qft-survey",
+  "location": "/home/zheng/.local/share/aether/skill-evolution/cd18fbc2…/skills/ai-qft-survey",
+  "use_count": 8,
+  "use_count_at_last_scan": 7,
+  "idle_scans": 0,
+  "last_used_at": "2026-06-12T01:25:00.000Z",
+  "recent_uses": [
+    { "session_id": "ses_8c1f…", "at": "2026-06-08T14:02:00.000Z" },
+    { "session_id": "ses_8c1f…", "at": "2026-06-08T14:40:00.000Z" },
+    { "session_id": "ses_148db4…", "at": "2026-06-12T01:25:00.000Z" }
+  ],
+  "state": "active",
+  "pinned": false,
+  "archived_at": null
+}
+```
+
+> 读法：同一 `session_id`（`ses_8c1f…`）出现两条 → 这个 skill 在那次会话里被加载了 2 次（每次加载都记，D17）。回溯时按 `session_id` 去那个项目的会话 DB 翻过程。
+
+### 常量（[`usage.ts`](./usage.ts)）
+
+```ts
+const MAX_RECENT_USES = 50  // recent_uses 列表上限；超过从头部丢最老（Q-N 待定值）
+```
+
+> 放在 `usage.ts` 模块内、**不**进 `CuratorConfig`：这是存储细节、不是用户该调的归档旋钮（YAGNI）。
+
+---
+
+## 核心机制详解
+
+### 1. bumpUse 追加事件 + 滑动窗口截断
+
+`bumpUse` 在 skill 被加载时调用（[`skill.ts:69`](../../tool/skill.ts#L69)）。改造后流程：
+
+```
+① resolveScope(location) → 不在 <projectId>/skills/<name> 范围内则直接 return（沿用）
+② load 账本，取/建该 skill 的记录 rec（沿用）
+③ rec.use_count += 1                                  （沿用）
+④ rec.last_used_at = now.toISOString()                （沿用）
+⑤ 【新增】若有 sessionId：
+     rec.recent_uses.push({ session_id: sessionId, at: now.toISOString() })
+     若 rec.recent_uses.length > MAX_RECENT_USES：
+        从头部 splice 掉多出来的（保留最近 N 条）
+⑥ save 账本（原子写，沿用）
+   —— 整段 try/catch 包住，失败只吞，不挡加载（沿用 X3）
+```
+
+**改前**（[`usage.ts:229-242`](./usage.ts#L229)）：
+```ts
+export async function bumpUse(root: string, location: string, now: Date = new Date()): Promise<void> {
+  const scope = resolveScope(root, location)
+  if (!scope) return
+  try {
+    const data = await load(root)
+    const rec = data[scope.key] ?? emptyRecord(scope)
+    rec.use_count += 1
+    rec.last_used_at = now.toISOString()
+    data[scope.key] = rec
+    await save(root, data)
+  } catch {}
+}
+```
+
+**改后**（伪代码，落地按现有风格）：
+```ts
+export async function bumpUse(
+  root: string, location: string, sessionId?: string, now: Date = new Date(),
+): Promise<void> {
+  const scope = resolveScope(root, location)
+  if (!scope) return
+  try {
+    const data = await load(root)
+    const rec = data[scope.key] ?? emptyRecord(scope)
+    rec.use_count += 1
+    rec.last_used_at = now.toISOString()
+    if (sessionId) {                                   // ← 新增：有会话 id 才记坐标（PB1）
+      rec.recent_uses.push({ session_id: sessionId, at: now.toISOString() })
+      if (rec.recent_uses.length > MAX_RECENT_USES)
+        rec.recent_uses.splice(0, rec.recent_uses.length - MAX_RECENT_USES)
+    }
+    data[scope.key] = rec
+    await save(root, data)
+  } catch {}
+}
+```
+
+- **`sessionId` 为何可选**：生产路径（skill.ts）永远传 `ctx.sessionID`，必有值；可选只是为了不冲掉现有 7 处 2 参测试调用（X1）。无 session id 时只 +1、不记坐标（不写半条没用的事件）。
+- **截断用 `splice(0, len-N)`**：一次性把头部多余的全切掉，保留尾部最近 N 条。
+
+### 2. session id 从哪来
+
+skill 加载工具 `SkillTool.execute(params, ctx)` 的上下文对象 `ctx`（工具运行时环境，类型见 [`tool.ts:17-27`](../../tool/tool.ts#L17)）上带 **`ctx.sessionID`**（当前会话 id，类型 `SessionID`，本质是个带品牌的字符串）。当前 [`skill.ts:69`](../../tool/skill.ts#L69) 调 `bumpUse` 时没传它，改造 = 把它传进去：
+
+```ts
+// 改前
+await Usage.bumpUse(Spawner.skillEvolutionRoot(), skill.location)
+// 改后
+await Usage.bumpUse(Spawner.skillEvolutionRoot(), skill.location, ctx.sessionID)
+```
+
+> `projectId` 不用从 ctx 取——账本靠 `resolveScope` 从 skill 路径 `<root>/<projectId>/skills/<name>` 解析出来，已经有了（X2）。
+
+### 3. 兼容：旧账本缺字段
+
+线上已有账本里的记录没有 `recent_uses`。两处兜底：
+- `load`（[`usage.ts:74`](./usage.ts#L74)）读到老记录时，把缺失的 `recent_uses` 补成 `[]`，保证后续 `.push` 不炸。
+- `emptyRecord`（[`usage.ts:58`](./usage.ts#L58)）新建记录时初始化 `recent_uses: []`。
+
+→ 升级到本版不会因为老记录缺字段而报错或误删（D18）。
+
+---
+
+## 为什么保持 await、不 fire-and-forget
+
+> 这是一个被问到、用实测拍板的决定。结论：**保持 `await`。**
+
+- **实测开销极小**：账本 `usage.json` 仅 ~1.8KB；一轮「读+解析+写回+原子 rename」实测 **0.337 ms/次**。多记 `recent_uses` 仅加几百字节，量级不变（仍亚毫秒）。
+- **不是瓶颈**：`bumpUse` 的 `await` 位于 [skill.ts:69](../../tool/skill.ts#L69)——在 `ctx.ask`（权限弹窗，可能等用户）之后、`ripgrep`（扫 skill 目录文件）之前。这两样才是大头；0.3ms 在它们面前忽略不计，更别提整体夹在一次大模型往返（以秒计）中。
+- **fire-and-forget 反而引入风险**：`bumpUse` 是读-改-写。不 await 的并发写会**互相覆盖**（丢 `use_count`/丢事件）；curator 已知有一个并发竞态，裸 fire-and-forget 会加重它；还有「写没落盘就被读」。拿这些风险换看不见的 0.3ms，不划算（D20）。
+- **真嫌慢的正解**（目前不需要、YAGNI）：串行化写队列（调用方不等、底层保证不打架），而非裸 fire-and-forget。
+
+---
+
+## 核心不变量
+
+> 在前两份设计文档不变量基础上，新增：
+
+1. **只记不判** — `recent_uses` 不参与任何归档/淘汰决定；归档仍只看 `idle_scans`（D14）。
+2. **缓存非真相源** — 会话 DB 是 skill 使用的权威全量记录；`recent_uses` 是近期窗口缓存，允许轻微不一致（D19）。
+3. **每次在范围内加载都落一条坐标** — 生产路径有 `sessionId` → 必追加（顾虑 4 数据完整性）。
+4. **事件列表有界** — `recent_uses.length ≤ MAX_RECENT_USES`，超出丢最老（D17）。
+5. **坐标只存指针不存内容** — 事件里只有 `session_id`+`at`（D16）。
+6. **缺字段不炸不误删** — 老账本缺 `recent_uses` 当 `[]` 处理（D18）。
+7. **不挡加载、保持 await** — best-effort 吞错；0.3ms 不优化成 fire-and-forget（D20）。
+
+> 沿用前两份文档不变量：归档判据零日历依赖、被用即清零无死亡螺旋、归档可恢复、pinned 跳过、原子写入、`skill_manage` 零触点。
+
+---
+
+## 决策记录
+
+> 编号接续 `IDLE_SCANS_DESIGN.md`（其到 D13 + D-A），本文档新增 D14–D21。
+
+- **D14：本分支只「记坐标」，不做「判好坏 / 淘汰」。** 判断没有现成判据、且依赖先有数据；记录是低风险增量，判断是高风险侵入，分步走。**已与用户对齐。**
+- **D15：`UsageRecord` 加 `recent_uses: UseEvent[]`；`bumpUse` 加可选 `sessionId?`。** 增量式，旧字段/旧 2 参调用不动。
+- **D16：每条事件只存 `session_id`+`at`，不存 `projectId`、不存会话内容。** projectId 由账本键隐含；会话过程靠 id 去 DB 回查。
+- **D17：粒度＝「每次加载记一条」，列表截断到最近 `MAX_RECENT_USES` 条（滑动窗口）。** **已对齐**：上限是有意的「近期窗口」——省 token + 评估只看近期、不被久远旧成绩干扰（用户提出的好处）。同会话多次加载 → 多条同 `session_id` 事件。
+- **D18：旧账本缺 `recent_uses` → 当 `[]` 处理（`load` + `emptyRecord` 兜底）。** 升级兼容，防报错/误删。
+- **D19：`recent_uses` 是近期窗口缓存，会话 DB 是权威全量源。** 查实 DB 已自动记录每次 skill 调用（[关键前提](#一个关键前提会话-db-已自动记录-skill-调用)）。账本这份为「现成索引/省得每次开 DB」，真要全量历史回 DB。
+- **D20：`bumpUse` 保持 `await`，不改 fire-and-forget。** 实测 0.3ms、非瓶颈；fire-and-forget 引入并发丢更新风险，不值（[为什么保持 await](#为什么保持-await不-fire-and-forget)）。
+- **D21：本分支不加评估字段（`disposition`/`reviewed_at`）。** 评估是后续工作（导师行189「评估是后边的事」），现在加 = 空占位（YAGNI）。**已与用户对齐**——顺导师「别一次性解决完、先记录」的增量风格。
+
+---
+
+## 开放问题
+
+- **Q-N：`MAX_RECENT_USES` 取多少？** 暂定 **50**、放 `usage.ts` 模块常量（不进 `CuratorConfig`，YAGNI）。50 够覆盖「最近一批会话」做近期评估，且账本不臃肿。**待用户最终拍板数值。**
+- **Q-M：要不要连 `message_id` 一起记？** 默认**不记**（YAGNI）。导师用「时间」就能定位到会话里具体哪条 user message（行113）；`ctx.messageID` 现成可取，日后若回溯需精确到「会话里第几步」再加。
+- ~~**Q-S：session id 能否定位回会话？**~~ **已查实解决**：能（DB 持久化、skill 调用落库、按 id 可取回）。
+
+> 实现按 YAGNI：只加「记坐标」这一处，核心逻辑走 TDD 先红后绿。
+
+---
+
+## 关键文件速查
+
+| 文件 | 本次职责 | 性质 |
+|------|------|:---:|
+| [`curator/usage.ts`](./usage.ts#L13) | `UsageRecord` 加 `recent_uses` + `UseEvent` 类型；`bumpUse` 加 `sessionId?` + 追加/截断；`emptyRecord`/`load` 兜底 `[]`；`MAX_RECENT_USES` 常量 | ⚠️ 增量改 |
+| [`tool/skill.ts`](../../tool/skill.ts#L69) | `bumpUse(...)` 补传 `ctx.sessionID`（保持 `await`） | ⚠️ 增量改 |
+| [`curator/usage.test.ts`](./usage.test.ts) | 加「追加事件 / 滑动窗口截断 / 缺字段兜底 / 无 sessionId」用例；现有用例补断言 `recent_uses` 默认 `[]` | ⚠️ 改测试 |
+| [`curator/constants.ts`](./constants.ts) | **不动**（N 是代码常量，非配置项） | — |
+| 归档判据 / `idle_scans` / `archiveSkill` / 孤儿自愈 / `shouldRunNow` / `skill_manage` | **不碰** | — |
+
+---
+
+## 复用组件核实（实现前必读）
+
+- **X1：`bumpUse` 调用点全部已知。** grep `bumpUse`：生产代码仅 [`skill.ts:69`](../../tool/skill.ts#L69) 一处；其余 7 处在 `usage.test.ts`/`curator.test.ts`，均为 2 参 `bumpUse(root, loc)` 形式 → `sessionId` 设为**可选第 3 参**，旧调用零破坏。
+- **X2：`projectId` 已由 `resolveScope` 提供。** 不需要从 ctx 另取项目 id（D16）。
+- **X3：`bumpUse` 的 best-effort 契约不变。** 仍整段 `try/catch` 吞错，记坐标失败绝不影响 skill 加载；保持 `await`（D20）。
+- **X4（已查实）：会话 DB 可按 id 检索、已记 skill 调用。** SQLite 每项目一库 `aether-<projectId>.db`，`part` 表 `data` JSON 含 `tool='skill'` + session_id + 时间 + skill 名；按 `session_id` 可取回（[关键前提](#一个关键前提会话-db-已自动记录-skill-调用)）。
+
+---
+
+## 命题清单
+
+> 把全文压成可判定真假的断言，分组、组内按重要度递减。
+
+### PA. 定位与边界
+- PA1. 本分支只往账本追加「近期使用坐标」，**不**改归档/淘汰任何行为（D14）。
+- PA2. `recent_uses` 是近期窗口缓存，会话 DB 是权威全量源；二者可轻微不一致（D19）。
+- PA3. 每次在范围内的 skill 加载（生产路径必带 `sessionId`）→ `recent_uses` 追加一条 `{ session_id, at }`（顾虑 4）。
+
+### PB. 写入机制
+- PB1. `bumpUse` 有 `sessionId` → push 一条事件；无则只 `use_count+1`、不记坐标。
+- PB2. `recent_uses.length > MAX_RECENT_USES` → 从头部丢最老的，长度恒 ≤ N（D17）。
+- PB3. 同一 `session_id` 多次加载 → 多条同 id 事件（每次加载记一条，不去重）。
+- PB4. `use_count`/`last_used_at`/`idle_scans` 写入时机与值完全不变。
+- PB5. `bumpUse` 保持 `await`（D20）。
+
+### PC. 兼容
+- PC1. 老账本记录缺 `recent_uses` → `load` 当 `[]`，`.push` 不炸（D18）。
+- PC2. `emptyRecord` 新建记录 `recent_uses` 初始为 `[]`。
+- PC3. 旧 2 参 `bumpUse(root, loc)` 调用仍合法（X1）。
+
+### PD. 数据结构
+- PD1. `UsageRecord` 含 `recent_uses: UseEvent[]`；`UseEvent = { session_id, at }`（D15）。
+- PD2. 不含评估字段 `disposition`/`reviewed_at`（D21）。
+
+### PH. 边界与失败用例（测试必须覆盖）
+- PH1. **写→读接力**：连调 `bumpUse` 两次（带不同 session id）→ `load` 回来 `recent_uses` 有 2 条、id/时间对得上（核心接缝）。
+- PH2. **滑动窗口**：调 `bumpUse` N+1 次 → `recent_uses` 恰好 N 条、头部最老被挤掉、尾部最新。
+- PH3. **缺字段兜底**：手写无 `recent_uses` 的老记录 → `bumpUse` 一次 → 不炸、`recent_uses` 变 1 条。
+- PH4. **范围外不记**：非 `<projectId>/skills/` 下 → 不产生任何记录/事件。
+- PH5. **无 sessionId**：`bumpUse(root, loc)` 不传 session → `use_count+1` 但 `recent_uses` 仍空。
+
+---
+
+## 测试与红绿里程碑
+
+> 核心逻辑走 TDD（先红后绿、婴儿步）。**每个里程碑独立走红→绿**，交付展示两次跑测输出（红：实现没写时失败；绿：写完通过）。从 `packages/opencode` 目录内跑 `usage.test.ts`。
+
+### ⚠️ 假绿陷阱与依赖顺序
+
+- **S1（写→读接力）是核心接缝、最该先看到红**：真的连调 `bumpUse` 两次再 `load` 回来断言 `recent_uses` 明细——验证「写进事件 → 读得出事件」这条接缝。旧实现没 `recent_uses` 字段，`load` 回来 `undefined` → 断言「有 2 条」自然红。**禁止手填 recent_uses 再只测读**——必须让写和读在测里接力跑（CLAUDE.md 写读接缝铁律）。
+- **S2（滑动窗口）有假绿陷阱**：断言要写**恰好 == N** 且**头部最老那条已不在、尾部是最新那条**，双向钉死；写成「长度 ≥ N」会恒真假绿。
+
+### 红绿总览（按依赖排序）
+
+| 次序 | 里程碑 | 红（先写失败测试）| 绿（实现）| 命题/边界 | 接缝 |
+|---|---|---|---|---|:---:|
+| **S1** | **写→读接力（核心，先停点）** | `bumpUse(root, loc, "ses_A")`、`bumpUse(root, loc, "ses_B")` → `load` → `recent_uses` 恰 2 条、`session_id` 依次 A/B、`at` 非空 | push 事件 | PA3/PB1/PH1 | ★★写读接力 |
+| S2 | 滑动窗口截断 | `bumpUse` 跑 `MAX_RECENT_USES+1` 次 → `recent_uses` 恰 N 条、头部最老被挤掉、尾部最新还在 | splice 截断 | PB2/PH2 | ★ |
+| S3 | 同会话多次记多条 | 同一 session id 连调 2 次 → 2 条同 id 事件（不去重）| 不去重 | PB3 | |
+| S4 | 缺字段兜底 | 手写无 `recent_uses` 的老记录入账本 → `bumpUse` 一次 → 不抛、`recent_uses` 变 1 条 | load/emptyRecord 兜 `[]` | PC1/PH3 | 防崩 |
+| S5 | 无 sessionId 不记坐标（防回归）| `bumpUse(root, loc)` 不传 session → `use_count==1` 且 `recent_uses` 为空 | 可选参数分支 | PB1/PH5 | 防回归 |
+| S6 | 范围外不记 | 非 `skills/` 下 skill → load 无记录、无事件 | 沿用 resolveScope | PH4 | |
+
+> 顺序：S1 先停点（接缝跑通）。S2 验有界。S3 验粒度。S4/S5 防崩/防回归。S6 沿用既有边界。
+
+### 收尾验证（实现完成后）
+
+- `bun --cwd packages/opencode typecheck`，贴结果。
+- 从 `packages/opencode` 跑 `usage.test.ts`，贴 **S1 / S2** 的「红→绿」两次输出。
+- 现有 `curator.test.ts`（归档判据那批）不受影响，回归跑一遍确认全绿。
+- 归档判据 / `idle_scans` / `skill_manage` 一行不改。
+
+---
+
+## 范围说明
+
+本块（「记会话」）承接组会顾虑 3、4，**但本分支只做其中第一步**：
+
+1. **【本分支】记近期坐标**：每次用 skill 把 `session id + 时间` 攒进账本 `recent_uses`（近期窗口缓存/索引）。只攒索引，不判好坏、不淘汰。
+2. **【后续】机械检索 + 拼上下文**：评估某 skill 时，从账本拿 projectId → 开那一个项目库 `aether-<projectId>.db` → **机械（确定性代码）**查出使用位置 + 拼出每处上下文窗口。**不让 AI 自己钻 DB**（已验证：`part`+`message` 两表一条 SQL 就能把一次 skill 调用前后的会话过程按顺序拉出来）。
+3. **【后续】AI 判好坏 + 据判断删/降权**：把机械拼好的上下文喂 AI，判断「这个被频繁调的 skill 是正面还是负面」→ 留/降权/归档（顾虑 3）。评估专门批量做，不每次都做（导师行189）。
+
+> 另：组会还提到「给 skill 发 ID（git commit 时分配），解决靠名字重名」（导师注「暂时不关键」），与本块无关，不在此。
+
+---
+
+## 用户体验
+
+| | 体验 |
+|---|---|
+| **本分支前** | 账本只知道每个 skill「一共用过几次、最近一次什么时候」，**不知道**它具体在哪些会话里被用过；想回头评估某个 skill 当初有没有真帮上忙，curator 手里没有现成的「去翻哪几次会话」的索引。|
+| **本分支后** | 账本额外记下每个 skill「最近若干次分别在哪次会话、什么时候被用」。对你来说：**为日后「回看某个 skill 近期表现好不好、该不该留」备好了一份现成的近期索引**——评估时只看近期、省 token，也不会被它很久以前的旧表现误导。|
+
+**边界（诚实说清）**：① 本分支**纯后台记录，界面无任何变化、无新功能**——你现在看不到、也用不到这些坐标，它只是被悄悄存进账本当索引。② 本分支**不会自动判断或删除任何 skill**——「烂 skill 反被保留」要等后续「机械检索 + AI 判好坏 + 删/降权」做完才治得了。③ 这份 `recent_uses` 是**近期窗口缓存**，全量权威记录在会话 DB；真要完整历史，回 DB 查。

--- a/packages/opencode/src/skill-evolution/curator/curator.test.ts
+++ b/packages/opencode/src/skill-evolution/curator/curator.test.ts
@@ -53,6 +53,7 @@ function record(projectId: string, name: string, location: string, over: Partial
     location,
     use_count: 0,
     last_used_at: null,
+    recent_uses: [],
     state: "active",
     pinned: false,
     archived_at: null,

--- a/packages/opencode/src/skill-evolution/curator/usage.test.ts
+++ b/packages/opencode/src/skill-evolution/curator/usage.test.ts
@@ -46,6 +46,129 @@ describe("Usage.bumpUse", () => {
     }
   })
 
+  // S1 (核心接缝): 写→读接力 — 连调两次带不同 session id，load 回来事件明细对得上
+  test("appends a recent_uses event per call (write→read seam)", async () => {
+    const tmp = await makeTmp()
+    try {
+      const loc = await makeSkill(tmp.path, "proj1", "foo")
+      await Usage.bumpUse(tmp.path, loc, "ses_A", new Date("2026-06-08T14:02:00.000Z"))
+      await Usage.bumpUse(tmp.path, loc, "ses_B", new Date("2026-06-12T01:25:00.000Z"))
+
+      const data = await Usage.load(tmp.path)
+      const rec = data["proj1/foo"]
+      expect(rec).toBeDefined()
+      expect(rec!.recent_uses).toHaveLength(2)
+      expect(rec!.recent_uses[0]).toEqual({ session_id: "ses_A", at: "2026-06-08T14:02:00.000Z" })
+      expect(rec!.recent_uses[1]).toEqual({ session_id: "ses_B", at: "2026-06-12T01:25:00.000Z" })
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // S2 (有界 + 假绿陷阱): N+1 次 → 恰 N 条、头部最老被挤掉、尾部最新还在
+  test("slides the window to keep only the most recent MAX_RECENT_USES events", async () => {
+    const tmp = await makeTmp()
+    try {
+      const loc = await makeSkill(tmp.path, "proj1", "foo")
+      const n = Usage.MAX_RECENT_USES
+      for (let i = 0; i <= n; i++) {
+        // i 从 0 到 n，共 n+1 次；session id 编号便于辨认头尾
+        await Usage.bumpUse(tmp.path, loc, `ses_${i}`)
+      }
+
+      const data = await Usage.load(tmp.path)
+      const rec = data["proj1/foo"]!
+      expect(rec.recent_uses).toHaveLength(n) // 恰好 N，不是 ≥N
+      expect(rec.recent_uses[0]!.session_id).toBe("ses_1") // 最老的 ses_0 被挤掉
+      expect(rec.recent_uses[n - 1]!.session_id).toBe(`ses_${n}`) // 尾部是最新
+      expect(rec.use_count).toBe(n + 1) // use_count 不封顶
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // S3: 同一 session id 多次加载 → 多条同 id 事件 (不去重)
+  test("records one event per load even within the same session", async () => {
+    const tmp = await makeTmp()
+    try {
+      const loc = await makeSkill(tmp.path, "proj1", "foo")
+      await Usage.bumpUse(tmp.path, loc, "ses_same")
+      await Usage.bumpUse(tmp.path, loc, "ses_same")
+
+      const data = await Usage.load(tmp.path)
+      const rec = data["proj1/foo"]!
+      expect(rec.recent_uses).toHaveLength(2)
+      expect(rec.recent_uses.map((e) => e.session_id)).toEqual(["ses_same", "ses_same"])
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // S4: 缺字段兜底 — 老账本记录无 recent_uses → bumpUse 不抛、变 1 条
+  test("backfills recent_uses for legacy records missing the field", async () => {
+    const tmp = await makeTmp()
+    try {
+      const loc = await makeSkill(tmp.path, "proj1", "foo")
+      // 手写一条没有 recent_uses 的老记录
+      const dir = path.join(tmp.path, "curator")
+      await fs.mkdir(dir, { recursive: true })
+      const legacy = {
+        "proj1/foo": {
+          projectId: "proj1",
+          name: "foo",
+          location: path.dirname(loc),
+          use_count: 5,
+          use_count_at_last_scan: 5,
+          idle_scans: 0,
+          last_used_at: "2026-06-01T00:00:00.000Z",
+          state: "active",
+          pinned: false,
+          archived_at: null,
+        },
+      }
+      await fs.writeFile(path.join(dir, "usage.json"), JSON.stringify(legacy), "utf-8")
+
+      await Usage.bumpUse(tmp.path, loc, "ses_new")
+
+      const data = await Usage.load(tmp.path)
+      const rec = data["proj1/foo"]!
+      expect(rec.use_count).toBe(6)
+      expect(rec.recent_uses).toHaveLength(1)
+      expect(rec.recent_uses[0]!.session_id).toBe("ses_new")
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // S5 (防回归): 不传 sessionId → use_count+1 但不记坐标
+  test("increments use_count without recording a coordinate when sessionId is absent", async () => {
+    const tmp = await makeTmp()
+    try {
+      const loc = await makeSkill(tmp.path, "proj1", "foo")
+      await Usage.bumpUse(tmp.path, loc)
+
+      const data = await Usage.load(tmp.path)
+      const rec = data["proj1/foo"]!
+      expect(rec.use_count).toBe(1)
+      expect(rec.recent_uses).toEqual([])
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // 新记录默认 recent_uses 为 []
+  test("a freshly upserted record has an empty recent_uses array", async () => {
+    const tmp = await makeTmp()
+    try {
+      const loc = await makeSkill(tmp.path, "proj1", "foo")
+      await Usage.bumpUse(tmp.path, loc)
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/foo"]!.recent_uses).toEqual([])
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
   // M2: 范围过滤 — 不在 <projectId>/skills/ 下的 skill 不记账
   test("does not record out-of-scope skills", async () => {
     const tmp = await makeTmp()
@@ -140,6 +263,36 @@ describe("Usage.load", () => {
 
       const data = await Usage.load(tmp.path)
       expect(data).toEqual({})
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // load() heals legacy records on its own — even when bumpUse never runs
+  // (recordScanResult/setState rely on load returning a well-formed record).
+  test("backfills missing recent_uses to [] for legacy records on load", async () => {
+    const tmp = await makeTmp()
+    try {
+      const dir = path.join(tmp.path, "curator")
+      await fs.mkdir(dir, { recursive: true })
+      const legacy = {
+        "proj1/foo": {
+          projectId: "proj1",
+          name: "foo",
+          location: "/some/where",
+          use_count: 3,
+          use_count_at_last_scan: 3,
+          idle_scans: 0,
+          last_used_at: null,
+          state: "active",
+          pinned: false,
+          archived_at: null,
+        },
+      }
+      await fs.writeFile(path.join(dir, "usage.json"), JSON.stringify(legacy), "utf-8")
+
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/foo"]!.recent_uses).toEqual([])
     } finally {
       await tmp.cleanup()
     }

--- a/packages/opencode/src/skill-evolution/curator/usage.ts
+++ b/packages/opencode/src/skill-evolution/curator/usage.ts
@@ -3,6 +3,19 @@ import os from "os"
 import path from "path"
 
 /**
+ * A single skill-use coordinate. Pointer only — the full session lives in the
+ * session DB and is fetched back by `session_id` when evaluation is needed.
+ * No `projectId`: the ledger key already scopes a record to one project. See
+ * SESSION_USAGE_DESIGN.md D16.
+ */
+export interface UseEvent {
+  /** Which session this use happened in (from ctx.sessionID). */
+  session_id: string
+  /** When it happened (UTC ISO 8601). */
+  at: string
+}
+
+/**
  * Per-skill usage record. Stored in the curator ledger
  * (`<root>/curator/usage.json`), keyed by `"<projectId>/<name>"`.
  *
@@ -17,6 +30,14 @@ export interface UsageRecord {
   location: string
   use_count: number
   last_used_at: string | null
+  /**
+   * Recent-window cache of the last MAX_RECENT_USES use coordinates, oldest
+   * first. NOT the source of truth — the session DB holds the authoritative full
+   * history; this is a convenience index so the curator carries a ready recent
+   * window. Each bumpUse with a sessionId appends one; over the cap the oldest
+   * are dropped from the front. See SESSION_USAGE_DESIGN.md D17/D19.
+   */
+  recent_uses: UseEvent[]
   state: "active" | "stale" | "archived"
   /** Skip auto-transitions. Read-only in this version (no setter, see Q2). */
   pinned: boolean
@@ -24,6 +45,13 @@ export interface UsageRecord {
 }
 
 export namespace Usage {
+  /**
+   * Cap on `recent_uses` length; over it, the oldest events are dropped. A
+   * storage detail, not a user-tunable archive knob, so it lives here and not in
+   * CuratorConfig (YAGNI). See SESSION_USAGE_DESIGN.md Q-N.
+   */
+  export const MAX_RECENT_USES = 50
+
   function curatorDir(root: string): string {
     return path.join(root, "curator")
   }
@@ -57,6 +85,7 @@ export namespace Usage {
       location: scope.skillDir,
       use_count: 0,
       last_used_at: null,
+      recent_uses: [],
       state: "active",
       pinned: false,
       archived_at: null,
@@ -72,7 +101,12 @@ export namespace Usage {
       if (!data || typeof data !== "object" || Array.isArray(data)) return {}
       const clean: Record<string, UsageRecord> = {}
       for (const [k, v] of Object.entries(data)) {
-        if (v && typeof v === "object") clean[k] = v as UsageRecord
+        if (v && typeof v === "object") {
+          const rec = v as UsageRecord
+          // Legacy records predate recent_uses; backfill so .push never throws.
+          if (!Array.isArray(rec.recent_uses)) rec.recent_uses = []
+          clean[k] = rec
+        }
       }
       return clean
     } catch {
@@ -201,7 +235,12 @@ export namespace Usage {
     return true
   }
 
-  export async function bumpUse(root: string, location: string, now: Date = new Date()): Promise<void> {
+  export async function bumpUse(
+    root: string,
+    location: string,
+    sessionId?: string,
+    now: Date = new Date(),
+  ): Promise<void> {
     const scope = resolveScope(root, location)
     if (!scope) return
     try {
@@ -209,6 +248,12 @@ export namespace Usage {
       const rec = data[scope.key] ?? emptyRecord(scope)
       rec.use_count += 1
       rec.last_used_at = now.toISOString()
+      if (sessionId) {
+        // Append this use's coordinate; trim the oldest over the recent window.
+        rec.recent_uses.push({ session_id: sessionId, at: now.toISOString() })
+        if (rec.recent_uses.length > MAX_RECENT_USES)
+          rec.recent_uses.splice(0, rec.recent_uses.length - MAX_RECENT_USES)
+      }
       data[scope.key] = rec
       await save(root, data)
     } catch {

--- a/packages/opencode/src/skill-evolution/review-agent.test.ts
+++ b/packages/opencode/src/skill-evolution/review-agent.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from "bun:test"
-import { serializeHistory, buildReviewPrompt, isReviewSession } from "./review-agent"
-import type { MessageSnapshot } from "./review-agent"
+import fs from "fs/promises"
+import path from "path"
+import { Spawner } from "./spawner"
+import {
+  serializeHistory,
+  buildReviewPrompt,
+  isReviewSession,
+  serializeSkillInventory,
+  collectSkillInventory,
+} from "./review-agent"
+import type { MessageSnapshot, SkillSummary } from "./review-agent"
 
 describe("serializeHistory", () => {
   test("produces XML block from message snapshots", () => {
@@ -86,6 +95,136 @@ describe("buildReviewPrompt", () => {
     ]
     const prompt = await buildReviewPrompt(messages, "test-project-abc", [])
     expect(prompt.toLowerCase()).not.toContain("do not modify")
+  })
+})
+
+describe("serializeSkillInventory", () => {
+  test("lists each skill's name, category and description with edit-first guidance", () => {
+    const skills: SkillSummary[] = [
+      { name: "ai-qft-survey", description: "Survey AI + QFT progress", category: "Research" },
+      { name: "review-pr", description: "Review a PR diff", category: "GitHub" },
+    ]
+    const out = serializeSkillInventory(skills)
+    expect(out).toContain("ai-qft-survey")
+    expect(out).toContain("Survey AI + QFT progress")
+    expect(out).toContain("review-pr")
+    expect(out).toContain("Review a PR diff")
+    // #3: nudge the reviewer toward editing an existing skill over making a near-duplicate
+    expect(out.toLowerCase()).toContain("prefer editing")
+  })
+
+  test("empty list yields a no-skills sentinel, no throw (boundary)", () => {
+    const out = serializeSkillInventory([])
+    expect(out.toLowerCase()).toContain("none")
+  })
+})
+
+describe("collectSkillInventory", () => {
+  test("reads name+description+category from the sub-project's SKILL.md (write→read seam)", async () => {
+    const folderName = "test-inventory-scan-fixture"
+    const base = Spawner.skillEvolutionBase(folderName)
+    const skillDir = path.join(Spawner.skillEvolutionDir(folderName), "my-skill")
+    await fs.rm(base, { recursive: true, force: true })
+    await fs.mkdir(skillDir, { recursive: true })
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      `---\nname: "my-skill"\ndescription: "Does a specific thing"\ncategory: "Testing"\n---\n\nbody`,
+    )
+    try {
+      const inv = await collectSkillInventory(folderName)
+      const found = inv.find((s) => s.name === "my-skill")
+      expect(found).toBeDefined()
+      expect(found!.description).toBe("Does a specific thing")
+      expect(found!.category).toBe("Testing")
+    } finally {
+      await fs.rm(base, { recursive: true, force: true })
+    }
+  })
+
+  test("missing dir yields empty list, no throw (boundary)", async () => {
+    const inv = await collectSkillInventory("nonexistent-folder-xyz-12345")
+    expect(inv).toEqual([])
+  })
+
+  test("does not read a `category:` line from the body when frontmatter omits it (frontmatter-scoped)", async () => {
+    const folderName = "test-inventory-bodyleak-fixture"
+    const base = Spawner.skillEvolutionBase(folderName)
+    const skillDir = path.join(Spawner.skillEvolutionDir(folderName), "leaky-skill")
+    await fs.rm(base, { recursive: true, force: true })
+    await fs.mkdir(skillDir, { recursive: true })
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      `---\nname: "leaky-skill"\ndescription: "real description"\n---\n\nSome body text.\ncategory: from-body\n`,
+    )
+    try {
+      const inv = await collectSkillInventory(folderName)
+      const found = inv.find((s) => s.name === "leaky-skill")
+      expect(found).toBeDefined()
+      expect(found!.description).toBe("real description")
+      // The `category:` line lives in the body, not the frontmatter — it must NOT leak in.
+      expect(found!.category).toBeUndefined()
+    } finally {
+      await fs.rm(base, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("serializeHistory tool input/output", () => {
+  test("includes tool input and output", () => {
+    const messages: MessageSnapshot[] = [
+      {
+        role: "assistant",
+        parts: [
+          {
+            type: "tool",
+            tool: "webfetch",
+            callID: "c1",
+            state: { status: "completed", input: { url: "https://example.com" }, output: "Status 200 OK body" },
+          },
+        ],
+      },
+    ]
+    const xml = serializeHistory(messages)
+    expect(xml).toContain("https://example.com")
+    expect(xml).toContain("Status 200 OK body")
+  })
+
+  test("truncates long output and marks it; full blob absent (truncation)", () => {
+    const big = "x".repeat(5000)
+    const messages: MessageSnapshot[] = [
+      {
+        role: "assistant",
+        parts: [{ type: "tool", tool: "bash", callID: "c2", state: { status: "completed", output: big } }],
+      },
+    ]
+    const xml = serializeHistory(messages)
+    expect(xml).toContain("truncated")
+    expect(xml).not.toContain(big)
+  })
+
+  test("tool part without state renders no input/output, no throw (boundary)", () => {
+    const messages: MessageSnapshot[] = [
+      { role: "assistant", parts: [{ type: "tool", tool: "bash", callID: "c3" }] },
+    ]
+    const xml = serializeHistory(messages)
+    expect(xml).toContain('name="bash"')
+    expect(xml).not.toContain("<input>")
+    expect(xml).not.toContain("<output>")
+  })
+
+  test("renders output for every tool_call in one message (boundary)", () => {
+    const messages: MessageSnapshot[] = [
+      {
+        role: "assistant",
+        parts: [
+          { type: "tool", tool: "webfetch", callID: "a", state: { output: "first-result" } },
+          { type: "tool", tool: "webfetch", callID: "b", state: { output: "second-result" } },
+        ],
+      },
+    ]
+    const xml = serializeHistory(messages)
+    expect(xml).toContain("first-result")
+    expect(xml).toContain("second-result")
   })
 })
 

--- a/packages/opencode/src/skill-evolution/review-agent.ts
+++ b/packages/opencode/src/skill-evolution/review-agent.ts
@@ -5,6 +5,7 @@ import { Instance } from "@/project/instance"
 import { Spawner } from "./spawner"
 import { SKILL_REVIEW_PROMPT_BASE } from "./constants"
 import { Filesystem } from "@/util/filesystem"
+import { ConfigMarkdown } from "@/config/markdown"
 import { Log } from "@/util/log"
 import { Database } from "@/storage/db"
 import { ProjectIdentity } from "@/project/identity"
@@ -96,7 +97,25 @@ export interface MessageSnapshot {
 }
 
 /**
+ * Char caps for tool input/output rendered into the review history. The reviewer
+ * only needs to see that a step ran and roughly what came back (so the B/VERIFIED
+ * gate has evidence to point at) — not the full payload. Stored outputs are
+ * already ≤50KB (normal-conversation Truncate.output); we tighten further here.
+ * See REVIEW_CONTEXT_DESIGN.md D3/Q1.
+ */
+const MAX_TOOL_OUTPUT_CHARS = 300
+const MAX_TOOL_INPUT_CHARS = 200
+
+/** Pure char truncation: keep the head, mark how much was dropped. */
+function truncateForReview(s: string, max: number): string {
+  if (s.length <= max) return s
+  return s.slice(0, max) + `…[truncated ${s.length - max} chars]`
+}
+
+/**
  * Serialize a conversation history snapshot into an XML block for the review prompt.
+ * Tool calls carry their (truncated) input + output so the B/VERIFIED gate can
+ * point at a real successful output — see REVIEW_CONTEXT_DESIGN.md D2.
  */
 export function serializeHistory(messages: ReadonlyArray<MessageSnapshot>): string {
   const lines: string[] = ["<conversation_history>"]
@@ -106,7 +125,22 @@ export function serializeHistory(messages: ReadonlyArray<MessageSnapshot>): stri
       if (part.type === "text" && part.text) {
         lines.push(`    <text>${escapeXml(part.text)}</text>`)
       } else if (part.type === "tool") {
-        lines.push(`    <tool_call name="${escapeXml(part.tool ?? "")}" id="${part.callID ?? ""}"/>`)
+        const state = part.state as { input?: unknown; output?: unknown } | undefined
+        const hasInput = state?.input !== undefined && state.input !== null
+        const inputStr = hasInput
+          ? truncateForReview(JSON.stringify(state!.input), MAX_TOOL_INPUT_CHARS)
+          : ""
+        const outputStr =
+          typeof state?.output === "string" ? truncateForReview(state.output, MAX_TOOL_OUTPUT_CHARS) : ""
+        const open = `    <tool_call name="${escapeXml(part.tool ?? "")}" id="${part.callID ?? ""}"`
+        if (!inputStr && !outputStr) {
+          lines.push(`${open}/>`)
+        } else {
+          lines.push(`${open}>`)
+          if (inputStr) lines.push(`      <input>${escapeXml(inputStr)}</input>`)
+          if (outputStr) lines.push(`      <output>${escapeXml(outputStr)}</output>`)
+          lines.push(`    </tool_call>`)
+        }
       }
     }
     lines.push("  </message>")
@@ -146,6 +180,57 @@ async function collectCategories(folderName: string): Promise<string[]> {
   return Array.from(categories)
 }
 
+/** One existing skill's identity, for the "what already exists" inventory. */
+export interface SkillSummary {
+  name: string
+  description: string
+  category?: string
+}
+
+/**
+ * Read the CURRENT sub-project's evolved skills (name + description + category
+ * from each SKILL.md). Sub-project scope only — not global, not shared — so the
+ * reviewer compares against the skills it could actually duplicate. See
+ * REVIEW_CONTEXT_DESIGN.md D5. Uses the project's canonical frontmatter parser
+ * (`ConfigMarkdown.parse`, gray-matter) so only the `---` block is read — never
+ * stray `key:` lines in the markdown body. best-effort: skills whose SKILL.md is
+ * unreadable or has invalid frontmatter are skipped.
+ */
+export async function collectSkillInventory(folderName: string): Promise<SkillSummary[]> {
+  const dir = Spawner.skillEvolutionDir(folderName)
+  const out: SkillSummary[] = []
+  const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => [])
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    try {
+      const md = await ConfigMarkdown.parse(path.join(dir, entry.name, "SKILL.md"))
+      const data = (md.data ?? {}) as { description?: unknown; category?: unknown }
+      out.push({
+        name: entry.name,
+        description: typeof data.description === "string" ? data.description : "",
+        category: typeof data.category === "string" ? data.category : undefined,
+      })
+    } catch {
+      // Skip skills whose SKILL.md is unreadable or has invalid frontmatter
+    }
+  }
+  return out
+}
+
+/** Render the sub-project skill inventory block for the review prompt. */
+export function serializeSkillInventory(skills: ReadonlyArray<SkillSummary>): string {
+  if (skills.length === 0) return "Existing skills in this project: (none yet)"
+  const lines = [
+    "Existing skills in this project (prefer EDITING one of these over creating a near-duplicate):",
+  ]
+  for (const s of skills) {
+    const cat = s.category ? ` [${s.category}]` : ""
+    const desc = s.description ? `: ${s.description}` : ""
+    lines.push(`  - ${s.name}${cat}${desc}`)
+  }
+  return lines.join("\n")
+}
+
 /**
  * Build the full review prompt for the background agent.
  */
@@ -159,7 +244,8 @@ export async function buildReviewPrompt(
     categories.length > 0
       ? categories.map((c) => `  - ${c}`).join("\n") + "\n"
       : "  (no existing categories yet)\n"
-  const sections = [serializeHistory(messages), "", SKILL_REVIEW_PROMPT_BASE + categoryHint]
+  const inventoryBlock = serializeSkillInventory(await collectSkillInventory(folderName))
+  const sections = [serializeHistory(messages), "", SKILL_REVIEW_PROMPT_BASE + categoryHint, "", inventoryBlock]
   const warning = buildEvolutionLockWarning(evolutionDisabledSkillNames)
   if (warning) sections.push("", warning)
   return sections.join("\n")
@@ -225,6 +311,9 @@ export async function spawnReview(input: {
         text: "text" in p ? (p as any).text : undefined,
         tool: "tool" in p ? (p as any).tool : undefined,
         callID: "callID" in p ? (p as any).callID : undefined,
+        // Carry tool input/output so serializeHistory can show the reviewer real
+        // evidence (truncated). See REVIEW_CONTEXT_DESIGN.md D2.
+        state: "state" in p ? (p as any).state : undefined,
       })),
     }))
 

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -66,7 +66,7 @@ export const SkillTool = Tool.define("skill", async (ctx) => {
 
       // Curator: record that this skill was loaded. Best-effort, in-scope-only,
       // never throws — must not affect skill loading.
-      await Usage.bumpUse(Spawner.skillEvolutionRoot(), skill.location)
+      await Usage.bumpUse(Spawner.skillEvolutionRoot(), skill.location, ctx.sessionID)
 
       const dir = path.dirname(skill.location)
       const base = pathToFileURL(dir).href


### PR DESCRIPTION
### Issue for this PR

Closes #1062

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

两个独立的 skill-evolution 增强：

**1. `recent_uses`（提交 `028d467`）**：curator 账本里每个 skill 加一个 `recent_uses: UseEvent[]`，记最近 50 次使用坐标 `{ session_id, at }`。改动集中在 `bumpUse`：原来只 `use_count +1` + 刷新 `last_used_at`，现在再追加一条事件、超 50 条从头部截断。配合账本键里已有的 `projectId` 凑齐「项目+会话+时间」，给后续回溯评估备索引。**只记不判**——不改归档、不删东西。每次 skill 调用本来就落会话 DB，`recent_uses` 只是 curator 自带的近期窗口缓存，故允许和 DB 轻微不一致。改动全增量、向后兼容（`load` 给旧账本缺字段补 `[]`、`bumpUse` 第三参 `sessionId?` 可选）。

**2. 评审 agent 补上下文（提交 `f50a5f1`）**：后台评审 agent 原来看不到当前子项目已有 skill、也看不到对话里工具调用的输入输出，导致无法「优先改已有 skill」、也没证据过 VERIFIED 关。新增 `collectSkillInventory`/`serializeSkillInventory`（经 `ConfigMarkdown.parse` 读 frontmatter），把已有 skill 清单带引导语接到 prompt；`serializeHistory` 渲染每次工具调用的输入/输出并截断（200/300 字符）防膨胀。

> 说明：本 PR 含两个 skill-evolution 增强，同属一条改进线，故合并提交。

### How did you verify your code works?

`cd packages/opencode && bun test src/skill-evolution/curator/usage.test.ts src/skill-evolution/review-agent.test.ts` → 45 pass / 0 fail。recent_uses 覆盖写→读接力、滑动窗口截断、同会话多次、无 sessionId、旧账本兜底；评审 agent 覆盖清单收集/渲染、工具输入输出渲染与截断。

### Screenshots / recordings

_非 UI 改动，无截图。_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
