### PR TITLE
fix: preserve explicit variant on model updates

### DIFF
--- a/packages/opencode/src/session/preference.ts
+++ b/packages/opencode/src/session/preference.ts
@@ -64,7 +64,14 @@ export namespace SessionPreference {
       sessionID: patch.sessionID,
       agent: patch.agent ?? prev?.agent,
       model: patch.model ?? prev?.model,
-      variant: patch.variant === null ? undefined : modelChanged ? undefined : (patch.variant ?? prev?.variant),
+      variant:
+        patch.variant === null
+          ? undefined
+          : patch.variant !== undefined
+            ? patch.variant
+            : modelChanged
+              ? undefined
+              : prev?.variant,
       autoAccept: patch.autoAccept ?? prev?.autoAccept,
     }
     store.set(patch.sessionID, merged)

--- a/packages/opencode/test/session/preference.test.ts
+++ b/packages/opencode/test/session/preference.test.ts
@@ -58,53 +58,6 @@ describe("SessionPreference", () => {
       })
     })
 
-    test("atomic model and variant patch keeps explicit variant", async () => {
-      await using tmp = await tmpdir()
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const id = sid()
-          await SessionPreference.update({
-            sessionID: id,
-            agent: "build",
-            model: { providerID: pid("openai"), modelID: mid("gpt-5") },
-            variant: "xhigh",
-          })
-          const pref = SessionPreference.get(id)!
-          expect(pref.agent).toBe("build")
-          expect(pref.model!.providerID).toBe(pid("openai"))
-          expect(pref.model!.modelID).toBe(mid("gpt-5"))
-          expect(pref.variant).toBe("xhigh")
-        },
-      })
-    })
-
-    test("model change with explicit variant uses supplied variant", async () => {
-      await using tmp = await tmpdir()
-      await Instance.provide({
-        directory: tmp.path,
-        fn: async () => {
-          const id = sid()
-          await SessionPreference.update({
-            sessionID: id,
-            agent: "build",
-            model: { providerID: pid("openai"), modelID: mid("gpt-4") },
-          })
-          await SessionPreference.update({ sessionID: id, variant: "low" })
-          await SessionPreference.update({
-            sessionID: id,
-            model: { providerID: pid("anthropic"), modelID: mid("claude-3") },
-            variant: "high",
-          })
-          const pref = SessionPreference.get(id)!
-          expect(pref.agent).toBe("build")
-          expect(pref.model!.providerID).toBe(pid("anthropic"))
-          expect(pref.model!.modelID).toBe(mid("claude-3"))
-          expect(pref.variant).toBe("high")
-        },
-      })
-    })
-
     test("variant: null clears variant; variant: undefined keeps previous", async () => {
       await using tmp = await tmpdir()
       await Instance.provide({

--- a/packages/opencode/test/session/preference.test.ts
+++ b/packages/opencode/test/session/preference.test.ts
@@ -58,6 +58,53 @@ describe("SessionPreference", () => {
       })
     })
 
+    test("atomic model and variant patch keeps explicit variant", async () => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const id = sid()
+          await SessionPreference.update({
+            sessionID: id,
+            agent: "build",
+            model: { providerID: pid("openai"), modelID: mid("gpt-5") },
+            variant: "xhigh",
+          })
+          const pref = SessionPreference.get(id)!
+          expect(pref.agent).toBe("build")
+          expect(pref.model!.providerID).toBe(pid("openai"))
+          expect(pref.model!.modelID).toBe(mid("gpt-5"))
+          expect(pref.variant).toBe("xhigh")
+        },
+      })
+    })
+
+    test("model change with explicit variant uses supplied variant", async () => {
+      await using tmp = await tmpdir()
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const id = sid()
+          await SessionPreference.update({
+            sessionID: id,
+            agent: "build",
+            model: { providerID: pid("openai"), modelID: mid("gpt-4") },
+          })
+          await SessionPreference.update({ sessionID: id, variant: "low" })
+          await SessionPreference.update({
+            sessionID: id,
+            model: { providerID: pid("anthropic"), modelID: mid("claude-3") },
+            variant: "high",
+          })
+          const pref = SessionPreference.get(id)!
+          expect(pref.agent).toBe("build")
+          expect(pref.model!.providerID).toBe(pid("anthropic"))
+          expect(pref.model!.modelID).toBe(mid("claude-3"))
+          expect(pref.variant).toBe("high")
+        },
+      })
+    })
+
     test("variant: null clears variant; variant: undefined keeps previous", async () => {
       await using tmp = await tmpdir()
       await Instance.provide({


### PR DESCRIPTION
### Issue for this PR

Fixes #1119

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A brand-new session promotes its draft preference by sending the selected model and reasoning-effort variant in one update. `SessionPreference.update` treated the initial model assignment as a model change and cleared the variant before considering the explicit value in that same update. The resulting preference event reset the Desktop/Web selector to `Default` after the first send.

This changes the merge precedence so an explicit variant is retained even when the model changes. Explicit `null` still clears the variant, and changing the model without supplying a variant still clears a stale value.

`packages/opencode/test/session/preference.test.ts` is listed as a protected CI/CD file for non-admin contributors, so this PR intentionally leaves that file unchanged. The initial atomic model-plus-variant and later model-switch-plus-variant cases were exercised locally before preparing the guard-compatible PR diff.

### How did you verify your code works?

- Verified two focused local regression cases: an initial atomic model-plus-`xhigh` update and a model switch with an explicit new variant. Both failed before the fix and passed after it.
- Ran `/Users/balth/.bun/bin/bun test test/session/preference.test.ts` from `packages/opencode` on the final PR branch: 12 tests passed with 33 assertions.
- Ran `/Users/balth/.bun/bin/bun typecheck` from `packages/opencode` with Bun on `PATH`.
- Built the prod-channel opencode sidecar and packaged a local macOS arm64 Electron app successfully with `OPENCODE_CHANNEL=prod`.

### Screenshots / recordings

No recording included. The visible symptom is the reasoning-effort selector changing to `Default` immediately after the first send.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR