### PR TITLE
fix: avoid flickering git changes refresh

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -786,6 +786,7 @@ function SessionPageContent(props: SessionPageProps = {}) {
   let diffFrame: number | undefined
   let diffTimer: number | undefined
   let watcherDiff: number | undefined
+  let vcsWatch: number | undefined
   const vcsTask = new Map<VcsMode, Promise<void>>()
   const vcsRun = new Map<VcsMode, number>()
 
@@ -1114,8 +1115,12 @@ function SessionPageContent(props: SessionPageProps = {}) {
         ? (evt.details.properties as Record<string, unknown>)
         : undefined
     const file = typeof props?.file === "string" ? props.file : undefined
-    if (!file || file.startsWith(".git/")) return
-    refreshVcs()
+    if (!file || file.startsWith(".git/") || file.includes("/.git/")) return
+    if (vcsWatch !== undefined) window.clearTimeout(vcsWatch)
+    vcsWatch = window.setTimeout(() => {
+      vcsWatch = undefined
+      refreshVcs({ silent: true })
+    }, 500)
   })
   onCleanup(stopVcs)
 
@@ -2220,6 +2225,7 @@ function SessionPageContent(props: SessionPageProps = {}) {
     if (diffFrame !== undefined) cancelAnimationFrame(diffFrame)
     if (diffTimer !== undefined) window.clearTimeout(diffTimer)
     if (watcherDiff !== undefined) window.clearTimeout(watcherDiff)
+    if (vcsWatch !== undefined) window.clearTimeout(vcsWatch)
     if (scrollStateFrame !== undefined) cancelAnimationFrame(scrollStateFrame)
     if (fillFrame !== undefined) cancelAnimationFrame(fillFrame)
   })


### PR DESCRIPTION
### Issue for this PR

Fixes #651

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Git changes panel was refreshed immediately for every file watcher event. That refresh path clears the current diff and marks the review as not ready, which can make the panel flicker through loading while watcher events are still arriving.

This addresses the remaining watcher path related to #651 by debouncing watcher-driven VCS refreshes, keeping the current diff visible with a silent refresh, and ignoring absolute `.git` watcher paths.

### How did you verify your code works?

- Ran `bun run typecheck` from `packages/app`.
- Push hook also ran `bun turbo typecheck` successfully.
- Verified in local dev web that prompt submission no longer causes repeated Git changes flicker.
- Verified in a local `v0.7.2-beta.1` desktop build with `OPENCODE_CHANNEL=prod` that prompt submission and file create/delete updates appear in Git changes without flicker.

### Screenshots / recordings

No recording included. This is a transient loading-state flicker; I verified manually with prompt submission and file create/delete while watching Git changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR