### PR TITLE
fix: add missing GLM-5.2 cost metadata in models-local

### DIFF
--- a/packages/opencode/src/provider/models-local.ts
+++ b/packages/opencode/src/provider/models-local.ts
@@ -35,7 +35,15 @@ export const additions = {
   "tatu-maas": MaaS.provider,
 } satisfies Record<string, ModelsDev.Provider>
 
-function glm(api: string, reason: string) {
+// Alibaba Bailian list price is CNY 8 / 2 (cache hit) / 28 per 1M tokens;
+// converted to USD at 1 USD ≈ 7.2 CNY to match models.dev's USD convention.
+const ALIBABA_COST = {
+  input: 1.11,
+  cache_read: 0.28,
+  output: 3.89,
+}
+
+function glm(api: string, reason: string, cost: Insert["cost"] = ALIBABA_COST) {
   return {
     id: "glm-5.2",
     name: "GLM-5.2",
@@ -64,9 +72,10 @@ function glm(api: string, reason: string) {
     options: {
       maxOutputTokens: 65_536,
     },
+    cost,
     meta: {
       reason,
-      verified_at: "2026-06-23",
+      verified_at: "2026-06-25",
     },
   } satisfies Insert
 }
@@ -88,6 +97,11 @@ export const inserts = {
     "glm-5.2": glm(
       "https://aihubmix.com/v1",
       "models.dev is missing aihubmix GLM-5.2 metadata; aihubmix exposes it through OpenAI-compatible chat completions",
+      // aihubmix list price: USD 1.13 input / 3.94 output per 1M tokens
+      {
+        input: 1.13,
+        output: 3.94,
+      },
     ),
   },
 } satisfies Inserts


### PR DESCRIPTION
### Issue for this PR

Closes #1080

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

为 `models-local.ts` 中插入的 GLM-5.2 补全此前缺失的 `cost` 字段。缺少该字段时成本计算（`tokens × cost ÷ 1,000,000`）结果恒为 0。alibaba / alibaba-cn 使用阿里云百炼人民币价（8 / 2 / 28 元）按 1 USD ≈ 7.2 CNY 折算为 USD（1.11 / 0.28 / 3.89）；aihubmix 用其自身美元价（input 1.13 / output 3.94）。实现上提取 `ALIBABA_COST` 常量，并给 `glm()` 增加可选 `cost` 参数以按 provider 区分计价。

### How did you verify your code works?

运行 `npx tsc --noEmit -p packages/opencode/tsconfig.json`，无类型错误（exit 0）。

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR