### PR TITLE
fix: prevent zombie sessions from silent LLM stream stalls

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -797,7 +797,9 @@ export namespace Config {
     evolution_enabled: z
       .boolean()
       .optional()
-      .describe("Global master switch for skill self-evolution. When false, no project triggers background review (default: true)"),
+      .describe(
+        "Global master switch for skill self-evolution. When false, no project triggers background review (default: true)",
+      ),
     creation_nudge_interval: z
       .number()
       .int()
@@ -1144,13 +1146,13 @@ export namespace Config {
                 .int()
                 .positive()
                 .describe(
-                  "Timeout in milliseconds for requests to this provider. Default is 300000 (5 minutes). Set to false to disable timeout.",
+                  "Total request timeout in ms. Applied to non-SSE responses only; SSE streams use chunkTimeout. Default is 300000 (5 minutes). Set to false to disable.",
                 ),
-              z.literal(false).describe("Disable timeout for this provider entirely."),
+              z.literal(false).describe("Disable request timeout for this provider entirely."),
             ])
             .optional()
             .describe(
-              "Timeout in milliseconds for requests to this provider. Default is 300000 (5 minutes). Set to false to disable timeout.",
+              "Total request timeout in ms. Applied to non-SSE responses only; SSE streams use chunkTimeout. Default is 300000 (5 minutes). Set to false to disable.",
             ),
           chunkTimeout: z
             .number()
@@ -1158,7 +1160,7 @@ export namespace Config {
             .positive()
             .optional()
             .describe(
-              "Timeout in milliseconds between streamed SSE chunks for this provider. If no chunk arrives within this window, the request is aborted.",
+              "Timeout in ms between streamed SSE chunks. Default is 600000 (10 minutes). If no chunk arrives within this window, the request is aborted.",
             ),
         })
         .catchall(z.any())

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -53,6 +53,7 @@ import { Installation } from "../installation"
 import { ModelID, ProviderID } from "./schema"
 
 const DEFAULT_CHUNK_TIMEOUT = 600_000
+const DEFAULT_REQUEST_TIMEOUT = 300_000
 
 export namespace Provider {
   const log = Log.create({ service: "provider" })
@@ -73,7 +74,7 @@ export namespace Provider {
       async pull(ctrl) {
         const part = await new Promise<Awaited<ReturnType<typeof reader.read>>>((resolve, reject) => {
           const id = setTimeout(() => {
-            const err = new Error("SSE read timed out")
+            const err = new DOMException("SSE read timed out", "TimeoutError")
             ctl.abort(err)
             void reader.cancel(err)
             reject(err)
@@ -1376,7 +1377,7 @@ export namespace Provider {
 
       const customFetch = options["fetch"]
       const chunkTimeout = options["chunkTimeout"] ?? DEFAULT_CHUNK_TIMEOUT
-      const requestTimeout = options["timeout"]
+      const requestTimeout = options["timeout"] ?? DEFAULT_REQUEST_TIMEOUT
       delete options["chunkTimeout"]
       delete options["timeout"]
 
@@ -1437,15 +1438,24 @@ export namespace Provider {
         }
 
         const proxy = proxyFor(input)
-        const res = await fetchFn(input, {
-          ...opts,
-          ...(proxy ? { proxy } : {}),
-          // @ts-ignore see here: https://github.com/oven-sh/bun/issues/16682
-          timeout: false,
-        })
+        let res: Response
+        try {
+          res = await fetchFn(input, {
+            ...opts,
+            ...(proxy ? { proxy } : {}),
+            // @ts-ignore see here: https://github.com/oven-sh/bun/issues/16682
+            timeout: false,
+          })
+        } catch (e) {
+          if (reqTimer) clearTimeout(reqTimer)
+          throw e
+        }
 
         const isSSE = res.headers.get("content-type")?.includes("text/event-stream")
-        if (isSSE) clearTimeout(reqTimer)
+        if (isSSE && reqTimer) {
+          clearTimeout(reqTimer)
+          reqTimer = undefined
+        }
 
         if (!chunkAbortCtl) return res
         return wrapSSE(res, chunkTimeout, chunkAbortCtl)

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1375,20 +1375,29 @@ export namespace Provider {
       if (existing) return existing
 
       const customFetch = options["fetch"]
-      const chunkTimeout = options["chunkTimeout"]
+      const chunkTimeout = options["chunkTimeout"] ?? DEFAULT_CHUNK_TIMEOUT
+      const requestTimeout = options["timeout"]
       delete options["chunkTimeout"]
+      delete options["timeout"]
 
       options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {
-        // Preserve custom fetch if it exists, wrap it with timeout logic
         const fetchFn = customFetch ?? fetch
         const opts = init ?? {}
         const chunkAbortCtl = typeof chunkTimeout === "number" && chunkTimeout > 0 ? new AbortController() : undefined
-        const signals: AbortSignal[] = []
-
-        if (opts.signal) signals.push(opts.signal)
+        const reqAbortCtl =
+          requestTimeout !== false && requestTimeout !== null && requestTimeout !== undefined
+            ? new AbortController()
+            : undefined
+        const signals: AbortSignal[] = [opts.signal].filter(Boolean) as AbortSignal[]
         if (chunkAbortCtl) signals.push(chunkAbortCtl.signal)
-        if (options["timeout"] !== undefined && options["timeout"] !== null && options["timeout"] !== false)
-          signals.push(AbortSignal.timeout(options["timeout"]))
+        if (reqAbortCtl) signals.push(reqAbortCtl.signal)
+        let reqTimer: ReturnType<typeof setTimeout> | undefined
+        if (reqAbortCtl) {
+          reqTimer = setTimeout(
+            () => reqAbortCtl.abort(new DOMException("Request timed out", "TimeoutError")),
+            requestTimeout as number,
+          )
+        }
 
         const combined = signals.length === 0 ? null : signals.length === 1 ? signals[0] : AbortSignal.any(signals)
         if (combined) opts.signal = combined
@@ -1434,6 +1443,9 @@ export namespace Provider {
           // @ts-ignore see here: https://github.com/oven-sh/bun/issues/16682
           timeout: false,
         })
+
+        const isSSE = res.headers.get("content-type")?.includes("text/event-stream")
+        if (isSSE) clearTimeout(reqTimer)
 
         if (!chunkAbortCtl) return res
         return wrapSSE(res, chunkTimeout, chunkAbortCtl)

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -936,11 +936,11 @@ export namespace MessageV2 {
           },
         ).toObject()
       case e instanceof DOMException && e.name === "TimeoutError":
-      case e instanceof Error && e.message === "SSE read timed out":
         return new MessageV2.APIError(
           {
             message: e.message,
             isRetryable: true,
+            metadata: { kind: "timeout" },
           },
           { cause: e },
         ).toObject()

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -935,6 +935,15 @@ export namespace MessageV2 {
             cause: e,
           },
         ).toObject()
+      case e instanceof DOMException && e.name === "TimeoutError":
+      case e instanceof Error && e.message === "SSE read timed out":
+        return new MessageV2.APIError(
+          {
+            message: e.message,
+            isRetryable: true,
+          },
+          { cause: e },
+        ).toObject()
       case MessageV2.OutputLengthError.isInstance(e):
         return e
       case LoadAPIKeyError.isInstance(e):

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -20,6 +20,7 @@ import { type ReviewCharAction, type createReviewCharCounter } from "@/skill-evo
 
 export namespace SessionProcessor {
   const DOOM_LOOP_THRESHOLD = 3
+  const MAX_RETRY = 3
   const log = Log.create({ service: "session.processor" })
 
   export type Info = Awaited<ReturnType<typeof create>>
@@ -405,7 +406,7 @@ export namespace SessionProcessor {
               })
             } else {
               const retry = SessionRetry.retryable(error)
-              if (retry !== undefined) {
+              if (retry !== undefined && attempt < MAX_RETRY) {
                 attempt++
                 const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
                 await SessionStatus.set(input.sessionID, {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -21,6 +21,7 @@ import { type ReviewCharAction, type createReviewCharCounter } from "@/skill-evo
 export namespace SessionProcessor {
   const DOOM_LOOP_THRESHOLD = 3
   const MAX_RETRY = 3
+  const MAX_RETRY_RATE_LIMIT = 5
   const log = Log.create({ service: "session.processor" })
 
   export type Info = Awaited<ReturnType<typeof create>>
@@ -406,7 +407,10 @@ export namespace SessionProcessor {
               })
             } else {
               const retry = SessionRetry.retryable(error)
-              if (retry !== undefined && attempt < MAX_RETRY) {
+              const isRateLimited =
+                retry === "Too Many Requests" || retry === "Rate Limited" || retry === "Provider is overloaded"
+              const maxRetry = isRateLimited ? MAX_RETRY_RATE_LIMIT : MAX_RETRY
+              if (retry !== undefined && attempt < maxRetry) {
                 attempt++
                 const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
                 await SessionStatus.set(input.sessionID, {

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -8,6 +8,7 @@ export namespace SessionRetry {
   export const RETRY_MAX_DELAY_NO_HEADERS = 30_000 // 30 seconds
   export const RETRY_MAX_DELAY = 2_147_483_647 // max 32-bit signed integer for setTimeout
   export const TIMEOUT_RETRY_INITIAL_DELAY = 30_000 // 30 seconds for timeout retries
+  export const TIMEOUT_RETRY_MAX_DELAY = 120_000 // 120 seconds cap for timeout retries
 
   export async function sleep(ms: number, signal: AbortSignal): Promise<void> {
     return new Promise((resolve, reject) => {
@@ -27,8 +28,9 @@ export namespace SessionRetry {
   }
 
   export function delay(attempt: number, error?: MessageV2.APIError) {
-    const isTimeout = error?.data.message === "SSE read timed out" || error?.data.message === "Request timed out"
+    const isTimeout = error?.data.metadata?.kind === "timeout"
     const base = isTimeout ? TIMEOUT_RETRY_INITIAL_DELAY : RETRY_INITIAL_DELAY
+    const cap = isTimeout ? TIMEOUT_RETRY_MAX_DELAY : RETRY_MAX_DELAY_NO_HEADERS
     if (error) {
       const headers = error.data.responseHeaders
       if (headers) {
@@ -54,11 +56,11 @@ export namespace SessionRetry {
           }
         }
 
-        return base * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1)
+        return Math.min(base * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), cap)
       }
     }
 
-    return Math.min(base * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), RETRY_MAX_DELAY_NO_HEADERS)
+    return Math.min(base * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), cap)
   }
 
   export function retryable(error: ReturnType<NamedError["toObject"]>) {

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -7,6 +7,7 @@ export namespace SessionRetry {
   export const RETRY_BACKOFF_FACTOR = 2
   export const RETRY_MAX_DELAY_NO_HEADERS = 30_000 // 30 seconds
   export const RETRY_MAX_DELAY = 2_147_483_647 // max 32-bit signed integer for setTimeout
+  export const TIMEOUT_RETRY_INITIAL_DELAY = 30_000 // 30 seconds for timeout retries
 
   export async function sleep(ms: number, signal: AbortSignal): Promise<void> {
     return new Promise((resolve, reject) => {
@@ -26,6 +27,8 @@ export namespace SessionRetry {
   }
 
   export function delay(attempt: number, error?: MessageV2.APIError) {
+    const isTimeout = error?.data.message === "SSE read timed out" || error?.data.message === "Request timed out"
+    const base = isTimeout ? TIMEOUT_RETRY_INITIAL_DELAY : RETRY_INITIAL_DELAY
     if (error) {
       const headers = error.data.responseHeaders
       if (headers) {
@@ -51,11 +54,11 @@ export namespace SessionRetry {
           }
         }
 
-        return RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1)
+        return base * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1)
       }
     }
 
-    return Math.min(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), RETRY_MAX_DELAY_NO_HEADERS)
+    return Math.min(base * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), RETRY_MAX_DELAY_NO_HEADERS)
   }
 
   export function retryable(error: ReturnType<NamedError["toObject"]>) {


### PR DESCRIPTION
### Issue for this PR

Closes #1098

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes zombie sessions caused by silent LLM SSE stream stalls. Two commits:

1. **`fix: prevent zombie sessions from silent LLM stream stalls`** — Enables `chunkTimeout` (10min) by default for SSE streams so silent connection drops abort instead of hanging forever. `requestTimeout` is only applied to non-SSE responses (cleared once SSE is detected). Timeout errors are now retryable with 30s/60s/120s backoff, and a `MAX_RETRY=3` cap prevents doom loops.

2. **`fix: harden timeout/retry logic for zombie session prevention`** — Addresses review findings on commit 1:
   - Add `DEFAULT_REQUEST_TIMEOUT` (300s) so non-SSE responses get timeout protection even when user doesn't configure `timeout`.
   - Wrap `fetchFn` in try/catch to clear `reqTimer` on network errors (timer leak fix).
   - Keep `reqTimer` active for non-SSE responses to preserve full-request timeout semantics.
   - Add `TIMEOUT_RETRY_MAX_DELAY` (120s) so timeout backoff 30s/60s/120s isn't capped to 30s.
   - Add `MAX_RETRY_RATE_LIMIT` (5) for rate-limit/overloaded errors, keeping `MAX_RETRY` (3) for timeouts.
   - Replace hardcoded string matching (`"SSE read timed out"`/`"Request timed out"`) with `metadata.kind === "timeout"` and unified `DOMException TimeoutError`.

### How did you verify your code works?

- `bun typecheck` passes in `packages/opencode`.
- Pre-push hook ran full-repo typecheck (12 packages) — all successful.
- Verified `wrapSSE` now throws `DOMException("TimeoutError")`, matching the `case` in `message-v2.ts`.
- Verified `requestTimeout` default (`300_000`) is applied via `?? DEFAULT_REQUEST_TIMEOUT`.
- Confirmed no unrelated files are included in this PR (only the 4 source files + 1 config doc tweak from commit 1).

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR