### PR TITLE
feat(sidebar): 项目图标运行中任务指示

### DIFF
--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -41,6 +41,22 @@ export const ProjectIcon = (props: { project: LocalProject; class?: string; noti
     }),
   )
   const notify = createMemo(() => props.notify && (hasPermissions() || unseenCount() > 0))
+  const isBusy = createMemo(() =>
+    dirs().some((directory) => {
+      const [store] = globalSync.child(directory, { bootstrap: false })
+      const ids = new Set([...Object.keys(store.session_status), ...Object.keys(store.message)])
+      return [...ids].some((id) => {
+        const status = store.session_status[id]
+        if (status?.type === "busy" || status?.type === "retry") return true
+        const pending = (store.message[id] ?? []).findLast(
+          (message) =>
+            message.role === "assistant" &&
+            typeof (message as { time?: { completed?: unknown } }).time?.completed !== "number",
+        )
+        return !!pending
+      })
+    }),
+  )
   const name = createMemo(() => props.project.name || getFilename(props.project.worktree))
   const recent = createMemo(() => globalSync.project.recentFromDir(props.project.worktree))
   const src = createMemo(() => {
@@ -67,6 +83,11 @@ export const ProjectIcon = (props: { project: LocalProject; class?: string; noti
             "bg-text-interactive-base": !hasPermissions() && !hasError(),
           }}
         />
+      </Show>
+      <Show when={isBusy()}>
+        <div class="absolute bottom-px right-px size-[14px] rounded-full bg-background-base flex items-center justify-center z-10">
+          <Spinner class="size-[10px] text-icon-interactive-base" />
+        </div>
       </Show>
     </div>
   )
@@ -414,12 +435,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
       >
         <div class="flex min-w-0 items-center gap-1">
           <div class="min-w-0 flex-1">
-            <Show
-              when={renaming()}
-              fallback={
-                item
-              }
-            >
+            <Show when={renaming()} fallback={item}>
               <div class={`flex items-center gap-3 min-w-0 ${props.dense ? "py-0.5" : "py-1"}`}>
                 <div class="shrink-0 size-6 flex items-center justify-center">
                   <Show


### PR DESCRIPTION
### Issue for this PR

Closes #1123

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

在 `ProjectIcon`（`packages/app/src/pages/layout/sidebar-items.tsx`）右下角新增一个脉冲 Spinner，当项目下任一会话的 agent 处于 busy/retry 状态或存在未完成的 assistant 消息时点亮，任务结束时熄灭。复用会话行同款 `Spinner` 组件，视觉一致。

关键点：`isBusy` 遍历 `session_status` 与 `message` 的 key 并集，而非仅遍历 `session_status`。原因——`loadSessions` 切回时会用后端快照 `reconcile` 覆盖 `session_status`，agent 在工具调用间隙短暂 idle 会让对应 key 被清掉；若只遍历 `session_status` 会漏掉仍在 `message` 里的未完成 assistant 消息，导致 Spinner 短暂熄灭。改为并集后，与会话行 `interactive = busy(status) || pending` 的判定完全对齐，且不受 reconcile 清 key 影响。

右上角现有通知点逻辑零改动，两者位置对角不冲突。

### How did you verify your code works?

- `bun typecheck`（`packages/app`）通过，无错误。
- 本地启动前后端，在某项目里触发 agent 运行：项目图标右下角出现脉冲 Spinner；切换到别的项目再切回，Spinner 不熄灭；agent 回合结束（消息 `time.completed` 被设）后熄灭。与会话行 Spinner 的亮灭时机一致。

### Screenshots / recordings

_待补充。_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR