### PR TITLE
fix(ui): indicate pending input on Task card subtitle

### DIFF
--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -30,6 +30,7 @@ import {
   QuestionInfo,
 } from "@opencode-ai/sdk/v2"
 import { useData } from "../context"
+import { hasPendingRequest } from "../utils/session-pending"
 import { useFileComponent } from "../context/file"
 import { useDialog } from "../context/dialog"
 import { type UiI18n, useI18n } from "../context/i18n"
@@ -1721,11 +1722,31 @@ ToolRegistry.register({
       if (typeof value === "string" && value) return value
       return childSessionId()
     })
+
+    const pending = createMemo(() => {
+      const sid = childSessionId()
+      if (!sid) return false
+      return hasPendingRequest(
+        data.store.session,
+        sid,
+        (id) => data.permission(id),
+        (id) => data.question(id),
+      )
+    })
+
     const running = createMemo(() => props.status === "pending" || props.status === "running")
 
     const href = createMemo(() => sessionLink(childSessionId(), location.pathname, data.sessionHref))
 
     const titleContent = () => <TextShimmer text={title()} active={running()} />
+
+    const warningSuffix = () => (
+      <>
+        {" — "}
+        {i18n.t("ui.tool.task.inputRequired")}
+        <Icon name="warning" size="small" />
+      </>
+    )
 
     const trigger = () => (
       <div data-slot="basic-tool-tool-info-structured">
@@ -1738,15 +1759,22 @@ ToolRegistry.register({
               <Match when={href()}>
                 <a
                   data-slot="basic-tool-tool-subtitle"
-                  class="clickable subagent-link"
+                  classList={{
+                    "clickable subagent-link": true,
+                    "text-text-on-warning-strong": pending(),
+                  }}
                   href={href()!}
                   onClick={(e) => e.stopPropagation()}
                 >
                   {subtitle()}
+                  <Show when={pending()}>{warningSuffix()}</Show>
                 </a>
               </Match>
               <Match when={true}>
-                <span data-slot="basic-tool-tool-subtitle">{subtitle()}</span>
+                <span data-slot="basic-tool-tool-subtitle" classList={{ "text-text-on-warning-strong": pending() }}>
+                  {subtitle()}
+                  <Show when={pending()}>{warningSuffix()}</Show>
+                </span>
               </Match>
             </Switch>
           </Show>

--- a/packages/ui/src/context/data.tsx
+++ b/packages/ui/src/context/data.tsx
@@ -1,4 +1,5 @@
 import type { Message, Session, Part, FileDiff, SessionStatus, ProviderListResponse } from "@opencode-ai/sdk/v2"
+import type { PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2/client"
 import { createSimpleContext } from "./helper"
 import { PreloadMultiFileDiffResult } from "@pierre/diffs/ssr"
 
@@ -29,7 +30,10 @@ export type SessionHrefFn = (sessionID: string) => string
 export const { use: useData, provider: DataProvider } = createSimpleContext({
   name: "Data",
   init: (props: {
-    data: Data
+    data: Data & {
+      permission?: { [sessionID: string]: PermissionRequest[] }
+      question?: { [sessionID: string]: QuestionRequest[] }
+    }
     directory: string
     onNavigateToSession?: NavigateToSessionFn
     onSessionHref?: SessionHrefFn
@@ -41,6 +45,8 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
       get directory() {
         return props.directory
       },
+      permission: (sid: string) => props.data.permission?.[sid],
+      question: (sid: string) => props.data.question?.[sid],
       navigateToSession: props.onNavigateToSession,
       sessionHref: props.onSessionHref,
     }

--- a/packages/ui/src/i18n/ar.ts
+++ b/packages/ui/src/i18n/ar.ts
@@ -151,6 +151,7 @@ export const dict = {
   "ui.fileSearch.nextMatch": "المطابقة التالية",
   "ui.fileSearch.close": "إغلاق البحث",
   "ui.tool.task": "مهمة",
+  "ui.tool.task.inputRequired": "إدخال مطلوب",
   "ui.tool.skill": "مهارة",
   "ui.basicTool.called": "تم استدعاء `{{tool}}`",
   "ui.toolErrorCard.failed": "فشل",

--- a/packages/ui/src/i18n/br.ts
+++ b/packages/ui/src/i18n/br.ts
@@ -151,6 +151,7 @@ export const dict = {
   "ui.fileSearch.nextMatch": "Próxima ocorrência",
   "ui.fileSearch.close": "Fechar busca",
   "ui.tool.task": "Tarefa",
+  "ui.tool.task.inputRequired": "Entrada necessária",
   "ui.tool.skill": "Habilidade",
   "ui.basicTool.called": "Chamou `{{tool}}`",
   "ui.toolErrorCard.failed": "Falhou",

--- a/packages/ui/src/i18n/bs.ts
+++ b/packages/ui/src/i18n/bs.ts
@@ -155,6 +155,7 @@ export const dict = {
   "ui.fileSearch.nextMatch": "Sljedeće",
   "ui.fileSearch.close": "Zatvori pretragu",
   "ui.tool.task": "Zadatak",
+  "ui.tool.task.inputRequired": "Unos potrebna",
   "ui.tool.skill": "Vještina",
   "ui.basicTool.called": "Pozvan `{{tool}}`",
   "ui.toolErrorCard.failed": "Neuspješno",

--- a/packages/ui/src/i18n/da.ts
+++ b/packages/ui/src/i18n/da.ts
@@ -150,6 +150,7 @@ export const dict = {
   "ui.fileSearch.nextMatch": "Næste match",
   "ui.fileSearch.close": "Luk søgning",
   "ui.tool.task": "Opgave",
+  "ui.tool.task.inputRequired": "Input kræves",
   "ui.tool.skill": "Færdighed",
   "ui.basicTool.called": "Kaldte `{{tool}}`",
   "ui.toolErrorCard.failed": "Fejlede",

--- a/packages/ui/src/i18n/de.ts
+++ b/packages/ui/src/i18n/de.ts
@@ -156,6 +156,7 @@ export const dict = {
   "ui.fileSearch.nextMatch": "Nächstes Ergebnis",
   "ui.fileSearch.close": "Suche schließen",
   "ui.tool.task": "Aufgabe",
+  "ui.tool.task.inputRequired": "Eingabe erforderlich",
   "ui.tool.skill": "Fähigkeit",
   "ui.basicTool.called": "`{{tool}}` aufgerufen",
   "ui.toolErrorCard.failed": "Fehlgeschlagen",

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -103,6 +103,7 @@ export const dict: Record<string, string> = {
   "ui.tool.glob": "Glob",
   "ui.tool.grep": "Grep",
   "ui.tool.task": "Task",
+  "ui.tool.task.inputRequired": "Input required",
   "ui.tool.webfetch": "Webfetch",
   "ui.tool.websearch": "Web Search",
   "ui.tool.codesearch": "Code Search",

--- a/packages/ui/src/i18n/es.ts
+++ b/packages/ui/src/i18n/es.ts
@@ -151,6 +151,7 @@ export const dict = {
   "ui.fileSearch.nextMatch": "Siguiente",
   "ui.fileSearch.close": "Cerrar búsqueda",
   "ui.tool.task": "Tarea",
+  "ui.tool.task.inputRequired": "Entrada requerida",
   "ui.tool.skill": "Habilidad",
   "ui.basicTool.called": "Llamado `{{tool}}`",
   "ui.toolErrorCard.failed": "Falló",

--- a/packages/ui/src/i18n/fr.ts
+++ b/packages/ui/src/i18n/fr.ts
@@ -151,6 +151,7 @@ export const dict = {
   "ui.fileSearch.nextMatch": "Suivant",
   "ui.fileSearch.close": "Fermer la recherche",
   "ui.tool.task": "Tâche",
+  "ui.tool.task.inputRequired": "Entrée requise",
   "ui.tool.skill": "Compétence",
   "ui.basicTool.called": "Appelé `{{tool}}`",
   "ui.toolErrorCard.failed": "Échoué",

--- a/packages/ui/src/i18n/ja.ts
+++ b/packages/ui/src/i18n/ja.ts
@@ -150,6 +150,7 @@ export const dict = {
   "ui.fileSearch.nextMatch": "次の一致",
   "ui.fileSearch.close": "検索を閉じる",
   "ui.tool.task": "タスク",
+  "ui.tool.task.inputRequired": "入力が必要",
   "ui.tool.skill": "スキル",
   "ui.basicTool.called": "`{{tool}}` を呼び出しました",
   "ui.toolErrorCard.failed": "失敗",

--- a/packages/ui/src/i18n/ko.ts
+++ b/packages/ui/src/i18n/ko.ts
@@ -151,6 +151,7 @@ export const dict = {
   "ui.fileSearch.nextMatch": "다음 항목",
   "ui.fileSearch.close": "검색 닫기",
   "ui.tool.task": "작업",
+  "ui.tool.task.inputRequired": "입력 필요",
   "ui.tool.skill": "스킬",
   "ui.basicTool.called": "`{{tool}}` 호출됨",
   "ui.toolErrorCard.failed": "실패",

--- a/packages/ui/src/i18n/no.ts
+++ b/packages/ui/src/i18n/no.ts
@@ -154,6 +154,7 @@ export const dict: Record<Keys, string> = {
   "ui.fileSearch.nextMatch": "Neste treff",
   "ui.fileSearch.close": "Lukk søk",
   "ui.tool.task": "Oppgave",
+  "ui.tool.task.inputRequired": "Inndata kreves",
   "ui.tool.skill": "Ferdighet",
   "ui.basicTool.called": "Kalte `{{tool}}`",
   "ui.toolErrorCard.failed": "Mislyktes",

--- a/packages/ui/src/i18n/pl.ts
+++ b/packages/ui/src/i18n/pl.ts
@@ -150,6 +150,7 @@ export const dict = {
   "ui.fileSearch.nextMatch": "Następne",
   "ui.fileSearch.close": "Zamknij wyszukiwanie",
   "ui.tool.task": "Zadanie",
+  "ui.tool.task.inputRequired": "Wymagane dane",
   "ui.tool.skill": "Umiejętność",
   "ui.basicTool.called": "Wywołano `{{tool}}`",
   "ui.toolErrorCard.failed": "Błąd",

--- a/packages/ui/src/i18n/ru.ts
+++ b/packages/ui/src/i18n/ru.ts
@@ -150,6 +150,7 @@ export const dict = {
   "ui.fileSearch.nextMatch": "Следующее",
   "ui.fileSearch.close": "Закрыть поиск",
   "ui.tool.task": "Задача",
+  "ui.tool.task.inputRequired": "Требуется ввод",
   "ui.tool.skill": "Навык",
   "ui.basicTool.called": "Вызван `{{tool}}`",
   "ui.toolErrorCard.failed": "Ошибка",

--- a/packages/ui/src/i18n/th.ts
+++ b/packages/ui/src/i18n/th.ts
@@ -152,6 +152,7 @@ export const dict = {
   "ui.fileSearch.nextMatch": "ถัดไป",
   "ui.fileSearch.close": "ปิดการค้นหา",
   "ui.tool.task": "งาน",
+  "ui.tool.task.inputRequired": "ต้องการข้อมูลเข้า",
   "ui.tool.skill": "ทักษะ",
   "ui.basicTool.called": "เรียกใช้ `{{tool}}`",
   "ui.toolErrorCard.failed": "ล้มเหลว",

--- a/packages/ui/src/i18n/tr.ts
+++ b/packages/ui/src/i18n/tr.ts
@@ -157,6 +157,7 @@ export const dict = {
   "ui.fileSearch.nextMatch": "Sonraki",
   "ui.fileSearch.close": "Aramayı kapat",
   "ui.tool.task": "Görev",
+  "ui.tool.task.inputRequired": "Girdi gerekli",
   "ui.tool.skill": "Yetenek",
   "ui.basicTool.called": "`{{tool}}` çağrıldı",
   "ui.toolErrorCard.failed": "Başarısız",

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -156,6 +156,7 @@ export const dict = {
   "ui.fileSearch.nextMatch": "下一个",
   "ui.fileSearch.close": "关闭搜索",
   "ui.tool.task": "任务",
+  "ui.tool.task.inputRequired": "需要输入",
   "ui.tool.skill": "技能",
   "ui.basicTool.called": "调用了 `{{tool}}`",
   "ui.toolErrorCard.failed": "失败",

--- a/packages/ui/src/i18n/zht.ts
+++ b/packages/ui/src/i18n/zht.ts
@@ -155,6 +155,7 @@ export const dict = {
   "ui.fileSearch.nextMatch": "下一個",
   "ui.fileSearch.close": "關閉搜尋",
   "ui.tool.task": "任務",
+  "ui.tool.task.inputRequired": "需要輸入",
   "ui.tool.skill": "技能",
   "ui.basicTool.called": "呼叫了 `{{tool}}`",
   "ui.toolErrorCard.failed": "失敗",

--- a/packages/ui/src/utils/session-pending.test.ts
+++ b/packages/ui/src/utils/session-pending.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test"
+import { hasPendingRequest } from "./session-pending"
+
+function session(id: string, parentID?: string) {
+  return { id, parentID } as any
+}
+
+type Getter = (sid: string) => unknown[] | undefined
+
+const undef = () => undefined
+const empty = () => [] as unknown[]
+const filled = () => [{}] as unknown[]
+
+describe("hasPendingRequest", () => {
+  test("no children, rootID has no request", () => {
+    expect(hasPendingRequest([session("root")], "root", undef, undef)).toBe(false)
+  })
+
+  test("direct child has pending permission", () => {
+    expect(
+      hasPendingRequest(
+        [session("root"), session("child", "root")],
+        "root",
+        (sid) => (sid === "child" ? filled() : undef()),
+        undef,
+      ),
+    ).toBe(true)
+  })
+
+  test("direct child has pending question", () => {
+    expect(
+      hasPendingRequest([session("root"), session("child", "root")], "root", undef, (sid) =>
+        sid === "child" ? filled() : undef(),
+      ),
+    ).toBe(true)
+  })
+
+  test("nested grandchild has pending request", () => {
+    expect(
+      hasPendingRequest(
+        [session("root"), session("child", "root"), session("grand", "child")],
+        "root",
+        (sid) => (sid === "grand" ? filled() : undef()),
+        undef,
+      ),
+    ).toBe(true)
+  })
+
+  test("child request resolved (empty array)", () => {
+    expect(
+      hasPendingRequest(
+        [session("root"), session("child", "root")],
+        "root",
+        (sid) => (sid === "child" ? empty() : undef()),
+        undef,
+      ),
+    ).toBe(false)
+  })
+
+  test("empty rootID", () => {
+    expect(hasPendingRequest([session("root")], "", undef, undef)).toBe(false)
+  })
+
+  test("non-global-sync DataProvider (undefined getters)", () => {
+    expect(hasPendingRequest([session("root"), session("child", "root")], "root", undef, undef)).toBe(false)
+  })
+
+  test("multiple children, only one has request", () => {
+    expect(
+      hasPendingRequest(
+        [session("root"), session("a", "root"), session("b", "root")],
+        "root",
+        (sid) => (sid === "b" ? filled() : undef()),
+        undef,
+      ),
+    ).toBe(true)
+  })
+
+  test("rootID itself has request", () => {
+    expect(hasPendingRequest([session("root")], "root", (sid) => (sid === "root" ? filled() : undef()), undef)).toBe(
+      true,
+    )
+  })
+})

--- a/packages/ui/src/utils/session-pending.ts
+++ b/packages/ui/src/utils/session-pending.ts
@@ -1,0 +1,34 @@
+import type { Session } from "@opencode-ai/sdk/v2"
+
+export function hasPendingRequest(
+  sessions: Session[],
+  rootID: string,
+  permission: (sid: string) => unknown[] | undefined,
+  question: (sid: string) => unknown[] | undefined,
+): boolean {
+  const childMap = new Map<string, string[]>()
+  for (const s of sessions) {
+    if (!s.parentID) continue
+    const list = childMap.get(s.parentID)
+    if (list) list.push(s.id)
+    else childMap.set(s.parentID, [s.id])
+  }
+
+  const visited = new Set<string>()
+  const queue = [rootID]
+  visited.add(rootID)
+  while (queue.length > 0) {
+    const current = queue.shift()!
+    if ((permission(current)?.length ?? 0) > 0 || (question(current)?.length ?? 0) > 0) return true
+    const children = childMap.get(current)
+    if (children) {
+      for (const c of children) {
+        if (!visited.has(c)) {
+          visited.add(c)
+          queue.push(c)
+        }
+      }
+    }
+  }
+  return false
+}


### PR DESCRIPTION
### Issue for this PR

Closes #1078

### Type of change

- [x] Bug fix

### What does this PR do?

When a subagent (sub-session) blocks on a permission approval or question, the parent Task card kept showing a shimmering "running" subtitle with no hint that the subagent was actually idle and waiting for input. Users had to open the subagent to discover it was blocked.

This adds a `hasPendingRequest` helper that walks the session tree rooted at the Task's child session (BFS over descendants via `parentID`) and returns `true` if the root or any descendant has a non-empty `permission` or `question` queue. When pending, the Task card subtitle now appends an "Input required" warning with a warning icon and applies a warning-strong text color, in both the link and plain subtitle variants. The `DataProvider` now exposes `permission(sid)` / `question(sid)` getters (optional, so non-global-sync providers stay unaffected), and a new i18n key `ui.tool.task.inputRequired` is added across all locales.

### How did you verify your code works?

Ran the new unit suite locally on `fix/task-card-input-required`:

```
cd packages/ui && bun test src/utils/session-pending.test.ts
# 9 pass, 0 fail, 9 expect() calls
```

Cases covered: root with no request, direct child pending permission, direct child pending question, nested grandchild pending, resolved (empty array) returns false, empty rootID, undefined getters (non-global-sync provider), multiple children where only one is pending, and root itself pending.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR