### PR TITLE
fix: avoid suspense when display image in session-review

### DIFF
--- a/packages/ui/src/components/file-media.tsx
+++ b/packages/ui/src/components/file-media.tsx
@@ -1,5 +1,5 @@
 import type { FileContent } from "@opencode-ai/sdk/v2"
-import { createEffect, createMemo, createResource, createSignal, Match, on, Show, Switch, type JSX } from "solid-js"
+import { createEffect, createMemo, createSignal, Match, on, Show, Switch, type JSX } from "solid-js"
 import { useI18n } from "../context/i18n"
 import { IconButton } from "./icon-button"
 import {
@@ -132,41 +132,67 @@ export function FileMedia(props: { media?: FileMediaOptions; fallback: () => JSX
     if (direct()) return
     if (!media.path || !media.readFile) return
 
-    return {
-      key: `${k}:${media.path}`,
-      kind: k,
-      path: media.path,
-      readFile: media.readFile,
-      onError: media.onError,
-    }
+    return `${k}:${media.path}`
   })
 
-  const [loaded] = createResource(request, async (input) => {
-    return input.readFile(input.path).then(
+  const [loaded, setLoaded] = createSignal<
+    { key: string; src: string; mime: string | undefined } | { key: string; error: true } | undefined
+  >()
+  const [loading, setLoading] = createSignal(false)
+  let seq = 0
+
+  const load = async (key: string) => {
+    const media = cfg()
+    const k = kind()
+    if (!media || (k !== "image" && k !== "audio") || !media.path || !media.readFile) {
+      return { key, error: true as const }
+    }
+
+    return media.readFile(media.path).then(
       (result) => {
-        const src = dataUrlFromMediaValue(result as any, input.kind)
+        const src = dataUrlFromMediaValue(result as any, k)
         if (!src) {
-          input.onError?.({ kind: input.kind })
-          return { key: input.key, error: true as const }
+          media.onError?.({ kind: k })
+          return { key, error: true as const }
         }
 
         return {
-          key: input.key,
+          key,
           src,
-          mime: input.kind === "audio" ? normalizeMimeType(result?.mimeType) : undefined,
+          mime: k === "audio" ? normalizeMimeType(result?.mimeType) : undefined,
         }
       },
       () => {
-        input.onError?.({ kind: input.kind })
-        return { key: input.key, error: true as const }
+        media.onError?.({ kind: k })
+        return { key, error: true as const }
       },
     )
-  })
+  }
+
+  createEffect(
+    on(request, (key) => {
+      seq++
+      const id = seq
+      if (!key) {
+        setLoaded(undefined)
+        setLoading(false)
+        return
+      }
+
+      setLoading(true)
+
+      void load(key).then((value) => {
+        if (id !== seq) return
+        setLoaded(value)
+        setLoading(false)
+      })
+    }),
+  )
 
   const remote = createMemo(() => {
     const input = request()
     const value = loaded()
-    if (!input || !value || value.key !== input.key) return
+    if (!input || !value || value.key !== input) return
     return value
   })
 
@@ -184,8 +210,9 @@ export function FileMedia(props: { media?: FileMediaOptions; fallback: () => JSX
   const status = createMemo(() => {
     if (direct()) return "ready" as const
     if (!request()) return "idle" as const
-    if (loaded.loading) return "loading" as const
-    if (remote()?.error) return "error" as const
+    if (loading()) return "loading" as const
+    const value = remote()
+    if (value && "error" in value) return "error" as const
     if (src()) return "ready" as const
     return "idle" as const
   })

--- a/packages/ui/src/components/session-review.tsx
+++ b/packages/ui/src/components/session-review.tsx
@@ -295,6 +295,21 @@ export const SessionReview = (props: SessionReviewProps) => {
 
                     const beforeText = () => (typeof diff.before === "string" ? diff.before : "")
                     const afterText = () => (typeof diff.after === "string" ? diff.after : "")
+                    const before = createMemo(() => ({
+                      name: file,
+                      contents: beforeText(),
+                    }))
+                    const after = createMemo(() => ({
+                      name: file,
+                      contents: afterText(),
+                    }))
+                    const media = createMemo(() => ({
+                      mode: "auto" as const,
+                      path: file,
+                      before: diff.before,
+                      after: diff.after,
+                      readFile: props.readFile,
+                    }))
                     const changedLines = () => diff.additions + diff.deletions
                     const mediaKind = createMemo(() => mediaKindFromPath(file))
 
@@ -387,6 +402,10 @@ export const SessionReview = (props: SessionReviewProps) => {
                     const handleLineSelectionEnd = (range: SelectedLineRange | null) => {
                       if (!props.onLineComment) return
                       commentsUi.onLineSelectionEnd(range)
+                    }
+
+                    const handleRendered = () => {
+                      props.onDiffRendered?.()
                     }
 
                     return (
@@ -493,9 +512,7 @@ export const SessionReview = (props: SessionReviewProps) => {
                                     mode="diff"
                                     preloadedDiff={diff.preloaded}
                                     diffStyle={diffStyle()}
-                                    onRendered={() => {
-                                      props.onDiffRendered?.()
-                                    }}
+                                    onRendered={handleRendered}
                                     enableLineSelection={props.onLineComment != null}
                                     enableHoverUtility={props.onLineComment != null}
                                     onLineSelected={handleLineSelected}
@@ -506,21 +523,9 @@ export const SessionReview = (props: SessionReviewProps) => {
                                     renderHoverUtility={props.onLineComment ? commentsUi.renderHoverUtility : undefined}
                                     selectedLines={selectedLines()}
                                     commentedLines={commentedLines()}
-                                    before={{
-                                      name: file,
-                                      contents: typeof diff.before === "string" ? diff.before : "",
-                                    }}
-                                    after={{
-                                      name: file,
-                                      contents: typeof diff.after === "string" ? diff.after : "",
-                                    }}
-                                    media={{
-                                      mode: "auto",
-                                      path: file,
-                                      before: diff.before,
-                                      after: diff.after,
-                                      readFile: props.readFile,
-                                    }}
+                                    before={before()}
+                                    after={after()}
+                                    media={media()}
                                   />
                                 </Match>
                               </Switch>


### PR DESCRIPTION
### Issue for this PR

Closes #1096

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- 将 FileMedia 的远程媒体加载从 createResource 改为本地 createSignal + createEffect。
- 使用请求序号避免过期异步结果覆盖新请求。
- 将 media request key 稳定为 kind:path，避免父级无关刷新重复读取同一媒体。
- 稳定 SessionReview 传给 file viewer 的 before / after / media props，减少无关重绘。

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

bun typecheck
bun run test:unit file-media.vitest.tsx

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
