### PR TITLE
fix(app): 移除侧边栏新建项目入口

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -61,7 +61,6 @@ import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme/context"
 import { useCommand, type CommandOption } from "@/context/command"
 import { ConstrainDragXAxis, getDraggableId } from "@/utils/solid-dnd"
 import { DialogSelectDirectory } from "@/components/dialog-select-directory"
-import { DialogNewProject } from "@/components/dialog-new-project"
 import { DialogEditProject } from "@/components/dialog-edit-project"
 import { SessionImportInput } from "@/components/session-import-input"
 import { DebugBar } from "@/components/debug-bar"
@@ -1821,19 +1820,6 @@ export default function Layout(props: ParentProps) {
     }
   }
 
-  function newProject() {
-    dialog.show(
-      () => (
-        <DialogNewProject
-          onSelect={(result) => {
-            if (result) openProject(result)
-          }}
-        />
-      ),
-      () => {},
-    )
-  }
-
   const deleteWorkspace = async (
     root: string,
     directory: string,
@@ -2925,9 +2911,6 @@ export default function Layout(props: ParentProps) {
       handleDragStart={handleDragStart}
       handleDragEnd={handleDragEnd}
       handleDragOver={handleDragOver}
-      newProjectLabel={language.t("command.project.new")}
-      showNewProject={platform.platform === "desktop"}
-      onNewProject={newProject}
       openProjectLabel={language.t("command.project.open")}
       openProjectKeybind={() => command.keybind("project.open")}
       onOpenProject={chooseProject}

--- a/packages/app/src/pages/layout/sidebar-shell.tsx
+++ b/packages/app/src/pages/layout/sidebar-shell.tsx
@@ -28,9 +28,6 @@ export const SidebarContent = (props: {
   handleDragStart: (event: unknown) => void
   handleDragEnd: () => void
   handleDragOver: (event: DragEvent) => void
-  showNewProject?: boolean
-  newProjectLabel: JSX.Element
-  onNewProject: () => void
   openProjectLabel: JSX.Element
   openProjectKeybind: Accessor<string | undefined>
   onOpenProject: () => void
@@ -125,17 +122,6 @@ export const SidebarContent = (props: {
               <SortableProvider ids={props.projects().map((p) => p.worktree)}>
                 <For each={props.projects()}>{(project) => props.renderProject(project)}</For>
               </SortableProvider>
-              <Show when={props.showNewProject !== false}>
-                <Tooltip placement={placement()} value={props.newProjectLabel}>
-                  <IconButton
-                    icon="new-session"
-                    variant="ghost"
-                    size="large"
-                    onClick={props.onNewProject}
-                    aria-label={typeof props.newProjectLabel === "string" ? props.newProjectLabel : undefined}
-                  />
-                </Tooltip>
-              </Show>
               <Tooltip
                 placement={placement()}
                 value={

--- a/packages/app/src/pages/layout/sidebar-shell.vitest.tsx
+++ b/packages/app/src/pages/layout/sidebar-shell.vitest.tsx
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import { render } from "solid-js/web"
+import { SidebarContent } from "./sidebar-shell"
+
+vi.mock("@thisbeyond/solid-dnd", () => ({
+  DragDropProvider: (props: { children?: unknown }) => props.children,
+  DragDropSensors: () => null,
+  DragOverlay: (props: { children?: unknown }) => props.children,
+  SortableProvider: (props: { children?: unknown }) => props.children,
+  closestCenter: () => null,
+}))
+
+vi.mock("@/utils/solid-dnd", () => ({
+  ConstrainDragXAxis: () => null,
+}))
+
+vi.mock("@opencode-ai/ui/icon", () => ({
+  Icon: () => null,
+}))
+
+vi.mock("@opencode-ai/ui/icon-button", () => ({
+  IconButton: (props: { icon?: string; onClick?: () => void; "aria-label"?: string }) => (
+    <button type="button" data-icon={props.icon} aria-label={props["aria-label"]} onClick={props.onClick} />
+  ),
+}))
+
+vi.mock("@opencode-ai/ui/tooltip", () => ({
+  Tooltip: (props: { children?: unknown }) => props.children,
+  TooltipKeybind: (props: { children?: unknown }) => props.children,
+}))
+
+vi.mock("@opencode-ai/ui/dropdown-menu", () => ({
+  DropdownMenu: Object.assign((props: { children?: unknown }) => props.children, {
+    Trigger: (props: { as?: (input: Record<string, unknown>) => unknown; children?: unknown }) =>
+      props.as ? props.as(props) : props.children,
+    Portal: (props: { children?: unknown }) => props.children,
+    Content: (props: { children?: unknown }) => props.children,
+    Item: (props: { children?: unknown }) => props.children,
+    ItemLabel: (props: { children?: unknown }) => props.children,
+    Separator: () => null,
+  }),
+}))
+
+vi.mock("@opencode-ai/ui/context/dialog", () => ({
+  useDialog: () => ({
+    show: () => undefined,
+  }),
+}))
+
+vi.mock("@opencode-ai/ui/toast", () => ({
+  showToast: () => undefined,
+}))
+
+vi.mock("@/context/auth", () => ({
+  useAuth: () => ({
+    isAuthenticated: false,
+    account: undefined,
+    logout: async () => undefined,
+  }),
+}))
+
+vi.mock("@/context/language", () => ({
+  useLanguage: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock("@/context/mobile", () => ({
+  status: () => "disconnected",
+}))
+
+function mount() {
+  const host = document.createElement("div")
+  document.body.append(host)
+  const off = render(
+    () => (
+      <SidebarContent
+        opened={() => false}
+        aimMove={() => undefined}
+        projects={() => []}
+        renderProject={() => null}
+        handleDragStart={() => undefined}
+        handleDragEnd={() => undefined}
+        handleDragOver={() => undefined}
+        openProjectLabel="Open project"
+        openProjectKeybind={() => "mod+o"}
+        onOpenProject={() => undefined}
+        renderProjectOverlay={() => null}
+        settingsLabel={() => "Settings"}
+        settingsKeybind={() => undefined}
+        onOpenSettings={() => undefined}
+        helpLabel={() => "Help"}
+        onOpenHelp={() => undefined}
+        renderPanel={() => null}
+      />
+    ),
+    host,
+  )
+  return { host, off }
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ""
+})
+
+afterEach(() => {
+  document.body.innerHTML = ""
+  vi.restoreAllMocks()
+})
+
+describe("SidebarContent project actions", () => {
+  test("keeps open project action without rendering new project action", () => {
+    const { host, off } = mount()
+
+    expect(host.querySelector('[aria-label="New project"]')).toBeNull()
+    expect(host.querySelector('[aria-label="command.project.new"]')).toBeNull()
+    expect(host.querySelector('[aria-label="Open project"]')).not.toBeNull()
+
+    off()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #1107

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Removes the Electron-only “new project” action from the sidebar rail. The sidebar now keeps only the existing “open project” action, which already covers opening project directories.

This also removes the unused sidebar-specific `DialogNewProject` wiring from the layout while leaving the home page “new project” entry intact.

A component test was added to verify the sidebar no longer renders the new project action and still renders the open project action.

### How did you verify your code works?

- `bun typecheck` from `packages/app`
- `bun run ./script/vitest.ts run --config ./vitest.config.ts src/pages/layout/sidebar-shell.vitest.tsx` from `packages/app`
- Push hook ran `bun turbo typecheck`, 12 tasks passed

### Screenshots / recordings

<img width="876" height="506" alt="image" src="https://github.com/user-attachments/assets/e1add5af-fd86-4b9e-ac17-79af01208ecc" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR