### PR TITLE
fix(session): 修复消息 ID 回绕后已有对话无法回复

### DIFF
--- a/packages/app/src/components/quick-reading/quick-reading-first-read-gate.tsx
+++ b/packages/app/src/components/quick-reading/quick-reading-first-read-gate.tsx
@@ -280,7 +280,9 @@ export const QuickReadingFirstReadGate: Component<{
   createEffect(() => {
     const id = pending()
     if (!id || status().type !== "idle") return
-    const done = messages().some((item) => item.role === "assistant" && item.id > id && typeof item.time.completed === "number")
+    const done = messages().some(
+      (item) => item.role === "assistant" && item.parentID === id && typeof item.time.completed === "number",
+    )
     if (!done) return
     setPending(undefined)
   })

--- a/packages/app/src/components/reading-mode/reading-first-read-gate-pdf.tsx
+++ b/packages/app/src/components/reading-mode/reading-first-read-gate-pdf.tsx
@@ -445,7 +445,7 @@ export const ReadingFirstReadGate: Component<{ sessionID: string }> = (props) =>
     if (!triggerID || patching()) return
 
     const assistantDone = messages().some(
-      (item) => item.role === "assistant" && item.id > triggerID && typeof item.time.completed === "number",
+      (item) => item.role === "assistant" && item.parentID === triggerID && typeof item.time.completed === "number",
     )
     if (!assistantDone) return
 

--- a/packages/app/src/components/session/session-context-tab.tsx
+++ b/packages/app/src/components/session/session-context-tab.tsx
@@ -16,6 +16,7 @@ import { useSessionLayout } from "@/pages/session/session-layout"
 import { getSessionContextMetrics } from "./session-context-metrics"
 import { estimateSessionContextBreakdown, type SessionContextBreakdownKey } from "./session-context-breakdown"
 import { createSessionContextFormatter } from "./session-context-format"
+import { MessageOrder } from "@/utils/message-order"
 
 const BREAKDOWN_COLOR: Record<SessionContextBreakdownKey, string> = {
   system: "var(--syntax-info)",
@@ -116,7 +117,7 @@ export function SessionContextTab() {
     () => {
       const revert = info()?.revert?.messageID
       if (!revert) return userMessages()
-      return userMessages().filter((m) => m.id < revert)
+      return MessageOrder.before(userMessages(), revert)
     },
     emptyUserMessages,
     { equals: same },

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -15,12 +15,12 @@ const rootSession = (input: { id: string; parentID?: string; archived?: number }
     },
   }) as Session
 
-const userMessage = (id: string, sessionID: string) =>
+const userMessage = (id: string, sessionID: string, created = 1) =>
   ({
     id,
     sessionID,
     role: "user",
-    time: { created: 1 },
+    time: { created },
     agent: "assistant",
     model: { providerID: "openai", modelID: "gpt" },
   }) as Message
@@ -385,6 +385,24 @@ describe("applyDirectoryEvent", () => {
 
     expect(store.message[sessionID]?.map((x) => x.id)).toEqual(["msg_1", "msg_3"])
     expect(store.part.msg_2).toBeUndefined()
+  })
+
+  test("inserts post-rollover message events by creation time", () => {
+    const sessionID = "ses_1"
+    const [store, setStore] = createStore(
+      baseState({ message: { [sessionID]: [userMessage("msg_fe", sessionID, 1)] } }),
+    )
+
+    applyDirectoryEvent({
+      event: { type: "message.updated", properties: { info: userMessage("msg_00", sessionID, 2) } },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+
+    expect(store.message[sessionID]?.map((x) => x.id)).toEqual(["msg_fe", "msg_00"])
   })
 
   test("upserts and prunes message parts", () => {

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -14,6 +14,7 @@ import type {
 import type { State, VcsCache } from "./types"
 import { trimSessions } from "./session-trim"
 import { dropSessionCaches } from "./session-cache"
+import { MessageOrder } from "@/utils/message-order"
 
 const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
 
@@ -219,16 +220,16 @@ export function applyDirectoryEvent(input: {
         input.setStore("message", info.sessionID, [info])
         break
       }
-      const result = Binary.search(messages, info.id, (m) => m.id)
-      if (result.found) {
-        input.setStore("message", info.sessionID, result.index, reconcile(info))
+      const at = MessageOrder.index(messages, info.id)
+      if (at >= 0) {
+        input.setStore("message", info.sessionID, at, reconcile(info))
         break
       }
       input.setStore(
         "message",
         info.sessionID,
         produce((draft) => {
-          draft.splice(result.index, 0, info)
+          draft.splice(MessageOrder.insert(draft, info), 0, info)
         }),
       )
       break
@@ -239,8 +240,8 @@ export function applyDirectoryEvent(input: {
         produce((draft) => {
           const messages = draft.message[props.sessionID]
           if (messages) {
-            const result = Binary.search(messages, props.messageID, (m) => m.id)
-            if (result.found) messages.splice(result.index, 1)
+            const at = MessageOrder.index(messages, props.messageID)
+            if (at >= 0) messages.splice(at, 1)
           }
           delete draft.part[props.messageID]
         }),

--- a/packages/app/src/context/sync-optimistic.test.ts
+++ b/packages/app/src/context/sync-optimistic.test.ts
@@ -4,11 +4,11 @@ import { applyOptimisticAdd, applyOptimisticRemove, mergeOptimisticPage } from "
 
 type Text = Extract<Part, { type: "text" }>
 
-const userMessage = (id: string, sessionID: string): Message => ({
+const userMessage = (id: string, sessionID: string, created = 1): Message => ({
   id,
   sessionID,
   role: "user",
-  time: { created: 1 },
+  time: { created },
   agent: "assistant",
   model: { providerID: "openai", modelID: "gpt" },
 })
@@ -37,6 +37,22 @@ describe("sync optimistic reducers", () => {
 
     expect(draft.message[sessionID]?.map((x) => x.id)).toEqual(["msg_1", "msg_2"])
     expect(draft.part.msg_1?.map((x) => x.id)).toEqual(["prt_1", "prt_2"])
+  })
+
+  test("applyOptimisticAdd keeps a post-rollover message at the end", () => {
+    const sessionID = "ses_1"
+    const draft = {
+      message: { [sessionID]: [userMessage("msg_fe", sessionID, 1)] },
+      part: {} as Record<string, Part[] | undefined>,
+    }
+
+    applyOptimisticAdd(draft, {
+      sessionID,
+      message: userMessage("msg_00", sessionID, 2),
+      parts: [],
+    })
+
+    expect(draft.message[sessionID]?.map((x) => x.id)).toEqual(["msg_fe", "msg_00"])
   })
 
   test("applyOptimisticRemove removes message and part entries", () => {

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -18,6 +18,7 @@ import type { Message, Part } from "@opencode-ai/sdk/v2/client"
 import { SESSION_CACHE_LIMIT, dropSessionCaches, pickSessionCacheEvictions } from "./global-sync/session-cache"
 import { useLanguage } from "./language"
 import { formatServerError } from "@/utils/server-errors"
+import { MessageOrder } from "@/utils/message-order"
 
 const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
 
@@ -42,12 +43,6 @@ const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
 function scopeError(err: unknown) {
   const msg = err instanceof Error ? err.message : typeof err === "string" ? err : ""
   return /project not registered|not registered|session not found|project not found|404/i.test(msg)
-}
-
-function merge<T extends { id: string }>(a: readonly T[], b: readonly T[]) {
-  const map = new Map(a.map((item) => [item.id, item] as const))
-  for (const item of b) map.set(item.id, item)
-  return [...map.values()].sort((x, y) => cmp(x.id, y.id))
 }
 
 type OptimisticStore = {
@@ -105,9 +100,9 @@ export function mergeOptimisticPage(page: MessagePage, items: OptimisticItem[]) 
   const confirmed: string[] = []
 
   for (const item of items) {
-    const result = Binary.search(session, item.message.id, (message) => message.id)
-    const found = result.found
-    if (!found) session.splice(result.index, 0, item.message)
+    const at = MessageOrder.index(session, item.message.id)
+    const found = at >= 0
+    if (!found) session.splice(MessageOrder.insert(session, item.message), 0, item.message)
 
     const current = part.get(item.message.id)
     if (found && hasParts(current, item.parts)) {
@@ -130,8 +125,7 @@ export function mergeOptimisticPage(page: MessagePage, items: OptimisticItem[]) 
 export function applyOptimisticAdd(draft: OptimisticStore, input: OptimisticAddInput) {
   const messages = draft.message[input.sessionID]
   if (messages) {
-    const result = Binary.search(messages, input.message.id, (m) => m.id)
-    messages.splice(result.index, 0, input.message)
+    messages.splice(MessageOrder.insert(messages, input.message), 0, input.message)
   } else {
     draft.message[input.sessionID] = [input.message]
   }
@@ -141,8 +135,8 @@ export function applyOptimisticAdd(draft: OptimisticStore, input: OptimisticAddI
 export function applyOptimisticRemove(draft: OptimisticStore, input: OptimisticRemoveInput) {
   const messages = draft.message[input.sessionID]
   if (messages) {
-    const result = Binary.search(messages, input.messageID, (m) => m.id)
-    if (result.found) messages.splice(result.index, 1)
+    const at = MessageOrder.index(messages, input.messageID)
+    if (at >= 0) messages.splice(at, 1)
   }
   delete draft.part[input.messageID]
 }
@@ -150,9 +144,8 @@ export function applyOptimisticRemove(draft: OptimisticStore, input: OptimisticR
 function setOptimisticAdd(setStore: (...args: unknown[]) => void, input: OptimisticAddInput) {
   setStore("message", input.sessionID, (messages: Message[] | undefined) => {
     if (!messages) return [input.message]
-    const result = Binary.search(messages, input.message.id, (m) => m.id)
     const next = [...messages]
-    next.splice(result.index, 0, input.message)
+    next.splice(MessageOrder.insert(next, input.message), 0, input.message)
     return next
   })
   setStore("part", input.message.id, sortParts(input.parts))
@@ -161,10 +154,10 @@ function setOptimisticAdd(setStore: (...args: unknown[]) => void, input: Optimis
 function setOptimisticRemove(setStore: (...args: unknown[]) => void, input: OptimisticRemoveInput) {
   setStore("message", input.sessionID, (messages: Message[] | undefined) => {
     if (!messages) return messages
-    const result = Binary.search(messages, input.messageID, (m) => m.id)
-    if (!result.found) return messages
+    const at = MessageOrder.index(messages, input.messageID)
+    if (at < 0) return messages
     const next = [...messages]
-    next.splice(result.index, 1)
+    next.splice(at, 1)
     return next
   })
   setStore("part", (part: Record<string, Part[] | undefined>) => {
@@ -343,7 +336,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         input.client.session.messages({ sessionID: input.sessionID, limit: input.limit, before: input.before }),
       )
       const items = (messages.data ?? []).filter((x) => !!x?.info?.id)
-      const session = items.map((x) => x.info).sort((a, b) => cmp(a.id, b.id))
+      const session = MessageOrder.sort(items.map((x) => x.info))
       const part = items.map((message) => ({ id: message.info.id, part: sortParts(message.parts) }))
       const cursor = messages.response.headers.get("x-next-cursor") ?? undefined
       return {
@@ -370,7 +363,25 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
       setMeta("loading", key, true)
       await fetchMessages(input)
+        .then(async (page) => {
+          if (!tracked(input.directory, input.sessionID)) return
+          const [store] = globalSync.child(input.directory, { bootstrap: false })
+          const revert = store.session.find((item) => item.id === input.sessionID)?.revert?.messageID
+          const known = store.message[input.sessionID]?.some((item) => item.id === revert)
+          if (revert && !known && !page.session.some((item) => item.id === revert)) {
+            const result = await input.client.session
+              .message({ sessionID: input.sessionID, messageID: revert })
+              .catch(() => undefined)
+            const item = result?.data
+            if (item?.info?.id) {
+              page.session = MessageOrder.sort([...page.session, item.info])
+              page.part.push({ id: item.info.id, part: sortParts(item.parts) })
+            }
+          }
+          return page
+        })
         .then((page) => {
+          if (!page) return
           if (!tracked(input.directory, input.sessionID)) return
           const next = mergeOptimisticPage(page, getOptimistic(input.directory, input.sessionID))
           for (const messageID of next.confirmed) {
@@ -378,7 +389,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           }
           const [store] = globalSync.child(input.directory, { bootstrap: false })
           const cached = input.mode === "prepend" ? (store.message[input.sessionID] ?? []) : []
-          const message = input.mode === "prepend" ? merge(cached, next.session) : next.session
+          const message = input.mode === "prepend" ? MessageOrder.merge(cached, next.session) : next.session
           batch(() => {
             input.setStore("message", input.sessionID, reconcile(message, { key: "id" }))
             for (const p of next.part) {

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -56,6 +56,7 @@ import { Worktree as WorktreeState } from "@/utils/worktree"
 import { setSessionHandoff } from "@/pages/session/handoff"
 import type { E2EWindow } from "@/testing/terminal"
 import { OpenIntent } from "@/utils/open-intent"
+import { MessageOrder } from "@/utils/message-order"
 
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme/context"
@@ -962,7 +963,7 @@ export default function Layout(props: ParentProps) {
 
             const items = (messages.data ?? []).filter((x) => !!x?.info?.id)
             const next = items.map((x) => x.info).filter((m): m is Message => !!m?.id)
-            const sorted = mergeByID([], next)
+            const sorted = MessageOrder.sort(next)
             const stale = markPrefetched(directory, sessionID)
             const cursor = messages.response.headers.get("x-next-cursor") ?? undefined
             const meta = {
@@ -980,7 +981,7 @@ export default function Layout(props: ParentProps) {
             }
 
             const current = store.message[sessionID] ?? []
-            const merged = mergeByID(
+            const merged = MessageOrder.merge(
               current.filter((item): item is Message => !!item?.id),
               sorted,
             )

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -73,6 +73,7 @@ import { Identifier } from "@/utils/id"
 import { extractPromptFromParts } from "@/utils/prompt"
 import { same } from "@/utils/same"
 import { formatServerError } from "@/utils/server-errors"
+import { MessageOrder } from "@/utils/message-order"
 
 const emptyUserMessages: UserMessage[] = []
 const emptyFollowups: (FollowupDraft & { id: string })[] = []
@@ -667,7 +668,7 @@ function SessionPageContent(props: SessionPageProps = {}) {
     () => {
       const revert = revertMessageID()
       if (!revert) return userMessages()
-      return userMessages().filter((m) => m.id < revert)
+      return MessageOrder.before(userMessages(), revert)
     },
     emptyUserMessages,
     {
@@ -2033,7 +2034,7 @@ function SessionPageContent(props: SessionPageProps = {}) {
       const sessionID = params.id
       if (!sessionID) return
 
-      const next = userMessages().find((item) => item.id > id)
+      const next = MessageOrder.next(userMessages(), id)
       const prev = prompt.current().slice()
       const last = info()?.revert
 
@@ -2142,9 +2143,7 @@ function SessionPageContent(props: SessionPageProps = {}) {
   const rolled = createMemo(() => {
     const id = revertMessageID()
     if (!id) return []
-    return userMessages()
-      .filter((item) => item.id >= id)
-      .map((item) => ({ id: item.id, text: line(item.id) }))
+    return MessageOrder.from(userMessages(), id).map((item) => ({ id: item.id, text: line(item.id) }))
   })
 
   const actions = { fork, revert }

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -18,7 +18,6 @@ import { ScrollView } from "@opencode-ai/ui/scroll-view"
 import { TextField } from "@opencode-ai/ui/text-field"
 import type { AssistantMessage, Message as MessageType, Part, TextPart, UserMessage } from "@opencode-ai/sdk/v2"
 import { showToast } from "@opencode-ai/ui/toast"
-import { Binary } from "@opencode-ai/util/binary"
 import { getFilename } from "@opencode-ai/util/path"
 import { Popover as KobaltePopover } from "@kobalte/core/popover"
 import { shouldMarkBoundaryGesture, normalizeWheelDelta } from "@/pages/session/message-gesture"
@@ -399,8 +398,7 @@ export function MessageTimeline(props: {
     const parentID = pending()?.parentID
     if (parentID) {
       const messages = sessionMessages()
-      const result = Binary.search(messages, parentID, (message) => message.id)
-      const message = result.found ? messages[result.index] : messages.find((item) => item.id === parentID)
+      const message = messages.find((item) => item.id === parentID)
       if (message && message.role === "user") return message.id
     }
 

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -23,6 +23,7 @@ import { createSessionTabs } from "@/pages/session/helpers"
 import { extractPromptFromParts } from "@/utils/prompt"
 import { UserMessage } from "@opencode-ai/sdk/v2"
 import { useSessionLayout } from "@/pages/session/session-layout"
+import { MessageOrder } from "@/utils/message-order"
 
 export type SessionCommandContext = {
   navigateMessageByOffset: (offset: number) => void
@@ -104,7 +105,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
   const visibleUserMessages = () => {
     const revert = info()?.revert?.messageID
     if (!revert) return userMessages()
-    return userMessages().filter((m) => m.id < revert)
+    return MessageOrder.before(userMessages(), revert)
   }
 
   const showAllFiles = () => {
@@ -452,7 +453,8 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
             return
           }
           const revert = info()?.revert?.messageID
-          const message = findLast(userMessages(), (x) => !revert || x.id < revert)
+          const list = userMessages()
+          const message = revert ? MessageOrder.prev(list, revert) : list.at(-1)
           if (!message) return
           await sdk.client.session.revert({ sessionID, messageID: message.id })
           const parts = sync.data.part[message.id]
@@ -460,7 +462,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
             const restored = extractPromptFromParts(parts, { directory: sdk.directory })
             prompt.set(restored)
           }
-          const priorMessage = findLast(userMessages(), (x) => x.id < message.id)
+          const priorMessage = MessageOrder.prev(list, message.id)
           setActiveMessage(priorMessage)
         },
       }),
@@ -479,16 +481,16 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
           }
           const revertMessageID = info()?.revert?.messageID
           if (!revertMessageID) return
-          const nextMessage = userMessages().find((x) => x.id > revertMessageID)
+          const list = userMessages()
+          const nextMessage = MessageOrder.next(list, revertMessageID)
           if (!nextMessage) {
             await sdk.client.session.unrevert({ sessionID })
             prompt.reset()
-            const lastMsg = findLast(userMessages(), (x) => x.id >= revertMessageID)
-            setActiveMessage(lastMsg)
+            setActiveMessage(list.at(-1))
             return
           }
           await sdk.client.session.revert({ sessionID, messageID: nextMessage.id })
-          const priorMsg = findLast(userMessages(), (x) => x.id < nextMessage.id)
+          const priorMsg = MessageOrder.prev(list, nextMessage.id)
           setActiveMessage(priorMsg)
         },
       }),

--- a/packages/app/src/utils/message-order.test.ts
+++ b/packages/app/src/utils/message-order.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+import { MessageOrder } from "./message-order"
+
+const item = (id: string, created: number) => ({ id, time: { created } })
+
+describe("MessageOrder", () => {
+  test("orders messages by creation time across an ID rollover", () => {
+    const old = item("msg_fe000000000000000000000000", 1)
+    const next = item("msg_00000000000000000000000000", 2)
+
+    expect(MessageOrder.sort([next, old])).toEqual([old, next])
+    expect(MessageOrder.insert([old], next)).toBe(1)
+  })
+
+  test("uses array position for message boundaries", () => {
+    const items = [item("msg_fe", 1), item("msg_00", 2), item("msg_01", 3)]
+
+    expect(MessageOrder.before(items, "msg_00").map((x) => x.id)).toEqual(["msg_fe"])
+    expect(MessageOrder.from(items, "msg_00").map((x) => x.id)).toEqual(["msg_00", "msg_01"])
+    expect(MessageOrder.prev(items, "msg_00")?.id).toBe("msg_fe")
+    expect(MessageOrder.next(items, "msg_00")?.id).toBe("msg_01")
+  })
+})

--- a/packages/app/src/utils/message-order.ts
+++ b/packages/app/src/utils/message-order.ts
@@ -1,0 +1,51 @@
+type Item = {
+  id: string
+  time: { created: number }
+}
+
+const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
+
+export namespace MessageOrder {
+  export function compare(a: Item, b: Item) {
+    return a.time.created - b.time.created || cmp(a.id, b.id)
+  }
+
+  export function sort<T extends Item>(items: readonly T[]) {
+    return [...items].sort(compare)
+  }
+
+  export function merge<T extends Item>(a: readonly T[], b: readonly T[]) {
+    const map = new Map(a.map((item) => [item.id, item] as const))
+    for (const item of b) map.set(item.id, item)
+    return sort([...map.values()])
+  }
+
+  export function index<T extends { id: string }>(items: readonly T[], id: string) {
+    return items.findIndex((item) => item.id === id)
+  }
+
+  export function insert<T extends Item>(items: readonly T[], item: T) {
+    const at = items.findIndex((current) => compare(current, item) > 0)
+    return at < 0 ? items.length : at
+  }
+
+  export function before<T extends { id: string }>(items: readonly T[], id: string) {
+    const at = index(items, id)
+    return at < 0 ? [...items] : items.slice(0, at)
+  }
+
+  export function from<T extends { id: string }>(items: readonly T[], id: string) {
+    const at = index(items, id)
+    return at < 0 ? [] : items.slice(at)
+  }
+
+  export function next<T extends { id: string }>(items: readonly T[], id: string) {
+    const at = index(items, id)
+    return at < 0 ? undefined : items[at + 1]
+  }
+
+  export function prev<T extends { id: string }>(items: readonly T[], id: string) {
+    const at = index(items, id)
+    return at <= 0 ? undefined : items[at - 1]
+  }
+}

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -741,20 +741,15 @@ export namespace Session {
         await SessionPreference.update({ sessionID: session.id, ...prefData })
       }
       const idMap = new Map<string, MessageID>()
-      const copyIDs = new Set<string>()
-      for (const msg of msgs) {
-        if (input.messageID && msg.info.id >= input.messageID) break
-        copyIDs.add(msg.info.id)
-      }
+      const at = input.messageID ? msgs.findIndex((msg) => msg.info.id === input.messageID) : msgs.length
+      const copy = msgs.slice(0, at < 0 ? msgs.length : at)
       const completedCompactionTriggers = new Set<string>()
-      for (const msg of msgs) {
-        if (!copyIDs.has(msg.info.id)) continue
+      for (const msg of copy) {
         if (msg.info.role === "assistant" && msg.info.summary && msg.info.finish && !msg.info.error)
           completedCompactionTriggers.add(msg.info.parentID)
       }
       const orphanedCompactionTriggers = new Set<string>()
-      for (const msg of msgs) {
-        if (!copyIDs.has(msg.info.id)) continue
+      for (const msg of copy) {
         if (
           msg.info.role === "user" &&
           msg.parts.some((part) => part.type === "compaction") &&
@@ -763,8 +758,7 @@ export namespace Session {
           orphanedCompactionTriggers.add(msg.info.id)
       }
 
-      for (const msg of msgs) {
-        if (input.messageID && msg.info.id >= input.messageID) break
+      for (const msg of copy) {
         if (orphanedCompactionTriggers.has(msg.info.id)) continue
         const newID = MessageID.ascending()
         idMap.set(msg.info.id, newID)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -334,7 +334,7 @@ export namespace SessionPrompt {
       if (
         lastAssistant?.finish &&
         !["tool-calls"].includes(lastAssistant.finish) &&
-        lastUser.id < lastAssistant.id
+        lastAssistant.parentID === lastUser.id
       ) {
         _finalResponse = true
         log.info("exiting loop", { sessionID })

--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -85,7 +85,8 @@ export namespace SessionRevert {
         const to = await Snapshot.track()
         diffs = to ? await Snapshot.diffFull(from, to) : []
       } else {
-        const remaining = all.filter((msg) => msg.info.id < revert!.messageID)
+        const at = all.findIndex((msg) => msg.info.id === revert!.messageID)
+        const remaining = at < 0 ? [] : all.slice(0, at)
         diffs = await SessionSummary.computeDiff({ messages: remaining })
       }
       await Storage.write(["session_diff", input.sessionID], diffs)
@@ -134,25 +135,10 @@ export namespace SessionRevert {
     const sessionID = session.id
     const msgs = await Session.messages({ sessionID })
     const messageID = session.revert.messageID
-    const preserve = [] as MessageV2.WithParts[]
-    const remove = [] as MessageV2.WithParts[]
-    let target: MessageV2.WithParts | undefined
-    for (const msg of msgs) {
-      if (msg.info.id < messageID) {
-        preserve.push(msg)
-        continue
-      }
-      if (msg.info.id > messageID) {
-        remove.push(msg)
-        continue
-      }
-      if (session.revert.partID) {
-        preserve.push(msg)
-        target = msg
-        continue
-      }
-      remove.push(msg)
-    }
+    const at = msgs.findIndex((msg) => msg.info.id === messageID)
+    const offset = session.revert.partID ? 1 : 0
+    const preserve = at < 0 ? msgs : msgs.slice(0, at + offset)
+    const remove = at < 0 ? [] : msgs.slice(at + offset)
     for (const msg of remove) {
       SyncEvent.run(MessageV2.Event.Removed, {
         sessionID: sessionID,
@@ -179,9 +165,9 @@ export namespace SessionRevert {
         sessionID: sessionID,
         messageID: msg.info.id,
       })
-      if (msg === target) target = undefined
     }
     const boundaryMsg = msgs.find((m) => m.info.id === messageID)
+    const target = session.revert.partID ? preserve.find((msg) => msg.info.id === messageID) : undefined
     const revertTime = (boundaryMsg?.info as MessageV2.Assistant | MessageV2.User)?.time?.created ?? 0
     for (const msg of preserve) {
       for (const part of msg.parts) {

--- a/packages/opencode/test/session/compaction-flow.test.ts
+++ b/packages/opencode/test/session/compaction-flow.test.ts
@@ -206,6 +206,44 @@ function main(hits: Hit[]) {
   return hits.filter((hit) => !JSON.stringify(hit.body).includes("Generate a title for this conversation"))
 }
 
+describe("session prompt loop", () => {
+  test("replies to the latest user when message IDs are nonmonotonic", async () => {
+    const srv = await stub([
+      { type: "text", text: "first answer" },
+      { type: "text", text: "second answer" },
+    ])
+    await using tmp = await setup(srv.url)
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({ title: "Pinned" })
+        await SessionPrompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          model,
+          parts: [{ type: "text", text: "first" }],
+        })
+        await Bun.sleep(2)
+        const user = await SessionPrompt.prompt({
+          sessionID: session.id,
+          messageID: MessageID.make("msg_00000000000000000000000000"),
+          agent: "build",
+          model,
+          noReply: true,
+          parts: [{ type: "text", text: "second" }],
+        })
+        const result = await SessionPrompt.loop({ sessionID: session.id })
+
+        expect(result.info.role).toBe("assistant")
+        if (result.info.role === "assistant") expect(result.info.parentID).toBe(user.info.id)
+        expect(texts([result])).toContain("second answer")
+        expect(main(srv.hits)).toHaveLength(2)
+      },
+    })
+  })
+})
+
 describe("session compaction flow", () => {
   test("auto compacts after finish-step usage crosses the model context budget", async () => {
     const srv = await stub([

--- a/packages/opencode/test/session/revert-compact.test.ts
+++ b/packages/opencode/test/session/revert-compact.test.ts
@@ -14,6 +14,41 @@ const projectRoot = path.join(__dirname, "../..")
 Log.init({ print: false })
 
 describe("revert + compact workflow", () => {
+  test("cleans up the chronological suffix when message IDs are nonmonotonic", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const ids = [
+          MessageID.make("msg_fe000000000000000000000000"),
+          MessageID.make("msg_ff000000000000000000000000"),
+          MessageID.make("msg_00000000000000000000000000"),
+        ]
+        for (const [at, id] of ids.entries()) {
+          await Session.updateMessage({
+            id,
+            role: "user",
+            sessionID: session.id,
+            agent: "build",
+            model: { providerID: ProviderID.make("test"), modelID: ModelID.make("test") },
+            time: { created: at + 1 },
+          })
+        }
+        await Session.setRevert({
+          sessionID: session.id,
+          revert: { messageID: ids[2] },
+          summary: { additions: 0, deletions: 0, files: 0 },
+        })
+
+        await SessionRevert.cleanup(await Session.get(session.id))
+        const msgs = await Session.messages({ sessionID: session.id })
+
+        expect(msgs.map((msg) => msg.info.id)).toEqual(ids.slice(0, 2))
+      },
+    })
+  })
+
   test("should properly handle compact command after revert", async () => {
     await using tmp = await tmpdir({ git: true })
     await Instance.provide({

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -8,6 +8,7 @@ import { MessageV2 } from "../../src/session/message-v2"
 import { Database, eq } from "../../src/storage/db"
 import { MessageID, PartID } from "../../src/session/schema"
 import { SessionTable } from "../../src/session/session.sql"
+import { tmpdir } from "../fixture/fixture"
 
 const projectRoot = path.join(__dirname, "../..")
 Log.init({ print: false })
@@ -144,6 +145,57 @@ describe("step-finish token propagation via Bus event", () => {
 })
 
 describe("session tree IDs", () => {
+  test("forks the chronological prefix when message IDs are nonmonotonic", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const root = await Session.create({ title: "Rollover" })
+        const first = MessageID.make("msg_fe000000000000000000000000")
+        const reply = MessageID.make("msg_ff000000000000000000000000")
+        const latest = MessageID.make("msg_00000000000000000000000000")
+        await Session.updateMessage({
+          id: first,
+          sessionID: root.id,
+          role: "user",
+          time: { created: 1 },
+          agent: "build",
+          model: { providerID: "test", modelID: "test" },
+        } as MessageV2.User)
+        await Session.updateMessage({
+          id: reply,
+          sessionID: root.id,
+          role: "assistant",
+          parentID: first,
+          time: { created: 2, completed: 2 },
+          providerID: "test",
+          modelID: "test",
+          mode: "build",
+          agent: "build",
+          path: { cwd: tmp.path, root: tmp.path },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          finish: "stop",
+        } as MessageV2.Assistant)
+        await Session.updateMessage({
+          id: latest,
+          sessionID: root.id,
+          role: "user",
+          time: { created: 3 },
+          agent: "build",
+          model: { providerID: "test", modelID: "test" },
+        } as MessageV2.User)
+
+        const child = await Session.fork({ sessionID: root.id, messageID: latest })
+        const msgs = await Session.messages({ sessionID: child.id })
+
+        expect(msgs).toHaveLength(2)
+        expect(msgs.map((msg) => msg.info.role)).toEqual(["user", "assistant"])
+        if (msgs[1]?.info.role === "assistant") expect(msgs[1].info.parentID).toBe(msgs[0]?.info.id)
+      },
+    })
+  })
+
   test("new root sessions get a treeID and forked children inherit it", async () => {
     await Instance.provide({
       directory: projectRoot,


### PR DESCRIPTION
### Issue for this PR

Closes #1133

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

修复消息 ID 时间戳回绕后，已有对话无法继续回复以及消息显示顺序异常的问题。

- 使用助手消息的 `parentID` 判断当前用户消息是否已完成回复，不再依赖消息 ID 的字典序。
- 前端统一按照消息创建时间排序，并使用数组位置处理撤销、恢复和时间线边界。
- 调整会话 fork 和 revert，使其按照实际消息顺序确定保留范围。
- 增加非单调消息 ID 的回复、排序、fork 和 revert 回归测试。

### How did you verify your code works?

- 在 `packages/app` 运行 `bun typecheck`，检查通过。
- 运行应用端 Bun 单元测试：436 项通过，0 项失败。
- 新增的会话回复、消息排序、fork 和 revert 回归场景均通过。
- 在 Aether 桌面开发环境中手动验证：已有对话能够继续发送消息并收到助手回复。

### Screenshots / recordings

不适用，本次修改没有视觉样式变更。

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR