### PR TITLE
feat(curator): 相对使用率归档 + 稳定技能身份 + 账本健壮性

### DIFF
--- a/packages/opencode/src/skill-evolution/curator/RELATIVE_USAGE_DESIGN.md
+++ b/packages/opencode/src/skill-evolution/curator/RELATIVE_USAGE_DESIGN.md
@@ -1,0 +1,321 @@
+# Curator 归档判据 — 「相对调用占比 + 出生曝光窗口」设计文档
+
+> 状态：**设计草案 v1**，待团队 / 导师对齐后进入实现（实现走 TDD）。
+> 读者：团队开发者 + 组会评审 + 照本实现的人（含 yolo 沙盒会话——它没有讨论上下文，本文档即唯一说明书）。
+> 出处：2026-06-16 周会，导师否掉「按固定时间归档」，要求改成**按调用占比**判归档（见 `/home/zheng/code/transcribe/2026-06-16/skill归档机制分析-2026-06-16.md` 的红线 R1/R2、军令 M1/M2）。会后与用户对齐：用「出生水位 + 曝光窗口」给新建 skill 一段公平试用期，且**用调用量计、不用天数计**，以免再踩固定时间红线。
+> 关联：本目录 [`CURATOR_DESIGN.md`](./CURATOR_DESIGN.md)（curator 整体设计）、[`SESSION_USAGE_DESIGN.md`](./SESSION_USAGE_DESIGN.md)（`recent_uses` 近期使用坐标，**已实现**）。本文档**只改「归档判据」这一块**——调度（多久跑一次）、孤儿清理、钉住保护、`recent_uses` 记录、归档搬移动作全部沿用，不重述。
+>
+> **基线说明（重要）**：本文档基于当前分支的**真实代码**，已 `git diff upstream/dev..HEAD` 核实——`constants.ts` / `curator.ts` 相对上游**零改动**，归档判据是**最原始的「按日历天数」**（`archiveAfterDays=90` / `staleAfterDays=30`）；`usage.ts` 仅由 [`SESSION_USAGE_DESIGN.md`](./SESSION_USAGE_DESIGN.md) 那个 commit 加了 `recent_uses`。**本分支从未引入过 `idle_scans`（曾有一个改 idle_scans 的 commit 已被完全丢弃，当它不存在）**，故 `SESSION_USAGE_DESIGN.md` 文中残留的 `idle_scans` / `IDLE_SCANS_DESIGN.md` 引用对当前代码无效——本文档替换的是更早的「按日历天数」判据，不涉及 idle_scans。
+
+---
+
+## 目录
+
+- [设计原则](#设计原则)
+- [解决了什么问题](#解决了什么问题)
+- [现状 → 改后](#现状--改后)
+- [对旧文件的修改](#对旧文件的修改)
+- [核心机制详解](#核心机制详解)
+  - [1. 出生水位 born_at_project_total](#1-出生水位-born_at_project_total)
+  - [2. 曝光窗口 + 试用期闸门](#2-曝光窗口--试用期闸门)
+  - [3. 占比判归档](#3-占比判归档)
+- [数值走查（对齐导师的例子）](#数值走查对齐导师的例子)
+- [格式样例](#格式样例)
+- [核心不变量](#核心不变量)
+- [决策记录](#决策记录)
+- [开放问题](#开放问题)
+- [关键文件速查](#关键文件速查)
+- [复用组件核实（实现前必读）](#复用组件核实实现前必读)
+- [命题清单](#命题清单)
+- [测试与红绿里程碑](#测试与红绿里程碑)
+- [范围说明](#范围说明)
+- [用户体验](#用户体验)
+
+---
+
+## 设计原则
+
+1. **判据只看「相对调用量」，绝不看时间**：归档与否，只由"某 skill 的调用占比"决定，不掺任何"几天没用"的口径。这是导师军令 M1（"归档判据不准用固定时间"）的硬约束——连保护新 skill 的"试用期"也用**调用次数**计、不用天数计。
+2. **绝对低占比截断，不是删末位**：占比低于阈值才归档；若所有 skill 占比都在阈值之上，**一个都不归档**（导师军令 M2）。不存在"每轮把当前用得最少的那个删掉"。
+3. **新 skill 有公平试用期**：新建 skill 占比天然≈0，不能一出生就被秒归档。给每个 skill 一段"出生后曝光窗口"，窗口没满之前不判——窗口用调用量度量（原则 1）。
+4. **最小改动、贴现有结构**：只改 [`curator.ts`](./curator.ts)（归档判定段）、[`constants.ts`](./constants.ts)（配置字段）、[`usage.ts`](./usage.ts)（账本加一个字段 + 出生记水位 + 一个求和函数）三个文件；调度、孤儿清理、`recent_uses`、`archiveSkill` 搬移一律复用。
+5. **best-effort、永不挡会话**：账本读不到 / 字段缺失 → 退化成安全默认（老记录当"从一开始就在"处理），绝不让 curator 失败拖垮会话（沿用 `maybeRun` 的 try/catch）。
+
+---
+
+## 解决了什么问题
+
+### 问题 A：现状判据是「按日历天数」，撞导师红线 M1
+
+- **现状（真实代码）**：[`applyAutomaticTransitions`](./curator.ts#L116) 用 `daysSince`（活动锚点到现在多少天，[curator.ts:147-158](./curator.ts#L147)）驱动 `active → stale → archived`：
+  - `daysSince ≥ archiveAfterDays(90)` 且非 archived → 归档；
+  - `daysSince ≥ staleAfterDays(30)` 且 active → 标 `stale`（陈旧）；
+  - `daysSince < staleAfterDays` 且 stale → 复活回 active。
+  - 活动锚点 = `max(last_used_at, SKILL.md 文件 mtime)`。
+- **后果**：本质是"多久没用就归档"，是**固定时间判据**。导师 6/16 明确否掉"归档判据用固定时间"（分析文档 M1 / R1）。
+- **要换成**：按相对调用占比，见[核心机制](#核心机制详解)。
+
+### 问题 B：纯占比会「秒删」新建 skill（须避免）
+
+- 假想现状（若只做"占比 < 阈值就归档"）：刚生成的 skill `use_count = 0`，占比必然 = 0 < 任意阈值 → 下一次扫描立刻归档，哪怕它 5 分钟前才被造出来。
+- 后果：违背"给新 skill 机会"，易误杀 AI 刚进化出的好 skill。对应分析文档 Q3。
+- 解法：见[核心机制 2](#2-曝光窗口--试用期闸门)的"出生曝光窗口"。
+
+### 问题 C：全局分母会「稀释」闲置项目里的好 skill（须避免）
+
+- 若分母用**全局**总数：项目 A 闲置、项目 B/C 在猛跑 → 全局总数被 B/C 顶飞，A 里 skill X 的 `use_count` 冻住 → X 占比一路缩水到归档。
+- 后果：X 一点不烂，掉占比纯因**它所在项目最近没人碰**；而把分母顶上去的 B/C 调用，X **够都够不着**（skill 项目隔离，[skill/index.ts:151](../../skill/index.ts#L151)）。等于拿它没机会接的调用判它死刑。
+- 解法：分母改成**本项目内**总数（D2）。项目闲置 → 本项目总数也冻住 → X 占比稳住不被稀释。**用户提出的漏洞，本次修掉。**
+
+### 本次【不】解决（留给后续，见[范围说明](#范围说明)）
+
+- 导师的**第二条线**——"被频繁调用但其实是烂 skill（触发太灵敏、叫起来没帮上忙）"，要进会话看 transcript 交 AI 判正负作用（分析文档 I4/Q4）。**这正是 commit 已加的 [`recent_uses`](./SESSION_USAGE_DESIGN.md) 坐标将来要喂的那条线**——与本文档的占比法并列、数据可复用，但本次不实现。
+- **分母含不含用户手动装 / 内置 skill**（见[开放问题 Q2](#开放问题)）——当前数据只统计进化区 skill，扩范围是更大改动，回去与导师确认后另做。
+- 归档**能否自动复活**（分析文档 Q5）——当前 `archiveSkill` 是单向搬移、只能手动 `restoreSkill`，本次维持，见[开放问题 Q4](#开放问题)。
+
+---
+
+## 现状 → 改后
+
+| 维度 | 现状（真实代码） | 改后 |
+|---|---|---|
+| 归档判据 | `daysSince ≥ archiveAfterDays(90)`（按日历天数） | `use_count / 出生后曝光量 < archiveUsageShare(0.001)`（按相对调用占比） |
+| 中间态 `stale` | `daysSince ≥ staleAfterDays(30)` 标陈旧，回暖再复活 | **取消按时间的标陈旧/复活**（导师只要"归档"一档；多一档是 YAGNI） |
+| 新 skill 保护 | 无（靠"刚建 mtime 新、daysSince 小"自然延迟） | **出生曝光窗口**：出生后累计曝光 < `minExposureCalls(1000)` 不判 |
+| 分母（占比的总数） | — | **本项目内**（同 projectId）所有 skill 的 `use_count` 之和（含已 archived 的历史计数） |
+| 配置字段 | `staleAfterDays` / `archiveAfterDays` | `archiveUsageShare` / `minExposureCalls`（删掉前两个） |
+| `recent_uses` / 钉住 / 孤儿清理 / 7 天巡查 | 有 | **保留不动** |
+
+---
+
+## 对旧文件的修改
+
+> 每处标注 **侵入式**（改了旧行为，有回归风险）还是 **增量式**（只加内容、旧路径不变）。
+
+| 旧文件:位置 | 改什么 | 性质 | 依据 |
+|---|---|:---:|---|
+| [`constants.ts :: CuratorConfig`](./constants.ts#L1) | 删 `staleAfterDays`/`archiveAfterDays`，加 `archiveUsageShare`(默认 0.001)、`minExposureCalls`(默认 1000)；同步改 `DEFAULT_CURATOR_CONFIG` | **侵入式**（配置形状变，连带 [`hook.ts:63`](../hook.ts#L63) 的 spread） | D1/D3 |
+| [`usage.ts :: UsageRecord`](./usage.ts#L26) | 新增字段 `born_at_project_total: number`（出生时**本项目**总调用数） | **增量式**（加字段；老记录缺它时 `load` 回填 0，D4） | D2/D4 |
+| [`usage.ts :: emptyRecord`](./usage.ts#L81) / [`seedIfMissing`](./usage.ts#L180) / [`bumpUse`](./usage.ts#L238) | 记录首次创建时，把"当前**本项目**总调用数"算出来写进 `born_at_project_total` | **侵入式**（建记录这一步多算一次本项目总数、多写一个字段） | D2/D5 |
+| [`usage.ts`](./usage.ts) **新增** `projectUseCount(data, projectId)` | 纯函数：把账本里**同一 projectId 下**所有记录的 `use_count` 求和 | **增量式**（新函数） | D6 |
+| [`curator.ts :: applyAutomaticTransitions`](./curator.ts#L116) 判定段 [147-158](./curator.ts#L147) | 删掉 `daysSince` 那套 active/stale/archived/复活；换成"按项目分组先算各项目总数 → 逐 skill 用本项目曝光窗口 → 占比判归档" | **侵入式**（核心判据整段替换） | D1/D3/D7 |
+| [`curator.ts`](./curator.ts) 孤儿清理 [168-183](./curator.ts#L168) / 钉住跳过 / `scanSkills` / 调度 `shouldRunNow` | **保留不动** | 不改 | D7 |
+
+> **不碰**：`usage.ts` 里 `recent_uses` 那套（commit 已实现，服务第二条线）、`archiveSkill`/`restoreSkill` 搬移逻辑、`bumpUse` 的 `recent_uses`/`use_count`/`last_used_at` 现有写入、`resolveScope` 范围过滤。
+
+---
+
+## 核心机制详解
+
+### 1. 出生水位 born_at_project_total
+
+- 账本记录 `UsageRecord`（[usage.ts:26](./usage.ts#L26)，每个 skill 一条，存在 `<root>/curator/usage.json`）新增字段 `born_at_project_total: number`。
+- **写入时机**：这条记录**第一次被创建**时（`seedIfMissing` 种入，或 `bumpUse` 首次 upsert），把"此刻账本里**同一项目**（同 projectId）所有 skill 的 `use_count` 之和"算出来写进 `born_at_project_total`，**之后永不改**。
+- 含义：这条 skill"出生"那一刻，**它所在的那个项目**已累计发生了多少次 skill 调用。例：它出生时本项目已 50000 次 → `born_at_project_total = 50000`。
+- 老记录兼容：早于本功能的记录没有这个字段，`load`（[usage.ts:96](./usage.ts#L96)）回填为 `0`，等价于"从一开始就在"（D4）。
+
+### 2. 曝光窗口 + 试用期闸门
+
+- **出生后曝光量** = `当前本项目总数 − born_at_project_total`。含义：自这条 skill 出生以来，**它所在项目**又发生了多少次 skill 调用——也就是它"本来有多少次机会被选中"。这才是判它的**公平分母**。
+- **为什么是本项目、不是全局**：skill 是**项目隔离**的——进化区 skill 只在自己项目里能被加载（[skill/index.ts:151](../../skill/index.ts#L151)），别的项目的调用它**够都够不着**。若用全局总数当分母，一个项目闲置、别的项目在猛跑，闲置项目里好好的 skill 占比会被别人的调用**稀释到归档**——拿它没机会接的调用判它的死刑。改成本项目后：项目闲置 → 本项目总数也一起冻住 → 它的曝光量/占比稳住不被稀释（D2）。
+- **试用期闸门**：曝光量 `< minExposureCalls`（默认 1000）→ 这条 skill 跳过，不判、不归档。等于给每个新 skill 一段"**本项目**再跑 1000 次调用"的试用期。
+- 关键：窗口用**调用次数**度量、不是天数——所以它不是固定时间判据，不踩 M1（D3）。
+
+### 3. 占比判归档
+
+- 曝光量 `≥ minExposureCalls` 后，算 **占比 = `use_count / 出生后曝光量`**，`< archiveUsageShare`（默认 0.001 = 千分之一）→ 归档。
+- 归档动作复用现有 [`archiveSkill`](./usage.ts#L158)：把 skill 目录**搬到** `<root>/<projectId>/archive/<name>/`、记录标 `archived`——**搬移不删除**，可手动 `restoreSkill` 复活，但自动逻辑不会复活它（搬走后它不在可加载目录里，`use_count` 不再涨）。
+- `pinned`（钉住）记录永远跳过；`archived` 记录不重复判（沿用现有 `state !== "archived"` 守卫）。
+- **本项目总数里包含同项目 archived skill 的历史 `use_count`**：那些调用真实发生过，计入才让本项目总数单调、`born_at_project_total` 锚点一致（D6）。但 archived 记录本身不参与"被判归档"。
+
+---
+
+## 数值走查（对齐导师的例子）
+
+> 设 `archiveUsageShare = 0.001`、`minExposureCalls = 1000`。「当前本项目总数」「曝光量」都只算 skill **自己那个项目**内的调用。
+
+| 场景 | born_at_project_total | 当前本项目总数 | 曝光量 | 它的 use_count | 占比 | 结果 |
+|---|---|---|---|---|---|---|
+| 导师原例：老 skill 没人用 | 0 | 1000 | 1000 | 0 | 0 | **归档** ✅ |
+| 老 skill 偶尔用 | 0 | 1000 | 1000 | 5 | 0.005 | 留 |
+| 5 个 skill 平分（M2 反例） | 0 | 1000 | 1000 | 200 | 0.2 | 留（一个都不删）|
+| 刚出生的新 skill | 50000 | 50300 | 300 | 0 | — | **跳过**（试用期未满）|
+| 新 skill 熬过试用期仍没人用 | 50000 | 51000 | 1000 | 0 | 0 | **归档** |
+| 新 skill 试用期内被用起来 | 50000 | 51000 | 1000 | 7 | 0.007 | 留 |
+| **闲置项目的好 skill**（别的项目在猛跑） | 0 | 1000（本项目冻住） | 1000 | 5 | 0.005 | **留** ✅ |
+
+> 第 4 行是出生窗口相对"纯占比"的增量价值（没窗口它会被秒删）；**末行是本次"单项目分母"的增量价值**：哪怕别的项目又跑了几万次，本项目总数冻在 1000，它的占比稳在 0.005、不被稀释——换全局分母它早被冲到归档。
+
+---
+
+## 格式样例
+
+**改后的账本记录（`usage.json` 里一条；`born_at_project_total` 是本次新增、`recent_uses` 是上个 commit 已有）**：
+
+```json
+{
+  "<projectId>/my-skill": {
+    "projectId": "<projectId>",
+    "name": "my-skill",
+    "location": "/home/.../skill-evolution/<projectId>/skills/my-skill",
+    "use_count": 0,
+    "born_at_project_total": 50000,
+    "last_used_at": null,
+    "recent_uses": [],
+    "state": "active",
+    "pinned": false,
+    "archived_at": null
+  }
+}
+```
+
+**改后的配置（`CuratorConfig`，删两个加两个）**：
+
+```ts
+export interface CuratorConfig {
+  enabled: boolean
+  intervalHours: number        // 保留：多久跑一次扫描（默认 7×24）——调度，非判据
+  archiveUsageShare: number    // 新增：占比阈值，默认 0.001（千分之一）
+  minExposureCalls: number     // 新增：出生后曝光量门槛，默认 1000
+  // 删除：staleAfterDays / archiveAfterDays（按天数的旧判据）
+}
+```
+
+---
+
+## 核心不变量
+
+1. **判据零时间** — 归档与否只由相对调用占比决定；保护新 skill 的窗口也用调用量计，无任何"天数/日历"口径（M1）。
+2. **绝对截断、非删末位** — 占比都在阈值之上时一个都不归档（M2）。
+3. **新 skill 必有窗口** — 出生后曝光量 `< minExposureCalls` 的记录绝不被归档。
+4. **搬移不删除** — 归档只把目录搬进 `archive/`，可手动复活（沿用 `archiveSkill`）。
+5. **best-effort** — 账本损坏 / 字段缺失 → 安全退化，curator 失败不拖垮会话。
+6. **分母按项目隔离** — 占比的分母只算 skill 自己项目（同 projectId）内的调用；别的项目的调用不进它的分母（D2）。
+7. **范围不变** — 仍只统计 / 只归档进化区（`<root>/<projectId>/skills/`）的 skill，不新增扫描面。
+8. **不动 recent_uses** — 上个 commit 的 `recent_uses` 记录逻辑一行不改（它服务第二条线）。
+
+---
+
+## 决策记录
+
+> 本文档**自有编号 D1…，与 CURATOR / SESSION_USAGE 的 D 编号互不干扰**（不接续——因为本文档替换的判据与那些是另一主题）。
+
+- **D1：归档判据换成「相对调用占比」，彻底删掉按日历天数那套（`staleAfterDays`/`archiveAfterDays` + `daysSince` 逻辑）。** 原因：导师军令 M1。占比 = `use_count / 出生后曝光量`，`< archiveUsageShare` 归档。属侵入式（核心判据整段替换 + 配置字段换）。
+- **D2：给每条记录加「出生水位 `born_at_project_total`」，分母用「本项目出生后曝光量 = 当前本项目总数 − 本项目出生水位」——既不算它出生前的调用、也不算别的项目的调用。** 原因：公平分母 = "它真正有机会被选中的次数"，须同时扣掉两类够不着的机会：①**时间维度**——它出生前发生的调用（用 `born_at_project_total` 扣）；②**项目维度**——别的项目的调用（用"本项目"扣，因为 skill 项目隔离、[skill/index.ts:151](../../skill/index.ts#L151) 只加载当前项目进化区）。漏掉②就会出现"闲置项目的好 skill 被别项目的调用稀释到归档"的误杀。**已与用户对齐（用户提出项目维度这一漏洞）。**
+- **D3：新 skill 的"试用期"用调用量计（`minExposureCalls`，默认 1000），不用天数计。** 原因：用天数就又变成固定时间判据、踩 M1。用"出生后世界再跑 1000 次调用"既给了保护，又全程是相对调用量。门槛是超参数（分析文档 I3：导师明说阈值是"你自己调的超参数"）。
+- **D4：老记录缺 `born_at_project_total` → `load` 回填 0（视为"从一开始就在"）。** 原因：向后兼容；`born=0` 时曝光量=本项目总数，公式退化回导师原例，对老 skill 行为一致（见走查表第 1 行）。
+- **D5：出生水位在"记录第一次创建"时写死（`seedIfMissing` / `bumpUse` 首次 upsert）。** 原因：这是唯一能拿到"出生那一刻本项目总数"的时机；之后不改，否则窗口口径会漂。
+- **D6：分母（本项目总数）= 账本里**同一 projectId 下**所有记录（含 `archived`）的 `use_count` 求和；新增纯函数 `projectUseCount(data, projectId)`。** 原因：archived skill 的调用真实发生过，计入才让本项目总数单调、出生水位锚点自洽；但 archived 记录本身不参与被判归档。抽成纯函数便于单测（不碰文件 I/O）。
+- **D7：保留钉住跳过、孤儿清理 / heal、`scanSkills`、7 天调度间隔、`recent_uses`。** 原因：这些与"归档判据"正交，导师没要求动；`intervalHours` 是"多久巡一次"的调度、不是判据，不踩 M1（删了反而每次会话都跑、费性能）。中间态 `stale` 的**按时间标记/复活**取消（D1 连带），但 `stale` 值保留在类型 union 里以兼容老记录 + 给第二条线预留。
+- **D8：本次只做"占比归档"（导师第一条线），不做"灵敏烂 skill"（第二条线 I4）。** 原因：第二条线要进会话读 transcript 交 AI 判正负作用，是另一套机制，且正好复用上个 commit 的 `recent_uses` 坐标，独立设计独立实现，避免一次摊太大又踩 I6（别私自扩方案）。
+
+---
+
+## 开放问题
+
+> 这几条是导师**只给了方向、没给可执行细节**的地方，或须回去对齐口径的。动手前最好先要个准话（对应分析文档 Q1–Q5）。
+
+- **Q1：`archiveUsageShare` / `minExposureCalls` 初值定多少？** 暂定 0.001 / 1000（贴导师举的"1000 次"例子）。导师明说阈值是超参数自己调，但没给初值范围。**待确认初值是否合理。**
+- ~~**Q2-a：分母算全局还是单项目？**~~ **已定：单项目**（同 projectId 内求和，见 D2 / [问题 C](#解决了什么问题)）。理由：skill 项目隔离，全局分母会稀释闲置项目的好 skill。用户拍板。
+- **Q2-b（地基，仍开放）：单项目分母里含不含用户手动装 / 内置 skill？** 当前数据**只统计进化区 skill**——`bumpUse` 虽对每个 skill 加载都调，但 `resolveScope`（[usage.ts:68](./usage.ts#L68)）对不在 `<root>/<projectId>/skills/` 下的 skill 直接 no-op，所以 `~/.claude/skills` 下手装的、内置的都不计。导师说"包含其它 skill"若指"连手装/内置也进分母"，需先扩统计范围（改 `resolveScope` 口径 + 落盘位置），是更大改动。**须回去与导师确认。**
+- **Q3：试用期闸门用「出生后曝光量」对不对，还是用别的口径？** 备选：①出生后本项目曝光量（本文方案）；②干脆"本项目总数 ≥ 某固定值才开始判"（更糙，老/新 skill 不分开）。本文选①。**待确认。**
+- **Q4：归档是「硬搬走、只能手动复活」还是「软降权、自动可复活」？** 当前 `archiveSkill` 是单向搬移，自动逻辑不复活。会上 SPEAKER_06 提过"给权重、按权重抽取、留复活机会"，导师未明确采纳或否决。**须确认（分析文档 Q5）。**
+- **Q5：要不要保留一个中间告警态（类似旧 `stale`），还是直接 active→archived？** 本文按 KISS 直接两态。若导师想要"先警告再归档"，再加。**待定。**
+
+---
+
+## 关键文件速查
+
+| 文件 | 作用 | 性质 |
+|---|---|:---:|
+| [`curator.ts`](./curator.ts) | `applyAutomaticTransitions` 纯逻辑归档扫描（本次改判定段 147-158，保留调度/孤儿清理） | ⚠️ 侵入改 |
+| [`usage.ts`](./usage.ts) | `UsageRecord` 加 `born_at_project_total` + 出生记水位 + 新增 `projectUseCount`；`recent_uses` 不碰 | ⚠️ 增量+侵入 |
+| [`constants.ts`](./constants.ts) | `CuratorConfig` / `DEFAULT_CURATOR_CONFIG`（删两字段加两字段） | ⚠️ 侵入改 |
+| [`hook.ts`](../hook.ts#L63) | `Curator.maybeRun` 调用点，spread `DEFAULT_CURATOR_CONFIG`（字段跟着变） | ⚠️ 连带改 |
+| [`skill.ts`](../../tool/skill.ts#L69) | 每次 skill 加载调 `bumpUse` 的唯一入口（本次不改，仅依赖） | — |
+| [`curator.test.ts`](./curator.test.ts) / [`usage.test.ts`](./usage.test.ts) | 现有测试（本次重写归档判定相关用例；`recent_uses` 用例不动） | ⚠️ 改测试 |
+
+---
+
+## 复用组件核实（实现前必读）
+
+- **X1：归档判据现状已 git 核实是「原始按日历天数」。** `git diff upstream/dev..HEAD -- constants.ts curator.ts` 为空 → 这两文件未被本分支任何 commit 改过；`usage.ts` 仅多 `recent_uses`。**本分支无 `idle_scans`**，本文档替换的是 `daysSince`/`archiveAfterDays` 那套。
+- **X2：`use_count` 确实累计、每次 skill 加载 +1。** `bumpUse`（[usage.ts:238](./usage.ts#L238)）`use_count += 1`，由 [`skill.ts:69`](../../tool/skill.ts#L69) 在每次加载时调用——分母数据现成。
+- **X3：但 `bumpUse` 只对进化区 skill 生效。** `resolveScope`（[usage.ts:68](./usage.ts#L68)）对不在 `<root>/<projectId>/skills/<name>` 下的 location 返回 null → no-op。所以分母天然只含进化区 skill（直接定义了 Q2 的现状）。
+- **X4：`archiveSkill`（[usage.ts:158](./usage.ts#L158)）已实现"搬到 archive/ + 标 archived + 名字冲突加时间戳后缀"，可直接复用。** 归档动作不用新写。
+- **X5：`applyAutomaticTransitions` 当前已是"逐 skill 扫 + 读账本 + 判定"结构。** 本次只把 [147-158](./curator.ts#L147) 的 `daysSince` 判定块换掉，循环外先**按 projectId 分组**算各项目总数（或判每条时调 `projectUseCount(ledger, s.projectId)`）；孤儿清理 [168-183](./curator.ts#L168) 原样保留。
+- **X6：`DEFAULT_CURATOR_CONFIG` 被 [`hook.ts:63`](../hook.ts#L63) spread 进 `maybeRun`。** 换字段后这里跟着变（不改逻辑）；测试里多处引用 `DEFAULT_CURATOR_CONFIG`/`archiveAfterDays`/`staleAfterDays`，需同步。
+
+---
+
+## 命题清单
+
+### PA. 占比归档主逻辑
+- A1. 某 skill 出生后曝光量 ≥ 1000 且 `use_count / 曝光量 < 0.001` → 被归档（目录搬进 archive/、记录标 archived）。
+- A2. 某 skill 占比 ≥ 0.001 → 不被归档。
+- A3. 5 个 skill 占比都 ≥ 0.001（如各 1/5）→ 一个都不归档（M2 不删末位）。
+
+### PB. 出生窗口 / 试用期
+- B1. 出生后曝光量 < 1000 的 skill，哪怕占比 0，也不被归档（试用期保护）。
+- B2. `born_at_project_total` 在记录首次创建时写入"当时本项目总数"，之后不变。
+- B3. 老记录无 `born_at_project_total` → 当 0 处理，行为同"从一开始就在"。
+
+### PC. 分母 / 总数（按项目隔离）
+- C1. `projectUseCount(data, projectId)` = **同 projectId 下**所有记录 `use_count` 之和（含 archived）；别项目的记录不计入。
+- C2. 出生后曝光量 = 当前**本项目**总数 − `born_at_project_total`。
+- C3. 项目 A 闲置、项目 B 猛跑 → A 里 skill 的曝光量/占比不受 B 影响（项目隔离，问题 C）。
+
+### PD. 不回归（守住已实现的东西）
+- D1'. `recent_uses` 的追加/截断行为不被本次改动影响。
+- D2'. `archiveSkill`/`restoreSkill`、钉住跳过、孤儿清理行为不变。
+
+### PH. 边界与失败用例（测试必须覆盖）
+- H1. 账本为空 / 总数为 0 → 不抛错、不归档任何东西（曝光量 ≤ 0，被试用期闸门拦下）。
+- H2. `pinned` 的 skill 即使占比 0、曝光量够 → 仍跳过不归档。
+- H3. 账本文件损坏 / 字段类型异常 → `load` 返回安全值，扫描不抛错。
+
+---
+
+## 测试与红绿里程碑
+
+> 走 TDD：每个里程碑先写红测试（证明现状缺它）、再实现到绿。先红后绿两次输出都要留。从 `packages/opencode` 目录内跑。
+
+### ⚠️ 假绿陷阱 / 写读接缝（按 CLAUDE.md #15）
+
+- **测行为不测实现**：断言"这个 skill 被搬进 archive/ 且记录标 archived"，不要断言"调了 archiveSkill"。
+- **写读接缝必须接力跑**：`born_at_project_total` 是"创建时写、归档时读"的跨步状态——测试**不许出题人手填 `born_at_project_total`**，必须真跑 `seedIfMissing/bumpUse 创建 → 真的累加**同项目**别的 skill 的 use_count 把本项目总数顶上去 → 再跑 applyAutomaticTransitions 判归档`，让程序自己把出生水位攒过去，再断言结果。手填中间值就漏掉最容易坏的那道接缝。
+- **必须有先红**：在把判据从 `daysSince` 换成占比之前跑核心用例——构造一个"刚用过(daysSince 小)但占比为 0"的 skill，旧的按天数判据**不会**归档它、新占比判据**会**，这条用例在改之前应红，证明测试真在测占比而非恒绿。
+
+### 红绿总览（婴儿步，按依赖排序）
+
+1. **里程碑1（占比归档）**：红——造一个 born=0、use_count=0、daysSince 很小的 skill，再造**同项目**别的 skill 把本项目总数顶到 1000，断言它被归档；旧按天数判据因 daysSince 小不归档 → 红。绿——换占比判据后通过。
+2. **里程碑2（M2 不删末位）**：红/绿——同项目 5 个 skill 各占 1/5，断言一个都不归档。
+3. **里程碑3（出生窗口保护）**：红——born=50000、本项目总数顶到 50300（曝光 300<1000）、use_count=0，断言**不**被归档；漏窗口逻辑会误归档 → 红。绿——加窗口闸门后通过。
+4. **里程碑4（项目隔离，复现用户的反例）**：红——项目 A 有个 use_count=5 的好 skill（本项目总数 1000、占比 0.005）；项目 B 灌到几万次。用全局分母会把 A 的 skill 冲到归档 → 红。绿——改本项目分母后 A 的 skill 留住、B 的调用不影响它。
+5. **里程碑5（出生水位写读接力）**：真跑 创建→同项目累加→判 三步，断言新 skill 熬过 1000 本项目曝光仍 0 调用 → 归档；试用期内 → 不归档。
+6. **里程碑6（不回归 + 边界）**：`recent_uses` 用例仍绿；空账本 / pinned / 损坏账本各一条。
+
+### 收尾验证
+
+- 跑 `usage.test.ts` + `curator.test.ts` 全绿，贴红→绿两次输出。
+- 跑 `bun turbo typecheck --filter=aether`，贴 "successful"（确认删字段没漏改调用点）。
+
+---
+
+## 范围说明
+
+**本次做**：把 curator 的归档判据从"按日历天数"换成"按相对调用占比 + 出生曝光窗口"。改 `curator.ts`（判定段）、`constants.ts`（配置字段）、`usage.ts`（加 `born_at_project_total` + 出生记水位 + `projectUseCount`），连带 `hook.ts` 的 spread 与相关测试。
+
+**本次不做**（留给后续独立工作）：
+- 导师第二条线"灵敏烂 skill"（进会话读 transcript 判正负作用，I4/Q4）——复用上个 commit 的 `recent_uses` 坐标，独立做。
+- 分母扩到"含手动装 / 内置 skill"（Q2，须先与导师确认口径 + 改 `resolveScope`）。
+- 归档自动复活 / 权重抽取（Q4/Q5）。
+
+---
+
+## 用户体验
+
+- 对你来说的变化：skill 库会**自动清理真没人用的冷门 skill**，且清理标准**随你的使用量自动伸缩**——你用得多、库里某个 skill 占比掉到千分之一以下，它就被收进 archive/（可恢复，不是删）；你用得少、总量没攒起来，就谁也不动。而且**刚进化出来的新 skill 有一段"再跑 1000 次调用"的试用期**，不会一出生就被误清。
+- 没有界面变化；这是后台维护策略的改善。归档是"搬进 archive 文件夹"，需要时可手动恢复，不会真丢东西。
+
+> ⚠️ 注意：本文档是**设计草案**，尚未写代码、未跑测试，属"无法验证（纯文档）"。开放问题 Q1–Q5（尤其 Q2 分母口径）建议先与导师对齐，再进实现。

--- a/packages/opencode/src/skill-evolution/curator/SKILL_IDENTITY_DESIGN.md
+++ b/packages/opencode/src/skill-evolution/curator/SKILL_IDENTITY_DESIGN.md
@@ -1,0 +1,299 @@
+# Curator skill 身份 — 「唯一 id 替代按名字做 key」设计文档
+
+> 状态：**已实现 v1**(走 TDD,2026-06-18)。Q1 定走"路 A(加唯一 id)";Q2–Q7 已各定暂定方案并落地(见决策记录)。**仍建议把暂定方案(尤其 Q3 用 `ulid`、Q5 老 skill 回退不迁移)报导师知会一声**——这些是按合理默认实现的,非红线,但属"skill 身份"地基,留个记录。
+> **验证**:`skill-manage-tool.test.ts` / `usage.test.ts` / `curator.test.ts` 新增 id 用例先红后绿;整个 `src/skill-evolution/` 186 测试全绿、`bun turbo typecheck --filter=aether` 通过。**已知未自动化覆盖**:里程碑2–3(SKILL.md frontmatter 的 id 经 `Skill` 加载器解析 → 传给 `bumpUse`)这条生产链路靠 typecheck + 字段贯通保证,未写专门的加载器集成测试(该测试 harness 较重);根因修复(按 id 不撞)用直接给 `bumpUse` 传 id 的 usage 级测试覆盖。
+> 读者:团队开发者 + 组会评审 + 照本实现的人(含 yolo 沙盒会话——它没有讨论上下文,本文档即唯一说明书)。
+> 出处:2026-06-18 多轮 code-review 暴露的一个根因 bug——curator 按"名字"给 skill 当身份,导致"归档后同名重建"撞车(详见[解决了什么问题](#解决了什么问题))。前序设计见同目录 [`RELATIVE_USAGE_DESIGN.md`](./RELATIVE_USAGE_DESIGN.md)(相对调用占比归档判据)与 [`CURATOR_DESIGN.md`](./CURATOR_DESIGN.md)。
+> 关联:要碰 [`usage.ts`](./usage.ts)(账本读写)、[`curator.ts`](./curator.ts)(扫描/归档)、[`skill-manage-tool.ts`](../skill-manage-tool.ts)(创建 skill)、[`skill/index.ts`](../../skill/index.ts)(SKILL.md 解析)、[`tool/skill.ts`](../../tool/skill.ts)(加载入口)。**本文档只改"skill 身份/key"这一块——占比判据、出生水位、归档搬移、墓碑等沿用 `RELATIVE_USAGE_DESIGN.md`,不重述。**
+
+---
+
+## 目录
+
+- [设计原则](#设计原则)
+- [解决了什么问题](#解决了什么问题)
+- [现状 → 改后](#现状--改后)
+- [对旧文件的修改](#对旧文件的修改)
+- [核心机制详解](#核心机制详解)
+- [格式样例](#格式样例)
+- [核心不变量](#核心不变量)
+- [决策记录](#决策记录)
+- [开放问题](#开放问题)
+- [关键文件速查](#关键文件速查)
+- [复用组件核实(实现前必读)](#复用组件核实实现前必读)
+- [命题清单](#命题清单)
+- [测试与红绿里程碑](#测试与红绿里程碑)
+- [范围说明](#范围说明)
+- [用户体验](#用户体验)
+
+---
+
+## 设计原则
+
+1. **skill 的身份是"稳定唯一 id",不是名字。** 一个 skill 一旦创建就带一个永不复用的 id;名字只是给人看的标签,可以重名、可以改。账本(`usage.json`,记每个 skill 使用情况的文件)按 id 认人。
+2. **id 在创建时一次性盖死,之后不变、不复用。** 归档、改名、改内容都不改 id;一个 skill 被淘汰后,新建的同名 skill 拿到的是**另一个** id。
+3. **最小侵入、向后兼容。** 老 skill / 老账本没有 id → 平滑迁移,迁移期不能让 curator 崩或误判(沿用 `RELATIVE_USAGE_DESIGN.md` 的 best-effort 原则)。
+4. **只给"进化区 skill"上身份。** 手动装的 / 内置 skill 不归 curator 管(`resolveScope` 本就只认 `<root>/<projectId>/skills/<name>`),不强加 id。
+5. **id 从"已经解析好的 SKILL.md"取,不额外读盘热路径。** 加载 skill 时本就解析过 frontmatter(skill/index.ts 的 `Info`),id 顺着这条链传下去,不在每次加载时为了拿 id 再读一次文件。
+
+---
+
+## 解决了什么问题
+
+### 问题 A:按名字做 key → 归档后同名重建撞车(本次根因)
+
+- **现状(真实代码)**:账本每条记录的 key(唯一标识)= `项目id/名字`,由 [`resolveScope`](./usage.ts#L93)(把磁盘路径解析成 key 的函数,[usage.ts:110](./usage.ts#L110))和 [`scanSkills`](./curator.ts#L90)([curator.ts:104](./curator.ts#L104))从**路径**拼出来。**同项目 + 同名 = 同一条账。**
+- **后果(多轮 review 确认的 bug)**:一个 skill `foo` 被归档后(目录搬进 `archive/`、账标 `archived`,但账留着),若之后又新建一个**同名** `foo`:
+  1. 新 `foo` 加载时,[`bumpUse`](./usage.ts#L300)(每次加载记一笔)解析出的 key 跟旧 `archived` 账相同 → **撞上旧账,新 skill 拿不到自己的账,寄生在旧账上**。
+  2. `bumpUse` 落到 [usage.ts:332](./usage.ts#L332) `rec.use_count += 1`,把这条 `archived` 账的次数顶高,但状态仍是 `archived`。
+  3. curator 整理时,判断循环 [curator.ts:159](./curator.ts#L159) 和孤儿循环 [curator.ts:184](./curator.ts#L184) 都跳过 `archived` → **新 skill 永远不被判定**(既无归档保护、也永不被淘汰)。
+  4. 而 `projectUseCount`(算占比的分母,[usage.ts:79](./usage.ts#L79))把 `archived` 也求和 → 被顶高的次数**灌进分母 → 同项目别的 skill 占比被稀释 → 兄弟被误归档**。
+- **真实佐证**:见本分支 review 记录(narrowing rebirth 那轮);用例:`proj1/foo` 归档后重建并被调用 100 次 → 同项目 `bar` 占比被这 100 次稀释、被误判归档,而真正的流量来源 `foo` 永不被审。
+- **要换成**:给每个 skill 一个稳定唯一 id 当身份,旧 `foo`(id=A)与新 `foo`(id=B)天然是两条账,从源头不撞——见[核心机制](#核心机制详解)。
+
+### 问题 B:同名 skill 跨情形的隐患(顺带说明,非本次新增)
+
+- 名字可重用还会引出:同项目历史里出现过多个"同名但实为不同"的 skill 时,账本无法区分谁是谁;`hasArchivedCopy`(查归档副本,按名字精确匹配,[usage.ts:201](./usage.ts#L201))也会认错副本。id 化后这些一并消解。
+
+### 本次【不】解决(留给后续,见[范围说明](#范围说明))
+
+- **占比判据本身**(出生水位、试用期窗口、千分之一阈值)——沿用 `RELATIVE_USAGE_DESIGN.md`,本次不动。
+- **墓碑(`deleted`)复活逻辑**——上一轮已实现,本次不重做;但 id 化后"复活"语义会简化(见 [Q6](#开放问题)),待对齐。
+- **"路 B"(不加 id、靠"账标 archived 但活目录又出现了"来判重建)**——更省事的止血方案,曾与路 A 二选一;**Q1 已定走路 A,路 B 不再考虑**(见 [Q1](#开放问题))。
+- **并发写冲突、首次运行 O(N²)、死代码清理**——是另外的独立工作项,见 review 记录,不在本次范围。
+
+---
+
+## 现状 → 改后
+
+| 维度 | 现状(真实代码) | 改后 |
+|---|---|---|
+| skill 身份 | 路径里的"名字"(`项目id/名字`) | 创建时盖的**稳定唯一 id** |
+| 账本 key | `resolveScope`/`scanSkills` 从路径拼 `项目id/名字` | 用 id(暂定 `项目id/id`,见 [Q4](#开放问题)) |
+| 同名重建 | 撞旧账、寄生、污染分母、永不被判 | 新 skill 拿到**自己的新账**,正常被判;旧账冻结、不污染 |
+| id 存储 | 无 | SKILL.md frontmatter 加一个 `id` 字段(暂定,见 [Q2](#开放问题)) |
+| id 产生 | 无 | 创建 skill 时由 `skill-manage-tool` 盖(暂定,见 [Q3](#开放问题)) |
+| 老 skill / 老账本 | —— | 迁移:无 id 时回退到按名字(过渡期),见 [Q5](#开放问题) |
+| 占比判据 / 出生水位 / 归档搬移 | 有 | **保留不动**(沿用 `RELATIVE_USAGE_DESIGN.md`) |
+
+---
+
+## 对旧文件的修改
+
+> 每处标 **侵入式**(改了旧行为有回归风险)还是 **增量式**(只加内容旧路径不变)。依据指向决策记录 D#。
+
+| 旧文件:位置 | 改什么 | 性质 | 依据 |
+|---|---|:---:|---|
+| [`skill/index.ts :: Info`](../../skill/index.ts#L33) | frontmatter schema 加可选字段 `id` | **增量式**(加可选字段,旧 skill 无此字段仍解析通过) | D1/D3 |
+| [`skill-manage-tool.ts :: buildContent`](../skill-manage-tool.ts#L44) | `create` 动作时生成唯一 id 写进 frontmatter | **侵入式**(创建流程多盖一个字段) | D2 |
+| [`tool/skill.ts`](../../tool/skill.ts#L69) `bumpUse` 调用点 | 把已解析的 skill id 传给 `bumpUse`(不再只靠 location) | **侵入式**(签名加参) | D5 |
+| [`usage.ts :: resolveScope`](./usage.ts#L93) / `bumpUse` | key 改用 id(优先 id,缺失回退名字) | **侵入式**(key 口径变,核心) | D4/D7 |
+| [`usage.ts :: UsageRecord`](./usage.ts#L26) | 记录加 `id` 字段(并保留 `name` 作展示) | **增量式**(加字段;老记录回填,见 D7) | D4/D7 |
+| [`curator.ts :: scanSkills`](./curator.ts#L90) | 扫描时读 SKILL.md frontmatter 拿 id 来定 key | **侵入式**(scan 现在只 stat、不读内容,改成要读) | D3/D6 |
+| `usage.ts` / `curator.ts` 其余(占比判据、出生水位、归档搬移、墓碑、孤儿清理) | **保留不动** | 不改 | —— |
+
+---
+
+## 核心机制详解
+
+### 1. 身份从哪来:创建时盖 id
+
+- 进化 skill 由 AI 通过 [`skill-manage-tool`](../skill-manage-tool.ts) 的 `create` 动作创建,frontmatter 在 [`buildContent`](../skill-manage-tool.ts#L44)(拼 `---\nname...\ndescription...\n---` 的函数)里生成。
+- 改动:`create` 时生成一个**稳定唯一 id**(候选:UUID / 时间戳+随机后缀,见 [Q3](#开放问题)),写进 frontmatter 的 `id` 字段。一经写入永不改、永不复用(原则 2)。
+
+### 2. 身份怎么读:顺着已解析的 SKILL.md 传
+
+- 加载 skill 时,[`skill/index.ts`](../../skill/index.ts#L246) 本就用 `Info` schema 解析过 frontmatter。给 `Info` 加可选 `id`([skill/index.ts:33](../../skill/index.ts#L33)),解析结果就带上 id。
+- [`tool/skill.ts`](../../tool/skill.ts#L69) 调 `bumpUse` 时,把这个已解析的 id 一并传进去(原则 5,不为拿 id 再读一次盘)。
+
+### 3. 身份怎么用:账本按 id 认人
+
+- [`UsageRecord`](./usage.ts#L26)(账本一条记录)加 `id` 字段;key 改用 id(暂定 `项目id/id`,见 [Q4](#开放问题))。
+- [`resolveScope`](./usage.ts#L93) 在有 id 时用 id 拼 key;无 id(老 skill / 迁移期)回退到名字(D7)。
+- curator 的 [`scanSkills`](./curator.ts#L90) 改成读 SKILL.md frontmatter 拿 id 定 key(它现在只 `fs.stat`、不读内容,这是侵入点,见 [Q6](#开放问题) 讨论代价)。
+
+### 4. 为什么这样就不撞车
+
+- 旧 `foo`(id=A)归档 → 账 A 标 `archived`,**它的目录在 `archive/`,原位置 `skills/foo` 空了,没有任何活 skill 解析出 key A** → 账 A 的次数从此冻结(符合 D6 单调分母假设)。
+- 新 `foo`(id=B)→ 加载解析出 key B → 账本无 B → 新建账 B,正常计数、正常被判。
+- 账 A(archived,冻结)与账 B(active)各算各的:分母里 A 是合法的冻结历史、B 是自己的量,**新 skill 的流量不再灌到 A 上,不再稀释兄弟**。问题 A 的 1~4 全部消解。
+
+---
+
+## 格式样例
+
+**改后的 SKILL.md frontmatter(加 `id`;`name`/`description` 不变)**:
+
+```markdown
+---
+id: "skl_2026a1b2c3d4"          # 新增:创建时盖,永不变/不复用(格式见 Q3)
+name: "foo"
+description: "..."
+category: "Testing"
+---
+
+<body>
+```
+
+**改后的账本记录(`usage.json` 一条)**:
+
+```json
+{
+  "<projectId>/skl_2026a1b2c3d4": {
+    "id": "skl_2026a1b2c3d4",
+    "projectId": "<projectId>",
+    "name": "foo",
+    "location": "/home/.../<projectId>/skills/foo",
+    "use_count": 12,
+    "born_at_project_total": 50000,
+    "last_used_at": "...",
+    "recent_uses": [],
+    "state": "active",
+    "pinned": false,
+    "archived_at": null
+  }
+}
+```
+
+> 注:key 用 id,`name` 仍保留(展示 + 迁移期回退)。旧 `foo`(归档)与新 `foo` 会是两条不同 key 的账。
+
+---
+
+## 核心不变量
+
+1. **id 唯一且稳定** — 一个 skill 的 id 创建后永不变;不同 skill(含同名先后两个)id 必不同;id 永不复用。
+2. **同名不撞账** — 归档后同名重建,新 skill 必拿到与旧账不同的 key,得到自己的记录。
+3. **归档账冻结** — 一条 `archived` 账的 `use_count` 不再被任何活 skill 顶高(没有活 skill 解析到它的 key)。
+4. **分母不被污染** — 同项目占比的分母里,每条 `use_count` 都归属于唯一一个真实 skill,无"多个 skill 共用一条账"导致的虚高。
+5. **向后兼容** — 老 skill / 老账本无 id 时,系统按名字回退工作,不崩、不误删(迁移期)。
+6. **范围不变** — 仍只给 / 只管进化区(`<root>/<projectId>/skills/`)skill,不扩到手动装 / 内置。
+
+---
+
+## 决策记录
+
+> 本文档自有 D 编号,与 `RELATIVE_USAGE_DESIGN.md` / `CURATOR_DESIGN.md` 的 D 编号**互不干扰**。多数为**暂定**,待导师对齐(见开放问题)。
+
+- **D1:给 SKILL.md frontmatter 增一个可选 `id` 字段当 skill 身份。** 原因:身份必须随 skill 走、可被扫描读到;frontmatter 是 skill 自带、已被解析的地方,最自然。可选 → 老 skill 不带也能解析(增量式)。**待对齐(Q2:存 frontmatter 还是 sidecar)。**
+- **D2:id 在 `skill-manage-tool` 的 `create` 动作生成并写入。** 原因:这是进化 skill 唯一的创建入口,盖在这里能保证"出生即有 id"。**待对齐(Q3:id 格式/生成方式)。**
+- **D3:`Info` schema 加可选 `id`,加载链顺带解析。** 原因:复用已有解析,不新增读盘(原则 5)。
+- **D4:账本 `UsageRecord` 加 `id`,key 改用 id。** 原因:这是修复的核心——按 id 认人才能让同名不撞(不变量 2)。**待对齐(Q4:key 用 `项目id/id` 还是纯 id)。**
+- **D5:`bumpUse` 增 id 入参,由 `tool/skill.ts` 从已解析 skill 传入。** 原因:热路径拿 id 不额外读盘。
+- **D6:curator `scanSkills` 读 frontmatter 拿 id。** 原因:扫描必须能按 id 给磁盘 skill 定 key。代价:scan 从"只 stat"变"读+解析",见 [Q6](#开放问题)。
+- **D7:无 id 回退按名字 + 老记录迁移。** 原因:向后兼容(不变量 5)。**待对齐(Q5:迁移策略)。**
+
+---
+
+## 开放问题
+
+> `Q#` 编号。下面每条都给了**暂定建议方案**(已尽量定到可实现),但仍须**导师/团队最终拍板**——尤其涉及"改写用户 SKILL.md""scan 多读盘"这类有代价的决定。
+
+- **Q1(已定):走路 A(加唯一 id 治根),不走路 B。** 用户 2026-06-18 拍板。理由:B(不加 id、靠"账标 archived 但活目录又出现"检测式止血)收尾不干净(旧账/旧副本仍要权衡),A 从源头消除撞车。路 B 不再考虑。
+- **Q2:id 存哪?→ 建议:写进 SKILL.md frontmatter。** 它是 skill 的元数据(和 `name`/`description` 同类),放 frontmatter 最自然:跟着 skill 走、复用已有解析(不额外读盘)、随拷贝/移动一起带。**"只放 usage" 已排除**——账本只有"路径/名字"这把会被复用的把手,分不清同名新旧(这正是病根)。误删风险(用户/AI 手改 SKILL.md 删了 id 行)用"`edit` 动作保留 id + 缺失则按 Q5 回退"兜。备选 sidecar 文件(`.skill-id`)更防误删但多一个文件、易在拷贝时掉队——**倾向 frontmatter,待确认。**
+- **Q3:id 怎么生成?→ 已定:`skl_${ulid()}`(已实现于里程碑1)。** 起初想用 [`id/id.ts`](../../id/id.ts) 的 `Identifier.create`,但它的前缀表是写死的一组(`event|session|message|…`)、**没有 `skill`**,要用它得先改那个共享文件加前缀;而 `ulid`(已是现成依赖,memory 模块用 `mem_${ulid()}`)无需动共享代码、写法一致。故采用 `skl_${ulid()}`——唯一、稳定、不复用。**`create` 盖、`edit` 保留不重盖、`edit` 到无 id 老 skill 时顺手补盖一个**(用户已在改这个文件,属合理懒迁移)。
+- **Q4:账本 key 用 `项目id/id` 还是纯 `id`?→ 建议:`项目id/id`。** 与现有 `项目id/名字` 形态一致、迁移平滑;`projectUseCount`(算分母)本就按 projectId 过滤、记录里也存 projectId。**倾向 `项目id/id`,待确认。**
+- **Q5:老 skill / 老账本怎么迁移?→ 建议:新 skill 立即带 id;老的 / 无 id 的回退按名字(维持现状),不主动改写用户的 SKILL.md。** 关键洞察:只要"**新建**的 skill 都带 id",任何新建(包括占用一个老名字槽位的)都按 id 走、不撞 → **bug 对所有新 skill 即刻修复**;只有"两个都早于 id 功能的老 skill 同名"这种纯历史情形维持原样(本就如此、风险未新增)。给老 skill 补盖 id 作为**可选的一次性迁移脚本**,不自动跑(避免无差别改写用户文件)。**倾向最小侵入回退,待确认要不要做一次性补盖。**
+- **Q6:`scanSkills` 从"只 stat"改成"读 + 解析 frontmatter 拿 id"的代价可接受吗?→ 建议:接受。** 复用 `Info` 解析;curator 默认 7 天一次、跑后台、N(进化区 skill 数)不大,多一次读 + 解析 / skill 可接受。与 Q2 联动(若改 sidecar 则只读一小文件、更省)。**倾向接受,待确认。**
+- **Q7:id 化后墓碑(`deleted`)复活逻辑要不要收回?→ 建议:收回。** id 永不复用 → `deleted` 记录的 key 不会被任何新 skill 撞上 → bumpUse 里上一轮加的"复活"分支(撞到 deleted 就复活)变成死代码,id 化稳定后**移除**。**待 id 化落地后清理。**
+
+---
+
+## 关键文件速查
+
+| 文件 | 作用 | 性质 |
+|---|---|:---:|
+| [`usage.ts`](./usage.ts) | 账本读写;`resolveScope` 定 key、`UsageRecord`、`bumpUse`、`projectUseCount` | ⚠️ 侵入改 |
+| [`curator.ts`](./curator.ts) | 扫描/归档;`scanSkills` 定 key | ⚠️ 侵入改 |
+| [`skill-manage-tool.ts`](../skill-manage-tool.ts) | 进化 skill 创建入口;`buildContent` 拼 frontmatter | ⚠️ 侵入改 |
+| [`skill/index.ts`](../../skill/index.ts) | SKILL.md 解析(`Info` schema) | ⚠️ 增量改 |
+| [`tool/skill.ts`](../../tool/skill.ts) | skill 加载入口,调 `bumpUse` | ⚠️ 连带改 |
+| [`RELATIVE_USAGE_DESIGN.md`](./RELATIVE_USAGE_DESIGN.md) | 占比判据设计(本次不改,仅依赖) | — |
+
+---
+
+## 复用组件核实(实现前必读)
+
+> `X#` 编号。实现前先核实这些事实成立,别凭空假设。
+
+- **X1:`Info` schema 是 SKILL.md frontmatter 的唯一解析口。** [skill/index.ts:33](../../skill/index.ts#L33) `z.object({ name, description, ... })`,[:246](../../skill/index.ts#L246) `Info.pick(...).safeParse(md.data)`。加可选 `id` 后老 skill(无 id)仍 `safeParse` 通过 → 需核实可选字段不破坏现有解析。
+- **X2:`buildContent` 是进化 skill 写 frontmatter 的唯一处。** [skill-manage-tool.ts:44](../skill-manage-tool.ts#L44)。核实 `create` 与 `edit` 路径——`edit` 不能重盖/丢失已有 id。
+- **X3:`scanSkills` 现在只 `fs.stat(SKILL.md)`、不读内容。** [curator.ts:102](./curator.ts#L102)。改成读+解析是真实增量 I/O,需核实代价(Q6)。
+- **X4:`resolveScope` 现在纯靠路径,不读文件。** [usage.ts:93](./usage.ts#L93)。若 key 改用 id,resolveScope 要么也读文件、要么由调用方把 id 传进来(与 D5 一致)——核实两个调用方(`bumpUse`、`seedIfMissing`)都能拿到 id。
+- **X5:`bumpUse` 调用方是 [tool/skill.ts:69](../../tool/skill.ts#L69)(每次加载)。** 核实该处能拿到已解析的 skill id(来自 X1 的解析结果)。
+- **X6:已有 `usage.json` 记录无 `id` 字段。** 核实 `load` 的回填逻辑(沿用 RELATIVE_USAGE_DESIGN.md 的 best-effort backfill 模式)能安全处理。
+
+---
+
+## 命题清单
+
+> 按主题分组,每条是可判定真假的行为断言;对应要写的测试。
+
+### PA. id 身份
+- A1. `skill-manage-tool` 的 `create` 写出的 SKILL.md frontmatter 含一个非空 `id`。
+- A2. 对同一个 skill 多次 `edit`,`id` 保持不变(不被重盖)。
+- A3. 两次 `create`(哪怕同名)得到的 id 不同。
+
+### PB. 账本按 id 认人
+- B1. 加载一个带 id 的 skill → 账本记录的 key 由 id 决定,`name` 仍记录在案。
+- B2. 同项目、同名、不同 id 的两个 skill → 账本里是**两条**记录。
+- B3. 归档 id=A 后,新建同名 id=B 并调用 → A 的 `use_count` 不变(冻结),B 有自己的 `use_count`。
+
+### PC. 不污染分母(复现并修掉根因)
+- C1. 旧 `foo`(id=A)归档、新 `foo`(id=B)被调用 N 次 → 同项目兄弟 `bar` 的占比**不被这 N 次稀释**(对照:按名字做 key 时会被稀释 → 旧实现红)。
+- C2. 新 `foo`(id=B)占比够低且过试用期 → 被正常归档(不再"永不被判")。
+
+### PD. 向后兼容
+- D1'. 老 skill(SKILL.md 无 id)加载 → 不崩,按名字回退建账(迁移策略见 Q5 定案后细化)。
+- D2'. 老 `usage.json`(记录无 id)`load` → 不崩,安全处理。
+
+### PH. 边界与失败用例(必须覆盖)
+- H1. frontmatter 的 `id` 字段被手动删/损坏 → 解析不崩(回退按名字,best-effort)。
+- H2. 两个 skill 不慎拿到相同 id(理论冲突)→ 行为可定义(报警/二次区分),不静默错乱。
+- H3. 空账本 / 损坏账本 → 沿用现有 best-effort,不崩。
+
+---
+
+## 测试与红绿里程碑
+
+> 走 TDD,先红后绿,两次输出都留。从 `packages/opencode` 跑。
+
+### ⚠️ 假绿陷阱 / 写读接缝
+
+- **测行为不测实现**:断言"同名两 skill 在账本里是两条记录""兄弟占比不被稀释",不要断言"调了某函数"。
+- **写读接缝(关键)**:id 是"创建时写进 SKILL.md → 加载时读出来 → 账本按它建 key → 归档判据按它认人"的**跨多步、跨文件**状态。测试必须**真跑这条接力**:真用 `skill-manage-tool` 创建(写 id)→ 真加载(读 id)→ 真 `bumpUse`(按 id 建账)→ 真跑 curator 判一遍。**禁止出题人手填 id 直接喂账本**——那只测了"按 id 认人"这一个零件,没测"创建写进去的 id 到底被读出来、用对 key 没有"这条最容易坏的接缝。
+- **必须有先红**:C1(兄弟不被稀释)这条,在"按名字做 key"的旧实现下应**红**(兄弟被稀释/被误归档),改成按 id 后**绿**——这条用例证明测试真在测根因修复、不是恒绿。
+
+### 红绿里程碑(婴儿步,按依赖排序)
+
+1. **里程碑1(id 落盘)**:`create` 写出的 SKILL.md 含非空 id(A1);`edit` 不改 id(A2)。
+2. **里程碑2(id 读出)**:`Info` 解析带出 id;老 skill 无 id 解析不崩(X1/H1)。
+3. **里程碑3(账本按 id 建 key)**:`bumpUse` 用 id 当 key,记录带 id+name(B1)。
+4. **里程碑4(同名两条账)**:同项目同名不同 id → 两条记录(B2)。
+5. **里程碑5(根因修复,写读接力)**:真跑 创建A→归档A→创建同名B→调用B→curator 判,断言 A 冻结、B 自己计数、**兄弟不被稀释**(B3/C1/C2)。**这条是核心红→绿。**
+6. **里程碑6(兼容 + 边界)**:老账本/老 skill 回退(D1'/D2')、损坏 id(H1)、id 冲突(H2)。
+
+### 收尾验证
+
+- 跑 `usage.test.ts` + `curator.test.ts` + skill 创建相关测试全绿,贴红→绿。
+- 跑 `bun turbo typecheck --filter=aether`,贴 "successful"。
+
+---
+
+## 范围说明
+
+**本次做**:把 curator 的 skill 身份从"名字"换成"创建时盖的稳定唯一 id",修掉"归档后同名重建撞车"根因。改 `skill-manage-tool`(盖 id)、`skill/index.ts`(解析 id)、`tool/skill.ts`(传 id)、`usage.ts`/`curator.ts`(按 id 建 key + 记录加 id + 兼容),连带相关测试。
+
+**本次不做**(留给后续独立工作):
+- 占比判据 / 出生水位 / 试用期 / 阈值——沿用 `RELATIVE_USAGE_DESIGN.md`。
+- 路 B(检测式止血)——Q1 已定走路 A,路 B 不做。
+- 并发写冲突、首次运行 O(N²)、死代码清理(`forget`/死计数器/`mtimeMs`/`stale` 等)——独立工作项。
+- 墓碑/复活逻辑简化(Q7)——待 id 化定案后再评估。
+
+---
+
+## 用户体验
+
+- 对你来说的变化:**skill 库不会再"认错人"了**。以前一个 skill 被自动收进仓库后,你又做了一个**同名**的新 skill,系统会把它俩当成同一个——新 skill 既得不到"新手保护期"、又永远不会被正常清理,还会连累同项目别的好 skill 被误收。改完之后,每个 skill 有自己永久的"身份证",同名的新旧 skill 互不影响:新 skill 正常享受试用期和清理判定,老的归档记录乖乖冻结、不再拖累别人。
+- 没有界面变化;这是后台"谁是谁"的认人逻辑修正。
+
+> ⚠️ 本文档是**设计草案,尚未写代码、未跑测试**,属"无法验证(纯文档)"。**开放问题 Q1(A/B 路线)是地基决策,务必先与导师对齐再进实现**;Q2–Q7(id 存哪/怎么生成/key 形态/迁移/scan 代价/墓碑简化)也都待定。

--- a/packages/opencode/src/skill-evolution/curator/constants.ts
+++ b/packages/opencode/src/skill-evolution/curator/constants.ts
@@ -1,17 +1,26 @@
 export interface CuratorConfig {
   enabled: boolean
-  /** Minimum hours between curator runs. */
+  /** Minimum hours between curator runs (scheduling cadence, NOT an archive criterion). */
   intervalHours: number
-  /** Days of inactivity before a skill is marked stale. */
-  staleAfterDays: number
-  /** Days of inactivity before a skill is archived. */
-  archiveAfterDays: number
+  /**
+   * Archive a skill whose post-birth call share (use_count / post-birth exposure,
+   * within its own project) falls BELOW this. Default 0.001 (one in a thousand).
+   * See RELATIVE_USAGE_DESIGN.md D1.
+   */
+  archiveUsageShare: number
+  /**
+   * Birth trial window: a skill is not judged until its post-birth exposure
+   * (same-project calls since it was created) reaches this many. Measured in
+   * CALLS, not days, so the criterion stays time-free. Default 1000.
+   * See RELATIVE_USAGE_DESIGN.md D3.
+   */
+  minExposureCalls: number
 }
 
-/** Defaults match Hermes (curator/core.py): 7 days / 30 days / 90 days. */
+/** Defaults: weekly sweep; archive below 0.1% share once 1000 post-birth calls have passed. */
 export const DEFAULT_CURATOR_CONFIG: CuratorConfig = {
   enabled: true,
   intervalHours: 24 * 7,
-  staleAfterDays: 30,
-  archiveAfterDays: 90,
+  archiveUsageShare: 0.001,
+  minExposureCalls: 1000,
 }

--- a/packages/opencode/src/skill-evolution/curator/curator.test.ts
+++ b/packages/opencode/src/skill-evolution/curator/curator.test.ts
@@ -49,9 +49,11 @@ async function writeLedger(root: string, records: Record<string, UsageRecord>): 
 function record(projectId: string, name: string, location: string, over: Partial<UsageRecord> = {}): UsageRecord {
   return {
     projectId,
+    id: null,
     name,
     location,
     use_count: 0,
+    born_at_project_total: 0,
     last_used_at: null,
     recent_uses: [],
     state: "active",
@@ -59,6 +61,26 @@ function record(projectId: string, name: string, location: string, over: Partial
     archived_at: null,
     ...over,
   }
+}
+
+/**
+ * Set up an archivable skill: a target (use_count 0, born 0) plus a same-project
+ * sibling carrying `siblingUses` calls. The target's post-birth share is 0 over an
+ * exposure of `siblingUses`; with siblingUses ≥ minExposureCalls (default 1000) it
+ * is archivable, while the sibling (share 1) is kept. Overwrites the whole ledger.
+ * Returns the target skill dir.
+ */
+async function makeArchivable(root: string, projectId: string, name: string, siblingUses = 1000): Promise<string> {
+  const dir = await makeSkill(root, projectId, name, 0)
+  const sibDir = await makeSkill(root, projectId, `${name}-sib`, 0)
+  await writeLedger(root, {
+    [`${projectId}/${name}`]: record(projectId, name, dir, { use_count: 0, born_at_project_total: 0 }),
+    [`${projectId}/${name}-sib`]: record(projectId, `${name}-sib`, sibDir, {
+      use_count: siblingUses,
+      born_at_project_total: 0,
+    }),
+  })
+  return dir
 }
 
 describe("Curator.shouldRunNow", () => {
@@ -138,92 +160,70 @@ describe("Curator.applyAutomaticTransitions", () => {
     }
   })
 
-  // M11: 到期归档 (核心接缝, 先停点) — mtime 100 天前 → 移进 archive、archived
-  test("archives a skill inactive past archiveAfterDays", async () => {
-    const tmp = await makeTmp()
-    try {
-      const dir = await makeSkill(tmp.path, "proj1", "foo", 100 * DAY)
-      await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
-
-      expect(await exists(dir)).toBe(false)
-      expect(await exists(path.join(tmp.path, "proj1", "archive", "foo", "SKILL.md"))).toBe(true)
-      const data = await Usage.load(tmp.path)
-      expect(data["proj1/foo"]!.state).toBe("archived")
-    } finally {
-      await tmp.cleanup()
-    }
-  })
 })
 
 describe("Curator.applyAutomaticTransitions — transitions & edges", () => {
-  // M12: 标 stale — 40 天没动 → stale (未归档)
-  test("marks a skill stale after staleAfterDays", async () => {
+  // H2: pinned 跳过 (防假绿) — 占比够低本该归档, 但 pinned → 仍 active
+  test("skips pinned skills (never archives them even when share is below threshold)", async () => {
     const tmp = await makeTmp()
     try {
-      const dir = await makeSkill(tmp.path, "proj1", "foo", 40 * DAY)
-      await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
-      const data = await Usage.load(tmp.path)
-      expect(data["proj1/foo"]!.state).toBe("stale")
-      expect(await exists(dir)).toBe(true) // not archived
-    } finally {
-      await tmp.cleanup()
-    }
-  })
+      const dir = await makeArchivable(tmp.path, "proj1", "foo") // 占比 0 / 曝光 1000 → 本该归档
+      // 把目标记录改成 pinned (makeArchivable 写的是非 pinned)
+      const data0 = await Usage.load(tmp.path)
+      data0["proj1/foo"]!.pinned = true
+      await writeLedger(tmp.path, data0)
 
-  // M13: 复活 — stale 的 skill 又被用 (last_used_at=now) → 退回 active
-  test("reactivates a stale skill that was used recently", async () => {
-    const tmp = await makeTmp()
-    try {
-      const dir = await makeSkill(tmp.path, "proj1", "foo", 40 * DAY)
-      await writeLedger(tmp.path, {
-        "proj1/foo": record("proj1", "foo", dir, { state: "stale", last_used_at: NOW.toISOString() }),
-      })
       await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
       const data = await Usage.load(tmp.path)
-      expect(data["proj1/foo"]!.state).toBe("active")
-    } finally {
-      await tmp.cleanup()
-    }
-  })
-
-  // M14: pinned 跳过 (排 M11 后, 防假绿) — pinned 且 100 天没动 → 仍 active
-  test("skips pinned skills (never archives them)", async () => {
-    const tmp = await makeTmp()
-    try {
-      const dir = await makeSkill(tmp.path, "proj1", "foo", 100 * DAY)
-      await writeLedger(tmp.path, { "proj1/foo": record("proj1", "foo", dir, { pinned: true }) })
-      await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
-      const data = await Usage.load(tmp.path)
-      expect(data["proj1/foo"]!.state).toBe("active")
+      expect(data["proj1/foo"]!.state).toBe("active") // pinned → 跳过
       expect(await exists(dir)).toBe(true)
     } finally {
       await tmp.cleanup()
     }
   })
 
-  // M15: 新/刚改不误伤 (排 M11 后, 防假绿) — mtime=今天 → 仍 active
-  test("does not archive a fresh skill", async () => {
-    const tmp = await makeTmp()
-    try {
-      const dir = await makeSkill(tmp.path, "proj1", "foo", 0)
-      await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
-      const data = await Usage.load(tmp.path)
-      expect(data["proj1/foo"]!.state).toBe("active")
-      expect(await exists(dir)).toBe(true)
-    } finally {
-      await tmp.cleanup()
-    }
-  })
-
-  // M16: 孤儿自愈 — 账本有记录但目录没了 → 清掉, 不报错
-  test("prunes orphan records whose skill dir is gone", async () => {
+  // M16: 真孤儿 → 标 deleted (墓碑), 保留记录与计数, 不报错; 再跑一次不重复处理
+  test("tombstones an orphan record (deleted) instead of removing it, and is idempotent", async () => {
     const tmp = await makeTmp()
     try {
       const ghost = path.join(tmp.path, "proj1", "skills", "ghost")
-      await writeLedger(tmp.path, { "proj1/ghost": record("proj1", "ghost", ghost) })
-      await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
+      await writeLedger(tmp.path, { "proj1/ghost": record("proj1", "ghost", ghost, { use_count: 3 }) })
+
+      const counts = await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
       const data = await Usage.load(tmp.path)
-      expect(data["proj1/ghost"]).toBeUndefined()
+      expect(data["proj1/ghost"]).toBeDefined() // 记录保留, 不删
+      expect(data["proj1/ghost"]!.state).toBe("deleted")
+      expect(counts.orphans).toBe(1)
+
+      // 再跑一次: deleted 记录被跳过, 不再重复处理 (orphans 不再涨)
+      const counts2 = await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
+      expect(counts2.orphans).toBe(0)
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // bug①: 孤儿清理不能破坏分母单调性。forget 删记录会把它的 use_count 从本项目总数抹掉,
+  // 害得别的 skill 的出生水位对不上、曝光量算负 → 永远判不到。改成标 deleted 保留计数。
+  test("orphan cleanup keeps the forgotten skill's use_count in the project total (monotonic denominator)", async () => {
+    const tmp = await makeTmp()
+    try {
+      // bbb 在磁盘上 (活着); aaa 没有目录 (被外部删掉) 且 archive 无副本 → 真孤儿
+      const bDir = await makeSkill(tmp.path, "proj1", "bbb", 0)
+      const aGhost = path.join(tmp.path, "proj1", "skills", "aaa") // 故意不建目录
+      await writeLedger(tmp.path, {
+        "proj1/aaa": record("proj1", "aaa", aGhost, { use_count: 1000, born_at_project_total: 0 }),
+        // bbb 出生水位 1000 = 它创建时本项目总数 (含了 aaa 那 1000 次)
+        "proj1/bbb": record("proj1", "bbb", bDir, { use_count: 5, born_at_project_total: 1000 }),
+      })
+
+      await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
+
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/aaa"]).toBeDefined() // 不被删成 undefined
+      expect(data["proj1/aaa"]!.state).toBe("deleted")
+      // 关键不变量: aaa 的 1000 仍在本项目总数里 → 分母不回退, bbb 的曝光量 = 1005-1000 = 5 (不会变负)
+      expect(Usage.projectUseCount(data, "proj1")).toBe(1005)
     } finally {
       await tmp.cleanup()
     }
@@ -253,12 +253,18 @@ describe("Curator.applyAutomaticTransitions — transitions & edges", () => {
     }
   })
 
-  // M17: 跨项目同名 — 归档 proj1/foo 不影响 proj2/foo (复合键)
+  // M17: 跨项目同名 — 按占比归档 proj1/foo 不影响 proj2/foo (复合键 + 项目隔离分母)
   test("handles same-name skills in different projects independently", async () => {
     const tmp = await makeTmp()
     try {
-      const dir1 = await makeSkill(tmp.path, "proj1", "foo", 100 * DAY) // → archive
-      const dir2 = await makeSkill(tmp.path, "proj2", "foo", 0) // fresh → keep
+      const dir1 = await makeSkill(tmp.path, "proj1", "foo", 0) // proj1: 占比 0 → archive
+      const sib1 = await makeSkill(tmp.path, "proj1", "sib", 0)
+      const dir2 = await makeSkill(tmp.path, "proj2", "foo", 0) // proj2: 占比 1 → keep
+      await writeLedger(tmp.path, {
+        "proj1/foo": record("proj1", "foo", dir1, { use_count: 0, born_at_project_total: 0 }),
+        "proj1/sib": record("proj1", "sib", sib1, { use_count: 1000, born_at_project_total: 0 }),
+        "proj2/foo": record("proj2", "foo", dir2, { use_count: 1000, born_at_project_total: 0 }),
+      })
       await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
 
       const data = await Usage.load(tmp.path)
@@ -272,12 +278,54 @@ describe("Curator.applyAutomaticTransitions — transitions & edges", () => {
   })
 })
 
+describe("Curator.applyAutomaticTransitions — concurrency", () => {
+  // 路1 并发安全: 整理期间并发的 bumpUse 不被最后的写盘冲掉。
+  // 用 spy 在 curator 读完账本后立刻注入一次 bumpUse(bar)(模拟并发的 skill 加载),
+  // 断言整理结束后 bar 的次数仍是被加过的值。旧的"整本覆盖写"会把它盖回去 → 红。
+  test("does not clobber a concurrent bumpUse that lands during the sweep", async () => {
+    const tmp = await makeTmp()
+    let spy: ReturnType<typeof spyOn> | undefined
+    try {
+      const aaaDir = await makeSkill(tmp.path, "proj1", "aaa", 0) // 占比 0 → 会被归档
+      const sibDir = await makeSkill(tmp.path, "proj1", "sib", 0)
+      const barDir = await makeSkill(tmp.path, "proj1", "bar", 0) // 不归档, 会被并发 bump
+      await writeLedger(tmp.path, {
+        "proj1/aaa": record("proj1", "aaa", aaaDir, { use_count: 0, born_at_project_total: 0 }),
+        "proj1/sib": record("proj1", "sib", sibDir, { use_count: 1000, born_at_project_total: 0 }),
+        "proj1/bar": record("proj1", "bar", barDir, { use_count: 5, born_at_project_total: 0 }),
+      })
+
+      const realLoad = Usage.load
+      let injected = false
+      spy = spyOn(Usage, "load").mockImplementation(async (root: string) => {
+        const data = await realLoad(root)
+        if (!injected) {
+          injected = true
+          await Usage.bumpUse(tmp.path, barDir) // 并发: bar 5 → 6, 写盘
+        }
+        return data
+      })
+
+      await Curator.applyAutomaticTransitions(tmp.path, { now: NOW, config: DEFAULT_CURATOR_CONFIG })
+      spy.mockRestore()
+      spy = undefined
+
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/bar"]!.use_count).toBe(6) // 并发的 +1 必须留住, 不被整本覆盖回 5
+      expect(data["proj1/aaa"]!.state).toBe("archived") // 整理本身照常完成
+    } finally {
+      spy?.mockRestore()
+      await tmp.cleanup()
+    }
+  })
+})
+
 describe("Curator.maybeRun", () => {
   // 到期：跑流转 + 推进 lastRunAt/runCount
   test("runs a pass and advances state when due", async () => {
     const tmp = await makeTmp()
     try {
-      const dir = await makeSkill(tmp.path, "proj1", "foo", 100 * DAY)
+      const dir = await makeArchivable(tmp.path, "proj1", "foo") // 占比 0 / 曝光 1000 → 该归档
       await Curator.saveState(tmp.path, { lastRunAt: ago(8 * DAY), paused: false, runCount: 1 })
 
       const counts = await Curator.maybeRun(tmp.path, { now: NOW })
@@ -317,7 +365,7 @@ describe("Curator on/off switch wiring (config → getCuratorEnabled → maybeRu
     const tmp = await makeTmp()
     const spy = spyOn(Config, "get").mockResolvedValue({ skills: { curator_enabled: false } } as any)
     try {
-      const dir = await makeSkill(tmp.path, "proj1", "foo", 100 * DAY)
+      const dir = await makeArchivable(tmp.path, "proj1", "foo") // 本该按占比归档
       await Curator.saveState(tmp.path, { lastRunAt: ago(8 * DAY), paused: false, runCount: 1 })
 
       // 读那头: 写进 config 的 false 必须被 getCuratorEnabled 读出来
@@ -330,7 +378,7 @@ describe("Curator on/off switch wiring (config → getCuratorEnabled → maybeRu
         config: { ...DEFAULT_CURATOR_CONFIG, enabled },
       })
       expect(counts).toBeNull()
-      expect(await exists(dir)).toBe(true) // 没被归档 — 开关被尊重
+      expect(await exists(dir)).toBe(true) // 本该归档却没动 — 开关被尊重
     } finally {
       spy.mockRestore()
       await tmp.cleanup()
@@ -342,7 +390,7 @@ describe("Curator on/off switch wiring (config → getCuratorEnabled → maybeRu
     const tmp = await makeTmp()
     const spy = spyOn(Config, "get").mockResolvedValue({ skills: {} } as any)
     try {
-      const dir = await makeSkill(tmp.path, "proj1", "foo", 100 * DAY)
+      const dir = await makeArchivable(tmp.path, "proj1", "foo") // 占比 0 / 曝光 1000 → 该归档
       await Curator.saveState(tmp.path, { lastRunAt: ago(8 * DAY), paused: false, runCount: 1 })
 
       const enabled = await ConfigReader.getCuratorEnabled()
@@ -357,6 +405,186 @@ describe("Curator on/off switch wiring (config → getCuratorEnabled → maybeRu
       expect(await exists(dir)).toBe(false) // 已归档
     } finally {
       spy.mockRestore()
+      await tmp.cleanup()
+    }
+  })
+})
+
+// 占比判据 (RELATIVE_USAGE_DESIGN.md): 归档 = 出生后"本项目"调用占比 < 阈值，且出生后曝光量已过试用期窗口。
+// 写一个 record + 真实 skill 目录的 fixture，让 applyAutomaticTransitions 按占比判，断言搬不搬目录。
+describe("Curator.applyAutomaticTransitions — share-based archival", () => {
+  // 里程碑1: 占比低于阈值 → 归档。foo mtime=今天，旧按天数判据不会归档它 → 改前应红。
+  test("archives a skill whose post-birth call share is below archiveUsageShare", async () => {
+    const tmp = await makeTmp()
+    try {
+      const fooDir = await makeSkill(tmp.path, "proj1", "foo", 0) // 今天刚改 → 旧判据留它
+      const sibDir = await makeSkill(tmp.path, "proj1", "sib", 0)
+      // 同项目: foo 0 次 / sib 1000 次 → 本项目总数 1000, foo 出生水位 0 → 曝光 1000, 占比 0
+      await writeLedger(tmp.path, {
+        "proj1/foo": record("proj1", "foo", fooDir, { use_count: 0, born_at_project_total: 0 }),
+        "proj1/sib": record("proj1", "sib", sibDir, { use_count: 1000, born_at_project_total: 0 }),
+      })
+
+      await Curator.applyAutomaticTransitions(tmp.path, { now: NOW, config: DEFAULT_CURATOR_CONFIG })
+
+      expect(await exists(fooDir)).toBe(false)
+      expect(await exists(path.join(tmp.path, "proj1", "archive", "foo", "SKILL.md"))).toBe(true)
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/foo"]!.state).toBe("archived")
+      // sib 占比 1000/1000 = 1 → 留
+      expect(data["proj1/sib"]!.state).toBe("active")
+      expect(await exists(sibDir)).toBe(true)
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // 里程碑2 (M2 不删末位): 5 个 skill 各占 1/5 → 占比都在阈值之上 → 一个都不归档
+  test("archives none when every share is above threshold (no last-place delete)", async () => {
+    const tmp = await makeTmp()
+    try {
+      const led: Record<string, UsageRecord> = {}
+      for (const n of ["a", "b", "c", "d", "e"]) {
+        const dir = await makeSkill(tmp.path, "proj1", n, 0)
+        led[`proj1/${n}`] = record("proj1", n, dir, { use_count: 200, born_at_project_total: 0 })
+      }
+      await writeLedger(tmp.path, led)
+
+      const counts = await Curator.applyAutomaticTransitions(tmp.path, { now: NOW, config: DEFAULT_CURATOR_CONFIG })
+      expect(counts.archived).toBe(0) // 本项目总数 1000, 各占 0.2 ≥ 0.001 → 都留
+      const data = await Usage.load(tmp.path)
+      for (const n of ["a", "b", "c", "d", "e"]) expect(data[`proj1/${n}`]!.state).toBe("active")
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // 里程碑3 (出生窗口保护): 出生后曝光量 < minExposureCalls → 不判, 哪怕占比 0。
+  // 漏掉窗口闸门会误归档它 → 实现时若先不加窗口应红。
+  test("protects a newborn skill within its trial window (exposure < minExposureCalls)", async () => {
+    const tmp = await makeTmp()
+    try {
+      const fooDir = await makeSkill(tmp.path, "proj1", "foo", 0)
+      const sibDir = await makeSkill(tmp.path, "proj1", "sib", 0)
+      // 本项目总数 50300, foo 出生水位 50000 → 曝光 = 300 < 1000 → 试用期未满
+      await writeLedger(tmp.path, {
+        "proj1/foo": record("proj1", "foo", fooDir, { use_count: 0, born_at_project_total: 50000 }),
+        "proj1/sib": record("proj1", "sib", sibDir, { use_count: 50300, born_at_project_total: 0 }),
+      })
+
+      await Curator.applyAutomaticTransitions(tmp.path, { now: NOW, config: DEFAULT_CURATOR_CONFIG })
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/foo"]!.state).toBe("active") // 窗口保护
+      expect(await exists(fooDir)).toBe(true)
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // 里程碑4 (项目隔离, 复现用户反例): 别项目猛跑不该稀释本项目里好 skill 的占比。
+  test("project-isolated denominator — a busy other project does not dilute this one", async () => {
+    const tmp = await makeTmp()
+    try {
+      const aFoo = await makeSkill(tmp.path, "projA", "foo", 0)
+      const aSib = await makeSkill(tmp.path, "projA", "sib", 0)
+      const bBusy = await makeSkill(tmp.path, "projB", "busy", 0)
+      await writeLedger(tmp.path, {
+        "projA/foo": record("projA", "foo", aFoo, { use_count: 5, born_at_project_total: 0 }),
+        "projA/sib": record("projA", "sib", aSib, { use_count: 995, born_at_project_total: 0 }),
+        "projB/busy": record("projB", "busy", bBusy, { use_count: 50000, born_at_project_total: 0 }),
+      })
+
+      await Curator.applyAutomaticTransitions(tmp.path, { now: NOW, config: DEFAULT_CURATOR_CONFIG })
+      const data = await Usage.load(tmp.path)
+      // projA 本项目总数 = 1000, foo 占比 5/1000 = 0.005 ≥ 0.001 → 留
+      // (全局分母会算成 5/51000 ≈ 0.0001 → 被冲到归档, 正是本次要避免的)
+      expect(data["projA/foo"]!.state).toBe("active")
+      expect(await exists(aFoo)).toBe(true)
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // 里程碑5 (出生水位写读接力): 真跑 创建 → 同项目累加 → 判 三步, 不手填 born。
+  // 用小配置 (窗口 3 / 阈值 0.5) 避免上千次 bumpUse, 逻辑同默认值。
+  const SMALL = { ...DEFAULT_CURATOR_CONFIG, minExposureCalls: 3, archiveUsageShare: 0.5 }
+
+  test("relay: a newborn left unused IS archived once post-birth exposure passes the window", async () => {
+    const tmp = await makeTmp()
+    try {
+      const fillerDir = await makeSkill(tmp.path, "proj1", "filler", 0)
+      const newDir = await makeSkill(tmp.path, "proj1", "newbie", 0)
+      // 先把本项目顶到 3 → 创建 newbie (出生水位锁 3) → 再顶 3 (newbie 曝光 = 6-3 = 3 ≥ 3)
+      for (let i = 0; i < 3; i++) await Usage.bumpUse(tmp.path, fillerDir)
+      await Usage.seedIfMissing(tmp.path, newDir) // newbie 出生: born=3, use_count=0
+      for (let i = 0; i < 3; i++) await Usage.bumpUse(tmp.path, fillerDir)
+
+      await Curator.applyAutomaticTransitions(tmp.path, { now: NOW, config: SMALL })
+
+      const data = await Usage.load(tmp.path)
+      // newbie: 曝光 3 ≥ 3, 占比 0/3 = 0 < 0.5 → 归档
+      expect(data["proj1/newbie"]!.state).toBe("archived")
+      expect(await exists(newDir)).toBe(false)
+      // filler: 出生水位 0, 曝光 6, 占比 6/6 = 1 → 留
+      expect(data["proj1/filler"]!.state).toBe("active")
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  test("relay: the same newborn is protected while still inside the window (one fewer post-birth call)", async () => {
+    const tmp = await makeTmp()
+    try {
+      const fillerDir = await makeSkill(tmp.path, "proj1", "filler", 0)
+      const newDir = await makeSkill(tmp.path, "proj1", "newbie", 0)
+      for (let i = 0; i < 3; i++) await Usage.bumpUse(tmp.path, fillerDir)
+      await Usage.seedIfMissing(tmp.path, newDir) // born=3
+      for (let i = 0; i < 2; i++) await Usage.bumpUse(tmp.path, fillerDir) // 只加 2
+
+      await Curator.applyAutomaticTransitions(tmp.path, { now: NOW, config: SMALL })
+
+      const data = await Usage.load(tmp.path)
+      // newbie: 曝光 = 5-3 = 2 < 3 → 试用期未满 → 不判
+      expect(data["proj1/newbie"]!.state).toBe("active")
+      expect(await exists(newDir)).toBe(true)
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // H1 边界: 空账本 / 本项目总数为 0 → 曝光 ≤ 0, 试用期闸门拦下, 不归档、不抛
+  test("edge: empty/zero-total project archives nothing and does not throw", async () => {
+    const tmp = await makeTmp()
+    try {
+      const fooDir = await makeSkill(tmp.path, "proj1", "foo", 0)
+      // 唯一 skill, use_count 0, 出生水位 0 → 本项目总数 0, 曝光 0 < 1000
+      await Curator.applyAutomaticTransitions(tmp.path, { now: NOW, config: DEFAULT_CURATOR_CONFIG })
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/foo"]!.state).toBe("active")
+      expect(await exists(fooDir)).toBe(true)
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+})
+
+// SKILL_IDENTITY_DESIGN.md bug②: curator 必须和加载器用同一个解析器读 id, 否则非规范 id 两边读不一致 → split-brain。
+describe("Curator scanSkills reads id consistently with the loader", () => {
+  test("uses the YAML parser (not a regex) so a non-canonical id keys the same as the loader", async () => {
+    const tmp = await makeTmp()
+    try {
+      const dir = path.join(tmp.path, "proj1", "skills", "foo")
+      await fs.mkdir(dir, { recursive: true })
+      // 无引号 + 行尾注释: YAML 实际 id = "skl_x"; 手写正则会误抠成 "skl_x # note"
+      await fs.writeFile(path.join(dir, "SKILL.md"), `---\nid: skl_x # note\nname: foo\ndescription: test\n---\nBody\n`, "utf-8")
+
+      await Curator.applyAutomaticTransitions(tmp.path, { now: NOW })
+
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/skl_x"]).toBeDefined() // 按 YAML 真实 id 建 key
+      expect(data["proj1/skl_x"]!.id).toBe("skl_x")
+      expect(data["proj1/skl_x # note"]).toBeUndefined() // 不是正则误抠出来的那个
+    } finally {
       await tmp.cleanup()
     }
   })

--- a/packages/opencode/src/skill-evolution/curator/curator.test.ts
+++ b/packages/opencode/src/skill-evolution/curator/curator.test.ts
@@ -354,6 +354,22 @@ describe("Curator.maybeRun", () => {
       await tmp.cleanup()
     }
   })
+
+  // 到期跑完一轮 → 落出一份 usage.json.bak 备份 (#4)
+  test("a due run leaves a usage.json.bak backup", async () => {
+    const tmp = await makeTmp()
+    try {
+      await makeSkill(tmp.path, "proj1", "foo", 100 * DAY)
+      await Curator.saveState(tmp.path, { lastRunAt: ago(8 * DAY), paused: false, runCount: 1 })
+
+      await Curator.maybeRun(tmp.path, { now: NOW })
+
+      const bakFile = path.join(tmp.path, "curator", "usage.json.bak")
+      expect(await exists(bakFile)).toBe(true)
+    } finally {
+      await tmp.cleanup()
+    }
+  })
 })
 
 // 总开关接力 — 写(config 里的 curator_enabled)→ 读(getCuratorEnabled)→ 跑决定(maybeRun 的真实搬文件结果)

--- a/packages/opencode/src/skill-evolution/curator/curator.ts
+++ b/packages/opencode/src/skill-evolution/curator/curator.ts
@@ -1,6 +1,9 @@
 import fs from "fs/promises"
 import path from "path"
 import { Usage } from "./usage"
+
+/** Per-process counter for unique state.json temp-file names (see usage.ts tmpSeq, #1). */
+let stateTmpSeq = 0
 import { type CuratorConfig, DEFAULT_CURATOR_CONFIG } from "./constants"
 import { ConfigMarkdown } from "../../config/markdown"
 
@@ -41,7 +44,7 @@ export namespace Curator {
   export async function saveState(root: string, state: CuratorState): Promise<void> {
     const dir = curatorDir(root)
     await fs.mkdir(dir, { recursive: true })
-    const tmp = path.join(dir, `.state.${process.pid}.tmp`)
+    const tmp = path.join(dir, `.state.${process.pid}.${stateTmpSeq++}.tmp`)
     await fs.writeFile(tmp, JSON.stringify(state, null, 2), "utf-8")
     await fs.rename(tmp, stateFile(root))
   }
@@ -197,7 +200,7 @@ export namespace Curator {
         () => false,
       )
       if (live) continue
-      if (await Usage.hasArchivedCopy(root, rec.projectId, rec.name)) {
+      if (await Usage.hasArchivedCopy(root, rec)) {
         await Usage.setState(root, key, "archived", now)
         counts.healed++
       } else {

--- a/packages/opencode/src/skill-evolution/curator/curator.ts
+++ b/packages/opencode/src/skill-evolution/curator/curator.ts
@@ -228,6 +228,9 @@ export namespace Curator {
       const counts = await applyAutomaticTransitions(root, { now, config: opts.config })
       const state = await loadState(root)
       await saveState(root, { ...state, lastRunAt: now.toISOString(), runCount: state.runCount + 1 })
+      // Snapshot the now-validated ledger to usage.json.bak (weekly maintenance moment).
+      // If usage.json is ever corrupted, load() self-heals from this backup (#4).
+      await Usage.backupLedger(root)
       return counts
     } catch {
       // Best-effort: a curator failure must never break the session.

--- a/packages/opencode/src/skill-evolution/curator/curator.ts
+++ b/packages/opencode/src/skill-evolution/curator/curator.ts
@@ -2,6 +2,7 @@ import fs from "fs/promises"
 import path from "path"
 import { Usage } from "./usage"
 import { type CuratorConfig, DEFAULT_CURATOR_CONFIG } from "./constants"
+import { ConfigMarkdown } from "../../config/markdown"
 
 /** Scheduler state, persisted at `<root>/curator/state.json`. */
 export interface CuratorState {
@@ -86,11 +87,18 @@ export namespace Curator {
     healed: number
   }
 
-  /** Enumerate in-scope skills on disk: `<root>/<projectId>/skills/<name>/SKILL.md`. */
+  /**
+   * Enumerate in-scope skills on disk: `<root>/<projectId>/skills/<name>/SKILL.md`.
+   * Parses each SKILL.md with the SAME parser the skill loader uses (ConfigMarkdown /
+   * gray-matter) — NOT a private regex — so the `id` extracted here always matches the
+   * id bumpUse keys by; otherwise a non-canonical id (unquoted, trailing comment, …)
+   * would split one skill into two ledger keys. Parse failure / missing file → skip
+   * (consistent with the loader, which won't load it either). See SKILL_IDENTITY_DESIGN.md.
+   */
   async function scanSkills(
     root: string,
-  ): Promise<{ key: string; projectId: string; name: string; location: string; mtimeMs: number }[]> {
-    const out: { key: string; projectId: string; name: string; location: string; mtimeMs: number }[] = []
+  ): Promise<{ key: string; projectId: string; name: string; location: string; id?: string }[]> {
+    const out: { key: string; projectId: string; name: string; location: string; id?: string }[] = []
     const projects = await fs.readdir(root, { withFileTypes: true }).catch(() => [])
     for (const pe of projects) {
       if (!pe.isDirectory() || pe.name === "curator" || pe.name.startsWith(".")) continue
@@ -99,19 +107,28 @@ export namespace Curator {
       for (const se of skillDirs) {
         if (!se.isDirectory()) continue
         const location = path.join(skillsDir, se.name)
-        const stat = await fs.stat(path.join(location, "SKILL.md")).catch(() => null)
-        if (!stat) continue
-        out.push({ key: `${pe.name}/${se.name}`, projectId: pe.name, name: se.name, location, mtimeMs: stat.mtimeMs })
+        const md = await ConfigMarkdown.parse(path.join(location, "SKILL.md")).catch(() => null)
+        if (!md) continue
+        const id = typeof md.data.id === "string" ? md.data.id : undefined
+        const key = id ? `${pe.name}/${id}` : `${pe.name}/${se.name}`
+        out.push({ key, projectId: pe.name, name: se.name, location, id })
       }
     }
     return out
   }
 
   /**
-   * Pure-logic lifecycle pass (no AI). Scans every in-scope skill, seeds missing
-   * records, drives active→stale→archived by activity, reactivates revived
-   * skills, and prunes orphan records. Activity anchor = max(last_used_at,
-   * SKILL.md mtime). Pinned skills are skipped. Returns a change counter.
+   * Pure-logic lifecycle pass (no AI). Reads the ledger ONCE for the archive
+   * DECISIONS (so the denominator isn't re-summed per skill), but applies every
+   * actual change through a narrow read-modify-write (seedIfMissing/archiveSkill/
+   * setState) that re-reads the latest ledger and rewrites only the touched record.
+   * That keeps a concurrent bumpUse on the skill-load hot path from being clobbered
+   * by a stale whole-ledger overwrite. For every in-scope skill on disk: seed a
+   * missing record, else archive it when its post-birth call share within its own
+   * project falls below archiveUsageShare (once exposure clears the minExposureCalls
+   * trial window). Finally prune orphan records whose directory is gone: heal→archived
+   * if an archived copy exists, else tombstone→deleted (retaining use_count in the
+   * project denominator, D6). Pinned skills are never archived. Returns a change counter.
    */
   export async function applyAutomaticTransitions(
     root: string,
@@ -119,7 +136,6 @@ export namespace Curator {
   ): Promise<TransitionCounts> {
     const now = opts.now ?? new Date()
     const config = opts.config ?? DEFAULT_CURATOR_CONFIG
-    const DAY = 24 * 3600_000
     const counts: TransitionCounts = {
       checked: 0,
       seeded: 0,
@@ -130,44 +146,52 @@ export namespace Curator {
       healed: 0,
     }
 
+    // Read the ledger ONCE for the decisions below; the denominator (per-project total
+    // use_count) is the same for every skill in a project, so compute it once up front
+    // instead of re-summing per skill. Writes go through narrow helpers (see docstring).
+    const data = await Usage.load(root)
+    const projectTotals = new Map<string, number>()
+    for (const rec of Object.values(data)) {
+      projectTotals.set(rec.projectId, (projectTotals.get(rec.projectId) ?? 0) + rec.use_count)
+    }
+
     for (const s of await scanSkills(root)) {
       counts.checked++
 
-      const before = await Usage.load(root)
-      if (!before[s.key]) {
-        await Usage.seedIfMissing(root, s.location)
-        counts.seeded++
-      }
-
-      const data = await Usage.load(root)
       const rec = data[s.key]
-      if (!rec || rec.pinned) continue
+      if (!rec) {
+        // Newly seen on disk → seed a baseline record (narrow write). A freshly seeded
+        // skill has exposure 0 (born = current total), so it's never archived this pass.
+        await Usage.seedIfMissing(root, s.location, s.id)
+        counts.seeded++
+        continue
+      }
+      if (rec.pinned || rec.state === "archived" || rec.state === "deleted") continue
 
-      // Activity anchor = newest of (last load, last file change).
-      const lastUsedMs = rec.last_used_at ? new Date(rec.last_used_at).getTime() : -Infinity
-      const daysSince = (now.getTime() - Math.max(lastUsedMs, s.mtimeMs)) / DAY
-
-      if (daysSince >= config.archiveAfterDays && rec.state !== "archived") {
+      // Archive judgment: relative call share over the post-birth exposure window,
+      // measured WITHIN the skill's own project (skills are project-isolated, so
+      // other projects' calls are chances it never had). See RELATIVE_USAGE_DESIGN.md.
+      const exposure = (projectTotals.get(rec.projectId) ?? 0) - rec.born_at_project_total
+      // Birth trial window: too few post-birth chances yet → not judged (also guards
+      // exposure ≤ 0, e.g. an empty/zero-total project, against a divide-by-zero share).
+      if (exposure < config.minExposureCalls) continue
+      const share = rec.use_count / exposure
+      if (share < config.archiveUsageShare) {
         if (await Usage.archiveSkill(root, s.key, now)) counts.archived++
-      } else if (daysSince >= config.staleAfterDays && rec.state === "active") {
-        await Usage.setState(root, s.key, "stale", now)
-        counts.marked_stale++
-      } else if (daysSince < config.staleAfterDays && rec.state === "stale") {
-        await Usage.setState(root, s.key, "active", now)
-        counts.reactivated++
       }
     }
 
-    // Orphan cleanup: a non-archived record whose skill directory is gone.
-    // Two causes look identical (state≠archived + location missing):
-    //  - true orphan: skill deleted out-of-band (e.g. skill_manage delete) → forget.
-    //  - fake orphan: a concurrent write clobbered state back to active AFTER the
-    //    dir was moved to archive/ → heal back to archived, don't forget (else the
-    //    archived copy loses its ledger entry and becomes unrecoverable).
-    // Archived records legitimately have a non-existent location, so skip them.
+    // Orphan cleanup: re-read the latest ledger (now reflecting this pass's seeds/archives
+    // plus any concurrent bumpUse) and act on each record whose skill directory is gone.
+    // Two causes look identical (state active + location missing):
+    //  - true orphan: skill deleted out-of-band (e.g. skill_manage delete) → tombstone
+    //    as `deleted`, keeping its use_count in the project denominator (D6).
+    //  - fake orphan: a concurrent write clobbered state back to active AFTER the dir
+    //    was moved to archive/ → heal back to `archived` (an archived copy exists).
+    // Archived/deleted records legitimately have a non-existent location, so skip them.
     const ledger = await Usage.load(root)
     for (const [key, rec] of Object.entries(ledger)) {
-      if (rec.state === "archived") continue
+      if (rec.state === "archived" || rec.state === "deleted") continue
       const live = await fs.access(rec.location).then(
         () => true,
         () => false,
@@ -177,7 +201,7 @@ export namespace Curator {
         await Usage.setState(root, key, "archived", now)
         counts.healed++
       } else {
-        await Usage.forget(root, key)
+        await Usage.setState(root, key, "deleted", now)
         counts.orphans++
       }
     }

--- a/packages/opencode/src/skill-evolution/curator/usage.test.ts
+++ b/packages/opencode/src/skill-evolution/curator/usage.test.ts
@@ -17,11 +17,12 @@ function exists(p: string): Promise<boolean> {
 }
 
 /** Create an in-scope skill dir <root>/<projectId>/skills/<name>/SKILL.md, return SKILL.md path. */
-async function makeSkill(root: string, projectId: string, name: string): Promise<string> {
+async function makeSkill(root: string, projectId: string, name: string, id?: string): Promise<string> {
   const dir = path.join(root, projectId, "skills", name)
   await fs.mkdir(dir, { recursive: true })
   const loc = path.join(dir, "SKILL.md")
-  await fs.writeFile(loc, `---\nname: ${name}\ndescription: test\n---\nBody\n`, "utf-8")
+  const idLine = id ? `id: ${JSON.stringify(id)}\n` : ""
+  await fs.writeFile(loc, `---\n${idLine}name: ${name}\ndescription: test\n---\nBody\n`, "utf-8")
   return loc
 }
 
@@ -264,6 +265,85 @@ describe("Usage.restoreSkill", () => {
       const data = await Usage.load(tmp.path)
       expect(data["proj1/foo"]!.state).toBe("active")
       expect(data["proj1/foo"]!.archived_at).toBeNull()
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+})
+
+describe("Usage archive identity (#2: keyed by id, not name)", () => {
+  // 两个同名 foo、不同 id：归档后必须落到各自 id 命名的目录，互不覆盖。
+  // bug 态(按名字归档)：第一个进 archive/foo，第二个进 archive/foo-<时间戳>，
+  // 所以 archive/skl_A 不存在 → 红。修复后(按 id)：archive/skl_A、archive/skl_B 都在 → 绿。
+  test("same-name skills with different ids archive into separate id-named dirs (no overwrite)", async () => {
+    const tmp = await makeTmp()
+    try {
+      const locA = await makeSkill(tmp.path, "proj1", "foo", "skl_A")
+      await Usage.bumpUse(tmp.path, locA, undefined, undefined, "skl_A")
+      expect(await Usage.archiveSkill(tmp.path, "proj1/skl_A")).toBe(true)
+
+      // recreate "foo" at the same path with a different id, then archive it too
+      const locB = await makeSkill(tmp.path, "proj1", "foo", "skl_B")
+      await Usage.bumpUse(tmp.path, locB, undefined, undefined, "skl_B")
+      expect(await Usage.archiveSkill(tmp.path, "proj1/skl_B")).toBe(true)
+
+      // both archived copies coexist, each under its own id
+      expect(await exists(path.join(tmp.path, "proj1", "archive", "skl_A", "SKILL.md"))).toBe(true)
+      expect(await exists(path.join(tmp.path, "proj1", "archive", "skl_B", "SKILL.md"))).toBe(true)
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // 孤儿判定接缝：A(id skl_A)已归档；B(id skl_B、同名 foo)从没归档过(真孤儿)。
+  // hasArchivedCopy 必须按 B 自己的 id 查 → false；bug 态按名字查会看到 A 的副本 → true(红)。
+  test("hasArchivedCopy matches by id, so a reused name does not mask a true orphan", async () => {
+    const tmp = await makeTmp()
+    try {
+      const locA = await makeSkill(tmp.path, "proj1", "foo", "skl_A")
+      await Usage.bumpUse(tmp.path, locA, undefined, undefined, "skl_A")
+      await Usage.archiveSkill(tmp.path, "proj1/skl_A")
+
+      // A has an archived copy; B (different id, same name) never did
+      expect(await Usage.hasArchivedCopy(tmp.path, { projectId: "proj1", id: "skl_A", name: "foo" })).toBe(true)
+      expect(await Usage.hasArchivedCopy(tmp.path, { projectId: "proj1", id: "skl_B", name: "foo" })).toBe(false)
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // 恢复接缝：id 命名归档后，restoreSkill 必须按 id 找回(否则只改了归档、没改恢复 → 红)。
+  test("restoreSkill finds the id-named archive dir and moves it back", async () => {
+    const tmp = await makeTmp()
+    try {
+      const loc = await makeSkill(tmp.path, "proj1", "foo", "skl_A")
+      await Usage.bumpUse(tmp.path, loc, undefined, undefined, "skl_A")
+      await Usage.archiveSkill(tmp.path, "proj1/skl_A")
+      expect(await exists(loc)).toBe(false)
+
+      expect(await Usage.restoreSkill(tmp.path, "proj1/skl_A")).toBe(true)
+      expect(await exists(loc)).toBe(true)
+      expect((await Usage.load(tmp.path))["proj1/skl_A"]!.state).toBe("active")
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+})
+
+describe("Usage.save (#1: temp file must not collide under concurrency)", () => {
+  // 并发存档不应把账本写坏。注意:本仓库 #3(丢更新)未修,所以不能断言"所有记录都在"
+  // (并发 bumpUse 会互相覆盖记录数);这里只验"文件没被写花"——load 仍是合法 JSON、非空。
+  // 该测试在修复后稳定通过;bug 态(临时文件名写死)能否变红取决于时序,不保证必红。
+  test("concurrent writes leave the ledger as valid, non-empty JSON", async () => {
+    const tmp = await makeTmp()
+    try {
+      const locs = await Promise.all(
+        Array.from({ length: 25 }, (_, i) => makeSkill(tmp.path, "proj1", `s${i}`)),
+      )
+      await Promise.all(locs.map((loc) => Usage.bumpUse(tmp.path, loc)))
+
+      const data = await Usage.load(tmp.path)
+      expect(Object.keys(data).length).toBeGreaterThan(0)
     } finally {
       await tmp.cleanup()
     }

--- a/packages/opencode/src/skill-evolution/curator/usage.test.ts
+++ b/packages/opencode/src/skill-evolution/curator/usage.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import fs from "fs/promises"
 import os from "os"
 import path from "path"
-import { Usage } from "./usage"
+import { Usage, type UsageRecord } from "./usage"
 
 async function makeTmp(): Promise<{ path: string; cleanup: () => Promise<void> }> {
   const p = await fs.mkdtemp(path.join(os.tmpdir(), "curator-usage-test-"))
@@ -23,6 +23,24 @@ async function makeSkill(root: string, projectId: string, name: string): Promise
   const loc = path.join(dir, "SKILL.md")
   await fs.writeFile(loc, `---\nname: ${name}\ndescription: test\n---\nBody\n`, "utf-8")
   return loc
+}
+
+/** Build a ledger record for direct projectUseCount unit tests. */
+function rec(projectId: string, name: string, over: Partial<UsageRecord> = {}): UsageRecord {
+  return {
+    projectId,
+    id: null,
+    name,
+    location: `/x/${projectId}/skills/${name}`,
+    use_count: 0,
+    born_at_project_total: 0,
+    last_used_at: null,
+    recent_uses: [],
+    state: "active",
+    pinned: false,
+    archived_at: null,
+    ...over,
+  }
 }
 
 describe("Usage.bumpUse", () => {
@@ -303,6 +321,257 @@ describe("Usage.load", () => {
     try {
       const data = await Usage.load(tmp.path)
       expect(data).toEqual({})
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+})
+
+// SKILL_IDENTITY_DESIGN.md 里程碑5/6 (根因修复): 账本按 id 认人, 同名先后两个 skill 互不撞。
+describe("Usage.bumpUse keys by id (same-name skills don't collide)", () => {
+  // C1/B2: 旧 foo 归档后, 同名新 foo (不同 id) 拿到自己独立的账 —— 不撞、旧账冻结、不污染分母。
+  test("a re-created same-name skill with a different id gets its own record, not the archived one's", async () => {
+    const tmp = await makeTmp()
+    try {
+      const loc = await makeSkill(tmp.path, "proj1", "foo")
+      // 旧 foo (id=skl_A): 用 2 次 → 归档(按它的 id key)
+      await Usage.bumpUse(tmp.path, loc, undefined, undefined, "skl_A")
+      await Usage.bumpUse(tmp.path, loc, undefined, undefined, "skl_A")
+      await Usage.setState(tmp.path, "proj1/skl_A", "archived")
+      // 新 foo (id=skl_B) 在同名位置被用
+      await Usage.bumpUse(tmp.path, loc, undefined, undefined, "skl_B")
+
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/skl_A"]).toBeDefined() // 两条独立的账
+      expect(data["proj1/skl_B"]).toBeDefined()
+      expect(data["proj1/skl_A"]!.state).toBe("archived") // 旧的仍归档
+      expect(data["proj1/skl_A"]!.use_count).toBe(2) // 旧的次数冻结, 没被新 foo 顶高(不污染分母)
+      expect(data["proj1/skl_B"]!.state).toBe("active") // 新的独立活跃
+      expect(data["proj1/skl_B"]!.use_count).toBe(1)
+      expect(data["proj1/skl_B"]!.id).toBe("skl_B")
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // bug③: 同一个 id 从改名后的新目录加载 → 刷新 rec.location, 否则 curator 按旧路径误判'目录没了'而抖动
+  test("refreshes location when the same id is loaded from a renamed directory", async () => {
+    const tmp = await makeTmp()
+    try {
+      const fooLoc = await makeSkill(tmp.path, "proj1", "foo")
+      await Usage.bumpUse(tmp.path, fooLoc, undefined, undefined, "skl_x")
+      let data = await Usage.load(tmp.path)
+      expect(data["proj1/skl_x"]!.location).toBe(path.join(tmp.path, "proj1", "skills", "foo"))
+
+      // 文件夹改名 foo→bar (id 仍 skl_x), 从新路径加载
+      const barLoc = await makeSkill(tmp.path, "proj1", "bar")
+      await Usage.bumpUse(tmp.path, barLoc, undefined, undefined, "skl_x")
+      data = await Usage.load(tmp.path)
+      expect(data["proj1/skl_x"]!.location).toBe(path.join(tmp.path, "proj1", "skills", "bar")) // 刷新成当前路径
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // 兼容: 不传 id(老 skill)→ 仍按名字建 key, 记录 id 字段为 null
+  test("falls back to name-keying when no id is given; record id is null", async () => {
+    const tmp = await makeTmp()
+    try {
+      const loc = await makeSkill(tmp.path, "proj1", "bar")
+      await Usage.bumpUse(tmp.path, loc) // 无 id
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/bar"]).toBeDefined()
+      expect(data["proj1/bar"]!.id).toBeNull()
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // 兼容: 老账本记录无 id 字段 → load 回填 null
+  test("load backfills a missing id to null on legacy records", async () => {
+    const tmp = await makeTmp()
+    try {
+      const dir = path.join(tmp.path, "curator")
+      await fs.mkdir(dir, { recursive: true })
+      await fs.writeFile(
+        path.join(dir, "usage.json"),
+        JSON.stringify({
+          "proj1/foo": {
+            projectId: "proj1", name: "foo", location: "/x/proj1/skills/foo",
+            use_count: 3, born_at_project_total: 0, last_used_at: null, recent_uses: [],
+            state: "active", pinned: false, archived_at: null,
+          },
+        }),
+        "utf-8",
+      )
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/foo"]!.id).toBeNull()
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+})
+
+describe("Usage.projectUseCount", () => {
+  // C1: 同一 projectId 下 use_count 求和 (含 archived)，别项目不计入；无记录 → 0
+  test("sums same-project use_count including archived, excludes other projects", () => {
+    const data = {
+      "p1/a": rec("p1", "a", { use_count: 3 }),
+      "p1/b": rec("p1", "b", { use_count: 2, state: "archived" }), // archived 的历史调用仍计入 (D6)
+      "p2/x": rec("p2", "x", { use_count: 9 }), // 别项目 — 不进 p1 分母
+    }
+    expect(Usage.projectUseCount(data, "p1")).toBe(5)
+    expect(Usage.projectUseCount(data, "p2")).toBe(9)
+    expect(Usage.projectUseCount(data, "p3")).toBe(0) // 无该项目记录 → 0 (边界)
+  })
+})
+
+describe("Usage born_at_project_total (write→read seam)", () => {
+  // B2 (写读接缝): 真跑 累加同项目兄弟 → 再创建新 skill → load 读回；不手填出生水位。
+  // born 必须 = 创建那刻"本项目"已累计的调用数，且不含别项目的调用。
+  test("stamps born = same-project total at creation via bumpUse (not other projects)", async () => {
+    const tmp = await makeTmp()
+    try {
+      const a = await makeSkill(tmp.path, "proj1", "a")
+      const b = await makeSkill(tmp.path, "proj1", "b")
+      const x = await makeSkill(tmp.path, "proj2", "x")
+      // proj1 本项目总数顶到 3+2=5；proj2 单独 9 次 (不该进 proj1 的出生水位)
+      for (let i = 0; i < 3; i++) await Usage.bumpUse(tmp.path, a)
+      for (let i = 0; i < 2; i++) await Usage.bumpUse(tmp.path, b)
+      for (let i = 0; i < 9; i++) await Usage.bumpUse(tmp.path, x)
+
+      // 此刻创建 proj1 的新 skill c —— 出生水位应锁定为 5 (本项目)，与 proj2 的 9 无关
+      const c = await makeSkill(tmp.path, "proj1", "c")
+      await Usage.bumpUse(tmp.path, c)
+
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/c"]!.born_at_project_total).toBe(5)
+      expect(data["proj1/c"]!.use_count).toBe(1)
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // B2b: seedIfMissing 创建路径同样写出生水位 (use_count 仍为 0)
+  test("stamps born = same-project total at creation via seedIfMissing", async () => {
+    const tmp = await makeTmp()
+    try {
+      const a = await makeSkill(tmp.path, "proj1", "a")
+      for (let i = 0; i < 4; i++) await Usage.bumpUse(tmp.path, a)
+
+      const d = await makeSkill(tmp.path, "proj1", "d")
+      await Usage.seedIfMissing(tmp.path, d)
+
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/d"]!.born_at_project_total).toBe(4)
+      expect(data["proj1/d"]!.use_count).toBe(0)
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // R1 (墓碑复活): 一个被标 deleted 的记录, 同名 skill 在原位置重建后再被使用 →
+  // bumpUse 应把它复活成 active (否则 curator 永远跳过 deleted, 这个真在用的 skill 永世不判)。
+  // 关键: use_count 保留 (分母单调, 兄弟的出生水位算过它), 但 born 重盖给一段新的试用期。
+  test("revives a tombstoned (deleted) record on reuse: state→active, use_count kept, born re-stamped", async () => {
+    const tmp = await makeTmp()
+    try {
+      const loc = await makeSkill(tmp.path, "proj1", "foo") // 同名 skill 在原位置重建
+      const dir = path.join(tmp.path, "curator")
+      await fs.mkdir(dir, { recursive: true })
+      await fs.writeFile(
+        path.join(dir, "usage.json"),
+        JSON.stringify({
+          "proj1/foo": {
+            projectId: "proj1", name: "foo", location: path.dirname(loc),
+            use_count: 5, born_at_project_total: 0, last_used_at: null, recent_uses: [],
+            state: "deleted", pinned: false, archived_at: null,
+          },
+          "proj1/sib": {
+            projectId: "proj1", name: "sib", location: "/x/proj1/skills/sib",
+            use_count: 10, born_at_project_total: 0, last_used_at: null, recent_uses: [],
+            state: "active", pinned: false, archived_at: null,
+          },
+        }),
+        "utf-8",
+      )
+
+      await Usage.bumpUse(tmp.path, loc, "ses_reborn")
+
+      const data = await Usage.load(tmp.path)
+      const rec = data["proj1/foo"]!
+      expect(rec.state).toBe("active") // 复活 → curator 不再跳过它
+      expect(rec.use_count).toBe(6) // 旧计数保留 (5) + 本次 (1)，不是重置成 1 (保分母单调)
+      expect(rec.born_at_project_total).toBe(15) // 重盖 = 复活那刻本项目总数 foo(5)+sib(10) → 新试用期
+      expect(rec.recent_uses).toHaveLength(1) // 旧生命的缓存清掉, 只剩本次事件
+      expect(rec.recent_uses[0]!.session_id).toBe("ses_reborn")
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // R2 (归档不就地复活): archived 记录的目录已被搬到 archive/。在原位置就地复活会留下
+  // 无人认领的归档副本(日后可能把旧内容当正版恢复)→ 复活只管 deleted, 不管 archived。
+  test("does NOT revive an archived record in place (avoids orphaning its archive copy)", async () => {
+    const tmp = await makeTmp()
+    try {
+      const loc = await makeSkill(tmp.path, "proj1", "foo")
+      const dir = path.join(tmp.path, "curator")
+      await fs.mkdir(dir, { recursive: true })
+      await fs.writeFile(
+        path.join(dir, "usage.json"),
+        JSON.stringify({
+          "proj1/foo": {
+            projectId: "proj1", name: "foo", location: path.dirname(loc),
+            use_count: 3, born_at_project_total: 0, last_used_at: null, recent_uses: [],
+            state: "archived", pinned: false, archived_at: "2026-01-01T00:00:00.000Z",
+          },
+        }),
+        "utf-8",
+      )
+
+      await Usage.bumpUse(tmp.path, loc)
+
+      const data = await Usage.load(tmp.path)
+      const rec = data["proj1/foo"]!
+      expect(rec.state).toBe("archived") // 未被就地复活 (避免遗留孤立归档副本)
+      expect(rec.archived_at).toBe("2026-01-01T00:00:00.000Z") // 保持不变
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // B3 (只写一次): 已存在记录不重算 born —— 老记录回填 0 后，再 bumpUse 也不会被改成当前总数
+  test("does not recompute born for an existing record (legacy backfilled 0 stays 0)", async () => {
+    const tmp = await makeTmp()
+    try {
+      const foo = await makeSkill(tmp.path, "proj1", "foo")
+      const bar = await makeSkill(tmp.path, "proj1", "bar")
+      const dir = path.join(tmp.path, "curator")
+      await fs.mkdir(dir, { recursive: true })
+      // 老账本：foo 无 born 字段(回填 0)；bar 把本项目总数顶到 4
+      await fs.writeFile(
+        path.join(dir, "usage.json"),
+        JSON.stringify({
+          "proj1/foo": {
+            projectId: "proj1", name: "foo", location: path.dirname(foo),
+            use_count: 5, last_used_at: null, recent_uses: [],
+            state: "active", pinned: false, archived_at: null,
+          },
+          "proj1/bar": {
+            projectId: "proj1", name: "bar", location: path.dirname(bar),
+            use_count: 4, born_at_project_total: 0, last_used_at: null, recent_uses: [],
+            state: "active", pinned: false, archived_at: null,
+          },
+        }),
+        "utf-8",
+      )
+
+      await Usage.bumpUse(tmp.path, foo) // foo 已存在 → 不该把 born 改成当前总数(9)
+
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/foo"]!.born_at_project_total).toBe(0) // 回填 0 且未被重算
+      expect(data["proj1/foo"]!.use_count).toBe(6)
     } finally {
       await tmp.cleanup()
     }

--- a/packages/opencode/src/skill-evolution/curator/usage.test.ts
+++ b/packages/opencode/src/skill-evolution/curator/usage.test.ts
@@ -657,3 +657,61 @@ describe("Usage born_at_project_total (write→read seam)", () => {
     }
   })
 })
+
+// 账本备份 + 自愈 — usage.json 太重要, 损坏不能让历史归零 (#4)
+describe("Usage backup + self-heal", () => {
+  // 接缝: 主文件坏 → load 必须从 .bak 顶上, 而不是返回 {} 把历史抹掉, 并就地自愈主文件。
+  test("load() restores from .bak when the primary file is corrupt", async () => {
+    const tmp = await makeTmp()
+    try {
+      const loc = await makeSkill(tmp.path, "proj1", "foo")
+      await Usage.bumpUse(tmp.path, loc) // 写出一份好账本
+      const usageFile = path.join(tmp.path, "curator", "usage.json")
+      const bakFile = usageFile + ".bak"
+      await fs.copyFile(usageFile, bakFile) // 留一份好备份
+      await fs.writeFile(usageFile, "{ not valid json", "utf-8") // 主文件损坏
+
+      const data = await Usage.load(tmp.path)
+      expect(data["proj1/foo"]).toBeDefined() // 从 .bak 恢复, 不是 {}
+      expect(data["proj1/foo"]!.use_count).toBe(1)
+
+      // 主文件已被自愈成合法 JSON: 直接读盘也能拿到好数据
+      const onDisk = JSON.parse(await fs.readFile(usageFile, "utf-8"))
+      expect(onDisk["proj1/foo"].use_count).toBe(1)
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // 边界: 主文件不存在 (正常首次运行) 且无备份 → 仍返回 {}, 不去碰备份。
+  test("load() returns {} when primary is missing and there is no .bak", async () => {
+    const tmp = await makeTmp()
+    try {
+      const data = await Usage.load(tmp.path)
+      expect(data).toEqual({})
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+
+  // 接缝: 备份只存"验证过是好的"数据 — 主文件损坏时绝不拿坏数据覆盖好备份。
+  test("backupLedger writes .bak from a good ledger and never overwrites it with a corrupt primary", async () => {
+    const tmp = await makeTmp()
+    try {
+      const loc = await makeSkill(tmp.path, "proj1", "foo")
+      await Usage.bumpUse(tmp.path, loc) // 好账本, use_count 1
+      const usageFile = path.join(tmp.path, "curator", "usage.json")
+      const bakFile = usageFile + ".bak"
+
+      await Usage.backupLedger(tmp.path)
+      expect(await exists(bakFile)).toBe(true)
+      expect(JSON.parse(await fs.readFile(bakFile, "utf-8"))["proj1/foo"].use_count).toBe(1)
+
+      await fs.writeFile(usageFile, "garbage", "utf-8") // 主文件损坏
+      await Usage.backupLedger(tmp.path) // 必须跳过, 不能覆盖好备份
+      expect(JSON.parse(await fs.readFile(bakFile, "utf-8"))["proj1/foo"].use_count).toBe(1)
+    } finally {
+      await tmp.cleanup()
+    }
+  })
+})

--- a/packages/opencode/src/skill-evolution/curator/usage.ts
+++ b/packages/opencode/src/skill-evolution/curator/usage.ts
@@ -25,10 +25,28 @@ export interface UseEvent {
  */
 export interface UsageRecord {
   projectId: string
+  /**
+   * Stable unique skill identity, stamped into SKILL.md at creation (`skl_<ulid>`).
+   * The ledger keys records by id (`<projectId>/<id>`) so a skill archived/deleted
+   * and later RE-CREATED under the same name does NOT collide with the old record.
+   * `null` for legacy skills that predate the id field → those fall back to keying
+   * by name (`<projectId>/<name>`). See SKILL_IDENTITY_DESIGN.md.
+   */
+  id: string | null
   name: string
   /** Absolute path to the skill directory (lets archive/restore locate it). */
   location: string
   use_count: number
+  /**
+   * Sum of all SAME-PROJECT skills' use_count at the instant THIS record was
+   * first created — the skill's "birth water-mark". The curator judges a skill
+   * by its share over the window SINCE birth, within its own project:
+   *   exposure = projectUseCount(now, projectId) − born_at_project_total
+   * Per-project + post-birth so neither a dormant project nor other projects'
+   * calls can dilute its share. Legacy records predate this field → backfilled
+   * to 0 (treated as "present from the start"). See RELATIVE_USAGE_DESIGN.md D2.
+   */
+  born_at_project_total: number
   last_used_at: string | null
   /**
    * Recent-window cache of the last MAX_RECENT_USES use coordinates, oldest
@@ -38,7 +56,14 @@ export interface UsageRecord {
    * are dropped from the front. See SESSION_USAGE_DESIGN.md D17/D19.
    */
   recent_uses: UseEvent[]
-  state: "active" | "stale" | "archived"
+  /**
+   * Lifecycle state. `deleted` is a tombstone: the skill directory is gone with no
+   * archived copy (a true orphan), but the record is RETAINED so its historical
+   * use_count stays in projectUseCount — the per-project denominator must stay
+   * monotonic or siblings' post-birth exposure would shrink/go negative. See
+   * RELATIVE_USAGE_DESIGN.md D6. Tombstones are never scanned or re-judged.
+   */
+  state: "active" | "stale" | "archived" | "deleted"
   /** Skip auto-transitions. Read-only in this version (no setter, see Q2). */
   pinned: boolean
   archived_at: string | null
@@ -51,6 +76,21 @@ export namespace Usage {
    * CuratorConfig (YAGNI). See SESSION_USAGE_DESIGN.md Q-N.
    */
   export const MAX_RECENT_USES = 50
+
+  /**
+   * Sum of `use_count` over every ledger record in ONE project (same projectId),
+   * including archived ones (their calls really happened, so they keep the total
+   * monotonic — see RELATIVE_USAGE_DESIGN.md D6). Pure: operates on already-loaded
+   * ledger data, no file I/O. This is the denominator for a skill's archive share,
+   * and the value stamped into `born_at_project_total` at record creation.
+   */
+  export function projectUseCount(data: Record<string, UsageRecord>, projectId: string): number {
+    let sum = 0
+    for (const rec of Object.values(data)) {
+      if (rec.projectId === projectId) sum += rec.use_count
+    }
+    return sum
+  }
 
   function curatorDir(root: string): string {
     return path.join(root, "curator")
@@ -68,28 +108,49 @@ export namespace Usage {
   function resolveScope(
     root: string,
     location: string,
-  ): { key: string; projectId: string; name: string; skillDir: string } | null {
+    id?: string,
+  ): { key: string; projectId: string; name: string; skillDir: string; id: string | null } | null {
     const skillDir = location.endsWith("SKILL.md") ? path.dirname(location) : location
     const rel = path.relative(root, skillDir)
     const parts = rel.split(path.sep)
     if (parts.length !== 3) return null
     const [projectId, mid, name] = parts
     if (!projectId || mid !== "skills" || !name || projectId.startsWith("..")) return null
-    return { key: `${projectId}/${name}`, projectId, name, skillDir }
+    // Key by id when the skill has one; fall back to name for legacy/id-less skills.
+    const key = id ? `${projectId}/${id}` : `${projectId}/${name}`
+    return { key, projectId, name, skillDir, id: id ?? null }
   }
 
-  function emptyRecord(scope: { projectId: string; name: string; skillDir: string }): UsageRecord {
+  function emptyRecord(scope: { projectId: string; name: string; skillDir: string; id?: string | null }): UsageRecord {
     return {
       projectId: scope.projectId,
+      id: scope.id ?? null,
       name: scope.name,
       location: scope.skillDir,
       use_count: 0,
+      born_at_project_total: 0,
       last_used_at: null,
       recent_uses: [],
       state: "active",
       pinned: false,
       archived_at: null,
     }
+  }
+
+  /**
+   * Build a fresh record for a never-before-seen skill, stamping its birth
+   * water-mark = the same-project total at this instant (computed from `data`
+   * BEFORE the new record is inserted — its own use_count is 0 anyway). This is
+   * the SINGLE place birth is stamped; seedIfMissing and bumpUse both use it so
+   * the two creation paths can never assign different born values. See D2/D5.
+   */
+  function createRecord(
+    data: Record<string, UsageRecord>,
+    scope: { projectId: string; name: string; skillDir: string; id?: string | null },
+  ): UsageRecord {
+    const rec = emptyRecord(scope)
+    rec.born_at_project_total = projectUseCount(data, scope.projectId)
+    return rec
   }
 
   /** Read the whole ledger. Returns {} on missing/corrupt (defensive, never throws). */
@@ -105,6 +166,11 @@ export namespace Usage {
           const rec = v as UsageRecord
           // Legacy records predate recent_uses; backfill so .push never throws.
           if (!Array.isArray(rec.recent_uses)) rec.recent_uses = []
+          // Legacy records predate born_at_project_total; backfill to 0
+          // (= "present from the start", see RELATIVE_USAGE_DESIGN.md D4).
+          if (typeof rec.born_at_project_total !== "number") rec.born_at_project_total = 0
+          // Legacy records predate `id`; backfill to null (= key by name, not id).
+          if (typeof rec.id !== "string") rec.id = null
           clean[k] = rec
         }
       }
@@ -151,6 +217,25 @@ export namespace Usage {
   }
 
   /**
+   * Move a skill's directory to `<root>/<projectId>/archive/<name>/` (DISK ONLY —
+   * does not touch the ledger or save). Returns false if the source directory is
+   * missing. Name collisions get a timestamp suffix. Split out of archiveSkill so
+   * a batch pass (curator) can move the dir here and update the in-memory record
+   * itself, persisting the whole ledger once at the end. Best-effort caller-guarded.
+   */
+  async function moveToArchive(root: string, rec: UsageRecord, now: Date = new Date()): Promise<boolean> {
+    if (!(await pathExists(rec.location))) return false
+    const destRoot = archiveRoot(root, rec.projectId)
+    await fs.mkdir(destRoot, { recursive: true })
+    let dest = path.join(destRoot, rec.name)
+    if (await pathExists(dest)) {
+      dest = path.join(destRoot, `${rec.name}-${now.toISOString().replace(/[:.]/g, "-")}`)
+    }
+    await fs.rename(rec.location, dest)
+    return true
+  }
+
+  /**
    * Archive a skill: move its directory to `<root>/<projectId>/archive/<name>/`
    * and mark the ledger record `archived`. The directory is MOVED (recoverable),
    * never deleted. Returns false if the record or its directory is missing.
@@ -159,16 +244,7 @@ export namespace Usage {
     const data = await load(root)
     const rec = data[key]
     if (!rec) return false
-    if (!(await pathExists(rec.location))) return false
-
-    const destRoot = archiveRoot(root, rec.projectId)
-    await fs.mkdir(destRoot, { recursive: true })
-    let dest = path.join(destRoot, rec.name)
-    if (await pathExists(dest)) {
-      dest = path.join(destRoot, `${rec.name}-${now.toISOString().replace(/[:.]/g, "-")}`)
-    }
-
-    await fs.rename(rec.location, dest)
+    if (!(await moveToArchive(root, rec, now))) return false
     rec.state = "archived"
     rec.archived_at = now.toISOString()
     data[key] = rec
@@ -177,12 +253,12 @@ export namespace Usage {
   }
 
   /** Create a baseline record for an in-scope skill if none exists. No-op otherwise. */
-  export async function seedIfMissing(root: string, location: string): Promise<void> {
-    const scope = resolveScope(root, location)
+  export async function seedIfMissing(root: string, location: string, id?: string): Promise<void> {
+    const scope = resolveScope(root, location, id)
     if (!scope) return
     const data = await load(root)
     if (data[scope.key]) return
-    data[scope.key] = emptyRecord(scope)
+    data[scope.key] = createRecord(data, scope)
     await save(root, data)
   }
 
@@ -240,12 +316,38 @@ export namespace Usage {
     location: string,
     sessionId?: string,
     now: Date = new Date(),
+    id?: string,
   ): Promise<void> {
-    const scope = resolveScope(root, location)
+    const scope = resolveScope(root, location, id)
     if (!scope) return
     try {
       const data = await load(root)
-      const rec = data[scope.key] ?? emptyRecord(scope)
+      let rec = data[scope.key]
+      if (!rec) {
+        // First sight of this skill → create it (born water-mark stamped inside).
+        rec = createRecord(data, scope)
+      } else if (rec.state === "deleted") {
+        // A live skill is being loaded at a key whose record is a `deleted` tombstone (a
+        // true orphan — by definition no archive copy exists) — a new skill has reclaimed
+        // this slot. Revive it into the active lifecycle so the curator judges it again
+        // instead of skipping it forever. Keep use_count (the project denominator must stay
+        // monotonic — siblings' born water-marks already counted it), but re-stamp born for
+        // a fresh trial window and drop the previous life's recent-use cache.
+        //
+        // Only `deleted` is revived, NOT `archived`: an archived skill's directory was MOVED
+        // to archive/, so reviving in place would orphan that copy (and a later out-of-band
+        // delete could resurrect its stale content). An archived slot is left as-is; recovery
+        // goes through restoreSkill, which moves the copy back. See RELATIVE_USAGE_DESIGN.md.
+        rec.born_at_project_total = projectUseCount(data, scope.projectId)
+        rec.state = "active"
+        rec.archived_at = null
+        rec.recent_uses = []
+      }
+      // An existing active/stale record keeps its born untouched.
+      // Refresh location to the current path: with id-keying a record survives a directory
+      // rename, but a stale location would make the curator's orphan check think the skill
+      // is gone and flap it deleted↔revived every pass. See SKILL_IDENTITY_DESIGN.md bug③.
+      rec.location = scope.skillDir
       rec.use_count += 1
       rec.last_used_at = now.toISOString()
       if (sessionId) {

--- a/packages/opencode/src/skill-evolution/curator/usage.ts
+++ b/packages/opencode/src/skill-evolution/curator/usage.ts
@@ -3,6 +3,15 @@ import os from "os"
 import path from "path"
 
 /**
+ * Per-process monotonic counter for temp-file names. Combined with process.pid +
+ * hostname it makes every save's temp path unique, so two concurrent saves in the
+ * SAME process never write to the same temp file and corrupt it (#1). A counter
+ * (not Date.now/random) is enough: it's incremented synchronously, so concurrent
+ * callers always get distinct values.
+ */
+let tmpSeq = 0
+
+/**
  * A single skill-use coordinate. Pointer only — the full session lives in the
  * session DB and is fetched back by `session_id` when evaluation is needed.
  * No `projectId`: the ledger key already scopes a record to one project. See
@@ -184,7 +193,7 @@ export namespace Usage {
   async function save(root: string, data: Record<string, UsageRecord>): Promise<void> {
     const dir = curatorDir(root)
     await fs.mkdir(dir, { recursive: true })
-    const tmp = path.join(dir, `.usage.${process.pid}.${os.hostname()}.tmp`)
+    const tmp = path.join(dir, `.usage.${process.pid}.${os.hostname()}.${tmpSeq++}.tmp`)
     await fs.writeFile(tmp, JSON.stringify(data, null, 2), "utf-8")
     await fs.rename(tmp, usageFile(root))
   }
@@ -198,6 +207,19 @@ export namespace Usage {
     return path.join(root, projectId, "archive")
   }
 
+  /**
+   * The archive directory name for a record: its stable `id` when present, else the
+   * skill `name` (legacy id-less skills). Keying the on-disk archive by id — the SAME
+   * identity the ledger keys by — means two same-named skills with different ids land
+   * in different archive dirs and can never overwrite or mask each other. This closes
+   * the gap where the ledger went id-keyed but the archive layout stayed name-keyed
+   * (#2), and removes the same-name collision the timestamp-suffix fallback papered
+   * over (#6) for any skill that has an id. See SKILL_IDENTITY_DESIGN.md.
+   */
+  function archiveKey(rec: Pick<UsageRecord, "id" | "name">): string {
+    return rec.id ?? rec.name
+  }
+
   async function pathExists(p: string): Promise<boolean> {
     return fs.access(p).then(
       () => true,
@@ -206,14 +228,18 @@ export namespace Usage {
   }
 
   /**
-   * Whether an archived copy of a skill exists at `<root>/<projectId>/archive/<name>/`.
+   * Whether an archived copy of THIS record exists at `<root>/<projectId>/archive/<id-or-name>/`.
    * Used by orphan cleanup to tell a true orphan (skill deleted out-of-band) from a
    * fake one (record state clobbered back from `archived` to `active` by a concurrent
-   * write while the directory was already moved to archive/). Exact-match only: a
-   * timestamp-suffixed copy from an archive name-collision is not detected.
+   * write while the directory was already moved to archive/). Keyed by the record's id
+   * (via archiveKey), so a different skill that merely REUSES the same name is not
+   * mistaken for having an archived copy (#2).
    */
-  export async function hasArchivedCopy(root: string, projectId: string, name: string): Promise<boolean> {
-    return pathExists(path.join(archiveRoot(root, projectId), name))
+  export async function hasArchivedCopy(
+    root: string,
+    rec: Pick<UsageRecord, "projectId" | "id" | "name">,
+  ): Promise<boolean> {
+    return pathExists(path.join(archiveRoot(root, rec.projectId), archiveKey(rec)))
   }
 
   /**
@@ -227,9 +253,12 @@ export namespace Usage {
     if (!(await pathExists(rec.location))) return false
     const destRoot = archiveRoot(root, rec.projectId)
     await fs.mkdir(destRoot, { recursive: true })
-    let dest = path.join(destRoot, rec.name)
+    const base = archiveKey(rec)
+    let dest = path.join(destRoot, base)
     if (await pathExists(dest)) {
-      dest = path.join(destRoot, `${rec.name}-${now.toISOString().replace(/[:.]/g, "-")}`)
+      // For id-keyed skills `base` is unique so this branch is effectively dead; it
+      // only guards legacy id-less name collisions (and a stray leftover dir).
+      dest = path.join(destRoot, `${base}-${now.toISOString().replace(/[:.]/g, "-")}`)
     }
     await fs.rename(rec.location, dest)
     return true
@@ -298,7 +327,7 @@ export namespace Usage {
     const rec = data[key]
     if (!rec) return false
 
-    const archived = path.join(archiveRoot(root, rec.projectId), rec.name)
+    const archived = path.join(archiveRoot(root, rec.projectId), archiveKey(rec))
     if (!(await pathExists(archived))) return false
     if (await pathExists(rec.location)) return false // don't overwrite a live skill
 

--- a/packages/opencode/src/skill-evolution/curator/usage.ts
+++ b/packages/opencode/src/skill-evolution/curator/usage.ts
@@ -109,6 +109,41 @@ export namespace Usage {
     return path.join(curatorDir(root), "usage.json")
   }
 
+  /** Last-known-good backup of the ledger; written once per curator run. See #4. */
+  function bakFile(root: string): string {
+    return usageFile(root) + ".bak"
+  }
+
+  /**
+   * Parse + sanitize raw ledger JSON into clean records. Returns null when the text
+   * isn't a usable ledger object (invalid JSON / not an object / array) so callers can
+   * tell "corrupt" apart from "valid but empty {}". Backfills legacy-missing fields.
+   */
+  function parseLedger(raw: string): Record<string, UsageRecord> | null {
+    let data: unknown
+    try {
+      data = JSON.parse(raw)
+    } catch {
+      return null
+    }
+    if (!data || typeof data !== "object" || Array.isArray(data)) return null
+    const clean: Record<string, UsageRecord> = {}
+    for (const [k, v] of Object.entries(data)) {
+      if (v && typeof v === "object") {
+        const rec = v as UsageRecord
+        // Legacy records predate recent_uses; backfill so .push never throws.
+        if (!Array.isArray(rec.recent_uses)) rec.recent_uses = []
+        // Legacy records predate born_at_project_total; backfill to 0
+        // (= "present from the start", see RELATIVE_USAGE_DESIGN.md D4).
+        if (typeof rec.born_at_project_total !== "number") rec.born_at_project_total = 0
+        // Legacy records predate `id`; backfill to null (= key by name, not id).
+        if (typeof rec.id !== "string") rec.id = null
+        clean[k] = rec
+      }
+    }
+    return clean
+  }
+
   /**
    * Resolve a skill location to its ledger key + scope.
    * Returns null when the location is NOT under `<root>/<projectId>/skills/<name>`
@@ -162,31 +197,27 @@ export namespace Usage {
     return rec
   }
 
-  /** Read the whole ledger. Returns {} on missing/corrupt (defensive, never throws). */
+  /**
+   * Read the whole ledger. Never throws (defensive).
+   *  - primary missing (normal first run) → {} (don't touch any backup).
+   *  - primary present + valid → parsed records.
+   *  - primary present but CORRUPT → fall back to the last-known-good `.bak` so one bad
+   *    file can't wipe all usage history (#4); self-heal the primary from it so the next
+   *    save doesn't overwrite good data with {}. Both bad → {}.
+   */
   export async function load(root: string): Promise<Record<string, UsageRecord>> {
     const raw = await fs.readFile(usageFile(root), "utf-8").catch(() => null)
     if (raw === null) return {}
-    try {
-      const data = JSON.parse(raw)
-      if (!data || typeof data !== "object" || Array.isArray(data)) return {}
-      const clean: Record<string, UsageRecord> = {}
-      for (const [k, v] of Object.entries(data)) {
-        if (v && typeof v === "object") {
-          const rec = v as UsageRecord
-          // Legacy records predate recent_uses; backfill so .push never throws.
-          if (!Array.isArray(rec.recent_uses)) rec.recent_uses = []
-          // Legacy records predate born_at_project_total; backfill to 0
-          // (= "present from the start", see RELATIVE_USAGE_DESIGN.md D4).
-          if (typeof rec.born_at_project_total !== "number") rec.born_at_project_total = 0
-          // Legacy records predate `id`; backfill to null (= key by name, not id).
-          if (typeof rec.id !== "string") rec.id = null
-          clean[k] = rec
-        }
-      }
-      return clean
-    } catch {
-      return {}
+    const parsed = parseLedger(raw)
+    if (parsed) return parsed
+    // Primary exists but is corrupt — try the backup.
+    const bakRaw = await fs.readFile(bakFile(root), "utf-8").catch(() => null)
+    const fromBak = bakRaw === null ? null : parseLedger(bakRaw)
+    if (fromBak) {
+      await save(root, fromBak).catch(() => {}) // self-heal the primary; best-effort
+      return fromBak
     }
+    return {}
   }
 
   /** Write the ledger atomically (temp file + rename). Best-effort. */
@@ -196,6 +227,26 @@ export namespace Usage {
     const tmp = path.join(dir, `.usage.${process.pid}.${os.hostname()}.${tmpSeq++}.tmp`)
     await fs.writeFile(tmp, JSON.stringify(data, null, 2), "utf-8")
     await fs.rename(tmp, usageFile(root))
+  }
+
+  /**
+   * Snapshot the ledger to `usage.json.bak`, but ONLY when the primary parses cleanly —
+   * never copy a corrupt primary over a good backup (#4). Called once per curator run
+   * (the weekly maintenance moment). Best-effort, never throws.
+   */
+  export async function backupLedger(root: string): Promise<void> {
+    try {
+      const raw = await fs.readFile(usageFile(root), "utf-8").catch(() => null)
+      if (raw === null) return // nothing to back up yet
+      if (!parseLedger(raw)) return // corrupt primary → keep the existing good backup
+      const dir = curatorDir(root)
+      await fs.mkdir(dir, { recursive: true })
+      const tmp = path.join(dir, `.usage.bak.${process.pid}.${os.hostname()}.${tmpSeq++}.tmp`)
+      await fs.writeFile(tmp, raw, "utf-8")
+      await fs.rename(tmp, bakFile(root))
+    } catch {
+      // Best-effort: a backup failure must never break anything.
+    }
   }
 
   /**
@@ -367,6 +418,13 @@ export namespace Usage {
         // to archive/, so reviving in place would orphan that copy (and a later out-of-band
         // delete could resurrect its stale content). An archived slot is left as-is; recovery
         // goes through restoreSkill, which moves the copy back. See RELATIVE_USAGE_DESIGN.md.
+        //
+        // RARE in practice: a re-created skill gets a FRESH id (newSkillId on create), so it
+        // keys to a new slot and never lands on this tombstone. This branch only fires when the
+        // exact same id (or a legacy id-less name) returns after being tombstoned — e.g. a
+        // git/backup restore or rollback. KNOWN LIMITATION: use_count is carried forward (to
+        // keep the per-project denominator monotonic) yet born is re-stamped, so the prior
+        // life's calls inflate the new life's share slightly — acceptable given the rarity.
         rec.born_at_project_total = projectUseCount(data, scope.projectId)
         rec.state = "active"
         rec.archived_at = null

--- a/packages/opencode/src/skill-evolution/skill-manage-tool.test.ts
+++ b/packages/opencode/src/skill-evolution/skill-manage-tool.test.ts
@@ -92,6 +92,85 @@ describe("SkillManageTool skillLocation security", () => {
   })
 })
 
+// SKILL_IDENTITY_DESIGN.md 里程碑1: 每个进化 skill 在创建时盖一个稳定唯一 id 进 frontmatter;
+// edit 必须保留它(改内容不改身份)。id 是后续"按 id 认人、不按名字"的根。
+function readId(content: string): string | null {
+  const m = content.match(/^id:\s*(.+)$/m)
+  if (!m) return null
+  return m[1].trim().replace(/^['"]|['"]$/g, "")
+}
+
+describe("SkillManageTool stamps a stable unique id", () => {
+  // A1: create → frontmatter 有非空 id(带 skl_ 前缀)
+  test("create stamps a non-empty skl_ id into frontmatter", async () => {
+    const result = await SkillManageTool.execute({
+      action: "create",
+      name: "id-skill-a",
+      description: "d",
+      content: "body",
+      sessionProjectId: "test-id-proj",
+    })
+    try {
+      expect(result.ok).toBe(true)
+      const content = await fs.readFile(path.join(result.skillDir!, "SKILL.md"), "utf-8")
+      const id = readId(content)
+      expect(id).not.toBeNull()
+      expect(id!.startsWith("skl_")).toBe(true)
+      expect(id!.length).toBeGreaterThan("skl_".length)
+    } finally {
+      if (result.skillDir) await fs.rm(result.skillDir, { recursive: true, force: true })
+    }
+  })
+
+  // A3: 两次 create(哪怕同设置)→ id 不同
+  test("two creates get different ids", async () => {
+    const r1 = await SkillManageTool.execute({
+      action: "create", name: "id-skill-x", description: "d", content: "b", sessionProjectId: "test-id-proj",
+    })
+    const r2 = await SkillManageTool.execute({
+      action: "create", name: "id-skill-y", description: "d", content: "b", sessionProjectId: "test-id-proj",
+    })
+    try {
+      const id1 = readId(await fs.readFile(path.join(r1.skillDir!, "SKILL.md"), "utf-8"))
+      const id2 = readId(await fs.readFile(path.join(r2.skillDir!, "SKILL.md"), "utf-8"))
+      expect(id1).not.toBeNull()
+      expect(id2).not.toBeNull()
+      expect(id1).not.toBe(id2)
+    } finally {
+      if (r1.skillDir) await fs.rm(r1.skillDir, { recursive: true, force: true })
+      if (r2.skillDir) await fs.rm(r2.skillDir, { recursive: true, force: true })
+    }
+  })
+
+  // A2: edit 保留已有 id(改内容不改身份)
+  test("edit preserves an existing id", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "skill-id-keep-"))
+    try {
+      const originalDir = path.join(tmp, "project", ".claude", "skills", "id-keep")
+      await fs.mkdir(originalDir, { recursive: true })
+      await fs.writeFile(
+        path.join(originalDir, "SKILL.md"),
+        `---\nid: "skl_keepme123"\nname: "id-keep"\ndescription: "orig"\n---\n\nOriginal body`,
+      )
+
+      const result = await SkillManageTool.execute({
+        action: "edit",
+        name: "id-keep",
+        description: "updated",
+        content: "Updated body",
+        skillLocation: path.join(originalDir, "SKILL.md"),
+      })
+      expect(result.ok).toBe(true)
+
+      const content = await fs.readFile(path.join(result.skillDir!, "SKILL.md"), "utf-8")
+      expect(readId(content)).toBe("skl_keepme123") // id 不变
+      expect(content).toContain("Updated body") // 内容已改
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true })
+    }
+  })
+})
+
 describe("createBoundSkillManageTool skillLocationMap lookup", () => {
   test("resolves skillLocation from map when not provided in params", async () => {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "skill-bound-test-"))

--- a/packages/opencode/src/skill-evolution/skill-manage-tool.ts
+++ b/packages/opencode/src/skill-evolution/skill-manage-tool.ts
@@ -1,6 +1,7 @@
 import fs from "fs/promises"
 import path from "path"
 import z from "zod"
+import { ulid } from "ulid"
 import { ShadowWriter } from "./shadow-writer"
 import { Guard } from "./guard"
 import { Versions } from "./versions"
@@ -41,9 +42,17 @@ function parseFrontmatter(content: string): { meta: Record<string, string>; body
   return { meta, body }
 }
 
-function buildContent(name: string, description: string, body: string, category?: string): string {
+/** Mint a stable, unique, never-reused skill id. See SKILL_IDENTITY_DESIGN.md (Q3). */
+function newSkillId(): string {
+  return `skl_${ulid()}`
+}
+
+function buildContent(name: string, description: string, body: string, category?: string, id?: string): string {
+  // `id` is the skill's stable identity (SKILL_IDENTITY_DESIGN.md): stamped at create,
+  // preserved across edits, written FIRST in the frontmatter.
+  const idLine = id?.trim() ? `id: ${JSON.stringify(id.trim())}\n` : ""
   const categoryLine = category?.trim() ? `\ncategory: ${JSON.stringify(category.trim())}` : ""
-  return `---\nname: ${JSON.stringify(name)}\ndescription: ${JSON.stringify(description)}${categoryLine}\n---\n\n${body.trimStart()}`
+  return `---\n${idLine}name: ${JSON.stringify(name)}\ndescription: ${JSON.stringify(description)}${categoryLine}\n---\n\n${body.trimStart()}`
 }
 
 // ── Fuzzy patch ───────────────────────────────────────────────────────────────
@@ -239,7 +248,8 @@ export namespace SkillManageTool {
 
     const skillDir = await resolveAndPrepare(input)
     const skillMd = path.join(skillDir, "SKILL.md")
-    const fileContent = buildContent(input.name, input.description.trim(), input.content, input.category)
+    // Create stamps a fresh id (the skill's birth identity).
+    const fileContent = buildContent(input.name, input.description.trim(), input.content, input.category, newSkillId())
     await atomicWrite(skillMd, fileContent)
 
     return guardAndPublish(skillDir, "create")
@@ -252,8 +262,12 @@ export namespace SkillManageTool {
     const skillDir = await resolveAndPrepare(input)
     const skillMd = path.join(skillDir, "SKILL.md")
     const oldContent = await fs.readFile(skillMd, "utf-8").catch(() => null)
-    const existingCategory = oldContent ? parseFrontmatter(oldContent).meta.category : undefined
-    const fileContent = buildContent(input.name, input.description.trim(), input.content, input.category ?? existingCategory)
+    const oldMeta = oldContent ? parseFrontmatter(oldContent).meta : {}
+    // Preserve the existing id (identity is stable across edits). Do NOT mint one for a
+    // legacy id-less skill: that would orphan its existing name-keyed ledger record and
+    // start a duplicate id-keyed one. Legacy skills stay name-keyed. See SKILL_IDENTITY_DESIGN.md Q5.
+    const id = oldMeta.id
+    const fileContent = buildContent(input.name, input.description.trim(), input.content, input.category ?? oldMeta.category, id)
     await atomicWrite(skillMd, fileContent)
 
     return guardAndPublish(skillDir, "edit")

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -33,6 +33,12 @@ export namespace Skill {
   export const Info = z.object({
     name: z.string(),
     description: z.string(),
+    /**
+     * Stable unique skill id from frontmatter (`skl_<ulid>`); absent on legacy skills.
+     * `.catch(undefined)` so a non-string id (e.g. an external skill's `id: 123`) is
+     * IGNORED rather than failing the whole skill's parse (which would drop the skill).
+     */
+    id: z.string().optional().catch(undefined),
     location: z.string(),
     content: z.string(),
   })
@@ -243,7 +249,7 @@ export namespace Skill {
 
     if (!md) return
 
-    const parsed = Info.pick({ name: true, description: true }).safeParse(md.data)
+    const parsed = Info.pick({ name: true, description: true, id: true }).safeParse(md.data)
     if (!parsed.success) return
 
     if (state.skills[parsed.data.name]) {
@@ -258,6 +264,7 @@ export namespace Skill {
     state.skills[parsed.data.name] = {
       name: parsed.data.name,
       description: parsed.data.description,
+      id: parsed.data.id,
       location: match,
       content: md.content,
     }

--- a/packages/opencode/src/skill/skill-id-tolerance.test.ts
+++ b/packages/opencode/src/skill/skill-id-tolerance.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test"
+import { Skill } from "@/skill"
+
+// 回归防护(SKILL_IDENTITY_DESIGN.md bug①): frontmatter 里 id 不是字符串(如外部 skill 的 `id: 123`)
+// 不能让整条解析失败、把 skill 整个丢掉 —— 坏 id 当没有(undefined)即可。
+test("Info schema tolerates a non-string id instead of rejecting the whole skill", () => {
+  const parsed = Skill.Info.pick({ name: true, description: true, id: true }).safeParse({
+    name: "x",
+    description: "y",
+    id: 123, // 非字符串
+  })
+  expect(parsed.success).toBe(true)
+  expect(parsed.success && parsed.data.id).toBeUndefined() // 坏 id 被忽略, 不报错
+})

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -66,7 +66,7 @@ export const SkillTool = Tool.define("skill", async (ctx) => {
 
       // Curator: record that this skill was loaded. Best-effort, in-scope-only,
       // never throws — must not affect skill loading.
-      await Usage.bumpUse(Spawner.skillEvolutionRoot(), skill.location, ctx.sessionID)
+      await Usage.bumpUse(Spawner.skillEvolutionRoot(), skill.location, ctx.sessionID, undefined, skill.id)
 
       const dir = path.dirname(skill.location)
       const base = pathToFileURL(dir).href


### PR DESCRIPTION
### Issue for this PR

Closes #1074

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

把 curator 的归档判据从「自然日」换成「相对调用占比」,并给技能加稳定 id。

- **相对使用率归档**:技能在它自己项目内的「出生后调用份额」低于 `archiveUsageShare`、且曝光量过了 `minExposureCalls` 才归档。用按项目的分母 + 出生水位线(`born_at_project_total`),这样别的休眠项目不会稀释份额。孤儿清理改成打 tombstone(state="deleted")而不是直接 forget,被忘记的技能 use_count 仍留在分母里(单调不回退)。
- **稳定技能身份**:create 时给 SKILL.md 盖一个 `skl_<ulid>` id,edit 时保留;账本按 `<projectId>/<id>` 作键(老技能回退到 name)。这样「归档后又同名重建」的技能不再和旧的串味。id 用和加载器同一个 ConfigMarkdown 解析器读,避免两边不一致。
- **账本健壮性**:① 损坏时从 `usage.json.bak` 自愈,而不是静默清空;`backupLedger()` 只在主文件能正常解析时才备份(绝不用坏数据覆盖好备份)。② 保存用带进程内自增计数的唯一临时文件名,杜绝并发写出半截 JSON。③ 归档目录改按 id 作键,同名不同 id 的技能落到各自目录,不会互相覆盖或遮蔽。

为什么有效:相对占比让「该不该归档」只看技能在自己项目里的真实份额,跟日历无关;稳定 id 把「身份」和「名字」解耦,从根上消除同名碰撞;账本的自愈 + 唯一临时名 + 备份门槛,保证单一事实来源(use_count 分母)不会被损坏或并发写坏。

设计细节见 `RELATIVE_USAGE_DESIGN.md` 和 `SKILL_IDENTITY_DESIGN.md`。

### How did you verify your code works?

- `bun test src/skill-evolution/ src/skill/ test/skill/` → 249 pass / 0 fail
- `bun run typecheck`(opencode 包)→ 干净,exit 0
- 关键行为都带先红后绿的测试:账本损坏从 .bak 自愈、缺主文件无备份仍返回 {}、坏备份不覆盖好备份、并发写留下合法 JSON、同名不同 id 归档进各自目录、恢复按 id 找目录、非字符串 id 不丢整条技能。

### Screenshots / recordings

非 UI 改动,无。

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
