### PR TITLE
fix(provider): add Alibaba GLM-5.2 metadata

### DIFF
--- a/packages/opencode/src/provider/models-local.ts
+++ b/packages/opencode/src/provider/models-local.ts
@@ -35,7 +35,7 @@ export const additions = {
   "tatu-maas": MaaS.provider,
 } satisfies Record<string, ModelsDev.Provider>
 
-function glm(api: string) {
+function glm(api: string, reason: string) {
   return {
     id: "glm-5.2",
     name: "GLM-5.2",
@@ -62,8 +62,7 @@ function glm(api: string) {
     },
     options: {},
     meta: {
-      reason:
-        "models.dev is missing Alibaba Bailian GLM-5.2 metadata; Alibaba documents OpenAI-compatible chat completions with 1M context",
+      reason,
       verified_at: "2026-06-23",
     },
   } satisfies Insert
@@ -71,10 +70,22 @@ function glm(api: string) {
 
 export const inserts = {
   alibaba: {
-    "glm-5.2": glm("https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
+    "glm-5.2": glm(
+      "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+      "models.dev is missing Alibaba Bailian GLM-5.2 metadata; Alibaba documents OpenAI-compatible chat completions with 1M context",
+    ),
   },
   "alibaba-cn": {
-    "glm-5.2": glm("https://dashscope.aliyuncs.com/compatible-mode/v1"),
+    "glm-5.2": glm(
+      "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      "models.dev is missing Alibaba Bailian GLM-5.2 metadata; Alibaba documents OpenAI-compatible chat completions with 1M context",
+    ),
+  },
+  aihubmix: {
+    "glm-5.2": glm(
+      "https://aihubmix.com/v1",
+      "models.dev is missing aihubmix GLM-5.2 metadata; aihubmix exposes it through OpenAI-compatible chat completions",
+    ),
   },
 } satisfies Inserts
 

--- a/packages/opencode/src/provider/models-local.ts
+++ b/packages/opencode/src/provider/models-local.ts
@@ -22,13 +22,61 @@ type Patch = {
   meta?: Note
 }
 
+type Insert = ModelsDev.Model & {
+  meta?: Note
+}
+
 export type Overrides = Record<string, Patch>
+export type Inserts = Record<string, Record<string, Insert>>
 
 const log = Log.create({ service: "models.dev.local" })
 
 export const additions = {
   "tatu-maas": MaaS.provider,
 } satisfies Record<string, ModelsDev.Provider>
+
+function glm(api: string) {
+  return {
+    id: "glm-5.2",
+    name: "GLM-5.2",
+    family: "glm",
+    attachment: false,
+    reasoning: true,
+    tool_call: true,
+    interleaved: {
+      field: "reasoning_content",
+    },
+    temperature: true,
+    release_date: "",
+    modalities: {
+      input: ["text"],
+      output: ["text"],
+    },
+    provider: {
+      npm: "@ai-sdk/openai-compatible",
+      api,
+    },
+    limit: {
+      context: 1_000_000,
+      output: 128_000,
+    },
+    options: {},
+    meta: {
+      reason:
+        "models.dev is missing Alibaba Bailian GLM-5.2 metadata; Alibaba documents OpenAI-compatible chat completions with 1M context",
+      verified_at: "2026-06-23",
+    },
+  } satisfies Insert
+}
+
+export const inserts = {
+  alibaba: {
+    "glm-5.2": glm("https://dashscope-intl.aliyuncs.com/compatible-mode/v1"),
+  },
+  "alibaba-cn": {
+    "glm-5.2": glm("https://dashscope.aliyuncs.com/compatible-mode/v1"),
+  },
+} satisfies Inserts
 
 export const overrides = {
   opencode: {
@@ -80,10 +128,17 @@ function invalid(msg: string, strict: boolean) {
   log.warn(msg)
 }
 
+function clean(model: Insert): ModelsDev.Model {
+  const result = { ...model }
+  delete result.meta
+  return result
+}
+
 export function apply(
   data: Record<string, ModelsDev.Provider>,
   opts?: {
     additions?: Record<string, ModelsDev.Provider>
+    inserts?: Inserts
     overrides?: Overrides
     strict?: boolean
   },
@@ -95,6 +150,30 @@ export function apply(
     if (provider.id !== id) fail(`addition ${id} has mismatched id ${provider.id}`)
     if (result[id]) fail(`addition ${id} already exists`)
     result[id] = provider
+  }
+
+  for (const [id, map] of Object.entries<Record<string, Insert>>(opts?.inserts ?? inserts)) {
+    const provider = result[id]
+    if (!provider) {
+      invalid(`insert provider ${id} does not exist`, strict)
+      continue
+    }
+
+    const models = { ...provider.models }
+    for (const [mid, model] of Object.entries<Insert>(map)) {
+      if (model.id !== mid) fail(`insert model ${id}/${mid} has mismatched id ${model.id}`)
+      if (models[mid]) {
+        invalid(`insert model ${id}/${mid} already exists`, strict)
+        continue
+      }
+
+      models[mid] = clean(model)
+    }
+
+    result[id] = {
+      ...provider,
+      models,
+    }
   }
 
   for (const [id, patch] of Object.entries(opts?.overrides ?? overrides)) {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -51,6 +51,7 @@ test("models.dev local overlay applies provider additions", () => {
       additions: {
         test: provider,
       },
+      inserts: {},
       overrides: {},
       strict: true,
     },
@@ -68,6 +69,7 @@ test("models.dev local overlay rejects partial addition conflicts", () => {
         additions: {
           test: provider,
         },
+        inserts: {},
         overrides: {},
         strict: true,
       },
@@ -82,6 +84,7 @@ test("models.dev local overlay overrides only selected model metadata", () => {
     },
     {
       additions: {},
+      inserts: {},
       overrides: {
         test: {
           models: {
@@ -106,6 +109,68 @@ test("models.dev local overlay overrides only selected model metadata", () => {
   expect(data.test.models.model.provider?.api).toBe("https://api.example.com/v1")
   expect(data.test.models.other.provider?.npm).toBe("@ai-sdk/openai-compatible")
   expect("meta" in data.test.models.model).toBe(false)
+})
+
+test("models.dev local overlay inserts Alibaba GLM-5.2 models", () => {
+  const data = apply(
+    {
+      alibaba: {
+        ...provider,
+        id: "alibaba",
+        api: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+        models: {},
+      },
+      "alibaba-cn": {
+        ...provider,
+        id: "alibaba-cn",
+        api: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        models: {},
+      },
+    },
+    {
+      additions: {},
+      overrides: {},
+      strict: true,
+    },
+  )
+
+  const intl = data.alibaba.models["glm-5.2"]
+  const cn = data["alibaba-cn"].models["glm-5.2"]
+
+  expect(intl.limit.context).toBe(1_000_000)
+  expect(intl.limit.output).toBe(128_000)
+  expect(intl.provider?.npm).toBe("@ai-sdk/openai-compatible")
+  expect(intl.provider?.api).toBe("https://dashscope-intl.aliyuncs.com/compatible-mode/v1")
+  expect("meta" in intl).toBe(false)
+
+  expect(cn.limit.context).toBe(1_000_000)
+  expect(cn.limit.output).toBe(128_000)
+  expect(cn.provider?.npm).toBe("@ai-sdk/openai-compatible")
+  expect(cn.provider?.api).toBe("https://dashscope.aliyuncs.com/compatible-mode/v1")
+  expect("meta" in cn).toBe(false)
+
+  const info = Provider.fromModelsDevProvider(data["alibaba-cn"])
+  expect(info.models["glm-5.2"].api.npm).toBe("@ai-sdk/openai-compatible")
+  expect(info.models["glm-5.2"].api.url).toBe("https://dashscope.aliyuncs.com/compatible-mode/v1")
+  expect(info.models["glm-5.2"].capabilities.interleaved).toEqual({ field: "reasoning_content" })
+})
+
+test("models.dev local overlay rejects duplicate model insertions", () => {
+  expect(() =>
+    apply(
+      { test: provider },
+      {
+        additions: {},
+        inserts: {
+          test: {
+            model,
+          },
+        },
+        overrides: {},
+        strict: true,
+      },
+    ),
+  ).toThrow("insert model test/model already exists")
 })
 
 test("models.dev local overlay pins aihubmix gpt-5.5 to responses provider", () => {
@@ -134,6 +199,7 @@ test("models.dev local overlay pins aihubmix gpt-5.5 to responses provider", () 
     },
     {
       additions: {},
+      inserts: {},
       overrides: {
         aihubmix: {
           models: {
@@ -175,6 +241,7 @@ test("aihubmix gpt-5.5 model override wins over provider package override", () =
     },
     {
       additions: {},
+      inserts: {},
       overrides: {
         aihubmix: {
           models: {
@@ -202,6 +269,7 @@ test("models.dev local overlay rejects missing provider override", () => {
       {},
       {
         additions: {},
+        inserts: {},
         overrides: {
           missing: {
             models: {
@@ -225,6 +293,7 @@ test("models.dev local overlay rejects missing model override", () => {
       { test: provider },
       {
         additions: {},
+        inserts: {},
         overrides: {
           test: {
             models: {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -111,7 +111,7 @@ test("models.dev local overlay overrides only selected model metadata", () => {
   expect("meta" in data.test.models.model).toBe(false)
 })
 
-test("models.dev local overlay inserts Alibaba GLM-5.2 models", () => {
+test("models.dev local overlay inserts GLM-5.2 models", () => {
   const data = apply(
     {
       alibaba: {
@@ -126,6 +126,12 @@ test("models.dev local overlay inserts Alibaba GLM-5.2 models", () => {
         api: "https://dashscope.aliyuncs.com/compatible-mode/v1",
         models: {},
       },
+      aihubmix: {
+        ...provider,
+        id: "aihubmix",
+        api: "https://aihubmix.com/v1",
+        models: {},
+      },
     },
     {
       additions: {},
@@ -136,6 +142,7 @@ test("models.dev local overlay inserts Alibaba GLM-5.2 models", () => {
 
   const intl = data.alibaba.models["glm-5.2"]
   const cn = data["alibaba-cn"].models["glm-5.2"]
+  const hub = data.aihubmix.models["glm-5.2"]
 
   expect(intl.limit.context).toBe(1_000_000)
   expect(intl.limit.output).toBe(128_000)
@@ -149,10 +156,20 @@ test("models.dev local overlay inserts Alibaba GLM-5.2 models", () => {
   expect(cn.provider?.api).toBe("https://dashscope.aliyuncs.com/compatible-mode/v1")
   expect("meta" in cn).toBe(false)
 
+  expect(hub.limit.context).toBe(1_000_000)
+  expect(hub.limit.output).toBe(128_000)
+  expect(hub.provider?.npm).toBe("@ai-sdk/openai-compatible")
+  expect(hub.provider?.api).toBe("https://aihubmix.com/v1")
+  expect("meta" in hub).toBe(false)
+
   const info = Provider.fromModelsDevProvider(data["alibaba-cn"])
   expect(info.models["glm-5.2"].api.npm).toBe("@ai-sdk/openai-compatible")
   expect(info.models["glm-5.2"].api.url).toBe("https://dashscope.aliyuncs.com/compatible-mode/v1")
   expect(info.models["glm-5.2"].capabilities.interleaved).toEqual({ field: "reasoning_content" })
+
+  const mix = Provider.fromModelsDevProvider(data.aihubmix)
+  expect(mix.models["glm-5.2"].api.npm).toBe("@ai-sdk/openai-compatible")
+  expect(mix.models["glm-5.2"].api.url).toBe("https://aihubmix.com/v1")
 })
 
 test("models.dev local overlay rejects duplicate model insertions", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #1068

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a local models.dev model insertion path and uses it to provide missing GLM-5.2 metadata for these providers:

- `alibaba/glm-5.2`
- `alibaba-cn/glm-5.2`
- `aihubmix/glm-5.2`

The metadata pins OpenAI-compatible Chat Completions routing, provider-specific base URLs, 1M context, and 128K max output. Runtime-only metadata strips audit `meta` fields before provider conversion.

### How did you verify your code works?

- `git diff --cached --check`
- `cd packages/opencode && bun test test/provider/provider.test.ts`
- `cd packages/opencode && bun test test/provider/transform.test.ts --timeout 30000`
- `cd packages/opencode && bun typecheck`
- push hook: `bun turbo typecheck`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
