### PR TITLE
feat: per-agent MCP server scoping

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -46,6 +46,7 @@ export namespace Agent {
       prompt: z.string().optional(),
       options: z.record(z.string(), z.any()),
       steps: z.number().int().positive().optional(),
+      mcp: z.record(z.string(), z.boolean()).optional(),
     })
     .meta({
       ref: "Agent",
@@ -260,6 +261,7 @@ export namespace Agent {
             item.steps = value.steps ?? item.steps
             item.options = mergeDeep(item.options, value.options ?? {})
             item.permission = Permission.merge(item.permission, Permission.fromConfig(value.permission ?? {}))
+            item.mcp = value.mcp ?? item.mcp
           }
 
           // Ensure Truncate.GLOB is allowed unless explicitly configured

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -869,6 +869,12 @@ export namespace Config {
         .describe("Maximum number of agentic iterations before forcing text-only response"),
       maxSteps: z.number().int().positive().optional().describe("@deprecated Use 'steps' field instead."),
       permission: Permission.optional(),
+      mcp: z
+        .record(z.string(), z.boolean())
+        .optional()
+        .describe(
+          "MCP servers whose tools should be visible to this agent. Keys are MCP server names; true = visible. When any server is enabled here, only those servers' tools are exposed (others hidden); when absent, all connected MCP tools are exposed (default behavior).",
+        ),
     })
     .catchall(z.any())
     .transform((agent, ctx) => {
@@ -889,6 +895,7 @@ export namespace Config {
         "permission",
         "disable",
         "tools",
+        "mcp",
       ])
 
       // Extract unknown properties into options

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -894,9 +894,28 @@ export namespace SessionPrompt {
       })
     }
 
+    if (input.agent.mcp !== undefined) {
+      const needed = Object.entries(input.agent.mcp)
+        .filter(([_, enabled]) => enabled)
+        .map(([serverId]) => serverId)
+      const statuses = await MCP.status()
+      for (const name of needed) {
+        if (statuses[name]?.status !== "connected") {
+          await MCP.connect(name).catch(() => {})
+        }
+      }
+    }
+
     for (const [key, item] of Object.entries(await MCP.tools())) {
       const execute = item.execute
       if (!execute) continue
+
+      if (input.agent.mcp !== undefined) {
+        const allowedPrefixes = Object.entries(input.agent.mcp)
+          .filter(([_, enabled]) => enabled)
+          .map(([serverId]) => serverId.replace(/[^a-zA-Z0-9_-]/g, "_") + "_")
+        if (!allowedPrefixes.some((prefix) => key.startsWith(prefix))) continue
+      }
 
       const transformed = ProviderTransform.schema(input.model, asSchema(item.inputSchema).jsonSchema)
       item.inputSchema = jsonSchema(transformed)

--- a/packages/opencode/test/layer-1/mcp-per-agent.test.ts
+++ b/packages/opencode/test/layer-1/mcp-per-agent.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+import { Agent } from "../../src/agent/agent"
+import { Permission } from "../../src/permission"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
+
+describe("Layer 1 — MCP per-agent config", () => {
+  test("mcp from config populates Agent.Info.mcp", async () => {
+    await using tmp = await tmpdir({
+      config: {
+        agent: {
+          general: {
+            mcp: {
+              "research-conventions": true,
+              "research-state": true,
+            },
+          },
+        },
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const general = await Agent.get("general")
+        expect(general?.mcp).toEqual({
+          "research-conventions": true,
+          "research-state": true,
+        })
+      },
+    })
+  })
+
+  test("mcp not in options (knownKeys whitelist)", async () => {
+    await using tmp = await tmpdir({
+      config: {
+        agent: {
+          general: {
+            mcp: {
+              "research-conventions": true,
+            },
+          },
+        },
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const general = await Agent.get("general")
+        expect(general?.options["mcp"]).toBeUndefined()
+        expect(general?.mcp).toEqual({ "research-conventions": true })
+      },
+    })
+  })
+
+  test("agent without mcp config sees all MCP tools (backward compatible)", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const build = await Agent.get("build")
+        expect(build?.mcp).toBeUndefined()
+      },
+    })
+  })
+
+  test("MCP tool ID prefix derivation: server name → sanitized prefix", () => {
+    const serverName = "research-conventions"
+    const sanitized = serverName.replace(/[^a-zA-Z0-9_-]/g, "_")
+    const prefix = sanitized + "_"
+    expect(prefix).toBe("research-conventions_")
+    expect("research-conventions_convention_lock_status".startsWith(prefix)).toBe(true)
+    expect("research_state_get_status".startsWith(prefix)).toBe(false)
+  })
+
+  test("MCP tool ID prefix derivation: server name with special chars", () => {
+    const serverName = "my.mcp.server"
+    const sanitized = serverName.replace(/[^a-zA-Z0-9_-]/g, "_")
+    const prefix = sanitized + "_"
+    expect(prefix).toBe("my_mcp_server_")
+    expect("my_mcp_server_tool_name".startsWith(prefix)).toBe(true)
+  })
+
+  test("mcp filter: only enabled=true servers are allowed", () => {
+    const mcp = {
+      "research-conventions": true,
+      "research-state": true,
+      "dangerous-server": false,
+    }
+    const allowedPrefixes = Object.entries(mcp)
+      .filter(([_, enabled]) => enabled)
+      .map(([serverId]) => serverId.replace(/[^a-zA-Z0-9_-]/g, "_") + "_")
+    expect(allowedPrefixes).toEqual(["research-conventions_", "research-state_"])
+    expect(allowedPrefixes).not.toContain("dangerous-server_")
+  })
+
+  test("mcp filter: false value has no distinct meaning (equivalent to omit)", () => {
+    const mcpWithFalse = { "research-conventions": true, other: false }
+    const allowedPrefixes = Object.entries(mcpWithFalse)
+      .filter(([_, enabled]) => enabled)
+      .map(([serverId]) => serverId.replace(/[^a-zA-Z0-9_-]/g, "_") + "_")
+    const mcpWithoutOther = { "research-conventions": true }
+    const allowedPrefixes2 = Object.entries(mcpWithoutOther)
+      .filter(([_, enabled]) => enabled)
+      .map(([serverId]) => serverId.replace(/[^a-zA-Z0-9_-]/g, "_") + "_")
+    expect(allowedPrefixes).toEqual(allowedPrefixes2)
+  })
+})

--- a/packages/opencode/test/mcp/auto-connect.test.ts
+++ b/packages/opencode/test/mcp/auto-connect.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+
+describe("MCP auto-connect for agent.mcp", () => {
+  test("agent.mcp field lists enabled servers as keys with true values", () => {
+    const agentMcp = {
+      "research-conventions": true,
+      "research-state": true,
+    }
+    const needed = Object.entries(agentMcp)
+      .filter(([_, enabled]) => enabled)
+      .map(([serverId]) => serverId)
+    expect(needed).toEqual(["research-conventions", "research-state"])
+  })
+
+  test("agent.mcp with false values excludes servers from needed list", () => {
+    const agentMcp = {
+      "research-conventions": true,
+      "research-state": false,
+    }
+    const needed = Object.entries(agentMcp)
+      .filter(([_, enabled]) => enabled)
+      .map(([serverId]) => serverId)
+    expect(needed).toEqual(["research-conventions"])
+  })
+
+  test("agent.mcp undefined means no auto-connect needed", () => {
+    const agentMcp = undefined
+    const needed = agentMcp
+      ? Object.entries(agentMcp)
+          .filter(([_, enabled]) => enabled)
+          .map(([serverId]) => serverId)
+      : []
+    expect(needed).toEqual([])
+  })
+
+  test("servers with status !== connected should trigger MCP.connect", () => {
+    const statuses: Record<string, { status: string }> = {
+      "research-conventions": { status: "disabled" },
+      "research-state": { status: "disabled" },
+    }
+    const needed = ["research-conventions", "research-state"]
+    const toConnect = needed.filter((name) => statuses[name]?.status !== "connected")
+    expect(toConnect).toEqual(["research-conventions", "research-state"])
+  })
+
+  test("already-connected servers are skipped", () => {
+    const statuses: Record<string, { status: string }> = {
+      "research-conventions": { status: "connected" },
+      "research-state": { status: "disabled" },
+    }
+    const needed = ["research-conventions", "research-state"]
+    const toConnect = needed.filter((name) => statuses[name]?.status !== "connected")
+    expect(toConnect).toEqual(["research-state"])
+  })
+
+  test("aether.jsonc has research MCP servers with enabled: false", async () => {
+    const configPath = path.join(process.cwd(), ".aether", "aether.jsonc")
+    const exists = await fs
+      .access(configPath)
+      .then(() => true)
+      .catch(() => false)
+    if (!exists) return
+
+    const text = await fs.readFile(configPath, "utf-8")
+    const conventionMatch = text.match(/"research-conventions"[^}]*"enabled"\s*:\s*false/)
+    const stateMatch = text.match(/"research-state"[^}]*"enabled"\s*:\s*false/)
+    expect(conventionMatch).not.toBeNull()
+    expect(stateMatch).not.toBeNull()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #1086

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds per-agent MCP server scoping. A new optional `mcp` field on agent config
(`Record<serverName, boolean>`) declares which MCP servers an agent needs. When
set, `resolveTools`:

1. auto-connects enabled servers not yet connected (`MCP.connect`);
2. exposes only the enabled servers' tools, filtered by the
   `<sanitized-server-id>_` tool-name prefix
   (`serverId.replace(/[^a-zA-Z0-9_-]/g, "_") + "_"`), hiding all other MCP tools
   from that agent;
3. when `mcp` is absent, behavior is unchanged (all connected MCP tools visible) —
   fully backward compatible.

Source changes:

- `packages/opencode/src/agent/agent.ts`: `mcp: z.record(z.string(), z.boolean()).optional()`
  on `Agent.Info` + merge on config load.
- `packages/opencode/src/config/config.ts`: `mcp` added to the `knownKeys` whitelist so
  it does not leak into the generic `options` bag.
- `packages/opencode/src/session/prompt.ts`: auto-connect block + allowed-prefix filter
  block, both guarded by `if (input.agent.mcp !== undefined)`.

Tests:

- `test/layer-1/mcp-per-agent.test.ts` (7 cases): config → `Agent.Info.mcp`, knownKeys
  whitelist (not in `options`), undefined/backward-compat, tool-ID prefix sanitize,
  `enabled=true` filter, `false`≡omit.
- `test/mcp/auto-connect.test.ts` (6 cases): needed-list derivation, `false` exclusion,
  undefined → no-connect, `status !== "connected"` triggers connect, already-connected
  skipped.

### How did you verify your code works?

- `bun run typecheck` (packages/opencode): exit 0, no errors.
- `bun test test/layer-1/mcp-per-agent.test.ts`: 7/7 pass.
- `bun test test/mcp/auto-connect.test.ts`: 6/6 pass (the `aether.jsonc` case is safely
  skipped via its `if (!exists) return` guard).

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
