### PR TITLE
fix(kb): allow switching back to model list after Enter manually

### DIFF
--- a/packages/app/src/components/knowledge-dialog.tsx
+++ b/packages/app/src/components/knowledge-dialog.tsx
@@ -630,12 +630,28 @@ export const KnowledgeDialog: Component = () => {
                             <Show
                               when={!editLoadingModels() && (editModelOptions().length === 0 || useManualEditModel())}
                             >
-                              <input
-                                type="text"
-                                value={editModel()}
-                                onInput={(e) => setEditModel(e.currentTarget.value)}
-                                class="h-9 w-full rounded-md border border-border-base bg-surface-base px-3 text-14-regular text-text-strong"
-                              />
+                              <div class="flex flex-col gap-1.5">
+                                <input
+                                  type="text"
+                                  value={editModel()}
+                                  onInput={(e) => setEditModel(e.currentTarget.value)}
+                                  class="h-9 w-full rounded-md border border-border-base bg-surface-base px-3 text-14-regular text-text-strong"
+                                />
+                                <Show when={useManualEditModel() && editModelOptions().length > 0}>
+                                  <button
+                                    type="button"
+                                    onClick={() => {
+                                      setUseManualEditModel(false)
+                                      if (editModel() && !editModelOptions().includes(editModel())) {
+                                        setEditModel(editModelOptions()[0] ?? "")
+                                      }
+                                    }}
+                                    class="text-12-regular text-text-weak hover:text-text-base underline self-start"
+                                  >
+                                    Use model list
+                                  </button>
+                                </Show>
+                              </div>
                             </Show>
                           </div>
 
@@ -837,13 +853,29 @@ export const KnowledgeDialog: Component = () => {
                   />
                 </Show>
                 <Show when={!loadingModels() && (embeddingModelOptions().length === 0 || useManualModel())}>
-                  <input
-                    type="text"
-                    value={newModel()}
-                    onInput={(e) => setNewModel(e.currentTarget.value)}
-                    placeholder="text-embedding-3-small"
-                    class="h-9 w-full rounded-md border border-border-base bg-surface-base px-3 text-14-regular text-text-strong placeholder:text-text-weak focus:outline-none focus:ring-2 focus:ring-border-focus"
-                  />
+                  <div class="flex flex-col gap-1.5">
+                    <input
+                      type="text"
+                      value={newModel()}
+                      onInput={(e) => setNewModel(e.currentTarget.value)}
+                      placeholder="text-embedding-3-small"
+                      class="h-9 w-full rounded-md border border-border-base bg-surface-base px-3 text-14-regular text-text-strong placeholder:text-text-weak focus:outline-none focus:ring-2 focus:ring-border-focus"
+                    />
+                    <Show when={useManualModel() && embeddingModelOptions().length > 0}>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setUseManualModel(false)
+                          if (newModel() && !embeddingModelOptions().includes(newModel())) {
+                            setNewModel(embeddingModelOptions()[0] ?? "")
+                          }
+                        }}
+                        class="text-12-regular text-text-weak hover:text-text-base underline self-start"
+                      >
+                        Use model list
+                      </button>
+                    </Show>
+                  </div>
                 </Show>
               </div>
             </Show>

--- a/packages/app/src/components/settings-knowledge.tsx
+++ b/packages/app/src/components/settings-knowledge.tsx
@@ -450,13 +450,29 @@ export const SettingsKnowledge: Component = () => {
                     />
                   </Show>
                   <Show when={!loadingModels() && (embeddingModelOptions().length === 0 || useManualModel())}>
-                    <input
-                      type="text"
-                      value={newModel()}
-                      onInput={(e) => setNewModel(e.currentTarget.value)}
-                      placeholder="text-embedding-3-small"
-                      class="h-9 flex-1 max-w-xs rounded-md border border-border-base bg-surface-base px-3 text-14-regular text-text-strong placeholder:text-text-weak focus:outline-none focus:ring-2 focus:ring-border-focus"
-                    />
+                    <div class="flex flex-col gap-1.5 max-w-xs">
+                      <input
+                        type="text"
+                        value={newModel()}
+                        onInput={(e) => setNewModel(e.currentTarget.value)}
+                        placeholder="text-embedding-3-small"
+                        class="h-9 flex-1 rounded-md border border-border-base bg-surface-base px-3 text-14-regular text-text-strong placeholder:text-text-weak focus:outline-none focus:ring-2 focus:ring-border-focus"
+                      />
+                      <Show when={useManualModel() && embeddingModelOptions().length > 0}>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setUseManualModel(false)
+                            if (newModel() && !embeddingModelOptions().includes(newModel())) {
+                              setNewModel(embeddingModelOptions()[0] ?? "")
+                            }
+                          }}
+                          class="text-12-regular text-text-weak hover:text-text-base underline self-start"
+                        >
+                          Use model list
+                        </button>
+                      </Show>
+                    </div>
                   </Show>
                 </div>
               </Show>


### PR DESCRIPTION
### Issue for this PR

Closes #1121

### Type of change

- [x] Bug fix

### What does this PR do?

修复知识库嵌入模型选择 "Enter manually..." 后无法切回下拉菜单的问题。

**问题根因**：在嵌入模型选择的三个表单（设置页新增、对话框新增、对话框编辑）中，点击下拉菜单的 "Enter manually..." 选项时会执行 `setUseManualModel(true)`（编辑表单是 `setUseManualEditModel(true)`），但这个 signal 是单向的——代码中没有任何路径把它重置回 `false`。一旦为 true，渲染下拉菜单的 `<Show>` 分支条件 `!useManualModel()` 永远为 false，下拉菜单永久消失，用户被锁定在自由文本输入框里。

**修复方式**：在文本输入框下方添加一个 "Use model list" 小链接，仅在 `useManualModel() && embeddingModelOptions().length > 0`（编辑表单对应 `useManualEditModel() && editModelOptions().length > 0`）时显示。点击后：
1. `setUseManualModel(false)` → 下拉菜单重新出现
2. 若当前 `newModel` 不在选项列表里（用户手动输入了自定义值），重置为列表首项，避免下拉显示一个不在选项中的值

这样用户可以自由在 "Enter manually..." 与下拉列表间双向切换，符合原始设计意图（下拉里包含 "__manual__" 选项作为入口，本就该有反向通路）。

**为什么有效**：修复直接补上了缺失的反向通路（`setUseManualModel(false)`），与现有的正向通路（`setUseManualModel(true)`）对称。`<Show>` 条件 `!useManualModel()` 会重新满足，下拉菜单恢复渲染。重置 `newModel` 的 guard 避免了"下拉里选了一个不在 options 列表中的值"的边界情况。

### How did you verify your code works?

- `bun typecheck` 在 `packages/app` 通过（pre-push hook 自动运行，12/12 步骤通过）
- 三个表单（`settings-knowledge.tsx` 新增、`knowledge-dialog.tsx` 新增、`knowledge-dialog.tsx` 编辑）均对称应用了相同的修复模式
- 改动范围仅限两个文件，未触及共享 Select 组件或其他逻辑

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR