### PR TITLE
fix: expand ~ in local MCP command args before spawning

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -37,6 +37,11 @@ export namespace MCP {
   const log = Log.create({ service: "mcp" })
   const DEFAULT_TIMEOUT = 30_000
 
+  export function expandTilde(cmd: string[]): string[] {
+    const home = os.homedir()
+    return cmd.map((c) => c.replace(/^~/, home))
+  }
+
   export const Resource = z
     .object({
       name: z.string(),
@@ -313,9 +318,7 @@ export namespace MCP {
     }
 
     if (mcp.type === "local") {
-      const home = os.homedir()
-      const expanded = mcp.command.map((c) => c.replace(/^~/, home))
-      const [cmd, ...args] = expanded
+      const [cmd, ...args] = expandTilde(mcp.command)
       const cwd = Instance.directory
       const transport = new StdioClientTransport({
         stderr: "pipe",

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -11,6 +11,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js"
 import { Config } from "../config/config"
 import { Log } from "../util/log"
+import os from "os"
 import { NamedError } from "@opencode-ai/util/error"
 import z from "zod/v4"
 import { Instance } from "../project/instance"
@@ -312,7 +313,9 @@ export namespace MCP {
     }
 
     if (mcp.type === "local") {
-      const [cmd, ...args] = mcp.command
+      const home = os.homedir()
+      const expanded = mcp.command.map((c) => c.replace(/^~/, home))
+      const [cmd, ...args] = expanded
       const cwd = Instance.directory
       const transport = new StdioClientTransport({
         stderr: "pipe",

--- a/packages/opencode/test/mcp/tilde-expansion.test.ts
+++ b/packages/opencode/test/mcp/tilde-expansion.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+import os from "os"
+import { MCP } from "../../src/mcp"
+
+describe("expandTilde", () => {
+  test("replaces leading ~ with os.homedir() on each element", () => {
+    const home = os.homedir()
+    expect(MCP.expandTilde(["~/bin/uv", "run", "~/mcp/server.py"])).toEqual([
+      `${home}/bin/uv`,
+      "run",
+      `${home}/mcp/server.py`,
+    ])
+  })
+
+  test("leaves elements without ~ unchanged", () => {
+    expect(MCP.expandTilde(["uv", "run", "/absolute/path/server.py"])).toEqual([
+      "uv",
+      "run",
+      "/absolute/path/server.py",
+    ])
+  })
+
+  test("only replaces ~ anchored at start of string", () => {
+    expect(MCP.expandTilde(["path/with~/middle"])).toEqual(["path/with~/middle"])
+  })
+
+  test("does not mutate the input array", () => {
+    const cmd = ["~/bin/uv", "run"]
+    const copy = [...cmd]
+    MCP.expandTilde(cmd)
+    expect(cmd).toEqual(copy)
+  })
+
+  test("empty array yields empty array", () => {
+    expect(MCP.expandTilde([])).toEqual([])
+  })
+
+  test("~/.aether/bin/uv expands fully", () => {
+    const home = os.homedir()
+    expect(MCP.expandTilde(["~/.aether/bin/uv"])).toEqual([`${home}/.aether/bin/uv`])
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #1082

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`StdioClientTransport` (@modelcontextprotocol/sdk) spawns local MCP commands directly without a shell, so tilde expansion never happens. A config like `command: ["uv", "run", "~/.aether/mcp/server.py"]` passes `~/.aether/mcp/server.py` literally and the server fails to start with ENOENT (logs: `local mcp startup failed`).

This PR expands a leading `~` to `os.homedir()` on every element of the local MCP `command` array before spawning. The logic lives in an exported `MCP.expandTilde` helper (`packages/opencode/src/mcp/index.ts`) so it is unit-testable. The `/^~/` anchor only replaces a leading tilde, leaving `~` elsewhere in an argument untouched.

### How did you verify your code works?

Run from `packages/opencode`:
- `bun test test/mcp/tilde-expansion.test.ts` → 6 pass / 0 fail (covers: leading-`~` expansion, no-`~` unchanged, `^~` anchor only, input not mutated, empty array, `~/.aether/bin/uv`)
- `bun typecheck` → no errors

### Screenshots / recordings

Not applicable (no UI change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR