### PR TITLE
fix(ui): 修复 Electron 中 subagent 会话链接打开后白屏

### DIFF
--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1279,6 +1279,14 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
     if (part().tool !== "task") return
     return sessionLink(taskId(), useLocation().pathname, data.sessionHref)
   })
+  const taskClick = (event: MouseEvent) => {
+    event.stopPropagation()
+    const sid = taskId()
+    const nav = data.navigateToSession
+    if (!sid || !nav) return
+    event.preventDefault()
+    nav(sid)
+  }
   const taskSubtitle = createMemo(() => {
     if (part().tool !== "task") return undefined
     const value = input().description
@@ -1311,6 +1319,7 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
                   defaultOpen={props.defaultOpen}
                   subtitle={taskSubtitle()}
                   href={taskHref()}
+                  onHrefClick={taskClick}
                 />
               )
             }}
@@ -1737,6 +1746,14 @@ ToolRegistry.register({
     const running = createMemo(() => props.status === "pending" || props.status === "running")
 
     const href = createMemo(() => sessionLink(childSessionId(), location.pathname, data.sessionHref))
+    const click = (event: MouseEvent) => {
+      event.stopPropagation()
+      const sid = childSessionId()
+      const nav = data.navigateToSession
+      if (!sid || !nav) return
+      event.preventDefault()
+      nav(sid)
+    }
 
     const titleContent = () => <TextShimmer text={title()} active={running()} />
 
@@ -1764,7 +1781,7 @@ ToolRegistry.register({
                     "text-text-on-warning-strong": pending(),
                   }}
                   href={href()!}
-                  onClick={(e) => e.stopPropagation()}
+                  onClick={click}
                 >
                   {subtitle()}
                   <Show when={pending()}>{warningSuffix()}</Show>

--- a/packages/ui/src/components/message-part.vitest.tsx
+++ b/packages/ui/src/components/message-part.vitest.tsx
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, test, vi } from "vitest"
+import { render } from "solid-js/web"
+import type { Message, Part as PartType } from "@opencode-ai/sdk/v2"
+import { DataProvider } from "../context"
+import { Part } from "./message-part"
+
+vi.mock("@solidjs/router", () => ({
+  useLocation: () => ({ pathname: "/workspace/session/root" }),
+}))
+
+type Store = Parameters<typeof DataProvider>[0]["data"]
+
+const store = (): Store => ({
+  session: [],
+  session_status: {},
+  session_diff: {},
+  message: {},
+  part: {},
+})
+
+const message = (): Message => ({
+  id: "msg",
+  sessionID: "root",
+  role: "assistant",
+  time: {
+    created: 1,
+    completed: 2,
+  },
+  parentID: "user",
+  modelID: "model",
+  providerID: "provider",
+  mode: "build",
+  agent: "general",
+  path: {
+    cwd: "/tmp",
+    root: "/tmp",
+  },
+  cost: 0,
+  tokens: {
+    input: 0,
+    output: 0,
+    reasoning: 0,
+    cache: {
+      read: 0,
+      write: 0,
+    },
+  },
+})
+
+const task = (status: "completed" | "error"): PartType => ({
+  id: "part",
+  sessionID: "root",
+  messageID: "msg",
+  type: "tool",
+  callID: "call",
+  tool: "task",
+  state:
+    status === "completed"
+      ? {
+          status: "completed",
+          input: {
+            description: "Deep search topic",
+            subagent_type: "general",
+          },
+          output: "done",
+          title: "Deep search topic",
+          metadata: {
+            sessionId: "child",
+          },
+          time: {
+            start: 1,
+            end: 2,
+          },
+        }
+      : {
+          status: "error",
+          input: {
+            description: "Deep search topic",
+          },
+          error: "Error: task failed",
+          metadata: {
+            sessionId: "child",
+          },
+          time: {
+            start: 1,
+            end: 2,
+          },
+        },
+})
+
+function mount(part: PartType, nav?: (sid: string) => void) {
+  const host = document.createElement("div")
+  document.body.append(host)
+  const off = render(
+    () => (
+      <DataProvider
+        data={store()}
+        directory="/tmp"
+        onNavigateToSession={nav}
+        onSessionHref={(sid) => `/workspace/session/${sid}`}
+      >
+        <Part part={part} message={message()} />
+      </DataProvider>
+    ),
+    host,
+  )
+  return { host, off }
+}
+
+afterEach(() => {
+  document.body.innerHTML = ""
+})
+
+describe("task session links", () => {
+  test("uses app session navigation when available", () => {
+    const nav = vi.fn()
+    const { host, off } = mount(task("completed"), nav)
+    const link = host.querySelector("a.subagent-link")
+    expect(link?.getAttribute("href")).toBe("/workspace/session/child")
+
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true })
+    link?.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(nav).toHaveBeenCalledWith("child")
+
+    off()
+  })
+
+  test("keeps the href fallback when app session navigation is absent", () => {
+    const { host, off } = mount(task("completed"))
+    const link = host.querySelector("a.subagent-link")
+    expect(link?.getAttribute("href")).toBe("/workspace/session/child")
+
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true })
+    link?.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(false)
+
+    off()
+  })
+
+  test("uses app session navigation from error cards", () => {
+    const nav = vi.fn()
+    const { host, off } = mount(task("error"), nav)
+    const link = host.querySelector("a.subagent-link")
+    expect(link?.getAttribute("href")).toBe("/workspace/session/child")
+
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true })
+    link?.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(nav).toHaveBeenCalledWith("child")
+
+    off()
+  })
+})

--- a/packages/ui/src/components/tool-error-card.tsx
+++ b/packages/ui/src/components/tool-error-card.tsx
@@ -13,6 +13,7 @@ export interface ToolErrorCardProps extends Omit<ComponentProps<typeof Card>, "c
   defaultOpen?: boolean
   subtitle?: string
   href?: string
+  onHrefClick?: (event: MouseEvent) => void
 }
 
 export function ToolErrorCard(props: ToolErrorCardProps) {
@@ -23,7 +24,7 @@ export function ToolErrorCard(props: ToolErrorCardProps) {
   })
   const open = () => state.open
   const copied = () => state.copied
-  const [split, rest] = splitProps(props, ["tool", "error", "defaultOpen", "subtitle", "href"])
+  const [split, rest] = splitProps(props, ["tool", "error", "defaultOpen", "subtitle", "href", "onHrefClick"])
   const name = createMemo(() => {
     const map: Record<string, string> = {
       read: "ui.tool.read",
@@ -100,7 +101,10 @@ export function ToolErrorCard(props: ToolErrorCardProps) {
                         data-slot="basic-tool-tool-subtitle"
                         class="clickable subagent-link"
                         href={split.href!}
-                        onClick={(e) => e.stopPropagation()}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          split.onHrefClick?.(e)
+                        }}
                       >
                         {subtitle()}
                       </a>


### PR DESCRIPTION
### Issue for this PR

Closes #1109

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

修复 Electron 桌面版中点击 Task 工具结果里的 subagent 会话链接后，主界面变成空白的问题。

原因是 subagent 链接此前只作为普通 `<a href>` 处理。Electron 版使用 `MemoryRouter`，普通锚点跳转会绕过应用内路由。这个 PR 保留链接的 `href` fallback，但在存在应用内 session 导航回调时，改为阻止默认跳转并调用 `navigateToSession`。

同时覆盖了 Task 正常态和错误态卡片中的 subagent 链接，并新增组件测试。

### How did you verify your code works?

- `cd packages/ui; bun typecheck`
- `cd packages/ui; bun run test`
- `git push` 触发的仓库 typecheck hook 通过：12 tasks successful
- 手动验证 Electron 版中点击 subagent 会话链接不再白屏，可以正常打开子会话。

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR