### PR TITLE
fix(config): correct .aether/.opencode directory precedence order

### DIFF
--- a/packages/opencode/src/config/paths.ts
+++ b/packages/opencode/src/config/paths.ts
@@ -27,22 +27,8 @@ export namespace ConfigPaths {
 
     return [
       Global.Path.config,
-      ...(!Flag.OPENCODE_DISABLE_PROJECT_CONFIG
-        ? await Array.fromAsync(
-            Filesystem.up({
-              targets: [PROJECT, LEGACY_PROJECT],
-              start: directory,
-              stop: worktree,
-            }),
-          )
-        : []),
-      ...(await Array.fromAsync(
-        Filesystem.up({
-          targets: [PROJECT, LEGACY_PROJECT],
-          start: Global.Path.home,
-          stop: Global.Path.home,
-        }),
-      )),
+      // Binary-bundled defaults are lowest among .aether/.opencode roots so that
+      // user home and project config can override them.
       ...(await Array.fromAsync(
         Filesystem.up({
           targets: [PROJECT, LEGACY_PROJECT],
@@ -50,6 +36,26 @@ export namespace ConfigPaths {
           stop: binaryDir,
         }),
       )),
+      ...(await Array.fromAsync(
+        Filesystem.up({
+          targets: [PROJECT, LEGACY_PROJECT],
+          start: Global.Path.home,
+          stop: Global.Path.home,
+        }),
+      )),
+      // Project config takes precedence over global/binary defaults.
+      // Reverse so the deepest directory wins, consistent with projectFiles().
+      ...(!Flag.OPENCODE_DISABLE_PROJECT_CONFIG
+        ? (
+            await Array.fromAsync(
+              Filesystem.up({
+                targets: [PROJECT, LEGACY_PROJECT],
+                start: directory,
+                stop: worktree,
+              }),
+            )
+          ).reverse()
+        : []),
       ...(Flag.OPENCODE_CONFIG_DIR ? [Flag.OPENCODE_CONFIG_DIR] : []),
     ]
   }

--- a/packages/opencode/test/config/config-paths-order.test.ts
+++ b/packages/opencode/test/config/config-paths-order.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test, afterEach } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import { ConfigPaths } from "../../src/config/paths"
+import { Global } from "../../src/global"
+import { PROJECT } from "../../src/persist/naming"
+import { tmpdir } from "../fixture/fixture"
+
+afterEach(async () => {
+  await fs.rm(path.join(Global.Path.home, PROJECT), { recursive: true, force: true }).catch(() => {})
+})
+
+describe("ConfigPaths.directories — search order", () => {
+  test("directory order: global config → home dirs → binary dirs → project dirs → config dir", async () => {
+    const cwd = process.cwd()
+    const dirs = await ConfigPaths.directories(cwd, cwd)
+
+    expect(dirs.length).toBeGreaterThan(0)
+    expect(dirs[0]).toContain("aether")
+  })
+
+  test("project dirs appear after home dirs (reordered priority)", async () => {
+    // Seed .aether under the (isolated, per-process test) home dir so a home
+    // root is actually present, then a real project .aether so the project
+    // root is found. Without both, the ordering assertion is a silent no-op.
+    const home = path.join(Global.Path.home, PROJECT)
+    await fs.mkdir(home, { recursive: true })
+    await using tmp = await tmpdir({
+      init: async (d) => {
+        await fs.mkdir(path.join(d, PROJECT), { recursive: true })
+      },
+    })
+
+    const dirs = await ConfigPaths.directories(tmp.path, tmp.path)
+    const homeIdx = dirs.findIndex((d) => d === home)
+    const projectIdx = dirs.findIndex((d) => d === path.join(tmp.path, PROJECT))
+
+    expect(homeIdx).toBeGreaterThanOrEqual(0)
+    expect(projectIdx).toBeGreaterThanOrEqual(0)
+    expect(homeIdx).toBeLessThan(projectIdx)
+  })
+
+  test("Global.Path.config is always first", async () => {
+    const cwd = process.cwd()
+    const dirs = await ConfigPaths.directories(cwd, cwd)
+    expect(dirs[0]).toBe(Global.Path.config)
+  })
+
+  test("no duplicate directories in result", async () => {
+    const cwd = process.cwd()
+    const dirs = await ConfigPaths.directories(cwd, cwd)
+    expect(new Set(dirs).size).toBe(dirs.length)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #1084

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes `ConfigPaths.directories()` so the returned order is `global → binary → home → project (deepest first) → OPENCODE_CONFIG_DIR`. Previously project dirs were returned before home/binary dirs, so with `mergeDeep`'s later-wins semantics bundled binary defaults and home config overrode project-level `agents/`/`commands/`/`subagents/` — the opposite of the expected precedence (project > home > binary > global). Also fixes two latent issues: home now overrides `binaryDir` (user global > bundled defaults), and project dirs are reversed so the deepest directory wins, consistent with `projectFiles()`. Skill scanning is unaffected (uses its own `scanAllSkillPaths()`/`roots()`).

Adds a regression test `test/config/config-paths-order.test.ts` (migrated from `feat/research-agent-v2-docs`, with two no-op weaknesses fixed):

- Removed the `process.env.RESEARCH_AGENT_TEST !== "1"` skip guard so the suite actually runs in CI.
- The ordering test previously used a non-existent `/tmp/test-project` dir, so `Filesystem.up` found no `.aether`, leaving `projectIdx = -1` and the core assertion guarded out (a silent no-op). It now seeds a real project `.aether` via the `tmpdir` fixture and seeds `.aether` under the isolated test home, then asserts `homeIdx < projectIdx` with no guard.

### How did you verify your code works?

- `bun test test/config/config-paths-order.test.ts` → 4 pass, 0 fail.
- `bun typecheck` (from `packages/opencode`) → passes.
- Regression check: temporarily restored the buggy order (project before home) in `paths.ts`; the ordering test **fails** (`homeIdx=2, projectIdx=1`), confirming it actually catches the bug. Restored the fix → passes again.
- Confirmed no cross-test contamination (each test file runs in its own per-pid home dir; `afterEach` cleans the seeded home `.aether`). The 2 pre-existing timeouts in `config.test.ts` reproduce without this PR's changes.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR