### PR TITLE
feat: add collapse all button in file-tree

### DIFF
--- a/packages/app/src/context/file.tsx
+++ b/packages/app/src/context/file.tsx
@@ -483,6 +483,7 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
         children: tree.children,
         expand: tree.expandDir,
         collapse: tree.collapseDir,
+        collapseAll: tree.collapseAll,
         toggle(input: string) {
           if (tree.dirState(input)?.expanded) {
             tree.collapseDir(input)

--- a/packages/app/src/context/file/tree-store.ts
+++ b/packages/app/src/context/file/tree-store.ts
@@ -182,6 +182,19 @@ export function createFileTreeStore(options: TreeStoreOptions) {
     options.onExpandedChange?.(getExpandedSet())
   }
 
+  const collapseAll = () => {
+    setTree(
+      "dir",
+      produce((draft) => {
+        for (const key of Object.keys(draft)) {
+          if (!key) continue
+          draft[key].expanded = false
+        }
+      }),
+    )
+    options.onExpandedChange?.(getExpandedSet())
+  }
+
   const dirState = (input: string) => {
     const dir = options.normalizeDir(input)
     return tree.dir[dir]
@@ -204,6 +217,7 @@ export function createFileTreeStore(options: TreeStoreOptions) {
     refreshDir,
     expandDir,
     collapseDir,
+    collapseAll,
     dirState,
     children,
     node: (path: string) => tree.node[path],

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -526,6 +526,8 @@ export const dict = {
   "filePanel.newFileTooltip": "Create a new file in project root",
   "filePanel.newFolder": "New Folder",
   "filePanel.newFolderTooltip": "Create a new folder in project root",
+  "filePanel.collapseAll": "Collapse All",
+  "filePanel.collapseAllTooltip": "Collapse all expanded directories",
   "filePanel.refresh": "Refresh",
   "filePanel.refreshTooltip": "Refresh project file list",
   "filePanel.uploadFailed": "Upload failed",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -519,6 +519,8 @@ export const dict = {
   "filePanel.newFileTooltip": "在项目根目录新建文件",
   "filePanel.newFolder": "新建文件夹",
   "filePanel.newFolderTooltip": "在项目根目录新建文件夹",
+  "filePanel.collapseAll": "全部收起",
+  "filePanel.collapseAllTooltip": "收起所有已展开的目录",
   "filePanel.refresh": "刷新",
   "filePanel.refreshTooltip": "刷新项目文件列表",
   "filePanel.uploadFailed": "上传失败",

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -321,6 +321,9 @@ export function SessionSidePanel(props: {
     props.onRefresh()
   }
 
+  function handleCollapseAll() {
+    file.tree.collapseAll()
+  }
   const isDesktop = createMediaQuery("(min-width: 768px)")
 
   const state = createMemo(() =>
@@ -1128,6 +1131,16 @@ export function SessionSidePanel(props: {
                       >
                         <Icon name="folder-add-left" size="small" />
                         <span class="hidden @sm:block">{language.t("filePanel.newFolder")}</span>
+                      </button>
+                    </Tooltip>
+                    <Tooltip value={language.t("filePanel.collapseAllTooltip")}>
+                      <button
+                        type="button"
+                        class="flex items-center gap-1 px-2 py-1 rounded text-12-regular text-text-weak hover:text-text-base hover:bg-surface-raised-base-hover transition-colors"
+                        onClick={handleCollapseAll}
+                      >
+                        <Icon name="collapse" size="small" class="-rotate-90" />
+                        <span class="hidden @sm:block">{language.t("filePanel.collapseAll")}</span>
                       </button>
                     </Tooltip>
                     <Tooltip value={language.t("filePanel.refreshTooltip")}>


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

加上一键收起file-tree中所有展开的文件夹的按钮

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

bun typecheck
bun test ./src

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
