### PR TITLE
fix: 支持阿里百炼 DeepSeek V4 思考强度档位

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -577,12 +577,18 @@ export namespace ProviderTransform {
     const adaptiveEfforts = opus ? ["low", "medium", "high", "xhigh", "max"] : ["low", "medium", "high", "max"]
     if (
       /(^|\/)deepseek-v4-(pro|flash)$/.test(model.api.id.toLowerCase()) &&
-      ["deepseek", "vercel", "openrouter"].includes(model.providerID)
+      ["deepseek", "vercel", "openrouter", "alibaba-cn"].includes(model.providerID)
     ) {
       if (model.providerID === "openrouter") {
         return {
           high: { reasoning: { effort: "high" } },
           max: { reasoning: { effort: "max" } },
+        }
+      }
+      if (model.providerID === "alibaba-cn") {
+        return {
+          high: { reasoningEffort: "high" },
+          max: { reasoningEffort: "max" },
         }
       }
       return {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3159,6 +3159,28 @@ describe("ProviderTransform.variants", () => {
       expect(ProviderTransform.variants(model)).toEqual({})
     })
 
+    test("fixture alibaba cn deepseek v4 returns reasoning variants", async () => {
+      const flash = await sample("alibaba-cn", "deepseek-v4-flash")
+      const pro = await sample("alibaba-cn", "deepseek-v4-pro")
+      const r1 = await sample("alibaba-cn", "deepseek-r1")
+      const want = {
+        high: { reasoningEffort: "high" },
+        max: { reasoningEffort: "max" },
+      }
+
+      expect(ProviderTransform.variants(flash)).toEqual(want)
+      expect(ProviderTransform.variants(pro)).toEqual(want)
+      expect(ProviderTransform.variants(r1)).toEqual({})
+
+      const base = ProviderTransform.options({ model: pro, sessionID: "test", providerOptions: {} })
+      expect(ProviderTransform.providerOptions(pro, { ...base, ...want.max })).toEqual({
+        "alibaba-cn": {
+          enable_thinking: true,
+          reasoningEffort: "max",
+        },
+      })
+    })
+
     test("fixture chutes non-reasoning model has no variants", async () => {
       const model = await sample("chutes", "XiaomiMiMo/MiMo-V2-Flash-TEE")
       expect(model.api.npm).toBe("@ai-sdk/openai-compatible")


### PR DESCRIPTION
### Issue for this PR

Closes #1129

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

阿里百炼的 `alibaba-cn` provider 未包含在 DeepSeek V4 思考强度支持范围内，导致 V4 Pro 和 V4 Flash 仍然只能使用 `Default`。

本次修改：

- 为阿里云直供的 `deepseek-v4-pro` 和 `deepseek-v4-flash` 提供 `High`、`Max` 档位。
- 档位通过 `reasoningEffort` 传递，并继续使用现有的 `enable_thinking: true`。
- DeepSeek R1 等旧模型和其他未经验证的代理模型保持原有行为。

### How did you verify your code works?

- `bun test test/provider/transform.test.ts`：255 个测试通过。
- `bun typecheck`：通过。
- 回归测试验证：
  - V4 Pro/Flash 生成 `High` 和 `Max`。
  - 百炼 provider options 同时包含 `enable_thinking: true` 和对应 `reasoningEffort`。
  - DeepSeek R1 不生成思考强度档位。

> `packages/opencode/test/provider/transform.test.ts` 属于 CICD Guard 保护文件。本次回归测试为修复所必需，可能需要 CI/CD 管理员审核。

### Screenshots / recordings

Not applicable. This change uses the existing model variant selector and does not modify UI components.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR