### PR TITLE
fix: 支持 DeepSeek V4 思考强度档位

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -576,6 +576,21 @@ export namespace ProviderTransform {
       ["opus-4-6", "opus-4.6", "4-6-opus", "4.6-opus", "sonnet-4-6", "sonnet-4.6"].some((v) => api.includes(v))
     const adaptiveEfforts = opus ? ["low", "medium", "high", "xhigh", "max"] : ["low", "medium", "high", "max"]
     if (
+      /(^|\/)deepseek-v4-(pro|flash)$/.test(model.api.id.toLowerCase()) &&
+      ["deepseek", "vercel", "openrouter"].includes(model.providerID)
+    ) {
+      if (model.providerID === "openrouter") {
+        return {
+          high: { reasoning: { effort: "high" } },
+          max: { reasoning: { effort: "max" } },
+        }
+      }
+      return {
+        high: { thinking: { type: "enabled" }, reasoningEffort: "high" },
+        max: { thinking: { type: "enabled" }, reasoningEffort: "max" },
+      }
+    }
+    if (
       id.includes("deepseek") ||
       id.includes("minimax") ||
       id.includes("glm") ||

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1278,8 +1278,14 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
     const flash = await sample("deepseek", "deepseek-v4-flash")
     const pro = await sample("deepseek", "deepseek-v4-pro")
 
-    expect(ProviderTransform.variants(flash)).toEqual({})
-    expect(ProviderTransform.variants(pro)).toEqual({})
+    expect(ProviderTransform.variants(flash)).toEqual({
+      high: { thinking: { type: "enabled" }, reasoningEffort: "high" },
+      max: { thinking: { type: "enabled" }, reasoningEffort: "max" },
+    })
+    expect(ProviderTransform.variants(pro)).toEqual({
+      high: { thinking: { type: "enabled" }, reasoningEffort: "high" },
+      max: { thinking: { type: "enabled" }, reasoningEffort: "max" },
+    })
     expect(flash.capabilities.interleaved).toEqual({ field: "reasoning_content" })
     expect(pro.capabilities.interleaved).toEqual({ field: "reasoning_content" })
 
@@ -2616,10 +2622,13 @@ describe("ProviderTransform.variants", () => {
       expect(result.high).toEqual({ reasoning: { effort: "high" } })
     })
 
-    test("fixture deepseek v4 keeps openrouter package without generic variants", async () => {
+    test("fixture deepseek v4 returns openrouter reasoning variants", async () => {
       const model = await sample("openrouter", "deepseek/deepseek-v4-flash")
       expect(model.api.npm).toBe("@openrouter/ai-sdk-provider")
-      expect(ProviderTransform.variants(model)).toEqual({})
+      expect(ProviderTransform.variants(model)).toEqual({
+        high: { reasoning: { effort: "high" } },
+        max: { reasoning: { effort: "max" } },
+      })
     })
 
     test("fixture openrouter gpt-5.4 uses openrouter reasoning variants", async () => {
@@ -2844,9 +2853,12 @@ describe("ProviderTransform.variants", () => {
       })
     })
 
-    test("fixture vercel deepseek v4 does not create generic gateway variants", async () => {
+    test("fixture vercel deepseek v4 returns reasoning variants", async () => {
       const model = await sample("vercel", "deepseek/deepseek-v4-flash")
-      expect(ProviderTransform.variants(model)).toEqual({})
+      expect(ProviderTransform.variants(model)).toEqual({
+        high: { thinking: { type: "enabled" }, reasoningEffort: "high" },
+        max: { thinking: { type: "enabled" }, reasoningEffort: "max" },
+      })
     })
 
     test("fixture vercel claude opus 4.7 returns summarized adaptive variants", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #1125

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

DeepSeek 模型此前被统一排除在思考强度 variants 之外，导致 DeepSeek V4 Pro 和 V4 Flash 只能使用 `Default`。

本次修改仅为 DeepSeek V4 Pro/Flash 增加 `High` 和 `Max` 档位：

- DeepSeek 官方 API 与 Vercel AI Gateway 使用 `thinking.enabled` 和 `reasoningEffort`。
- OpenRouter 使用 `reasoning.effort`。
- 旧版 DeepSeek 模型和其他未经验证的 provider 保持原有行为。

### How did you verify your code works?

- `bun test test/provider/transform.test.ts`：254 个测试通过。
- `bun typecheck`：通过。
- 使用 DeepSeek V4 Flash 进行了真实请求验证：
  - `High` 最终请求包含 `reasoning_effort: "high"`。
  - `Max` 最终请求包含 `reasoning_effort: "max"`。

### Screenshots / recordings

Not applicable. This change uses the existing model variant selector and does not modify UI components.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR