### PR TITLE
feat: single-track permission contract for task subagent dispatch

### DIFF
--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -291,6 +291,33 @@ export namespace Permission {
     return rulesets.flat()
   }
 
+  export function intersection(parent: Ruleset, child: Ruleset): Ruleset {
+    const result: Ruleset = []
+    for (const rule of child) {
+      const parentRule = evaluate(rule.permission, rule.pattern, parent)
+      if (parentRule.action === "deny") {
+        result.push({ permission: rule.permission, pattern: rule.pattern, action: "deny" })
+      } else if (rule.action === "deny") {
+        result.push(rule)
+      } else if (rule.action === "allow" && parentRule.action === "allow") {
+        result.push(rule)
+      } else if (rule.action === "ask" && parentRule.action === "allow") {
+        result.push(rule)
+      } else {
+        result.push({ permission: rule.permission, pattern: rule.pattern, action: parentRule.action })
+      }
+    }
+    for (const parentRule of parent) {
+      const alreadyCovered = result.some(
+        (r) => Wildcard.match(r.permission, parentRule.permission) && Wildcard.match(r.pattern, parentRule.pattern),
+      )
+      if (!alreadyCovered && parentRule.action === "deny") {
+        result.push(parentRule)
+      }
+    }
+    return result
+  }
+
   const EDIT_TOOLS = ["edit", "write", "apply_patch", "multiedit"]
 
   export function disabled(tools: string[], ruleset: Ruleset): Set<string> {

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -66,6 +66,31 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       const hasTaskPermission = agent.permission.some((rule) => rule.permission === "task")
       const hasTodoWritePermission = agent.permission.some((rule) => rule.permission === "todowrite")
 
+      const callerAgent = ctx.agent ? await Agent.get(ctx.agent) : undefined
+
+      const sessionPermission = Permission.intersection(callerAgent?.permission ?? [], agent.permission)
+
+      // v0.6.0 fallback: deny task/todowrite for agents without explicit rules.
+      // Intersection only propagates existing deny rules — it doesn't create new ones.
+      // Agents with broad "*: allow" (like general) have no task/todowrite deny,
+      // but v0.6.0 explicitly denied these in session permission for all subagents.
+      const sessionDenyRules = [
+        ...(hasTodoWritePermission
+          ? []
+          : [{ permission: "todowrite" as const, pattern: "*" as const, action: "deny" as const }]),
+        ...(hasTaskPermission ? [] : [{ permission: "task" as const, pattern: "*" as const, action: "deny" as const }]),
+      ]
+
+      const finalPermission = [
+        ...sessionPermission,
+        ...sessionDenyRules,
+        ...(config.experimental?.primary_tools ?? []).map((t) => ({
+          permission: t,
+          pattern: "*",
+          action: "deny" as const,
+        })),
+      ]
+
       const session = await iife(async () => {
         if (params.task_id) {
           const found = await Session.get(SessionID.make(params.task_id)).catch(() => {})
@@ -75,31 +100,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
         return await Session.create({
           parentID: ctx.sessionID,
           title: params.description + ` (@${agent.name} subagent)`,
-          permission: [
-            ...(hasTodoWritePermission
-              ? []
-              : [
-                  {
-                    permission: "todowrite" as const,
-                    pattern: "*" as const,
-                    action: "deny" as const,
-                  },
-                ]),
-            ...(hasTaskPermission
-              ? []
-              : [
-                  {
-                    permission: "task" as const,
-                    pattern: "*" as const,
-                    action: "deny" as const,
-                  },
-                ]),
-            ...(config.experimental?.primary_tools?.map((t) => ({
-              pattern: "*",
-              action: "allow" as const,
-              permission: t,
-            })) ?? []),
-          ],
+          permission: finalPermission,
         })
       })
       const msg = await MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID })
@@ -127,6 +128,13 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       using _ = defer(() => ctx.abort.removeEventListener("abort", cancel))
       const promptParts = await SessionPrompt.resolvePromptParts(params.prompt)
 
+      // Single-track permission contract: finalPermission is set on the session
+      // via Session.create above and is the authoritative source. Do NOT pass
+      // `tools` to prompt here — PromptInput.tools is @deprecated and uses
+      // overwrite (not merge) semantics in prompt.ts:189-192; passing it would
+      // silently clobber the intersection-derived finalPermission. task.ts
+      // intentionally keeps permission on the session so the intersection results
+      // survive.
       const result = await SessionPrompt.prompt({
         messageID,
         sessionID: session.id,
@@ -135,11 +143,6 @@ export const TaskTool = Tool.define("task", async (ctx) => {
           providerID: model.providerID,
         },
         agent: agent.name,
-        tools: {
-          ...(hasTodoWritePermission ? {} : { todowrite: false }),
-          ...(hasTaskPermission ? {} : { task: false }),
-          ...Object.fromEntries((config.experimental?.primary_tools ?? []).map((t) => [t, false])),
-        },
         parts: promptParts,
       })
 

--- a/packages/opencode/test/layer-1/single-track-permission.test.ts
+++ b/packages/opencode/test/layer-1/single-track-permission.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import path from "path"
+import { Instance } from "../../src/project/instance"
+import { ProviderID, ModelID } from "../../src/provider/schema"
+import { Session } from "../../src/session"
+import { MessageV2 } from "../../src/session/message-v2"
+import { SessionPrompt } from "../../src/session/prompt"
+import { MessageID } from "../../src/session/schema"
+import { Agent } from "../../src/agent/agent"
+import { TaskTool } from "../../src/tool/task"
+import { Permission } from "../../src/permission"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+import { serve } from "../lib/server"
+
+Log.init({ print: false })
+
+type Usage = {
+  input: number
+  output: number
+}
+
+type Item =
+  | {
+      type: "text"
+      text: string
+      usage?: Usage
+    }
+  | {
+      type: "tool"
+      tool: string
+      input: unknown
+      usage?: Usage
+    }
+  | {
+      type: "error"
+      status: number
+      body: unknown
+    }
+
+type Hit = {
+  url: URL
+  body: Record<string, unknown>
+}
+
+const pid = ProviderID.make("single-track-local")
+const mid = ModelID.make("tiny")
+const model = { providerID: pid, modelID: mid }
+const servers: Array<ReturnType<typeof Bun.serve>> = []
+
+afterEach(() => {
+  for (const server of servers.splice(0)) server.stop()
+})
+
+function line(input: unknown) {
+  if (input === "done") return "data: [DONE]\n\n"
+  return `data: ${JSON.stringify(input)}\n\n`
+}
+
+function chunk(input: { text?: string; finish?: string; usage?: Usage; delta?: Record<string, unknown> }) {
+  return {
+    id: "chatcmpl-test",
+    object: "chat.completion.chunk",
+    choices: [
+      {
+        delta: input.delta ?? (input.text ? { content: input.text } : {}),
+        ...(input.finish ? { finish_reason: input.finish } : {}),
+      },
+    ],
+    ...(input.usage
+      ? {
+          usage: {
+            prompt_tokens: input.usage.input,
+            completion_tokens: input.usage.output,
+            total_tokens: input.usage.input + input.usage.output,
+          },
+        }
+      : {}),
+  }
+}
+
+function tool(item: Extract<Item, { type: "tool" }>) {
+  const args = JSON.stringify(item.input)
+  return [
+    line(
+      chunk({
+        delta: {
+          tool_calls: [
+            {
+              index: 0,
+              id: "call_test",
+              type: "function",
+              function: {
+                name: item.tool,
+                arguments: "",
+              },
+            },
+          ],
+        },
+      }),
+    ),
+    line(
+      chunk({
+        delta: {
+          tool_calls: [
+            {
+              index: 0,
+              function: {
+                arguments: args,
+              },
+            },
+          ],
+        },
+      }),
+    ),
+    line(chunk({ finish: "tool_calls", usage: item.usage })),
+  ]
+}
+
+function stream(item: Extract<Item, { type: "text" | "tool" }>) {
+  const body = [
+    line(chunk({})),
+    ...(item.type === "text"
+      ? [line(chunk({ text: item.text })), line(chunk({ finish: "stop", usage: item.usage }))]
+      : tool(item)),
+    line("done"),
+  ].join("")
+  return new Response(body, {
+    headers: { "Content-Type": "text/event-stream" },
+  })
+}
+
+async function stub(items: Item[]) {
+  const hits: Hit[] = []
+  const queue = [...items]
+  const server = await serve({
+    port: 0,
+    async fetch(req) {
+      const body = (await req.json().catch(() => ({}))) as Record<string, unknown>
+      const url = new URL(req.url)
+      hits.push({ url, body })
+      if (JSON.stringify(body).includes("Generate a title for this conversation")) {
+        return stream({ type: "text", text: "Single Track Test", usage: { input: 4, output: 2 } })
+      }
+      const item = queue.shift()
+      if (!item) return new Response(JSON.stringify({ error: "unexpected request" }), { status: 500 })
+      if (item.type === "error") {
+        return new Response(JSON.stringify(item.body), {
+          status: item.status,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+      return stream(item)
+    },
+  })
+  servers.push(server)
+  return {
+    hits,
+    url: `${server.url.origin}/v1`,
+  }
+}
+
+async function setup(url: string, cfg: Record<string, unknown> = {}) {
+  return tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          ...cfg,
+          provider: {
+            [pid]: {
+              name: "Single Track Local",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              models: {
+                [mid]: {
+                  name: "Tiny",
+                  tool_call: true,
+                  temperature: true,
+                  limit: { context: 100, output: 20 },
+                  modalities: {
+                    input: ["text", "image"],
+                    output: ["text"],
+                  },
+                },
+              },
+              options: {
+                apiKey: "test-key",
+                baseURL: url,
+              },
+            },
+            ...((cfg.provider as Record<string, unknown> | undefined) ?? {}),
+          },
+        }),
+      )
+    },
+  })
+}
+
+function main(hits: Hit[]) {
+  return hits.filter((hit) => !JSON.stringify(hit.body).includes("Generate a title for this conversation"))
+}
+
+describe("Layer 1.5 — single-track permission contract", () => {
+  test("prompt without tools preserves session.permission", async () => {
+    // noReply: true returns at prompt.ts:194, AFTER the tools→permission
+    // conversion block (prompt.ts:181-192). With no `tools` passed, the
+    // `permissions` array stays empty, `if (permissions.length > 0)` is false,
+    // so session.permission is NOT overwritten and the rich ruleset survives.
+    await using tmp = await setup("http://localhost:9/v1")
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const rich: Permission.Ruleset = [
+          { permission: "edit", pattern: "src/**", action: "allow" },
+          { permission: "edit", pattern: "*", action: "deny" },
+          { permission: "bash", pattern: "*", action: "deny" },
+        ]
+        const session = await Session.create({ permission: rich })
+
+        await SessionPrompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          model,
+          noReply: true,
+          parts: [{ type: "text", text: "test" }],
+        })
+
+        const updated = await Session.get(session.id)
+        expect(updated.permission).toEqual(rich)
+      },
+    })
+  })
+
+  test("task dispatch preserves finalPermission (no tools overwrite)", async () => {
+    const srv = await stub([
+      { type: "text", text: "ok", usage: { input: 4, output: 2 } },
+      { type: "text", text: "done", usage: { input: 4, output: 2 } },
+    ])
+    await using tmp = await setup(srv.url, {
+      experimental: { primary_tools: ["bash"] },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const parent = await Session.create({})
+        await SessionPrompt.prompt({
+          sessionID: parent.id,
+          agent: "build",
+          model,
+          parts: [{ type: "text", text: "dispatch" }],
+        })
+        const msgs = await Session.messages({ sessionID: parent.id })
+        const assistant = msgs.findLast((m) => m.info.role === "assistant")!
+
+        const caller = await Agent.get("build")
+        const tool = await TaskTool.init({ agent: caller! })
+        const result = await tool.execute(
+          { description: "test", prompt: "say hi", subagent_type: "general" },
+          {
+            sessionID: parent.id,
+            messageID: assistant.info.id,
+            agent: "build",
+            abort: AbortSignal.any([]),
+            messages: [],
+            metadata: () => {},
+            ask: async () => {},
+            extra: { bypassAgentCheck: true },
+          },
+        )
+
+        const child = await Session.get(result.metadata.sessionId)
+        const hasBashDeny = child.permission?.some(
+          (r) => r.permission === "bash" && r.pattern === "*" && r.action === "deny",
+        )
+        expect(hasBashDeny).toBe(true)
+      },
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #1088

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Replaces the dual permission paths (session `permission` array + deprecated `PromptInput.tools` overwrite) with a single authoritative source on the session for task subagent dispatch.

**Changes (3 files, +342/−30):**

1. **`permission/index.ts`** — Add `Permission.intersection(parent, child)`: computes the effective child ruleset constrained by the parent's deny rules. A child `allow` is only kept if the parent also allows; parent denies always propagate. Parent-only deny rules not covered by any child rule are appended.

2. **`tool/task.ts`** — Compute `finalPermission = intersection(callerAgent?.permission, subagent.permission)` + deny rules for `task`/`todowrite` when the subagent lacks explicit rules + `primary_tools` as `deny` (was `allow`). Set it once on `Session.create`. Stop passing the deprecated `tools` map to `SessionPrompt.prompt` — `PromptInput.tools` uses overwrite (not merge) semantics, which would silently clobber the intersection-derived permission.

3. **`test/layer-1/single-track-permission.test.ts`** — Two integration tests:
   - "prompt without tools preserves session.permission": verifies that when no `tools` is passed, `session.permission` survives a `SessionPrompt.prompt` call (the overwrite block is skipped).
   - "task dispatch preserves finalPermission (no tools overwrite)": end-to-end test that dispatches a subagent via `TaskTool.execute` and asserts the child session's permission contains the expected `bash: *: deny` rule (from `primary_tools`), proving `finalPermission` is not clobbered.

### How did you verify your code works?

- `bun typecheck` passes in `packages/opencode`
- `bun test test/layer-1/single-track-permission.test.ts` — 2 pass, 0 fail (with `RESEARCH_AGENT_TEST=1`)
- Verified the diff contains only single-track-permission-related changes — no unrelated features (owner/owns, fallback models, MCP, etc.) are included

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR