### PR TITLE
feat(provider): 为 Alibaba (China) 新增 qwen3.8-max 与 deepseek-v4-flash-0731 模型

### DIFF
--- a/packages/opencode/src/provider/models-local.ts
+++ b/packages/opencode/src/provider/models-local.ts
@@ -92,6 +92,85 @@ export const inserts = {
       "https://dashscope.aliyuncs.com/compatible-mode/v1",
       "models.dev is missing Alibaba Bailian GLM-5.2 metadata; Alibaba documents OpenAI-compatible chat completions with 1M context",
     ),
+    "qwen3.8-max": {
+      id: "qwen3.8-max",
+      name: "Qwen3.8 Max",
+      family: "qwen",
+      attachment: true,
+      reasoning: true,
+      tool_call: true,
+      structured_output: true,
+      interleaved: {
+        field: "reasoning_content",
+      },
+      temperature: true,
+      release_date: "",
+      modalities: {
+        input: ["text", "image", "video"],
+        output: ["text"],
+      },
+      provider: {
+        npm: "@ai-sdk/openai-compatible",
+        api: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      },
+      limit: {
+        context: 1_000_000,
+        input: 991_000,
+        output: 131_072,
+      },
+      options: {},
+      // Alibaba Bailian list price is CNY 12 / 1.2 (cache hit) / 36 per 1M tokens;
+      // converted to USD at 1 USD ≈ 7.2 CNY to match models.dev's USD convention.
+      cost: {
+        input: 1.67,
+        cache_read: 0.17,
+        output: 5.0,
+      },
+      meta: {
+        reason:
+          "models.dev is missing Alibaba Bailian qwen3.8-max metadata; Alibaba documents OpenAI-compatible hybrid reasoning with 1M context and image/video input",
+        verified_at: "2026-08-05",
+      },
+    },
+    "deepseek-v4-flash-0731": {
+      id: "deepseek-v4-flash-0731",
+      name: "DeepSeek V4 Flash 0731",
+      family: "deepseek",
+      attachment: false,
+      reasoning: true,
+      tool_call: true,
+      structured_output: true,
+      interleaved: {
+        field: "reasoning_content",
+      },
+      temperature: true,
+      release_date: "2026-07-31",
+      modalities: {
+        input: ["text"],
+        output: ["text"],
+      },
+      provider: {
+        npm: "@ai-sdk/openai-compatible",
+        api: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      },
+      limit: {
+        context: 1_000_000,
+        output: 393_216,
+      },
+      options: {},
+      // Alibaba Bailian list price is CNY 1 / 0.1 (cache hit) / 2 per 1M tokens;
+      // converted to USD at 1 USD ≈ 7.2 CNY to match models.dev's USD convention.
+      cost: {
+        input: 0.14,
+        cache_read: 0.01,
+        output: 0.28,
+      },
+      meta: {
+        reason:
+          "models.dev is missing Alibaba Bailian deepseek-v4-flash-0731 metadata; Alibaba documents OpenAI-compatible hybrid reasoning with 1M context and shared 393,216 output budget",
+        verified_at: "2026-08-05",
+      },
+    },
   },
   aihubmix: {
     "glm-5.2": glm(

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -178,6 +178,68 @@ test("models.dev local overlay inserts GLM-5.2 models", () => {
   expect(mix.models["glm-5.2"].api.url).toBe("https://aihubmix.com/v1")
 })
 
+test("models.dev local overlay inserts alibaba-cn qwen3.8-max and deepseek-v4-flash-0731", () => {
+  const data = apply(
+    {
+      alibaba: {
+        ...provider,
+        id: "alibaba",
+        api: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+        models: {},
+      },
+      "alibaba-cn": {
+        ...provider,
+        id: "alibaba-cn",
+        api: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        models: {},
+      },
+      aihubmix: {
+        ...provider,
+        id: "aihubmix",
+        api: "https://aihubmix.com/v1",
+        models: {},
+      },
+    },
+    {
+      additions: {},
+      overrides: {},
+      strict: true,
+    },
+  )
+
+  const qwen = data["alibaba-cn"].models["qwen3.8-max"]
+  expect(qwen.limit.context).toBe(1_000_000)
+  expect(qwen.limit.input).toBe(991_000)
+  expect(qwen.limit.output).toBe(131_072)
+  expect(qwen.attachment).toBe(true)
+  expect(qwen.reasoning).toBe(true)
+  expect(qwen.tool_call).toBe(true)
+  expect(qwen.modalities?.input).toEqual(["text", "image", "video"])
+  expect(qwen.cost?.input).toBe(1.67)
+  expect(qwen.cost?.output).toBe(5.0)
+  expect(qwen.provider?.npm).toBe("@ai-sdk/openai-compatible")
+  expect(qwen.provider?.api).toBe("https://dashscope.aliyuncs.com/compatible-mode/v1")
+  expect("meta" in qwen).toBe(false)
+
+  const ds = data["alibaba-cn"].models["deepseek-v4-flash-0731"]
+  expect(ds.limit.context).toBe(1_000_000)
+  expect(ds.limit.output).toBe(393_216)
+  expect(ds.attachment).toBe(false)
+  expect(ds.reasoning).toBe(true)
+  expect(ds.tool_call).toBe(true)
+  expect(ds.modalities?.input).toEqual(["text"])
+  expect(ds.cost?.input).toBe(0.14)
+  expect(ds.cost?.output).toBe(0.28)
+  expect(ds.provider?.api).toBe("https://dashscope.aliyuncs.com/compatible-mode/v1")
+  expect("meta" in ds).toBe(false)
+
+  const info = Provider.fromModelsDevProvider(data["alibaba-cn"])
+  expect(info.models["qwen3.8-max"].capabilities.interleaved).toEqual({ field: "reasoning_content" })
+  expect(info.models["qwen3.8-max"].capabilities.input.image).toBe(true)
+  expect(info.models["deepseek-v4-flash-0731"].capabilities.interleaved).toEqual({ field: "reasoning_content" })
+  expect(info.models["deepseek-v4-flash-0731"].capabilities.toolcall).toBe(true)
+})
+
 test("models.dev local overlay rejects duplicate model insertions", () => {
   expect(() =>
     apply(


### PR DESCRIPTION
### Issue for this PR

Closes #1127

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Alibaba (China)（`alibaba-cn`）提供商的模型列表缺少百炼新上线的 `qwen3.8-max` 和 `deepseek-v4-flash-0731`（models.dev 尚未收录）。本 PR 在 `packages/opencode/src/provider/models-local.ts` 的 `inserts["alibaba-cn"]` 中新增这两个模型的元数据，与既有的 GLM-5.2 本地 overlay 机制完全一致：若 models.dev 日后收录，`apply()` 会自动跳过，不会产生冲突。

元数据依据百炼官方文档与控制台核实：两者均为 1M 上下文的混合思考模型，支持工具调用；`qwen3.8-max` 最大输出 128K、支持图像/视频输入，`deepseek-v4-flash-0731` 输出共 393,216、纯文本；价格按北京区域定价以 1 USD ≈ 7.2 CNY 换算。不需要修改 transform/auth 逻辑——`transform.ts` 对 alibaba-cn 的 reasoning 模型已自动注入 `enable_thinking: true`，思考模式开箱即用。

### How did you verify your code works?

- `bun test test/provider`：411 个测试全部通过，其中包含新增的 overlay 插入断言（limit/cost/api URL/interleaved 能力）
- `bun run typecheck`（packages/opencode）通过；push 时触发的全仓 turbo typecheck 全部通过

### Screenshots / recordings

Not applicable.（非 UI 改动）

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR