### PR TITLE
fix(session): cap GLM output token budget

### DIFF
--- a/packages/opencode/src/provider/models-local.ts
+++ b/packages/opencode/src/provider/models-local.ts
@@ -58,9 +58,12 @@ function glm(api: string, reason: string) {
     },
     limit: {
       context: 1_000_000,
-      output: 128_000,
+      input: 868_928,
+      output: 131_072,
     },
-    options: {},
+    options: {
+      maxOutputTokens: 65_536,
+    },
     meta: {
       reason,
       verified_at: "2026-06-23",

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1517,10 +1517,12 @@ export namespace Provider {
 
     const provider = s.providers[model.providerID]
     const sdk = await getSDK(model)
+    const opts = { ...provider.options, ...model.options }
+    delete opts.maxOutputTokens
 
     try {
       const language = s.modelLoaders[model.providerID]
-        ? await s.modelLoaders[model.providerID](sdk, model.api.id, { ...provider.options, ...model.options })
+        ? await s.modelLoaders[model.providerID](sdk, model.api.id, opts)
         : sdk.languageModel(model.api.id)
       s.models.set(key, language)
       return language

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1159,7 +1159,8 @@ export namespace ProviderTransform {
     options: Record<string, unknown>,
     cfg?: Record<string, unknown>,
   ) {
-    const opts = chat(model, cfg) ? scrub(options) : options
+    const opts = { ...(chat(model, cfg) ? scrub(options) : options) }
+    delete opts.maxOutputTokens
 
     if (model.api.npm === "@ai-sdk/gateway") {
       // Gateway providerOptions are split across two namespaces:
@@ -1200,8 +1201,10 @@ export namespace ProviderTransform {
     return { [key]: opts }
   }
 
-  export function maxOutputTokens(model: Provider.Model): number {
-    return Math.min(model.limit.output, OUTPUT_TOKEN_MAX) || OUTPUT_TOKEN_MAX
+  export function maxOutputTokens(model: Provider.Model, options?: Record<string, unknown>): number {
+    const cap = options?.maxOutputTokens
+    const max = typeof cap === "number" && Number.isFinite(cap) && cap > 0 ? Math.floor(cap) : OUTPUT_TOKEN_MAX
+    return Math.min(model.limit.output, max) || max
   }
 
   export function schema(model: Provider.Model, schema: JSONSchema.BaseSchema | JSONSchema7): JSONSchema7 {

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -29,8 +29,6 @@ export namespace SessionCompaction {
     ),
   }
 
-  const COMPACTION_BUFFER = 20_000
-
   export async function isOverflow(input: { tokens: MessageV2.Assistant["tokens"]; model: Provider.Model }) {
     const config = await Config.get()
     if (config.compaction?.auto === false) return false
@@ -42,10 +40,8 @@ export namespace SessionCompaction {
       input.tokens.input + input.tokens.output + input.tokens.cache.read + input.tokens.cache.write
 
     const reserved =
-      config.compaction?.reserved ?? Math.min(COMPACTION_BUFFER, ProviderTransform.maxOutputTokens(input.model))
-    const usable = input.model.limit.input
-      ? input.model.limit.input - reserved
-      : context - ProviderTransform.maxOutputTokens(input.model)
+      config.compaction?.reserved ?? ProviderTransform.maxOutputTokens(input.model, input.model.options)
+    const usable = (input.model.limit.input ?? context) - reserved
     return count >= usable
   }
 

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -240,7 +240,7 @@ export namespace LLM {
     const maxOutputTokens =
       isOpenaiOauth || provider.id.includes("github-copilot")
         ? undefined
-        : ProviderTransform.maxOutputTokens(input.model)
+        : ProviderTransform.maxOutputTokens(input.model, params.options)
 
     const tools = await resolveTools(input)
 

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -145,19 +145,25 @@ test("models.dev local overlay inserts GLM-5.2 models", () => {
   const hub = data.aihubmix.models["glm-5.2"]
 
   expect(intl.limit.context).toBe(1_000_000)
-  expect(intl.limit.output).toBe(128_000)
+  expect(intl.limit.input).toBe(868_928)
+  expect(intl.limit.output).toBe(131_072)
+  expect(intl.options?.maxOutputTokens).toBe(65_536)
   expect(intl.provider?.npm).toBe("@ai-sdk/openai-compatible")
   expect(intl.provider?.api).toBe("https://dashscope-intl.aliyuncs.com/compatible-mode/v1")
   expect("meta" in intl).toBe(false)
 
   expect(cn.limit.context).toBe(1_000_000)
-  expect(cn.limit.output).toBe(128_000)
+  expect(cn.limit.input).toBe(868_928)
+  expect(cn.limit.output).toBe(131_072)
+  expect(cn.options?.maxOutputTokens).toBe(65_536)
   expect(cn.provider?.npm).toBe("@ai-sdk/openai-compatible")
   expect(cn.provider?.api).toBe("https://dashscope.aliyuncs.com/compatible-mode/v1")
   expect("meta" in cn).toBe(false)
 
   expect(hub.limit.context).toBe(1_000_000)
-  expect(hub.limit.output).toBe(128_000)
+  expect(hub.limit.input).toBe(868_928)
+  expect(hub.limit.output).toBe(131_072)
+  expect(hub.options?.maxOutputTokens).toBe(65_536)
   expect(hub.provider?.npm).toBe("@ai-sdk/openai-compatible")
   expect(hub.provider?.api).toBe("https://aihubmix.com/v1")
   expect("meta" in hub).toBe(false)

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -793,6 +793,60 @@ describe("ProviderTransform.providerOptions", () => {
       openrouter: { reasoning: { effort: "high" } },
     })
   })
+
+  test("strips maxOutputTokens from provider options", () => {
+    const model = createModel({
+      api: {
+        id: "test-model",
+        url: "https://api.test.com",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+
+    expect(ProviderTransform.providerOptions(model, { maxOutputTokens: 65_536, reasoningEffort: "high" })).toEqual({
+      test: { reasoningEffort: "high" },
+    })
+  })
+})
+
+describe("ProviderTransform.maxOutputTokens", () => {
+  const model = {
+    id: "test/model",
+    providerID: "test",
+    api: { id: "model", url: "https://test.com", npm: "@ai-sdk/openai-compatible" },
+    name: "Test Model",
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: false,
+      toolcall: true,
+      input: { text: true, audio: false, image: false, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+    limit: { context: 1_000_000, input: 868_928, output: 131_072 },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2026-06-23",
+  } as Provider.Model
+
+  test("uses default request cap without options", () => {
+    expect(ProviderTransform.maxOutputTokens(model)).toBe(OUTPUT_TOKEN_MAX)
+  })
+
+  test("uses explicit request cap", () => {
+    expect(ProviderTransform.maxOutputTokens(model, { maxOutputTokens: 65_536 })).toBe(65_536)
+  })
+
+  test("ignores invalid request cap", () => {
+    expect(ProviderTransform.maxOutputTokens(model, { maxOutputTokens: -1 })).toBe(OUTPUT_TOKEN_MAX)
+  })
+
+  test("does not exceed model output limit", () => {
+    expect(ProviderTransform.maxOutputTokens(model, { maxOutputTokens: 262_144 })).toBe(131_072)
+  })
 })
 
 describe("ProviderTransform.schema - gemini array items", () => {

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -16,6 +16,7 @@ function createModel(opts: {
   input?: number
   cost?: Provider.Model["cost"]
   npm?: string
+  options?: Provider.Model["options"]
 }): Provider.Model {
   return {
     id: "test-model",
@@ -36,7 +37,7 @@ function createModel(opts: {
       output: { text: true, image: false, audio: false, video: false },
     },
     api: { npm: opts.npm ?? "@ai-sdk/anthropic" },
-    options: {},
+    options: opts.options ?? {},
   } as Provider.Model
 }
 
@@ -113,45 +114,23 @@ describe("session.compaction.isOverflow", () => {
     })
   })
 
-  // ─── Bug reproduction tests ───────────────────────────────────────────
-  // These tests demonstrate that when limit.input is set, isOverflow()
-  // does not subtract any headroom for the next model response. This means
-  // compaction only triggers AFTER we've already consumed the full input
-  // budget, leaving zero room for the next API call's output tokens.
-  //
-  // Compare: without limit.input, usable = context - output (reserves space).
-  // With limit.input, usable = limit.input (reserves nothing).
-  //
-  // Related issues: #10634, #8089, #11086, #12621
-  // Open PRs: #6875, #12924
+  // Regression coverage for models that expose a separate input cap. The
+  // compaction boundary must reserve the same output budget used for requests.
+  // Related issues: #10634, #8089, #11086, #12621, #32656
 
-  test("BUG: no headroom when limit.input is set — compaction should trigger near boundary but does not", async () => {
+  test("reserves headroom when limit.input is set", async () => {
     await using tmp = await tmpdir()
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        // Simulate Claude with prompt caching: input limit = 200K, output limit = 32K
         const model = createModel({ context: 200_000, input: 200_000, output: 32_000 })
-
-        // We've used 198K tokens total. Only 2K under the input limit.
-        // On the next turn, the full conversation (198K) becomes input,
-        // plus the model needs room to generate output — this WILL overflow.
         const tokens = { input: 180_000, output: 15_000, reasoning: 0, cache: { read: 3_000, write: 0 } }
-        // count = 180K + 3K + 15K = 198K
-        // usable = limit.input = 200K (no output subtracted!)
-        // 198K > 200K = false → no compaction triggered
-
-        // WITHOUT limit.input: usable = 200K - 32K = 168K, and 198K > 168K = true ✓
-        // WITH limit.input: usable = 200K, and 198K > 200K = false ✗
-
-        // With 198K used and only 2K headroom, the next turn will overflow.
-        // Compaction MUST trigger here.
         expect(await SessionCompaction.isOverflow({ tokens, model })).toBe(true)
       },
     })
   })
 
-  test("BUG: without limit.input, same token count correctly triggers compaction", async () => {
+  test("without limit.input, same token count correctly triggers compaction", async () => {
     await using tmp = await tmpdir()
     await Instance.provide({
       directory: tmp.path,
@@ -171,24 +150,58 @@ describe("session.compaction.isOverflow", () => {
     })
   })
 
-  test("BUG: asymmetry — limit.input model allows 30K more usage before compaction than equivalent model without it", async () => {
+  test("uses the full output reservation for limit.input models", async () => {
     await using tmp = await tmpdir()
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
-        // Two models with identical context/output limits, differing only in limit.input
         const withInputLimit = createModel({ context: 200_000, input: 200_000, output: 32_000 })
         const withoutInputLimit = createModel({ context: 200_000, output: 32_000 })
-
-        // 170K total tokens — well above context-output (168K) but below input limit (200K)
-        const tokens = { input: 166_000, output: 10_000, reasoning: 0, cache: { read: 5_000, write: 0 } }
+        const tokens = { input: 164_000, output: 10_000, reasoning: 0, cache: { read: 0, write: 0 } }
 
         const withLimit = await SessionCompaction.isOverflow({ tokens, model: withInputLimit })
         const withoutLimit = await SessionCompaction.isOverflow({ tokens, model: withoutInputLimit })
 
-        // Both models have identical real capacity — they should agree:
-        expect(withLimit).toBe(true) // should compact (170K leaves no room for 32K output)
-        expect(withoutLimit).toBe(true) // correctly compacts (170K > 168K)
+        expect(withLimit).toBe(true)
+        expect(withoutLimit).toBe(true)
+      },
+    })
+  })
+
+  test("uses model maxOutputTokens option for the reserved budget", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = createModel({
+          context: 1_000_000,
+          input: 868_928,
+          output: 131_072,
+          options: { maxOutputTokens: 65_536 },
+        })
+        const tokens = { input: 800_000, output: 10_000, reasoning: 0, cache: { read: 0, write: 0 } }
+        expect(await SessionCompaction.isOverflow({ tokens, model })).toBe(true)
+      },
+    })
+  })
+
+  test("respects configured reserved budget without input limit", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            compaction: { reserved: 10_000 },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = createModel({ context: 100_000, output: 32_000 })
+        const tokens = { input: 85_000, output: 4_000, reasoning: 0, cache: { read: 0, write: 0 } }
+        expect(await SessionCompaction.isOverflow({ tokens, model })).toBe(false)
       },
     })
   })

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -570,6 +570,84 @@ describe("session.llm.stream", () => {
     })
   })
 
+  test("uses model maxOutputTokens option as request cap", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "alibaba-cn"
+    const modelID = "glm-5.2"
+
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = await Provider.getModel(ProviderID.make(providerID), ModelID.make(modelID))
+        const sessionID = SessionID.make("session-glm-52")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+        const user = {
+          id: MessageID.make("user-glm-52"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make(providerID), modelID: model.id },
+        } satisfies MessageV2.User
+
+        const stream = await LLM.stream({
+          user,
+          sessionID,
+          model,
+          agent,
+          system: ["You are a helpful assistant."],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        for await (const _ of stream.fullStream) {
+        }
+
+        const capture = await request
+        expect(capture.body.max_tokens).toBe(65_536)
+        expect(capture.body.maxOutputTokens).toBeUndefined()
+      },
+    })
+  })
+
   test("strips reasoning summary options from chat completions requests", async () => {
     const server = state.server
     if (!server) {


### PR DESCRIPTION
### Issue for this PR

Closes #1072

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Caps GLM-5.2 request output tokens at 65,536 while preserving its documented 1M context, 868,928 input, and 131,072 output limits.

The PR also prevents the internal `maxOutputTokens` option from being forwarded through provider options or model loader options, and updates compaction overflow checks to reserve the same model-level output budget for input-limited models.

### How did you verify your code works?

- `git diff --cached --check`
- `bun typecheck`
- `bun test test/provider/provider.test.ts test/provider/transform.test.ts test/session/compaction.test.ts test/session/llm.test.ts --timeout 30000`
- `git push -u origin fix/glm-output-budget-compaction` ran the repository push hook, including `bun turbo typecheck`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR