### PR TITLE
fix(memory): recover initialization and reflection failures

### DIFF
--- a/docs/memory-system.md
+++ b/docs/memory-system.md
@@ -1,0 +1,404 @@
+# Aether Memory System
+
+This document describes the currently implemented Aether memory system. The system is designed as a low-coupling long-term memory module: normal chat does not read old session transcripts, long-term memory is accessed through explicit tools or APIs, and Markdown remains the inspectable source of truth.
+
+Main code areas:
+
+- `packages/opencode/src/memory/`
+- `packages/opencode/src/tool/memory.ts`
+- `packages/opencode/src/server/routes/memory.ts`
+- `packages/app/src/components/settings-memory.tsx`
+
+## 1. Feature Summary
+
+Implemented today:
+
+- Long-term memory file: `AETHER_MEMORY.md`
+- Per-channel event database: `<channel>/memory.db`
+- Three memory types: `preference`, `fact`, `task`
+- Two scopes: `global`, `project:<project_id>`
+- Agent tools: `memory_search`, `memory_remember`, `memory_forget`, `memory_reflect`
+- HTTP API: `/memory/*`
+- Shortcut prompt injection that tells the agent when to call `memory_search`
+- Quick, daily, and manual reflection
+- Daily reflection cron direct action
+- Server startup catch-up
+- Service/API path for one-time historical session initialization
+- Background initialization progress, cancellation, and failure reporting
+- Deterministic fallback for provider/model reflection failures
+
+Not implemented:
+
+- Vector or embedding search
+- Reading old sessions as normal chat context
+- Session-level long-term memory scope
+- Multiple long-term Markdown files
+- Hard deletion of raw event history
+- Parallel historical session scanning
+
+## 2. Architecture
+
+The memory system has five layers:
+
+1. Markdown long-term memory: `AETHER_MEMORY.md`
+2. SQLite event and run log: `<channel>/memory.db`
+3. Memory service: remember, forget, search, reflect, initialize, startup catch-up
+4. Agent/API adapters: `memory_*` tools and `/memory` routes
+5. UI/Cron integration: Settings > Memory and the daily reflection cron
+
+```mermaid
+flowchart TD
+  User["User message / Agent tool / HTTP API"] --> Service["Memory service"]
+  Service --> DB["<channel>/memory.db"]
+  Service --> Reflect["quick / daily / manual reflection"]
+  Reflect --> MD["AETHER_MEMORY.md"]
+  MD --> Search["memory_search"]
+  Search --> Agent["Agent response"]
+  MD --> Shortcut["Shortcut Directory"]
+  Shortcut --> Prompt["Small system prompt hint"]
+  Cron["builtin daily cron"] --> Reflect
+  UI["Settings > Memory"] --> Service
+```
+
+Core entry points:
+
+| File | Responsibility |
+| --- | --- |
+| `packages/opencode/src/memory/index.ts` | Main memory service |
+| `packages/opencode/src/memory/markdown.ts` | `AETHER_MEMORY.md` parsing/rendering |
+| `packages/opencode/src/memory/search.ts` | Markdown memory search and ranking |
+| `packages/opencode/src/memory/gate.ts` | Quick reflection gate |
+| `packages/opencode/src/memory/schema.sql.ts` | SQLite schema |
+| `packages/opencode/src/memory/installer.ts` | Installation, cron registration, startup catch-up |
+| `packages/opencode/src/memory/plugin.ts` | Chat hook and shortcut prompt injection |
+| `packages/opencode/src/tool/memory.ts` | Agent tools |
+| `packages/opencode/src/server/routes/memory.ts` | HTTP API |
+
+## 3. Storage
+
+### 3.1 `AETHER_MEMORY.md`
+
+The long-term source of truth lives in the global memory data directory:
+
+```text
+<global-memory-data-dir>/AETHER_MEMORY.md
+```
+
+`memory_search` only searches this file. It does not read old session files or raw events from `memory.db` as answer evidence.
+
+File layout:
+
+```text
+# Aether Memory
+
+<!--
+schema_version: 1
+updated_at: ...
+source: memory.db
+search_target: true
+-->
+
+## Shortcut Directory
+
+---
+
+## Preferences
+
+---
+
+## Facts
+
+---
+
+## Tasks
+```
+
+Example memory block:
+
+```text
+### PREF-answer-language
+- type: preference
+- scope: global
+- memory: The user prefers Chinese replies by default.
+- confidence: 0.95
+- weight: 0.9
+- evidence: The user explicitly requested Chinese replies by default.
+- updated_at: 2026-05-13T00:00:00.000Z
+- status: active
+```
+
+### 3.2 `<channel>/memory.db`
+
+Events, reflection runs, and lightweight settings are stored under the current channel:
+
+```text
+<channel>/memory.db
+```
+
+Main tables:
+
+| Table | Purpose |
+| --- | --- |
+| `memory_event` | Raw remember/forget events, source metadata, status, and reflection result |
+| `reflection_run` | Quick/daily/manual reflection run log |
+| `memory_setting` | Initialization state, reflection state, and other lightweight settings |
+
+Possible `memory_event.status` values:
+
+- `new`
+- `pending_important`
+- `applied`
+- `ignored`
+- `deleted`
+- `forgot`
+- `deprecated`
+- `superseded`
+
+## 4. Types and Scopes
+
+### 4.1 Types
+
+| type | Meaning |
+| --- | --- |
+| `preference` | User preferences, interaction style, durable profile information |
+| `fact` | Stable user facts, project facts, environment facts |
+| `task` | Long-running tasks, follow-ups, persistent constraints |
+
+### 4.2 Scopes
+
+| scope | Meaning |
+| --- | --- |
+| `global` | Applies across projects |
+| `project:<project_id>` | Applies only to the specified project |
+
+During search, the current project is a ranking signal rather than a hard filter. Relevant project-scoped memories rank above global memories, but global memories can still be recalled.
+
+## 5. Agent Tools
+
+### 5.1 `memory_search`
+
+Searches long-term memory. The agent should call it before answering whenever durable user identity, preferences, project facts, prior decisions, long-running tasks, or previously stated constraints may affect the answer.
+
+Parameters:
+
+- `query`
+- `mode?`: `search | overview`
+- `types?`: `preference | fact | task`
+- `limit?`
+- `currentProjectID?`
+
+Results are ranked by relevance, scope, weight, and recency, and use Markdown memory block ids as evidence identifiers.
+
+### 5.2 `memory_remember`
+
+Records user-requested memory. The tool writes a `memory_event`, then triggers quick reflection. `AETHER_MEMORY.md` is updated only after reflection accepts the memory.
+
+Parameters:
+
+- `text`
+- `type?`
+- `project_id?`
+
+Agents should not edit `AETHER_MEMORY.md` directly.
+
+### 5.3 `memory_forget`
+
+Forgets matching long-term memories. Natural-language requests are searched first; the Memory service then deletes matching Markdown blocks.
+
+Parameters:
+
+- `query?`
+- `ids?`
+- `type?`
+
+If nothing matches, no permanent ban is recorded. Forgetting is a one-time deletion, not a rule that similar information can never be remembered again.
+
+### 5.4 `memory_reflect`
+
+Runs memory reflection. It defaults to `quick`; `daily` should be used only when the user explicitly asks for global, daily, or full memory organization.
+
+Parameters:
+
+- `mode?`: `quick | daily | manual`
+- `reason?`
+
+## 6. Reflection and Initialization
+
+### 6.1 Quick reflection
+
+Quick reflection makes important explicit memories visible across sessions as soon as possible.
+
+Triggers:
+
+- `memory_remember`
+- High-value user memory signals detected by the `chat.message` hook
+- Default `memory_reflect`
+
+To control resource usage, `shouldQuickReflect()` filters low-signal one-off messages. Events that need LLM judgment can be stored and later handled by quick or daily reflection.
+
+### 6.2 Daily reflection
+
+Daily reflection globally organizes long-term memory, deduplicates similar entries, handles conflicts, and updates `AETHER_MEMORY.md` plus the Shortcut Directory.
+
+Triggers:
+
+- Built-in cron direct action: `memory.reflect.daily`
+- Startup catch-up
+- Manual Settings > Memory action
+- `memory_reflect` with explicit `daily` mode
+
+Daily reflection scans discovered channel `memory.db` files sequentially and does not perform parallel scanning.
+
+### 6.3 Provider fallback
+
+When LLM reflection fails due to provider/model/structured-output/provider-options errors, the service:
+
+1. Retries provider-option BadRequest failures once with safer provider options.
+2. Falls back to deterministic reflection if the retry fails or the model is unavailable.
+3. Marks the reflection summary with `fallback` so this is not reported as a clean LLM-only success.
+
+Abort and cancellation errors do not use fallback; they are treated as interruptions.
+
+### 6.4 Historical session initialization
+
+Initialization imports possible long-term memories from old session user messages.
+
+Behavior:
+
+- Scans sessions one at a time to keep CPU usage low.
+- Primarily analyzes user messages; assistant messages are only supporting context when needed.
+- Writes candidates to `memory_event`, then lets reflection update `AETHER_MEMORY.md`.
+- `/memory/initialize/start` starts a background task and is not tied to the HTTP request lifecycle.
+- `/memory/initialize/cancel` aborts the current initialization task.
+- Non-abort extractor errors are recorded as `error_count` and `last_error`; if no items are imported, initialization is marked `failed`.
+
+Note: the Settings > Memory initialization button may be disabled by upstream UI policy. The service/API path remains available.
+
+```mermaid
+sequenceDiagram
+  participant UI as UI/API
+  participant Memory as Memory service
+  participant DB as memory.db
+  participant LLM as LLM extractor
+  participant MD as AETHER_MEMORY.md
+
+  UI->>Memory: initialize/start
+  Memory-->>UI: status=started
+  loop one session at a time
+    Memory->>LLM: extract user-memory candidates
+    LLM-->>Memory: candidates or error
+    Memory->>DB: write memory_event / progress
+  end
+  Memory->>Memory: daily reflect imported events
+  Memory->>MD: update long-term memory
+```
+
+## 7. Prompt Injection
+
+The memory system does not inject the full long-term memory file into the system prompt. It injects only a compact Shortcut Directory hint that tells the agent when it may need to call `memory_search`.
+
+Injected content does not include:
+
+- Full memory bodies
+- `target_ids`
+- Raw events
+- Old session transcripts
+
+Agents should treat shortcuts as a search index, not as facts.
+
+## 8. Cron Integration
+
+The memory system reuses cron direct actions.
+
+Built-in action:
+
+```text
+memory.reflect.daily
+```
+
+Built-in job id:
+
+```text
+builtin.memory.daily_reflect
+```
+
+Default time:
+
+```text
+03:00
+```
+
+Installation syncs this built-in job and disables legacy daily reflection jobs. When memory is globally disabled, the daily cron job is synced as disabled and memory reflection itself does not run. If only the daily reflection switch is disabled, only cron-triggered daily reflection is blocked; users can still run manual daily reflection while global memory is enabled.
+
+## 9. HTTP API
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/memory/status` | Read memory status, counts, and initialization state |
+| `POST` | `/memory/search` | Search long-term memory |
+| `POST` | `/memory/reflect` | Run quick/daily/manual reflection |
+| `POST` | `/memory/initialize/start` | Start background historical session initialization |
+| `POST` | `/memory/initialize/cancel` | Cancel initialization |
+| `POST` | `/memory/daily-reflect/sync` | Sync the built-in daily reflect cron from config |
+
+Agents should normally use the `memory_*` tools instead of calling these HTTP APIs directly.
+
+## 10. Settings UI
+
+Settings > Memory provides lightweight management:
+
+- Global memory switch
+- Daily reflection switch and time
+- Status card
+- Initialization status display
+- Manual search
+- Manual quick/daily reflection
+
+Whether the initialization import button is clickable depends on the current upstream UI policy. The backend API and status display are independent.
+
+## 11. Lifecycle
+
+`installMemory()` returns:
+
+- `service`
+- `start()`
+- `stop()`
+- `purge()`
+
+Semantics:
+
+- `start()`: sync the daily reflect cron and run startup catch-up checks.
+- `stop()`: abort background initialization, wait briefly for cleanup, close the memory DB, and keep data.
+- `purge()`: delete `AETHER_MEMORY.md`, reflection state, and all channel `memory.db` files including WAL/SHM files.
+
+## 12. Integration Points
+
+The memory module avoids modifying the agent/session main loop. Current integration points are:
+
+| File | Purpose |
+| --- | --- |
+| `packages/opencode/src/server/server.ts` | Mount `/memory` routes and install memory during server lifecycle |
+| `packages/opencode/src/tool/registry.ts` | Register `memory_*` agent tools |
+| `packages/opencode/src/plugin/index.ts` | Register the memory plugin |
+| `packages/opencode/src/config/config.ts` | Add memory configuration |
+| `packages/opencode/src/cron/index.ts` | Support the memory direct action |
+| `packages/app/src/context/global-sdk.tsx` | Expose memory client helpers |
+| `packages/app/src/utils/server.ts` | Expose memory API helpers |
+| `packages/app/src/components/dialog-settings.tsx` | Add the Settings > Memory tab |
+
+## 13. Tests
+
+Recommended local checks:
+
+```bash
+bun run --cwd packages/opencode test test/memory/memory.test.ts --timeout 120000
+bun run --cwd packages/opencode test test/cron/cron.test.ts test/memory/abort-leak.test.ts --timeout 120000
+bun run --cwd packages/opencode typecheck
+```
+
+Frontend settings page checks:
+
+```bash
+bun run --cwd packages/app ./script/vitest.ts run --config ./vitest.config.ts src/components/settings-memory.vitest.tsx
+bun run --cwd packages/app typecheck
+```

--- a/docs/memory-system.zh-CN.md
+++ b/docs/memory-system.zh-CN.md
@@ -1,181 +1,92 @@
-# Aether Memory 系统（当前实现）
+# Aether Memory 系统
 
-本文描述当前代码中已经落地的 memory 基础设施实现，目标代码范围主要在：
+本文描述当前已经落地的 Aether memory 系统。它的定位是一个低耦合的长期记忆模块：正常对话不读取旧 session transcript，长期记忆通过工具/API 显式访问，并以 Markdown 作为可检查的事实源。
+
+主要代码范围：
 
 - `packages/opencode/src/memory/`
 - `packages/opencode/src/tool/memory.ts`
 - `packages/opencode/src/server/routes/memory.ts`
-- `packages/opencode/src/server/server.ts`
-- `packages/opencode/src/cron/index.ts`
 - `packages/app/src/components/settings-memory.tsx`
 
-本文只描述**当前已经实现**的能力、接口和边界。
+## 1. 功能概览
 
-## 0. 当前已实现功能总览
+当前已经实现：
 
-当前已经落地的 memory 功能可以直接概括为：
+- 长期记忆文件：`AETHER_MEMORY.md`
+- 按 channel 隔离的事件库：`<channel>/memory.db`
+- 三种长期记忆类型：`preference`、`fact`、`task`
+- 两种作用范围：`global`、`project:<project_id>`
+- Agent 工具：`memory_search`、`memory_remember`、`memory_forget`、`memory_reflect`
+- HTTP API：`/memory/*`
+- Shortcut prompt 注入，用于提示 agent 何时调用 `memory_search`
+- quick reflection、daily reflection、manual reflection
+- daily reflection cron direct action
+- server startup catch-up
+- 历史 session 初始化导入的 service/API 通路
+- 后台初始化进度、取消、失败记录
+- provider/model 类 reflection 失败的确定性 fallback
 
-- 单一长期记忆文件 `AETHER_MEMORY.md`
-- 按 channel 隔离的 `memory.db` 原始事件与反思日志
-- 三种长期记忆类型：
-  - `preference`
-  - `fact`
-  - `task`
-- 两种长期记忆 scope：
-  - `global`
-  - `project:<project_id>`
-- 四个 agent 工具：
-  - `memory_search`
-  - `memory_remember`
-  - `memory_forget`
-  - `memory_reflect`
-- `/memory` HTTP API
-- Settings > Memory 管理页
-- shortcut 目录注入
-- quick reflection 与 daily reflection
-- 首次初始化导入旧 session 的用户消息
-- built-in daily reflection cron direct action
-- `stop()` / `purge()` 生命周期接口
-
-当前**还没有**落地的部分：
+当前不包含：
 
 - 向量库或 embedding 检索
-- 多 Markdown 长期记忆源
-- 直接编辑 `AETHER_MEMORY.md` 的前端编辑器
+- 读取旧 session 作为普通对话上下文
 - session 级长期记忆 scope
-- hard delete 历史原始事件
+- 多个长期 Markdown 文件
+- hard delete 原始事件历史
 - 并行扫描历史 session
 
-## 1. 设计目标
+## 2. 架构
 
-当前 memory 系统被实现为一层**模块化长期记忆基础设施**，而不是把历史 session 当作可随时读取的记忆库。
+Memory 系统分为五层：
 
-设计目标是：
-
-- 正常对话时不读取旧 session transcript
-- Agent 只通过 `memory_search` 获取长期记忆正文
-- 长期记忆最终集中到一个 Markdown 文件中，便于检查、备份和迁移
-- 原始写入、forget 请求和 reflection 运行记录进入 SQLite，便于审计和补跑
-- 显式记忆尽快跨 session 可见
-- 低信号消息不过度触发 LLM reflection
-- daily reflection 能整理重复、相似和冲突记忆
-- 尽量减少对 agent/session 主链路的侵入
-
-当前版本定位为：
-
-- 本地单用户长期记忆系统
-- Markdown 作为长期事实源
-- SQLite 作为事件日志和运行日志
-- Tool/API/UI 三种入口共享同一套 `Memory` service
-
-## 2. 整体架构
-
-当前实现可分成 5 层：
-
-1. **Markdown 长期记忆层**
-   - `AETHER_MEMORY.md`
-   - 保存可搜索的长期记忆和 shortcut 目录
-
-2. **Event / Run Log 层**
-   - `<channel>/memory.db`
-   - 保存 `memory_event`、`reflection_run` 和 `memory_setting`
-
-3. **Memory Service 层**
-   - 负责 remember、forget、search、reflect、initialize、startup catch-up
-
-4. **Agent / API 适配层**
-   - `memory_*` agent tools
-   - `/memory` HTTP routes
-
-5. **UI / Cron 集成层**
-   - Settings > Memory
-   - daily reflection cron direct action
+1. Markdown 长期记忆层：`AETHER_MEMORY.md`
+2. SQLite 事件与运行日志层：`<channel>/memory.db`
+3. Memory service：remember、forget、search、reflect、initialize、startup catch-up
+4. Agent/API 适配层：`memory_*` tools 与 `/memory` routes
+5. UI/Cron 集成层：Settings > Memory 与 daily reflection cron
 
 ```mermaid
 flowchart TD
-  User["用户消息或工具调用"] --> Service["Memory service"]
+  User["用户消息 / Agent 工具 / HTTP API"] --> Service["Memory service"]
   Service --> DB["<channel>/memory.db"]
-  Service --> Reflect["quick/daily reflection"]
+  Service --> Reflect["quick / daily / manual reflection"]
   Reflect --> MD["AETHER_MEMORY.md"]
   MD --> Search["memory_search"]
-  Search --> Agent["Agent"]
+  Search --> Agent["Agent 回答"]
   MD --> Shortcut["Shortcut Directory"]
-  Shortcut --> Prompt["极小 system prompt 注入"]
-  Cron["Daily reflection cron"] --> Reflect
+  Shortcut --> Prompt["短提示注入 system prompt"]
+  Cron["builtin daily cron"] --> Reflect
   UI["Settings > Memory"] --> Service
 ```
 
-## 2.1 核心代码入口
+核心入口：
 
-当前最关键的入口文件是：
+| 文件 | 职责 |
+| --- | --- |
+| `packages/opencode/src/memory/index.ts` | Memory service 主实现 |
+| `packages/opencode/src/memory/markdown.ts` | `AETHER_MEMORY.md` parse/render |
+| `packages/opencode/src/memory/search.ts` | Markdown 记忆检索与排序 |
+| `packages/opencode/src/memory/gate.ts` | quick reflection gate |
+| `packages/opencode/src/memory/schema.sql.ts` | SQLite 表定义 |
+| `packages/opencode/src/memory/installer.ts` | 安装、cron 注册、startup catch-up |
+| `packages/opencode/src/memory/plugin.ts` | chat hook 与 shortcut prompt 注入 |
+| `packages/opencode/src/tool/memory.ts` | Agent 工具 |
+| `packages/opencode/src/server/routes/memory.ts` | HTTP API |
 
-- `packages/opencode/src/memory/index.ts`
-  - 核心 memory service 实现
-- `packages/opencode/src/memory/markdown.ts`
-  - `AETHER_MEMORY.md` parse / render
-- `packages/opencode/src/memory/search.ts`
-  - Markdown 记忆检索
-- `packages/opencode/src/memory/gate.ts`
-  - quick reflection 确定性 gate
-- `packages/opencode/src/memory/schema.sql.ts`
-  - SQLite 表定义
-- `packages/opencode/src/memory/installer.ts`
-  - memory 安装、daily cron 注册、startup catch-up
-- `packages/opencode/src/memory/plugin.ts`
-  - shortcut prompt 注入
-- `packages/opencode/src/tool/memory.ts`
-  - agent tools
-- `packages/opencode/src/server/routes/memory.ts`
-  - `/memory` HTTP 路由
-- `packages/app/src/components/settings-memory.tsx`
-  - Settings > Memory UI
+## 3. 存储结构
 
-## 3. 持久化结构
+### 3.1 `AETHER_MEMORY.md`
 
-### 3.1 `memory.db`
-
-原始事件与 reflection 运行记录保存在当前 channel 下：
-
-```text
-<channel>/memory.db
-```
-
-`memory.db` 不是长期记忆事实源，也不是正常对话时的搜索目标。它主要用于：
-
-- 记录 `remember` / `forget` 原始请求
-- 记录 quick/daily/manual reflection 输入和结果
-- 标记事件状态
-- 支持 missed daily reflection 补跑
-- 支持首次初始化导入旧 session 后继续走同一套 reflection 链路
-
-核心表：
-
-- `memory_event`
-- `reflection_run`
-- `memory_setting`
-
-`memory_event.status` 当前可能值包括：
-
-- `new`
-- `pending_important`
-- `applied`
-- `ignored`
-- `deleted`
-- `forgot`
-- `deprecated`
-- `superseded`
-
-### 3.2 `AETHER_MEMORY.md`
-
-长期记忆保存在全局 memory 数据目录下：
+长期记忆事实源保存在全局 memory 数据目录：
 
 ```text
 <global-memory-data-dir>/AETHER_MEMORY.md
 ```
 
-它是当前唯一长期记忆事实源。`memory_search` 只搜索这个文件，不读取旧 session 文件，也不读取 `memory.db` raw event。
+`memory_search` 只搜索该文件，不读取旧 session 文件，也不读取 raw event 作为答案证据。
 
-当前 Markdown 顶层结构固定为：
+文件结构：
 
 ```text
 # Aether Memory
@@ -202,7 +113,7 @@ search_target: true
 ## Tasks
 ```
 
-长期记忆 block 示例：
+记忆条目示例：
 
 ```text
 ### PREF-answer-language
@@ -216,60 +127,71 @@ search_target: true
 - status: active
 ```
 
-## 4. 记忆类型与 scope
+### 3.2 `<channel>/memory.db`
 
-### 4.1 type
+事件、反思运行记录和设置保存在当前 channel 目录：
 
-当前只允许三种长期记忆类型：
+```text
+<channel>/memory.db
+```
 
-- `preference`
-  - 用户偏好、表达方式、工作方式、稳定画像
-- `fact`
-  - 较稳定的客观事实、项目事实、环境事实
-- `task`
-  - 持续任务、长期待办、需要后续跟进的事项
+核心表：
 
-### 4.2 scope
+| 表 | 用途 |
+| --- | --- |
+| `memory_event` | 记录 remember/forget 原始事件、source、状态和 reflection 结果 |
+| `reflection_run` | 记录 quick/daily/manual reflection 运行日志 |
+| `memory_setting` | 保存初始化状态、reflection 状态等轻量设置 |
 
-当前只允许两类长期记忆 scope：
+`memory_event.status` 可能值：
 
-- `global`
-  - 跨项目成立的用户偏好、事实或任务
-- `project:<project_id>`
-  - 只对某个 project 成立的事实、偏好或任务
+- `new`
+- `pending_important`
+- `applied`
+- `ignored`
+- `deleted`
+- `forgot`
+- `deprecated`
+- `superseded`
 
-`memory_search` 会把当前 project 作为排序加权信号，而不是默认硬过滤。当前 project scoped 记忆在相关查询中会优先于 global 记忆。
+## 4. 作用范围与类型
+
+### 4.1 类型
+
+| type | 语义 |
+| --- | --- |
+| `preference` | 用户偏好、交互风格、稳定画像 |
+| `fact` | 稳定事实、项目事实、环境事实 |
+| `task` | 长期任务、待跟进事项、持续约束 |
+
+### 4.2 Scope
+
+| scope | 语义 |
+| --- | --- |
+| `global` | 跨项目成立 |
+| `project:<project_id>` | 仅对指定 project 成立 |
+
+搜索时，当前 project 是排序加权信号，不是硬过滤。相关的 project memory 会优先于 global memory，但 global memory 仍可被召回。
 
 ## 5. Agent 工具
 
 ### 5.1 `memory_search`
 
-用途：
-
-- 搜索长期记忆
-- 只读 `AETHER_MEMORY.md`
-- 返回按相关度、scope、权重和新近程度排序的结果
-- 当请求可能依赖长期用户或项目上下文时，应优先调用：
-  - 用户身份、画像、偏好
-  - 项目事实、历史决策、既往约束
-  - recurring tasks 或用户曾经要求长期遵循的规则
-  - “你记得什么”“按我之前说的来”这类宽泛记忆问题
+搜索长期记忆。Agent 在回答可能依赖用户身份、偏好、项目事实、历史决策、长期任务或“之前说过的约束”时应主动调用。
 
 参数：
 
 - `query`
-- `types?`
+- `mode?`: `search | overview`
+- `types?`: `preference | fact | task`
 - `limit?`
 - `currentProjectID?`
 
+返回结果按相关度、scope、weight、recency 排序，并以 Markdown memory block id 标识证据。
+
 ### 5.2 `memory_remember`
 
-用途：
-
-- 记录用户明确要求记住的内容
-- 写入当前 channel 的 `memory.db`
-- 触发 quick reflection
-- quick reflection 通过后才会更新 `AETHER_MEMORY.md`
+记录用户明确要求记住的内容。该工具写入 `memory_event`，再触发 quick reflection；只有 reflection 接受后才会更新 `AETHER_MEMORY.md`。
 
 参数：
 
@@ -277,18 +199,11 @@ search_target: true
 - `type?`
 - `project_id?`
 
-注意：
-
-- `memory_remember` 不直接 raw edit Markdown。
-- Agent 不能绕过 service 直接写长期记忆文件。
+Agent 不应直接编辑 `AETHER_MEMORY.md`。
 
 ### 5.3 `memory_forget`
 
-用途：
-
-- 按自然语言 query 或 memory id 查找并删除长期记忆
-- 删除通过 Memory service 完成
-- 未找到匹配时不会写永久禁止项
+忘记匹配的长期记忆。自然语言请求会先搜索候选，再由 Memory service 删除匹配的 Markdown block。
 
 参数：
 
@@ -296,64 +211,104 @@ search_target: true
 - `ids?`
 - `type?`
 
-当前实现是 tombstone / service 删除语义，不做历史 raw event 的 hard delete。
+未找到匹配时不会记录永久禁止项。忘记是一次性删除，不代表以后永远不能重新记住类似内容。
 
 ### 5.4 `memory_reflect`
 
-用途：
-
-- 手动触发 reflection
-- 默认是 quick reflection
-- 用户明确要求全局/每日/完整整理时可使用 daily mode
+手动触发 reflection。默认 `quick`，只有用户明确要求全局/每日/完整整理时才使用 `daily`。
 
 参数：
 
-- `mode?`
-  - `quick`
-  - `daily`
-  - `manual`
+- `mode?`: `quick | daily | manual`
 - `reason?`
 
-## 6. Reflection 链路
+## 6. Reflection 与初始化链路
 
-### 6.1 Quick Reflection
+### 6.1 Quick reflection
 
-Quick reflection 主要处理当前 channel 中需要尽快判断的事件。
+quick reflection 用于尽快把重要的显式记忆跨 session 可见。
 
 触发来源：
 
 - `memory_remember`
-- 显式或高置信用户输入
-- memory 工具入口前的 pending 处理
+- `chat.message` hook 识别到的高价值用户记忆信号
+- `memory_reflect` 默认模式
 
-资源控制：
+为控制资源消耗，`shouldQuickReflect()` 会过滤低信号的一次性消息；需要 LLM 判断的事件会入库并等待 quick/daily reflection。
 
-- 每条用户消息可以先入库
-- 但是否调用 LLM 由 `shouldQuickReflect()` gate 决定
-- 低信号一次性问题不会立即触发 LLM
+### 6.2 Daily reflection
 
-### 6.2 Daily Reflection
-
-Daily reflection 用于全局整理和压缩长期记忆。
+daily reflection 用于全局整理、去重、合并相似项、处理冲突，并更新 `AETHER_MEMORY.md` 和 Shortcut Directory。
 
 触发来源：
 
-- built-in daily reflection cron
-- Settings > Memory 手动按钮
-- `memory_reflect` 明确指定 daily
+- built-in cron direct action：`memory.reflect.daily`
 - startup catch-up
+- Settings > Memory 手动触发
+- `memory_reflect` 显式指定 `daily`
 
-Daily reflection 会顺序扫描所有发现到的 channel `memory.db`，汇总 pending event 后更新同一个 `AETHER_MEMORY.md`。
+daily reflection 会顺序扫描可发现 channel 的 `memory.db`，不会并行扫描。
 
-### 6.3 Startup Catch-up
+### 6.3 Provider fallback
 
-server 启动安装 memory 时会调用 `Memory.startupCatchup()`。
+当 LLM reflection 因 provider/model/structured-output/provider-options 类错误失败时，service 会：
 
-如果当天尚未有成功 daily reflection，且 memory 与 daily reflection 都开启，会在后台触发一次 daily reflection。该补跑不阻塞 server 启动。
+1. 对 provider option BadRequest 类错误先用更保守 provider options 重试一次。
+2. 仍失败或模型不可用时，使用 deterministic fallback 处理候选事件。
+3. 在 reflection summary 中标记 `fallback`，避免表现成完全成功的 LLM 整理。
 
-## 7. Daily Reflection Cron
+Abort/cancel 类错误不会 fallback，会按中断处理。
 
-Memory 系统复用 cron 的 direct action 能力。
+### 6.4 历史 session 初始化
+
+初始化导入用于从旧 session 的用户消息中提取可能的长期记忆。
+
+行为：
+
+- 逐个 session 串行扫描，避免高 CPU 占用。
+- 主要分析用户消息；assistant 消息只作为必要上下文。
+- 候选内容先写入 `memory_event`，再通过 reflection 进入 `AETHER_MEMORY.md`。
+- `/memory/initialize/start` 现在只启动后台任务，不绑定 HTTP request 生命周期。
+- `/memory/initialize/cancel` 会中断当前初始化任务。
+- extractor 非中断错误会记录 `error_count` 和 `last_error`；如果没有导入任何条目则标记 `failed`。
+
+注意：当前 Settings > Memory 中的初始化导入按钮可能按上游要求处于禁用状态；service/API 通路仍保留。
+
+```mermaid
+sequenceDiagram
+  participant UI as UI/API
+  participant Memory as Memory service
+  participant DB as memory.db
+  participant LLM as LLM extractor
+  participant MD as AETHER_MEMORY.md
+
+  UI->>Memory: initialize/start
+  Memory-->>UI: status=started
+  loop one session at a time
+    Memory->>LLM: extract user-memory candidates
+    LLM-->>Memory: candidates or error
+    Memory->>DB: write memory_event / progress
+  end
+  Memory->>Memory: daily reflect imported events
+  Memory->>MD: update long-term memory
+```
+
+## 7. Prompt 注入策略
+
+Memory 系统不把完整长期记忆注入 system prompt。注入内容只包含 Shortcut Directory 的精简主题提示，用来提醒 agent 何时调用 `memory_search`。
+
+注入内容不包含：
+
+- memory 正文
+- `target_ids`
+- raw event
+- 旧 session transcript
+
+Agent 不应把 shortcut 当作事实，只能把它当成“可能需要搜索记忆”的索引。
+
+## 8. Cron 集成
+
+Memory 系统复用 cron 的 direct action。
 
 内置 action：
 
@@ -367,80 +322,41 @@ memory.reflect.daily
 builtin.memory.daily_reflect
 ```
 
-默认调度时间：
+默认时间：
 
 ```text
-0 3 * * *
+03:00
 ```
 
-Settings > Memory 中的 daily reflection 开关和时间会同步到该 cron job。若用户已经自定义过该内置 job，安装时默认保留已有定义；显式更新设置时才会重新同步。
+安装时会同步该内置 job，并禁用旧版 legacy daily reflect job。memory 总开关关闭时，daily cron 会被同步为 disabled，且 memory reflection 本身不会执行。若只是 daily reflection 开关关闭，则只影响 cron 触发；在 memory 总开关开启时，用户仍可手动执行 daily reflection。
 
-## 8. HTTP API
+## 9. HTTP API
 
-当前 `/memory` 路由提供：
+| 方法 | 路径 | 用途 |
+| --- | --- | --- |
+| `GET` | `/memory/status` | 查询 memory 状态、条目数、初始化状态 |
+| `POST` | `/memory/search` | 搜索长期记忆 |
+| `POST` | `/memory/reflect` | 执行 quick/daily/manual reflection |
+| `POST` | `/memory/initialize/start` | 后台启动历史 session 初始化 |
+| `POST` | `/memory/initialize/cancel` | 取消初始化 |
+| `POST` | `/memory/daily-reflect/sync` | 按配置同步 built-in daily reflect cron |
 
-- `GET /memory/status`
-  - 查询 memory 状态、Markdown 是否存在、条目数量、初始化状态等
-- `POST /memory/search`
-  - 调用 `Memory.search`
-- `POST /memory/reflect`
-  - 调用 `Memory.reflect`
-- `POST /memory/initialize/start`
-  - 启动一次性历史 session 初始化
-- `POST /memory/initialize/cancel`
-  - 取消初始化
-- `POST /memory/daily-reflect/sync`
-  - 按配置同步 built-in daily reflection cron job
+Agent 正常应使用 `memory_*` tools，而不是直接调用 HTTP API。
 
-这些 API 主要供 Settings UI 使用。Agent 正常应通过 `memory_*` tools 访问 memory 能力。
+## 10. Settings UI
 
-## 9. Settings > Memory
-
-当前 UI 已实现：
+Settings > Memory 当前承担轻量管理职责：
 
 - memory 总开关
-- daily reflection 开关
-- daily reflection 时间设置
-- 初始化导入旧 session
-- 初始化进度展示
-- memory 状态卡片
+- daily reflection 开关和时间
+- 状态卡片
+- 初始化状态展示
 - 手动 search
 - 手动 quick/daily reflect
 
-初始化导入旧 session 时：
+初始化导入按钮是否可点击取决于当前上游 UI 策略；后端接口和状态展示独立存在。
 
-- 逐个 session 串行扫描
-- 主要分析用户消息
-- 将候选内容写入 `memory.db`
-- 再通过 reflection 生成长期 Markdown
-- 不使用多线程并发扫描
-
-## 10. Prompt 注入策略
-
-当前 memory 系统不把完整长期记忆注入 system prompt。
-
-注入内容只包含 `Shortcut Directory` 生成的精简主题目录：
-
-- shortcut
-- topics/triggers
-
-注入时不会包含：
-
-- `target_ids`
-- `instruction`
-- 具体 memory 正文
-
-这些内容只用于提醒 Agent 判断是否应该调用 `memory_search`。Agent 不应把 shortcut 当作完整事实使用。
-
-触发原则：
-
-- 不要求 topic 精确匹配；只要问题可能因为长期记忆而改变答案，就应先调用 `memory_search`
-- 对宽泛画像问题使用简短的概览式关键词查询，例如 `user profile preference project constraints`
-- 对普通无上下文问题不需要调用，例如纯算术或完全自包含的问题
-
-Shortcut topic 的生成会优先保留用户原始表达中的主题词，再补充 reflection 后的 memory 文本。这样可以避免 LLM 在整理记忆时改写措辞后，把原始可召回主题丢掉。
-
-## 11. 生命周期接口
+## 11. 生命周期
 
 `installMemory()` 返回：
 
@@ -451,60 +367,38 @@ Shortcut topic 的生成会优先保留用户原始表达中的主题词，再�
 
 语义：
 
-- `start()`
-  - 同步 daily reflection job
-  - 执行 startup catch-up 检查
-- `stop()`
-  - 停止 memory 侧后台状态
-  - 不删除数据
-- `purge()`
-  - 删除全局 `AETHER_MEMORY.md`
-  - 删除 reflection state
-  - 删除各 channel 下的 `memory.db` 及 WAL/SHM 文件
+- `start()`：同步 daily reflect cron，并执行 startup catch-up 检查。
+- `stop()`：中断后台初始化任务，等待短暂收尾，关闭 memory DB，不删除数据。
+- `purge()`：删除 `AETHER_MEMORY.md`、reflection state、各 channel `memory.db` 及 WAL/SHM 文件。
 
-## 12. 当前侵入式修改
+## 12. 主干接入点
 
-除新增 memory 模块、文档和测试外，当前实现对主干文件有以下接入点：
+Memory 模块尽量不改 agent/session 主循环。当前主干接入点如下：
 
-- `packages/opencode/src/server/server.ts`
-  - 挂载 `/memory` route
-  - server 启动时安装 memory
-
-- `packages/opencode/src/tool/registry.ts`
-  - 注册 `memory_search`、`memory_remember`、`memory_forget`、`memory_reflect`
-
-- `packages/opencode/src/plugin/index.ts`
-  - 注册 memory plugin，注入 shortcut prompt
-
-- `packages/opencode/src/config/config.ts`
-  - 增加 memory 配置项
-
-- `packages/opencode/src/cron/index.ts`
-  - 支持 memory direct action 所需的 direct handler 机制
-
-- `packages/app/src/context/global-sdk.tsx`
-  - 注册 memory client helper
-
-- `packages/app/src/utils/server.ts`
-  - 增加 memory API client helper
-
-- `packages/app/src/components/dialog-settings.tsx`
-  - 增加 Settings > Memory tab
-
-这些修改的目的都是把 memory 作为可安装模块暴露给 server、agent tools、settings UI 和 cron direct action，而不是改写 SessionPrompt 主循环。
+| 文件 | 目的 |
+| --- | --- |
+| `packages/opencode/src/server/server.ts` | 挂载 `/memory` routes，server 生命周期安装 memory |
+| `packages/opencode/src/tool/registry.ts` | 注册 `memory_*` agent tools |
+| `packages/opencode/src/plugin/index.ts` | 注册 memory plugin |
+| `packages/opencode/src/config/config.ts` | 增加 memory 配置项 |
+| `packages/opencode/src/cron/index.ts` | 支持 memory direct action |
+| `packages/app/src/context/global-sdk.tsx` | 暴露 memory client helper |
+| `packages/app/src/utils/server.ts` | 暴露 memory API helper |
+| `packages/app/src/components/dialog-settings.tsx` | 增加 Settings > Memory tab |
 
 ## 13. 测试
 
-当前 memory 相关测试主要在：
-
-- `packages/opencode/test/memory/memory.test.ts`
-- `packages/app/src/components/settings-memory.vitest.tsx`
-
-建议本地验证命令：
+推荐本地验证：
 
 ```bash
-bun run --cwd packages/opencode test test/memory/memory.test.ts test/cron/cron.test.ts --timeout 60000
+bun run --cwd packages/opencode test test/memory/memory.test.ts --timeout 120000
+bun run --cwd packages/opencode test test/cron/cron.test.ts test/memory/abort-leak.test.ts --timeout 120000
 bun run --cwd packages/opencode typecheck
+```
+
+前端设置页相关测试：
+
+```bash
 bun run --cwd packages/app ./script/vitest.ts run --config ./vitest.config.ts src/components/settings-memory.vitest.tsx
 bun run --cwd packages/app typecheck
 ```

--- a/packages/opencode/src/memory/index.ts
+++ b/packages/opencode/src/memory/index.ts
@@ -108,6 +108,7 @@ let documentCache: { path: string; mtimeMs: number; doc: MemoryDocument } | unde
 let db: BunSqlite | undefined
 let initializeCancelled = false
 let initializeAbortController: AbortController | undefined
+let initializeTask: Promise<{ status: "cancelled" | "succeeded" | "failed"; scanned: number; imported: number }> | undefined
 let scannerForTest: (() => AsyncGenerator<SessionForInitialization>) | undefined
 let extractorForTest:
   | ((session: SessionForInitialization, signal?: AbortSignal) => Promise<InitializerCandidate[]>)
@@ -182,6 +183,14 @@ function isRetryableReflectionProviderError(error: unknown) {
   const message = errorMessage(error)
   if (!/badrequest|bad request|invalid request|validation|400/i.test(message)) return false
   return /reasoning[_\s-]?effort|reasoning|provider.?options?|temperature|top[_\s-]?p|topP|unsupported/i.test(message)
+}
+
+function isFallbackReflectionProviderError(error: unknown) {
+  if (isAbortLike(error)) return false
+  const message = errorMessage(error)
+  return /provider|model|nosuchmodel|modelnotfound|badrequest|bad request|invalid request|validation|400|schema|json|object|structured|unsupported|temperature|reasoning/i.test(
+    message,
+  )
 }
 
 function safeReflectionProviderOptions(model: Provider.Model) {
@@ -505,12 +514,7 @@ async function extractMemoryCandidates(
   const ruleCandidates = extractRuleMemoryCandidates(session)
   if (ruleCandidates.length > 0) return ruleCandidates
   if (!sessionLooksWorthLLMInitialization(session)) return []
-  try {
-    return await llmInitializeExtractor(session, signal)
-  } catch (error) {
-    if (isAbortLike(error) || signal?.aborted) throw error
-    return []
-  }
+  return await runInitializeExtractor(session, signal)
 }
 
 async function sleep(ms: number) {
@@ -892,6 +896,7 @@ async function llmReflector(input: {
 async function llmInitializeExtractor(
   session: SessionForInitialization,
   signal?: AbortSignal,
+  options?: { safeProviderOptions?: boolean },
 ): Promise<InitializerCandidate[]> {
   throwIfAborted(signal)
   const model = await Provider.defaultModel()
@@ -954,12 +959,18 @@ async function llmInitializeExtractor(
       2,
     ),
   }
+  const retryProviderOptions = options?.safeProviderOptions ? safeReflectionProviderOptions(resolved) : undefined
   const params = {
     model: language,
-    temperature: 0,
+    ...(options?.safeProviderOptions ? {} : { temperature: 0 }),
     schema: InitializationOutput,
     abortSignal: signal,
     messages: [{ role: "system", content: system }, userMessage],
+    ...(retryProviderOptions
+      ? {
+          providerOptions: ProviderTransform.providerOptions(resolved, retryProviderOptions),
+        }
+      : {}),
   } satisfies Parameters<typeof generateObject>[0]
   throwIfAborted(signal)
   const authInfo = await Auth.get(model.providerID)
@@ -971,6 +982,7 @@ async function llmInitializeExtractor(
             ...params,
             messages: [userMessage],
             providerOptions: ProviderTransform.providerOptions(resolved, {
+              ...(retryProviderOptions ?? {}),
               store: false,
               instructions: system,
             }),
@@ -999,6 +1011,16 @@ async function llmInitializeExtractor(
     })
     .filter((item): item is InitializerCandidate => item !== undefined)
     .slice(0, 8)
+}
+
+async function runInitializeExtractor(session: SessionForInitialization, signal?: AbortSignal) {
+  try {
+    return await llmInitializeExtractor(session, signal)
+  } catch (error) {
+    if (!isRetryableReflectionProviderError(error)) throw error
+    throwIfAborted(signal)
+    return await llmInitializeExtractor(session, signal, { safeProviderOptions: true })
+  }
 }
 
 async function llmForgetDecide(input: { query: string; candidates: MemoryBlock[]; signal?: AbortSignal }) {
@@ -1078,12 +1100,26 @@ async function runReflector(input: ReflectionInput) {
   throwIfAborted(input.signal)
   const reflect = (safeProviderOptions: boolean) =>
     reflectorForTest ? reflectorForTest(input) : llmReflector({ ...input, safeProviderOptions })
+  const fallback = async (error: unknown) =>
+    (await deterministicReflector(input)).map((candidate) => ({
+      ...candidate,
+      evidence: `Deterministic fallback after LLM reflection failed: ${errorMessage(error).slice(0, 120)}`,
+    }))
   try {
     return await reflect(false)
   } catch (error) {
-    if (!isRetryableReflectionProviderError(error)) throw error
+    if (!isRetryableReflectionProviderError(error)) {
+      if (isFallbackReflectionProviderError(error)) return await fallback(error)
+      throw error
+    }
     throwIfAborted(input.signal)
-    return await reflect(true)
+    try {
+      return await reflect(true)
+    } catch (retryError) {
+      if (isAbortLike(retryError) || input.signal?.aborted) throw retryError
+      if (isFallbackReflectionProviderError(retryError)) return await fallback(retryError)
+      throw retryError
+    }
   }
 }
 
@@ -1222,7 +1258,11 @@ export namespace Memory {
   }
 
   export async function stop() {
+    const runningInitialize = initializeTask
     initializeAbortController?.abort()
+    if (runningInitialize) {
+      await Promise.race([runningInitialize.catch(() => undefined), sleep(2_000)])
+    }
     initializeAbortController = undefined
     db?.close()
     db = undefined
@@ -1233,6 +1273,7 @@ export namespace Memory {
     scannerForTest = undefined
     extractorForTest = undefined
     settingsForTest = undefined
+    initializeTask = undefined
   }
 
   export async function purge() {
@@ -1460,6 +1501,9 @@ export namespace Memory {
         throwIfAborted(input.signal)
         const before = await readDocument()
         const candidates = await runReflector({ events, doc: before, mode: input.mode, signal: input.signal })
+        const fallbackUsed = candidates.some((candidate) =>
+          candidate.evidence.includes("Deterministic fallback after LLM reflection failed:"),
+        )
         throwIfAborted(input.signal)
         let merged: ReturnType<typeof mergeCandidates> = { updatedIDs: [], eventResults: {}, shortcutChanged: false }
         if (candidates.length) {
@@ -1508,7 +1552,13 @@ export namespace Memory {
           updatedIDs: merged.updatedIDs,
           deletedIDs: [],
           shortcutChanged: merged.shortcutChanged,
-          summary: changed ? `Applied ${merged.updatedIDs.length} memory update(s).` : "No changes.",
+          summary: fallbackUsed
+            ? changed
+              ? `Applied ${merged.updatedIDs.length} memory update(s) with fallback.`
+              : "No changes with fallback."
+            : changed
+              ? `Applied ${merged.updatedIDs.length} memory update(s).`
+              : "No changes.",
         }
       } catch (error) {
         openDb()
@@ -1542,6 +1592,8 @@ export namespace Memory {
     const startedAt = Date.now()
     let scanned = 0
     let imported = 0
+    let errorCount = 0
+    let lastError: string | undefined
     const writeInitializationProgress = (patch: Record<string, unknown> = {}) =>
       writeReflectionState({
         initialization: {
@@ -1560,7 +1612,7 @@ export namespace Memory {
       for await (const session of scanner()) {
         if (initializationWasCancelled(signal)) break
         scanned++
-        if (!sessionHasMemorySignal(session)) {
+        if (!sessionHasMemorySignal(session) && !sessionLooksWorthLLMInitialization(session)) {
           await writeInitializationProgress({
             current_session_id: session.sessionID,
             current_project_id: session.projectID ?? null,
@@ -1569,9 +1621,24 @@ export namespace Memory {
           continue
         }
         throwIfAborted(signal)
-        const candidates = extractorForTest
-          ? await extractorForTest(session, signal)
-          : await extractMemoryCandidates(session, signal)
+        let candidates: InitializerCandidate[] = []
+        try {
+          candidates = extractorForTest
+            ? await extractorForTest(session, signal)
+            : await extractMemoryCandidates(session, signal)
+        } catch (error) {
+          if (isAbortLike(error) || signal?.aborted) throw error
+          errorCount++
+          lastError = errorMessage(error).slice(0, 500)
+          await writeInitializationProgress({
+            current_session_id: session.sessionID,
+            current_project_id: session.projectID ?? null,
+            error_count: errorCount,
+            last_error: lastError,
+          })
+          await sleep(250)
+          continue
+        }
         throwIfAborted(signal)
         for (const candidate of candidates) {
           insertEvent({
@@ -1614,7 +1681,11 @@ export namespace Memory {
         initializeCancelled = true
       })
     }
-    const status = initializationWasCancelled(signal) ? ("cancelled" as const) : ("succeeded" as const)
+    const status = initializationWasCancelled(signal)
+      ? ("cancelled" as const)
+      : errorCount > 0 && imported === 0
+        ? ("failed" as const)
+        : ("succeeded" as const)
     await writeReflectionState({
       initialization: {
         status,
@@ -1622,10 +1693,58 @@ export namespace Memory {
         completed_at: Date.now(),
         scanned,
         imported,
+        ...(errorCount > 0 ? { error_count: errorCount, last_error: lastError } : {}),
       },
     })
     if (initializeAbortController === controller) initializeAbortController = undefined
     return { status, scanned, imported }
+  }
+
+  export async function startInitialize() {
+    const state = await readReflectionState()
+    const current = typeof state.initialization === "object" && state.initialization ? state.initialization : {}
+    const status = (current as Record<string, unknown>).status
+    if (initializeTask || status === "running" || status === "reflecting") {
+      return {
+        ...(current as Record<string, unknown>),
+        status: "running" as const,
+      }
+    }
+    await writeReflectionState({
+      initialization: {
+        status: "running",
+        started_at: Date.now(),
+        updated_at: Date.now(),
+        scanned: 0,
+        imported: 0,
+      },
+    })
+    initializeTask = initialize({ confirm: true })
+      .catch(async (error) => {
+        const latest = await readReflectionState()
+        const initialization =
+          typeof latest.initialization === "object" && latest.initialization
+            ? (latest.initialization as Record<string, unknown>)
+            : {}
+        const failed = {
+          status: "failed" as const,
+          scanned: typeof initialization.scanned === "number" ? initialization.scanned : 0,
+          imported: typeof initialization.imported === "number" ? initialization.imported : 0,
+          completed_at: Date.now(),
+          last_error: errorMessage(error).slice(0, 500),
+        }
+        await writeReflectionState({
+          initialization: {
+            ...initialization,
+            ...failed,
+          },
+        })
+        return failed
+      })
+      .finally(() => {
+        initializeTask = undefined
+      })
+    return { status: "started" as const }
   }
 
   export async function startupCatchup() {

--- a/packages/opencode/src/server/routes/memory.ts
+++ b/packages/opencode/src/server/routes/memory.ts
@@ -83,7 +83,7 @@ export const MemoryRoutes = lazy(() =>
           },
         },
       }),
-      async (c) => c.json(await Memory.initialize({ confirm: true, signal: c.req.raw.signal })),
+      async (c) => c.json(await Memory.startInitialize()),
     )
     .post(
       "/initialize/cancel",

--- a/packages/opencode/test/memory/memory.test.ts
+++ b/packages/opencode/test/memory/memory.test.ts
@@ -999,6 +999,110 @@ describe("memory service", () => {
     expect(sawAbort).toBe(true)
   })
 
+  test("startInitialize runs import in the background without waiting for completion", async () => {
+    let releaseImport!: () => void
+    const release = new Promise<void>((resolve) => {
+      releaseImport = resolve
+    })
+    Memory.setSessionScannerForTest(async function* () {
+      yield {
+        channelID: "latest",
+        projectID: "project-a",
+        sessionID: "one",
+        messages: [{ role: "user" as const, text: "请记住我默认喜欢中文回答", createdAt: 1 }],
+      }
+    })
+    Memory.setInitializerExtractorForTest(async () => {
+      await release
+      return [
+        {
+          text: "用户偏好默认用中文回答。",
+          type: "preference" as const,
+          scope: "global" as const,
+        },
+      ]
+    })
+
+    const started = await Memory.startInitialize()
+
+    expect(started.status).toBe("started")
+    const running = await Memory.status()
+    expect(running.initialization).toMatchObject({ status: "running" })
+
+    releaseImport()
+    let finished = await Memory.status()
+    for (let index = 0; index < 20; index++) {
+      if ((finished.initialization as { status?: string }).status !== "running") break
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      finished = await Memory.status()
+    }
+    expect(finished.initialization).toMatchObject({ status: "succeeded", scanned: 1, imported: 1 })
+  })
+
+  test("initialize records extractor errors instead of silently reporting a clean empty import", async () => {
+    Memory.setSessionScannerForTest(async function* () {
+      yield {
+        channelID: "latest",
+        projectID: "project-a",
+        sessionID: "broken-extractor",
+        messages: [{ role: "user" as const, text: "请记住我默认喜欢中文回答", createdAt: 1 }],
+      }
+    })
+    Memory.setInitializerExtractorForTest(async () => {
+      throw new Error("provider bad request during initialization")
+    })
+
+    const result = await Memory.initialize({ confirm: true })
+
+    expect(result.status).toBe("failed")
+    expect(result.scanned).toBe(1)
+    expect(result.imported).toBe(0)
+    const status = await Memory.status()
+    expect(status.initialization).toMatchObject({
+      status: "failed",
+      scanned: 1,
+      imported: 0,
+      error_count: 1,
+    })
+    expect(JSON.stringify(status.initialization)).toContain("provider bad request")
+  })
+
+  test("initialize sends broad but non-keyword sessions to the extractor", async () => {
+    const seen: string[] = []
+    Memory.setSessionScannerForTest(async function* () {
+      yield {
+        channelID: "latest",
+        projectID: "project-a",
+        sessionID: "broad-profile",
+        messages: [
+          {
+            role: "user" as const,
+            text:
+              "I work on multi-loop Feynman integral reduction and often compare symbolic workflows across Mathematica, Kira, and custom TypeScript agents. The durable part is my research context, not a one-shot command.",
+            createdAt: 1,
+          },
+        ],
+      }
+    })
+    Memory.setInitializerExtractorForTest(async (session) => {
+      seen.push(session.sessionID)
+      return [
+        {
+          text: "User works on multi-loop Feynman integral reduction workflows.",
+          type: "fact" as const,
+          scope: "global" as const,
+        },
+      ]
+    })
+
+    const result = await Memory.initialize({ confirm: true })
+
+    expect(result).toEqual({ status: "succeeded", scanned: 1, imported: 1 })
+    expect(seen).toEqual(["broad-profile"])
+    const found = await Memory.search({ query: "Feynman integral reduction", limit: 5 })
+    expect(found.results[0]?.memory).toContain("Feynman")
+  })
+
   test("initialize imports matching user messages with the production extractor", async () => {
     Memory.setSessionScannerForTest(async function* () {
       yield {
@@ -1125,6 +1229,24 @@ describe("memory service", () => {
     const reflected = await Memory.reflect({ mode: "daily", reason: "test" })
     expect(reflected.changed).toBe(true)
     expect(calls).toBe(2)
+    expect((await Memory.search({ query: "中文回答", limit: 5 })).results[0]?.memory).toContain("中文回答")
+  })
+
+  test("daily reflection falls back to deterministic candidates when the provider is unavailable", async () => {
+    Memory.setReflectorForTest(async () => {
+      throw new Error("ProviderModelNotFoundError: default model unavailable")
+    })
+    await Memory.remember({
+      text: "我希望默认用中文回答",
+      type: "preference",
+      intent: "observed",
+      source: { createdAt: Date.now(), role: "user" },
+    })
+
+    const reflected = await Memory.reflect({ mode: "daily", reason: "test" })
+
+    expect(reflected.changed).toBe(true)
+    expect(reflected.summary).toContain("fallback")
     expect((await Memory.search({ query: "中文回答", limit: 5 })).results[0]?.memory).toContain("中文回答")
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #1091

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Fixes memory initialization and reflection recovery paths:

- Starts historical memory initialization as a background task instead of tying it to the HTTP request signal.
- Records initialization extractor errors in status instead of reporting a clean empty import.
- Retries reflection/extraction once with safer provider options for provider-option BadRequest failures.
- Falls back to deterministic reflection for provider/model/structured-output runtime failures and marks the summary with `fallback`.
- Sends broad durable session context to the initializer extractor instead of skipping it too early.
- Rewrites the memory system docs in Chinese and adds an English version.

The code changes stay inside the memory module, memory route, and memory tests.

### How did you verify your code works?

- `bun test test/memory/memory.test.ts --timeout 120000`
- `bun test test/cron/cron.test.ts test/memory/abort-leak.test.ts --timeout 120000`
- `bun run typecheck` from `packages/opencode`
- `git diff --check`
- Push hook ran `bun turbo typecheck`: 12/12 tasks successful.

### Screenshots / recordings

N/A. No UI behavior changed.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
