### PR TITLE
feat: lazy load config of project

### DIFF
--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -9,6 +9,7 @@ import type {
 } from "@opencode-ai/sdk/v2/client"
 import { showToast } from "@opencode-ai/ui/toast"
 import { getFilename } from "@opencode-ai/util/path"
+import { retry } from "@opencode-ai/util/retry"
 import {
   createContext,
   createMemo,
@@ -38,7 +39,14 @@ import {
 import { trimSessions } from "./global-sync/session-trim"
 import type { ProjectMeta } from "./global-sync/types"
 import { SESSION_RECENT_LIMIT } from "./global-sync/types"
-import { isRoot, normalizeDir, sanitizeProject, sanitizeRecent } from "./global-sync/utils"
+import {
+  isRoot,
+  normalizeAgentList,
+  normalizeDir,
+  normalizeProviderList,
+  sanitizeProject,
+  sanitizeRecent,
+} from "./global-sync/utils"
 import { formatServerError } from "@/utils/server-errors"
 
 type GlobalStore = {
@@ -341,6 +349,21 @@ function createGlobalSync() {
     return promise
   }
 
+  async function loadActiveMetadata(directory: string) {
+    directory = normalizeDir(directory)
+    if (!directory) return
+    const [, setStore] = children.child(directory, { bootstrap: false })
+    const sdk = sdkFor(directory)
+    await Promise.allSettled([
+      retry(() => sdk.app.agents().then((x) => setStore("agent", normalizeAgentList(x.data)))),
+      retry(() => sdk.command.list().then((x) => setStore("command", x.data ?? []))),
+      retry(() => sdk.config.get().then((x) => setStore("config", x.data!))),
+      retry(() => sdk.provider.list().then((x) => setStore("provider", normalizeProviderList(x.data!)))),
+      retry(() => sdk.mcp.status().then((x) => setStore("mcp", x.data!))),
+      retry(() => sdk.lsp.status().then((x) => setStore("lsp", x.data!))),
+    ])
+  }
+
   async function bootstrapInstance(directory: string) {
     directory = normalizeDir(directory)
     if (!directory) return
@@ -483,6 +506,7 @@ function createGlobalSync() {
 
   const projectApi = {
     loadSessions,
+    loadActiveMetadata,
     list: () => globalStore.project,
     recent: () => globalStore.recent.filter((item) => !isRoot(item.directory)),
     get(id?: string) {

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -16,7 +16,7 @@ import { retry } from "@opencode-ai/util/retry"
 import { batch } from "solid-js"
 import { reconcile, type SetStoreFunction, type Store } from "solid-js/store"
 import type { State, VcsCache } from "./types"
-import { cmp, normalizeAgentList, normalizeProviderList } from "./utils"
+import { cmp, normalizeProviderList } from "./utils"
 import { formatServerError } from "@/utils/server-errors"
 
 type GlobalStore = {
@@ -182,8 +182,6 @@ export async function bootstrapDirectory(input: {
       seededProject
         ? Promise.resolve()
         : retry(() => input.sdk.project.current()).then((x) => input.setStore("project", x.data!.id)),
-    () => retry(() => input.sdk.app.agents().then((x) => input.setStore("agent", normalizeAgentList(x.data)))),
-    () => retry(() => input.sdk.config.get().then((x) => input.setStore("config", x.data!))),
     () =>
       retry(() =>
         input.sdk.path.get().then((x) => {
@@ -201,7 +199,6 @@ export async function bootstrapDirectory(input: {
           if (next) input.vcsCache.setStore("value", next)
         }),
       ),
-    () => retry(() => input.sdk.command.list().then((x) => input.setStore("command", x.data ?? []))),
     () =>
       retry(() =>
         input.sdk.permission.list().then((x) => {
@@ -250,17 +247,7 @@ export async function bootstrapDirectory(input: {
       ),
   ]
 
-  const slow = [
-    () =>
-      retry(() =>
-        input.sdk.provider.list().then((x) => {
-          input.setStore("provider", normalizeProviderList(x.data!))
-        }),
-      ),
-    () => Promise.resolve(input.loadSessions(input.directory)),
-    () => retry(() => input.sdk.mcp.status().then((x) => input.setStore("mcp", x.data!))),
-    () => retry(() => input.sdk.lsp.status().then((x) => input.setStore("lsp", x.data!))),
-  ]
+  const slow = [() => Promise.resolve(input.loadSessions(input.directory))]
 
   const errs = errors(await runAll(fast))
   if (errs.length > 0) {

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -160,7 +160,9 @@ export default function Layout(props: ParentProps) {
   const currentDir = createMemo(() => decode64(params.dir) ?? "")
 
   createEffect(() => {
-    ActiveDirectory.set(currentDir())
+    const dir = currentDir()
+    ActiveDirectory.set(dir)
+    if (dir) void globalSync.project.loadActiveMetadata(dir)
   })
   onCleanup(() => ActiveDirectory.set(""))
 

--- a/packages/opencode/src/file/watcher.ts
+++ b/packages/opencode/src/file/watcher.ts
@@ -255,11 +255,8 @@ export namespace FileWatcher {
           )
         }
 
-        const cfg = yield* Effect.promise(() => Config.get())
-
         return {
           backend,
-          cfgIgnores: cfg.watcher?.ignore ?? [],
           subscribe,
         }
       })
@@ -280,7 +277,8 @@ export namespace FileWatcher {
             const state = yield* setup()
             if (!state) return
 
-            const ignore = [...FileIgnore.PATTERNS, ...state.cfgIgnores, ...protecteds(Instance.directory)]
+            const cfg = yield* Effect.promise(() => Config.get())
+            const ignore = [...FileIgnore.PATTERNS, ...(cfg.watcher?.ignore ?? []), ...protecteds(Instance.directory)]
 
             if (enabled) {
               if (state.backend !== "inotify") {
@@ -319,7 +317,7 @@ export namespace FileWatcher {
               )
               const vcsDir =
                 result.exitCode === 0 ? path.resolve(Instance.project.worktree, result.text().trim()) : undefined
-              if (vcsDir && !state.cfgIgnores.includes(".git") && !state.cfgIgnores.includes(vcsDir)) {
+              if (vcsDir) {
                 const ignore = (yield* Effect.promise(() => readdir(vcsDir).catch(() => []))).filter(
                   (entry) => entry !== "HEAD",
                 )

--- a/packages/opencode/src/mobile/base.ts
+++ b/packages/opencode/src/mobile/base.ts
@@ -5,6 +5,7 @@ import z from "zod"
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { GlobalBus } from "@/bus/global"
+import { ActiveInstance } from "@/project/active-instance"
 import { Instance } from "@/project/instance"
 import { InstanceBootstrap } from "@/project/bootstrap"
 import { Project } from "@/project/project"
@@ -132,6 +133,7 @@ export abstract class MobileManagerBase {
     { text: string; messageId: string; effectiveDir: string; mediaAttachments?: MediaAttachment[] }
   > = {}
   protected _activePrompt = new Map<string, { sessionId: string; messageId: string; directory: string }>()
+  protected _activeScopes = new Set<string>()
   protected _processedIds = new Map<string, number>()
   protected _busUnsubs: (() => void)[] = []
   protected _manualStop = false
@@ -194,6 +196,31 @@ export abstract class MobileManagerBase {
 
   protected dir() {
     return platformDir(this.adapter.platform)
+  }
+
+  protected async provide<R>(dir: string, fn: () => R): Promise<R> {
+    return Instance.provide({ directory: dir, init: InstanceBootstrap, fn })
+  }
+
+  protected owner(scope: string): string {
+    return `mobile:${this.adapter.platform}:${scope || "default"}`
+  }
+
+  protected activateScope(scope: string, dir: string): void {
+    const next = this.normDir(dir)
+    if (!next) return
+    this._activeScopes.add(scope)
+    ActiveInstance.activateOwner(this.owner(scope), next)
+  }
+
+  protected deactivateScope(scope: string): void {
+    this._activeScopes.delete(scope)
+    ActiveInstance.deactivateOwner(this.owner(scope))
+  }
+
+  protected deactivateAllScopes(): void {
+    for (const scope of this._activeScopes) ActiveInstance.deactivateOwner(this.owner(scope))
+    this._activeScopes.clear()
   }
 
   protected oldDir() {
@@ -304,10 +331,10 @@ export abstract class MobileManagerBase {
       this._initialSessionId = ""
     } else {
       this._initialDir = this.projectDir(visibleProjects[0])
-      const recent = await Instance.provide({
-        directory: this._initialDir,
-        fn: () => [...Session.list({ directory: this._initialDir, roots: true, limit: 1 })],
-      })
+      const recent = await this.provide(this._initialDir, () => [
+        ...Session.list({ directory: this._initialDir, roots: true, limit: 1 }),
+      ])
+      this.activateScope("__default__", this._initialDir)
       if (recent.length > 0 && !recent[0].time?.archived) {
         this._initialSessionId = recent[0].id
       } else {
@@ -333,17 +360,13 @@ export abstract class MobileManagerBase {
       sessionToCanonicalScope[sessionId] = key
       const dir = this._scopeDirs[key] ?? this._initialDir
       try {
-        const found = await Instance.provide({
-          directory: dir,
-          fn: () => Session.get(SessionID.make(sessionId)),
-        })
+        const found = await this.provide(dir, () => Session.get(SessionID.make(sessionId)))
         if (found.time?.archived) {
           staleKeys.push(key)
         } else {
-          const recent = await Instance.provide({
-            directory: dir,
-            fn: () => [...Session.list({ directory: dir, roots: true, limit: 1 })].filter((s) => !s.time?.archived),
-          })
+          const recent = await this.provide(dir, () =>
+            [...Session.list({ directory: dir, roots: true, limit: 1 })].filter((s) => !s.time?.archived),
+          )
           if (recent[0] && recent[0].id !== sessionId) {
             refreshed.push({ scope: key, newId: recent[0].id })
           }
@@ -361,10 +384,8 @@ export abstract class MobileManagerBase {
     if (staleKeys.length > 0 || refreshed.length > 0) await this.saveSessionMap()
 
     if (this._initialDir) {
-      await Instance.provide({
-        directory: this._initialDir,
-        fn: () => {},
-      })
+      await this.provide(this._initialDir, () => {})
+      this.activateScope("__default__", this._initialDir)
     }
 
     this._initialized = true
@@ -375,10 +396,7 @@ export abstract class MobileManagerBase {
 
   protected async buildModelList(): Promise<ModelEntry[]> {
     try {
-      const providers = await Instance.provide({
-        directory: this._initialDir,
-        fn: () => Provider.list(),
-      })
+      const providers = await this.provide(this._initialDir, () => Provider.list())
       const entries: ModelEntry[] = []
       let index = 1
       for (const [providerID, info] of Object.entries(providers)) {
@@ -533,10 +551,7 @@ export abstract class MobileManagerBase {
     )
     let sessionTitle = sessionId.slice(0, 8)
     try {
-      const info = await Instance.provide({
-        directory: dir,
-        fn: () => this.allSessionsQuery(dir).find((s) => s.id === sessionId),
-      })
+      const info = await this.provide(dir, () => this.allSessionsQuery(dir).find((s) => s.id === sessionId))
       if (info?.title) sessionTitle = info.title
     } catch {}
     sessionTitle = this.clip(sessionTitle, 24)
@@ -561,30 +576,20 @@ export abstract class MobileManagerBase {
 
   protected async setPref(scope: string, patch: Record<string, any>): Promise<void> {
     const ctx = await this.commandCtx(scope)
-    await Instance.provide({
-      directory: ctx.dir,
-      fn: () => SessionPreference.update({ sessionID: SessionID.make(ctx.sessionId), ...patch }),
-    })
+    await this.provide(ctx.dir, () => SessionPreference.update({ sessionID: SessionID.make(ctx.sessionId), ...patch }))
   }
 
   protected async inheritPreference(newSessionId: string, dir: string): Promise<void> {
-    const candidates = await Instance.provide({
-      directory: dir,
-      fn: () => [...Session.list({ directory: dir, roots: true, limit: 20 })].map((s) => s.id),
-    })
-    await Instance.provide({
-      directory: dir,
-      fn: () => SessionPreference.inheritFor(newSessionId, candidates),
-    })
+    const candidates = await this.provide(dir, () =>
+      [...Session.list({ directory: dir, roots: true, limit: 20 })].map((s) => s.id),
+    )
+    await this.provide(dir, () => SessionPreference.inheritFor(newSessionId, candidates))
   }
 
   protected async currentSession(scope: string, create?: boolean): Promise<string | undefined> {
     const dir = this.effectiveDir(scope)
     if (!dir) return
-    const recent = await Instance.provide({
-      directory: dir,
-      fn: () => this.allSessionsQuery(dir, 20),
-    })
+    const recent = await this.provide(dir, () => this.allSessionsQuery(dir, 20))
     const pinned = this.sessionMap[scope]
     if (pinned) {
       const stillValid = recent.some((s) => s.id === pinned)
@@ -597,10 +602,9 @@ export abstract class MobileManagerBase {
       return recent[0].id
     }
     if (!create) return
-    const session = await Instance.provide({
-      directory: dir,
-      fn: () => Session.create({ title: `${this.platformName()}对话 - ${new Date().toISOString()}` }),
-    })
+    const session = await this.provide(dir, () =>
+      Session.create({ title: `${this.platformName()}对话 - ${new Date().toISOString()}` }),
+    )
     await this.inheritPreference(session.id, dir)
     this.sessionMap[scope] = session.id
     await this.saveSessionMap()
@@ -658,10 +662,7 @@ export abstract class MobileManagerBase {
         }
         if (active) {
           try {
-            await Instance.provide({
-              directory: active.directory,
-              fn: () => SessionPrompt.cancel(SessionID.make(active.sessionId)),
-            })
+            await this.provide(active.directory, () => SessionPrompt.cancel(SessionID.make(active.sessionId)))
           } catch {}
         }
         await this.clearRuntime(scope)
@@ -716,21 +717,18 @@ export abstract class MobileManagerBase {
           return
         }
         try {
-          await Instance.provide({
-            directory: active.directory,
-            fn: async () => {
-              const msgs = await MessageV2.filterCompacted(MessageV2.stream(SessionID.make(active.sessionId)))
-              const lastUser = msgs.findLast((msg) => msg.info.role === "user")
-              if (!lastUser) throw new Error("no user message")
-              await Session.updatePart({
-                id: PartID.ascending(),
-                messageID: lastUser.info.id,
-                sessionID: SessionID.make(active.sessionId),
-                type: "text",
-                text: "-用户补充：" + steerText,
-                metadata: { steer: true },
-              })
-            },
+          await this.provide(active.directory, async () => {
+            const msgs = await MessageV2.filterCompacted(MessageV2.stream(SessionID.make(active.sessionId)))
+            const lastUser = msgs.findLast((msg) => msg.info.role === "user")
+            if (!lastUser) throw new Error("no user message")
+            await Session.updatePart({
+              id: PartID.ascending(),
+              messageID: lastUser.info.id,
+              sessionID: SessionID.make(active.sessionId),
+              type: "text",
+              text: "-用户补充：" + steerText,
+              metadata: { steer: true },
+            })
           })
           await this.replySession(scope, reply, "✅ 已追加引导信息，AI将在下一轮处理中看到。")
         } catch (err) {
@@ -863,33 +861,26 @@ export abstract class MobileManagerBase {
 
     const pref = SessionPreference.get(sid)
     if (pref?.autoAccept) {
-      const session = await Instance.provide({
-        directory: effectiveDir,
-        fn: () => Session.get(SessionID.make(sid)),
-      })
+      const session = await this.provide(effectiveDir, () => Session.get(SessionID.make(sid)))
       if (!session.permission?.some((r) => r.permission === "*" && r.action === "allow")) {
-        await Instance.provide({
-          directory: effectiveDir,
-          fn: () =>
-            Session.setPermission({
-              sessionID: SessionID.make(sid),
-              permission: [{ permission: "*", pattern: "*", action: "allow" }],
-            }),
-        })
+        await this.provide(effectiveDir, () =>
+          Session.setPermission({
+            sessionID: SessionID.make(sid),
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          }),
+        )
       }
     }
 
     console.log(`[${this.adapter.platform}] sending to aether, session:`, sid, localISOString())
 
     try {
-      const msg = await Instance.provide({
-        directory: effectiveDir,
-        fn: () =>
-          SessionPrompt.prompt({
-            sessionID: SessionID.make(sid),
-            parts: [{ type: "text", text: promptText }],
-          }),
-      })
+      const msg = await this.provide(effectiveDir, () =>
+        SessionPrompt.prompt({
+          sessionID: SessionID.make(sid),
+          parts: [{ type: "text", text: promptText }],
+        }),
+      )
       console.log(`[${this.adapter.platform}] aether responded, parts:`, msg?.parts?.length, localISOString())
 
       const responseText = this.extractResponseText(msg)
@@ -897,14 +888,12 @@ export abstract class MobileManagerBase {
         const msgModel =
           msg?.info?.role === "assistant" ? { providerID: msg.info.providerID, modelID: msg.info.modelID } : undefined
         if (msgModel && !SessionPreference.get(sid)?.model) {
-          await Instance.provide({
-            directory: effectiveDir,
-            fn: () =>
-              SessionPreference.update({
-                sessionID: SessionID.make(sid),
-                model: { providerID: ProviderID.make(msgModel.providerID), modelID: ModelID.make(msgModel.modelID) },
-              }),
-          })
+          await this.provide(effectiveDir, () =>
+            SessionPreference.update({
+              sessionID: SessionID.make(sid),
+              model: { providerID: ProviderID.make(msgModel.providerID), modelID: ModelID.make(msgModel.modelID) },
+            }),
+          )
         }
         console.log(`[${this.adapter.platform}] replying:`, responseText.slice(0, 100), localISOString())
         await this.replySession(scope, reply, responseText)
@@ -939,14 +928,12 @@ export abstract class MobileManagerBase {
         if (freshId && freshId !== sid) {
           this._activePrompt.set(scope, { sessionId: freshId, messageId, directory: effectiveDir })
           try {
-            const msg = await Instance.provide({
-              directory: effectiveDir,
-              fn: () =>
-                SessionPrompt.prompt({
-                  sessionID: SessionID.make(freshId),
-                  parts: [{ type: "text", text: promptText }],
-                }),
-            })
+            const msg = await this.provide(effectiveDir, () =>
+              SessionPrompt.prompt({
+                sessionID: SessionID.make(freshId),
+                parts: [{ type: "text", text: promptText }],
+              }),
+            )
             const responseText = this.extractResponseText(msg)
             if (responseText) {
               await this.replySession(scope, reply, responseText)
@@ -970,10 +957,7 @@ export abstract class MobileManagerBase {
   ): Promise<string[]> {
     if (!attachments || attachments.length === 0) return []
 
-    const projectID = await Instance.provide({
-      directory: effectiveDir,
-      fn: () => Instance.project.id,
-    })
+    const projectID = await this.provide(effectiveDir, () => Instance.project.id)
     const destDir = filesDir(projectID)
     await mkdir(destDir, { recursive: true })
 
@@ -1142,10 +1126,9 @@ export abstract class MobileManagerBase {
     void this.clearRuntime(scope)
 
     const dir = this.effectiveDir(scope)
-    const session = await Instance.provide({
-      directory: dir,
-      fn: () => Session.create({ title: `${this.platformName()}对话 - ${new Date().toISOString()}` }),
-    })
+    const session = await this.provide(dir, () =>
+      Session.create({ title: `${this.platformName()}对话 - ${new Date().toISOString()}` }),
+    )
     await this.inheritPreference(session.id, dir)
     this.sessionMap[scope] = session.id
     await this.saveSessionMap()
@@ -1238,26 +1221,23 @@ export abstract class MobileManagerBase {
       await this.replyCmd(targetId, scope, "❌ 压缩当前会话前，请先使用 /model 选择模型。")
       return
     }
-    await Instance.provide({
-      directory: ctx.dir,
-      fn: async () => {
-        const msgs = await Session.messages({ sessionID: SessionID.make(ctx.sessionId) })
-        let currentAgent = await Agent.defaultAgent()
-        for (let i = msgs.length - 1; i >= 0; i--) {
-          const info = msgs[i].info
-          if (info.role === "user") {
-            currentAgent = info.agent || (await Agent.defaultAgent())
-            break
-          }
+    await this.provide(ctx.dir, async () => {
+      const msgs = await Session.messages({ sessionID: SessionID.make(ctx.sessionId) })
+      let currentAgent = await Agent.defaultAgent()
+      for (let i = msgs.length - 1; i >= 0; i--) {
+        const info = msgs[i].info
+        if (info.role === "user") {
+          currentAgent = info.agent || (await Agent.defaultAgent())
+          break
         }
-        await SessionCompaction.create({
-          sessionID: SessionID.make(ctx.sessionId),
-          agent: ctx.pref?.agent ?? currentAgent,
-          model,
-          auto: false,
-        })
-        await SessionPrompt.loop({ sessionID: SessionID.make(ctx.sessionId) })
-      },
+      }
+      await SessionCompaction.create({
+        sessionID: SessionID.make(ctx.sessionId),
+        agent: ctx.pref?.agent ?? currentAgent,
+        model,
+        auto: false,
+      })
+      await SessionPrompt.loop({ sessionID: SessionID.make(ctx.sessionId) })
     })
     await this.replyCmd(targetId, scope, "✅ 已开始压缩当前会话上下文，请稍后查看结果。")
   }
@@ -1267,12 +1247,9 @@ export abstract class MobileManagerBase {
     let agents: { name: string; hidden?: boolean }[] = []
     let current: string = "build"
     try {
-      await Instance.provide({
-        directory: ctx.dir,
-        fn: async () => {
-          agents = await Agent.list()
-          current = ctx.pref?.agent || (await Agent.defaultAgent())
-        },
+      await this.provide(ctx.dir, async () => {
+        agents = await Agent.list()
+        current = ctx.pref?.agent || (await Agent.defaultAgent())
       })
     } catch {
       await this.replyCmd(targetId, scope, "❌ 无法获取模式列表，请检查 Aether 服务是否正常。")
@@ -1338,10 +1315,7 @@ export abstract class MobileManagerBase {
       const pending = this._pendingPermissions[scope]
       if (pending) {
         delete this._pendingPermissions[scope]
-        await Instance.provide({
-          directory: ctx.dir,
-          fn: () => Permission.reply({ requestID: pending.id, reply: "always" }),
-        })
+        await this.provide(ctx.dir, () => Permission.reply({ requestID: pending.id, reply: "always" }))
         await this.replyCmd(targetId, scope, "✅ 已开启自动接受权限，并已自动批准当前挂起的授权请求")
       } else {
         await this.replyCmd(targetId, scope, "✅ 已开启自动接受权限\n（后续权限请求将自动批准）")
@@ -1392,10 +1366,7 @@ export abstract class MobileManagerBase {
     const ctx = await this.commandCtx(scope)
     const model = this.resolveModel(scope)
     if (!model) return { names: [], current: ctx.pref?.variant }
-    const all = await Instance.provide({
-      directory: ctx.dir,
-      fn: () => Provider.list(),
-    })
+    const all = await this.provide(ctx.dir, () => Provider.list())
     const info = all[model.providerID]
     const item = info?.models?.[model.modelID] as { variants?: Record<string, unknown> } | undefined
     return {
@@ -1417,10 +1388,9 @@ export abstract class MobileManagerBase {
       for (const entry of projectSnapshot) {
         if (!entry.sandbox) continue
         try {
-          const latest = await Instance.provide({
-            directory: this.projectDir({ item: entry.item, activity: entry.activity }),
-            fn: () => [...Session.list({ directory: entry.sandbox!.directory, limit: 1 })],
-          })
+          const latest = await this.provide(this.projectDir({ item: entry.item, activity: entry.activity }), () => [
+            ...Session.list({ directory: entry.sandbox!.directory, limit: 1 }),
+          ])
           if (latest.length > 0) entry.activity = latest[0].time.updated
         } catch {}
       }
@@ -1583,21 +1553,19 @@ export abstract class MobileManagerBase {
       sessionId: newSessionId,
       sessionTitle,
       created,
-    } = await Instance.provide({
-      directory: newDir,
-      fn: async () => {
-        const recent = [...Session.list({ directory: newDir, roots: true, limit: 1 })]
-        if (recent.length > 0) {
-          return {
-            sessionId: recent[0].id,
-            sessionTitle: recent[0].title ?? recent[0].id.slice(0, 8),
-            created: false,
-          }
+    } = await this.provide(newDir, async () => {
+      const recent = [...Session.list({ directory: newDir, roots: true, limit: 1 })]
+      if (recent.length > 0) {
+        return {
+          sessionId: recent[0].id,
+          sessionTitle: recent[0].title ?? recent[0].id.slice(0, 8),
+          created: false,
         }
-        const session = await Session.create({ title: `${this.platformName()}对话 - ${new Date().toISOString()}` })
-        return { sessionId: session.id, sessionTitle: session.title, created: true }
-      },
+      }
+      const session = await Session.create({ title: `${this.platformName()}对话 - ${new Date().toISOString()}` })
+      return { sessionId: session.id, sessionTitle: session.title, created: true }
     })
+    this.activateScope(scope, newDir)
     if (created) await this.inheritPreference(newSessionId, newDir)
     this.sessionMap[scope] = newSessionId
     await this.saveSessionMap()
@@ -1628,22 +1596,19 @@ export abstract class MobileManagerBase {
       sessionId: newSessionId,
       sessionTitle,
       created,
-    } = await Instance.provide({
-      directory: newDir,
-      init: InstanceBootstrap,
-      fn: async () => {
-        const recent = [...Session.list({ directory: newDir, roots: true, limit: 1 })]
-        if (recent.length > 0) {
-          return {
-            sessionId: recent[0].id,
-            sessionTitle: recent[0].title ?? recent[0].id.slice(0, 8),
-            created: false,
-          }
+    } = await this.provide(newDir, async () => {
+      const recent = [...Session.list({ directory: newDir, roots: true, limit: 1 })]
+      if (recent.length > 0) {
+        return {
+          sessionId: recent[0].id,
+          sessionTitle: recent[0].title ?? recent[0].id.slice(0, 8),
+          created: false,
         }
-        const session = await Session.create({ title: `${this.platformName()}对话 - ${new Date().toISOString()}` })
-        return { sessionId: session.id, sessionTitle: session.title, created: true }
-      },
+      }
+      const session = await Session.create({ title: `${this.platformName()}对话 - ${new Date().toISOString()}` })
+      return { sessionId: session.id, sessionTitle: session.title, created: true }
     })
+    this.activateScope(scope, newDir)
     if (created) await this.inheritPreference(newSessionId, newDir)
     this.sessionMap[scope] = newSessionId
     await this.saveSessionMap()
@@ -1677,25 +1642,19 @@ export abstract class MobileManagerBase {
 
     const needRefresh = !arg || arg === "list"
     if (needRefresh) {
-      await Instance.provide({
-        directory: effectiveDir,
-        fn: async () => {
-          sessionSnapshots.set(
-            dirKey,
-            this.buildSessionEntries([...Session.list({ directory: effectiveDir, limit: 30 })]),
-          )
-        },
+      await this.provide(effectiveDir, async () => {
+        sessionSnapshots.set(
+          dirKey,
+          this.buildSessionEntries([...Session.list({ directory: effectiveDir, limit: 30 })]),
+        )
       })
     }
     if (!sessionSnapshots.has(dirKey) && arg) {
-      await Instance.provide({
-        directory: effectiveDir,
-        fn: async () => {
-          sessionSnapshots.set(
-            dirKey,
-            this.buildSessionEntries([...Session.list({ directory: effectiveDir, limit: 30 })]),
-          )
-        },
+      await this.provide(effectiveDir, async () => {
+        sessionSnapshots.set(
+          dirKey,
+          this.buildSessionEntries([...Session.list({ directory: effectiveDir, limit: 30 })]),
+        )
       })
     }
 
@@ -1741,10 +1700,9 @@ export abstract class MobileManagerBase {
     }
 
     if (!items.length) {
-      const session = await Instance.provide({
-        directory: effectiveDir,
-        fn: () => Session.create({ title: `${this.platformName()}对话 - ${new Date().toISOString()}` }),
-      })
+      const session = await this.provide(effectiveDir, () =>
+        Session.create({ title: `${this.platformName()}对话 - ${new Date().toISOString()}` }),
+      )
       await this.inheritPreference(session.id, effectiveDir)
       this.sessionMap[scope] = session.id
       await this.saveSessionMap()
@@ -1797,10 +1755,7 @@ export abstract class MobileManagerBase {
   }
 
   private async sessionTitle(sessionId: string, directory: string): Promise<string> {
-    const info = await Instance.provide({
-      directory,
-      fn: () => this.allSessionsQuery(directory).find((s) => s.id === sessionId),
-    })
+    const info = await this.provide(directory, () => this.allSessionsQuery(directory).find((s) => s.id === sessionId))
     return info?.title ?? sessionId.slice(0, 8)
   }
 
@@ -1892,10 +1847,9 @@ export abstract class MobileManagerBase {
     delete this._pendingQuestions[scope]
     delete this._questionProgress[scope]
     try {
-      await Instance.provide({
-        directory: active?.directory ?? this.effectiveDir(scope),
-        fn: () => Question.reply({ requestID: pending.id, answers: progress.answers }),
-      })
+      await this.provide(active?.directory ?? this.effectiveDir(scope), () =>
+        Question.reply({ requestID: pending.id, answers: progress.answers }),
+      )
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       this._pendingQuestions[scope] = pending
@@ -1928,10 +1882,9 @@ export abstract class MobileManagerBase {
     const active = this._activePrompt.get(scope)
     delete this._pendingPermissions[scope]
     try {
-      await Instance.provide({
-        directory: active?.directory ?? this.effectiveDir(scope),
-        fn: () => Permission.reply({ requestID: pending.id, reply }),
-      })
+      await this.provide(active?.directory ?? this.effectiveDir(scope), () =>
+        Permission.reply({ requestID: pending.id, reply }),
+      )
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       this._pendingPermissions[scope] = pending
@@ -1975,10 +1928,7 @@ export abstract class MobileManagerBase {
         if (info.sessionId === p.sessionID) {
           const pref = SessionPreference.get(info.sessionId)
           if (pref?.autoAccept) {
-            void Instance.provide({
-              directory: info.directory,
-              fn: () => Permission.reply({ requestID: p.id, reply: "always" }),
-            })
+            void this.provide(info.directory, () => Permission.reply({ requestID: p.id, reply: "always" }))
             return
           }
           this._pendingPermissions[scope] = p
@@ -2060,6 +2010,7 @@ export abstract class MobileManagerBase {
   }
 
   async clearSession(): Promise<void> {
+    this.deactivateAllScopes()
     try {
       await rm(this.file("sessions.json"), { force: true })
       await rm(this.file("hidden_projects.json"), { force: true })

--- a/packages/opencode/src/mobile/feishu.ts
+++ b/packages/opencode/src/mobile/feishu.ts
@@ -421,6 +421,7 @@ class FeishuManagerImpl extends MobileManagerBase {
     this._pendingConfirmCreate = {}
     this._activePrompt.clear()
     if (!reset) return
+    this.deactivateAllScopes()
     this._connectedModel = null
     this._scopeDirs = {}
     this._initialDir = ""
@@ -435,6 +436,7 @@ class FeishuManagerImpl extends MobileManagerBase {
   }
 
   override async clearSession(): Promise<void> {
+    this.deactivateAllScopes()
     try {
       const { rm } = await import("fs/promises")
       await rm(this.file("config.json"), { force: true })

--- a/packages/opencode/src/mobile/qq.ts
+++ b/packages/opencode/src/mobile/qq.ts
@@ -531,6 +531,7 @@ class QQManagerImpl extends MobileManagerBase {
     this._activePrompt.clear()
     this._chatInfos = {}
     if (!reset) return
+    this.deactivateAllScopes()
     this._connectedModel = null
     this._scopeDirs = {}
     this._initialDir = ""
@@ -545,6 +546,7 @@ class QQManagerImpl extends MobileManagerBase {
   }
 
   override async clearSession(): Promise<void> {
+    this.deactivateAllScopes()
     try {
       const { rm } = await import("fs/promises")
       await rm(this.file("config.json"), { force: true })

--- a/packages/opencode/src/mobile/wechat.ts
+++ b/packages/opencode/src/mobile/wechat.ts
@@ -509,6 +509,7 @@ class WeChatManagerImpl extends MobileManagerBase {
     this._qrcode = null
     this._contextTokens = {}
     this._seenIds.clear()
+    this.deactivateAllScopes()
     this.status = "idle"
   }
 

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -25,7 +25,6 @@ export async function InstanceBootstrap() {
   ShareNext.init()
   File.init()
   Vcs.init()
-  Snapshot.init()
   FileWatcher.initGit()
 
   await SessionRecovery.repairInterrupted().catch((error) => {
@@ -40,6 +39,7 @@ export async function InstanceBootstrap() {
     },
   )()
   const deferred = () => {
+    Snapshot.init()
     Format.init()
     Plugin.init()
     LSP.init()

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -21,14 +21,13 @@ import { ActiveInstance } from "@/project/active-instance"
 export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
   await fs.mkdir(path.join(Instance.directory, PROJECT), { recursive: true })
-  await Plugin.init()
+
   ShareNext.init()
-  Format.init()
-  await LSP.init()
   File.init()
   Vcs.init()
   Snapshot.init()
   FileWatcher.initGit()
+
   await SessionRecovery.repairInterrupted().catch((error) => {
     Log.Default.warn("failed to repair interrupted assistant messages", { error })
   })
@@ -41,6 +40,9 @@ export async function InstanceBootstrap() {
     },
   )()
   const deferred = () => {
+    Format.init()
+    Plugin.init()
+    LSP.init()
     FileWatcher.initFull()
   }
 

--- a/packages/opencode/test/mobile/active-instance.test.ts
+++ b/packages/opencode/test/mobile/active-instance.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { ActiveInstance } from "../../src/project/active-instance"
+import { MobileManagerBase } from "../../src/mobile/base"
+import type { MobileAdapter } from "../../src/mobile/base"
+
+const dirs: string[] = []
+
+const dir = () => {
+  const value = `/tmp/opencode-mobile-active-${Math.random().toString(36).slice(2)}`
+  dirs.push(value)
+  return value
+}
+
+const adapter: MobileAdapter = {
+  platform: "wechat",
+  replyText: async () => {},
+  replyFile: async () => {},
+  loadConfig: async () => null,
+  clearAuth: async () => {},
+  loadSession: async () => null,
+}
+
+class Manager extends MobileManagerBase {
+  override platformDir() {
+    return "wechat"
+  }
+
+  override platformName() {
+    return "WeChat"
+  }
+
+  open(scope: string, directory: string) {
+    this.activateScope(scope, directory)
+  }
+
+  close(scope: string) {
+    this.deactivateScope(scope)
+  }
+
+  closeAll() {
+    this.deactivateAllScopes()
+  }
+}
+
+afterEach(() => {
+  for (const item of dirs) ActiveInstance.forceDeactivate(item)
+  dirs.length = 0
+})
+
+describe("mobile active instances", () => {
+  test("uses a separate owner from browser leases", () => {
+    const root = dir()
+    const manager = new Manager(adapter)
+
+    ActiveInstance.activateOwner("lease:web", root)
+    manager.open("chat", root)
+
+    manager.close("chat")
+    expect(ActiveInstance.is(root)).toBe(true)
+
+    ActiveInstance.deactivateOwner("lease:web")
+    expect(ActiveInstance.is(root)).toBe(false)
+  })
+
+  test("moves a mobile scope between directories", () => {
+    const first = dir()
+    const second = dir()
+    const manager = new Manager(adapter)
+
+    manager.open("chat", first)
+    expect(ActiveInstance.is(first)).toBe(true)
+
+    manager.open("chat", second)
+    expect(ActiveInstance.is(first)).toBe(false)
+    expect(ActiveInstance.is(second)).toBe(true)
+
+    manager.closeAll()
+    expect(ActiveInstance.is(second)).toBe(false)
+  })
+})

--- a/packages/opencode/test/mobile/active-instance.test.ts
+++ b/packages/opencode/test/mobile/active-instance.test.ts
@@ -2,13 +2,14 @@ import { afterEach, describe, expect, test } from "bun:test"
 import { ActiveInstance } from "../../src/project/active-instance"
 import { MobileManagerBase } from "../../src/mobile/base"
 import type { MobileAdapter } from "../../src/mobile/base"
+import { tmpdir } from "../fixture/fixture"
 
 const dirs: string[] = []
 
-const dir = () => {
-  const value = `/tmp/opencode-mobile-active-${Math.random().toString(36).slice(2)}`
-  dirs.push(value)
-  return value
+const dir = async () => {
+  const tmp = await tmpdir()
+  dirs.push(tmp.path)
+  return tmp
 }
 
 const adapter: MobileAdapter = {
@@ -48,33 +49,33 @@ afterEach(() => {
 })
 
 describe("mobile active instances", () => {
-  test("uses a separate owner from browser leases", () => {
-    const root = dir()
+  test("uses a separate owner from browser leases", async () => {
+    await using root = await dir()
     const manager = new Manager(adapter)
 
-    ActiveInstance.activateOwner("lease:web", root)
-    manager.open("chat", root)
+    ActiveInstance.activateOwner("lease:web", root.path)
+    manager.open("chat", root.path)
 
     manager.close("chat")
-    expect(ActiveInstance.is(root)).toBe(true)
+    expect(ActiveInstance.is(root.path)).toBe(true)
 
     ActiveInstance.deactivateOwner("lease:web")
-    expect(ActiveInstance.is(root)).toBe(false)
+    expect(ActiveInstance.is(root.path)).toBe(false)
   })
 
-  test("moves a mobile scope between directories", () => {
-    const first = dir()
-    const second = dir()
+  test("moves a mobile scope between directories", async () => {
+    await using first = await dir()
+    await using second = await dir()
     const manager = new Manager(adapter)
 
-    manager.open("chat", first)
-    expect(ActiveInstance.is(first)).toBe(true)
+    manager.open("chat", first.path)
+    expect(ActiveInstance.is(first.path)).toBe(true)
 
-    manager.open("chat", second)
-    expect(ActiveInstance.is(first)).toBe(false)
-    expect(ActiveInstance.is(second)).toBe(true)
+    manager.open("chat", second.path)
+    expect(ActiveInstance.is(first.path)).toBe(false)
+    expect(ActiveInstance.is(second.path)).toBe(true)
 
     manager.closeAll()
-    expect(ActiveInstance.is(second)).toBe(false)
+    expect(ActiveInstance.is(second.path)).toBe(false)
   })
 })

--- a/packages/opencode/test/project/vcs.test.ts
+++ b/packages/opencode/test/project/vcs.test.ts
@@ -19,7 +19,7 @@ async function withVcs(directory: string, body: () => Promise<void>) {
   return Instance.provide({
     directory,
     fn: async () => {
-      FileWatcher.init()
+      FileWatcher.initGit()
       Vcs.init()
       await Bun.sleep(500)
       await body()
@@ -124,6 +124,28 @@ describeVcs("Vcs", () => {
       await pending
       const current = await Vcs.branch()
       expect(current).toBe(branch)
+    })
+  })
+
+  test("full watcher deactivation keeps git branch watcher alive", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const branch = `test-${Math.random().toString(36).slice(2)}`
+    await $`git branch ${branch}`.cwd(tmp.path).quiet()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        FileWatcher.initGit()
+        FileWatcher.initFull()
+        Vcs.init()
+        await Bun.sleep(500)
+        FileWatcher.deactivateFull()
+
+        const pending = nextBranchUpdate(tmp.path)
+        await fs.writeFile(path.join(tmp.path, ".git", "HEAD"), `ref: refs/heads/${branch}\n`)
+
+        expect(await pending).toBe(branch)
+      },
     })
   })
 })

--- a/packages/opencode/test/server/lease.test.ts
+++ b/packages/opencode/test/server/lease.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test"
+import { ActiveInstance } from "../../src/project/active-instance"
+import { Lease } from "../../src/server/lease"
+
+const ids: string[] = []
+const dirs: string[] = []
+
+const id = () => {
+  const value = `lease-${Math.random().toString(36).slice(2)}`
+  ids.push(value)
+  return value
+}
+
+const dir = () => {
+  const value = `/tmp/opencode-lease-${Math.random().toString(36).slice(2)}`
+  dirs.push(value)
+  return value
+}
+
+afterEach(() => {
+  for (const item of ids) Lease.drop(item)
+  for (const item of dirs) ActiveInstance.forceDeactivate(item)
+  ids.length = 0
+  dirs.length = 0
+})
+
+describe("Lease", () => {
+  test("does not double activate the same directory for one lease", () => {
+    const lease = id()
+    const root = dir()
+    let activations = 0
+    const off = ActiveInstance.subscribe((directory) => {
+      if (directory === root) activations++
+    })
+
+    try {
+      expect(Lease.touch(lease, root)).toBe(true)
+      expect(Lease.touch(lease, root)).toBe(true)
+      expect(ActiveInstance.is(root)).toBe(true)
+      expect(activations).toBe(1)
+
+      Lease.drop(lease)
+      expect(ActiveInstance.is(root)).toBe(false)
+    } finally {
+      off()
+    }
+  })
+
+  test("moves active ownership when a lease changes directory", () => {
+    const lease = id()
+    const first = dir()
+    const second = dir()
+
+    Lease.touch(lease, first)
+    expect(ActiveInstance.is(first)).toBe(true)
+
+    Lease.touch(lease, second)
+    expect(ActiveInstance.is(first)).toBe(false)
+    expect(ActiveInstance.is(second)).toBe(true)
+
+    Lease.drop(lease)
+    expect(ActiveInstance.is(second)).toBe(false)
+  })
+
+  test("expires directory ownership and can reactivate on a later ping", () => {
+    const lease = id()
+    const root = dir()
+    const now = spyOn(Date, "now")
+
+    try {
+      now.mockReturnValue(1_000)
+      Lease.touch(lease, root)
+      expect(ActiveInstance.is(root)).toBe(true)
+
+      now.mockReturnValue(32_000)
+      expect(Lease.count()).toBe(0)
+      expect(ActiveInstance.is(root)).toBe(false)
+
+      now.mockReturnValue(33_000)
+      Lease.touch(lease, root)
+      expect(ActiveInstance.is(root)).toBe(true)
+    } finally {
+      now.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #1100

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

1.进一步的懒加载，把`Snapshot.init()`,`Format.init()`,`Plugin.init()`,`LSP.init()`都放到activate之后；
2.mobile bridge 端也加入activate-instance的管理；
3.前端做懒加载，把不需要即时显示的数据都放到打开对应project之后在请求；

总的结果是project的config只有在activate之后才加载，也解决了#1100中启动时加载大量project Config导致的bun info进程风暴问题

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

bun typecheck
bun test ./src
mobile bridge连接实测

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
