### PR TITLE
fix(provider): 修复阿里 GLM-5.2 无正文输出

### DIFF
--- a/packages/opencode/src/provider/models-local.ts
+++ b/packages/opencode/src/provider/models-local.ts
@@ -35,103 +35,8 @@ export const additions = {
   "tatu-maas": MaaS.provider,
 } satisfies Record<string, ModelsDev.Provider>
 
-// Alibaba Bailian list price is CNY 8 / 2 (cache hit) / 28 per 1M tokens;
-// converted to USD at 1 USD ≈ 7.2 CNY to match models.dev's USD convention.
-const ALIBABA_COST = {
-  input: 1.11,
-  cache_read: 0.28,
-  output: 3.89,
-}
-
-function glm(api: string, reason: string, cost: Insert["cost"] = ALIBABA_COST) {
-  return {
-    id: "glm-5.2",
-    name: "GLM-5.2",
-    family: "glm",
-    attachment: false,
-    reasoning: true,
-    tool_call: true,
-    interleaved: {
-      field: "reasoning_content",
-    },
-    temperature: true,
-    release_date: "",
-    modalities: {
-      input: ["text"],
-      output: ["text"],
-    },
-    provider: {
-      npm: "@ai-sdk/openai-compatible",
-      api,
-    },
-    limit: {
-      context: 1_000_000,
-      input: 868_928,
-      output: 131_072,
-    },
-    options: {
-      maxOutputTokens: 65_536,
-    },
-    cost,
-    meta: {
-      reason,
-      verified_at: "2026-06-25",
-    },
-  } satisfies Insert
-}
-
 export const inserts = {
-  alibaba: {
-    "glm-5.2": glm(
-      "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-      "models.dev is missing Alibaba Bailian GLM-5.2 metadata; Alibaba documents OpenAI-compatible chat completions with 1M context",
-    ),
-  },
   "alibaba-cn": {
-    "glm-5.2": glm(
-      "https://dashscope.aliyuncs.com/compatible-mode/v1",
-      "models.dev is missing Alibaba Bailian GLM-5.2 metadata; Alibaba documents OpenAI-compatible chat completions with 1M context",
-    ),
-    "qwen3.8-max": {
-      id: "qwen3.8-max",
-      name: "Qwen3.8 Max",
-      family: "qwen",
-      attachment: true,
-      reasoning: true,
-      tool_call: true,
-      structured_output: true,
-      interleaved: {
-        field: "reasoning_content",
-      },
-      temperature: true,
-      release_date: "",
-      modalities: {
-        input: ["text", "image", "video"],
-        output: ["text"],
-      },
-      provider: {
-        npm: "@ai-sdk/openai-compatible",
-        api: "https://dashscope.aliyuncs.com/compatible-mode/v1",
-      },
-      limit: {
-        context: 1_000_000,
-        input: 991_000,
-        output: 131_072,
-      },
-      options: {},
-      // Alibaba Bailian list price is CNY 12 / 1.2 (cache hit) / 36 per 1M tokens;
-      // converted to USD at 1 USD ≈ 7.2 CNY to match models.dev's USD convention.
-      cost: {
-        input: 1.67,
-        cache_read: 0.17,
-        output: 5.0,
-      },
-      meta: {
-        reason:
-          "models.dev is missing Alibaba Bailian qwen3.8-max metadata; Alibaba documents OpenAI-compatible hybrid reasoning with 1M context and image/video input",
-        verified_at: "2026-08-05",
-      },
-    },
     "deepseek-v4-flash-0731": {
       id: "deepseek-v4-flash-0731",
       name: "DeepSeek V4 Flash 0731",
@@ -172,44 +77,9 @@ export const inserts = {
       },
     },
   },
-  aihubmix: {
-    "glm-5.2": glm(
-      "https://aihubmix.com/v1",
-      "models.dev is missing aihubmix GLM-5.2 metadata; aihubmix exposes it through OpenAI-compatible chat completions",
-      // aihubmix list price: USD 1.13 input / 3.94 output per 1M tokens
-      {
-        input: 1.13,
-        output: 3.94,
-      },
-    ),
-  },
 } satisfies Inserts
 
 export const overrides = {
-  opencode: {
-    models: {
-      "gpt-5.5": {
-        provider: {
-          npm: "@ai-sdk/openai",
-          api: "https://opencode.ai/zen/v1",
-        },
-        meta: {
-          reason: "Pin Responses API routing for opencode gpt-5.5 while stale models.dev caches age out",
-          verified_at: "2026-06-06",
-        },
-      },
-      "gpt-5.5-pro": {
-        provider: {
-          npm: "@ai-sdk/openai",
-          api: "https://opencode.ai/zen/v1",
-        },
-        meta: {
-          reason: "Pin Responses API routing for opencode gpt-5.5-pro while stale models.dev caches age out",
-          verified_at: "2026-06-06",
-        },
-      },
-    },
-  },
   aihubmix: {
     models: {
       "gpt-5.5": {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -565,6 +565,11 @@ export namespace ProviderTransform {
     return major > 4 || (major === 4 && minor >= 7)
   }
 
+  export function glm52(model: Provider.Model) {
+    const api = `${model.id} ${model.api.id}`.toLowerCase()
+    return ["glm-5.2", "glm-5-2", "glm-5p2"].some((id) => api.includes(id))
+  }
+
   export function variants(model: Provider.Model): Record<string, Record<string, any>> {
     if (!model.capabilities.reasoning) return {}
 
@@ -575,6 +580,45 @@ export namespace ProviderTransform {
       opus ||
       ["opus-4-6", "opus-4.6", "4-6-opus", "4.6-opus", "sonnet-4-6", "sonnet-4.6"].some((v) => api.includes(v))
     const adaptiveEfforts = opus ? ["low", "medium", "high", "xhigh", "max"] : ["low", "medium", "high", "max"]
+    if (
+      glm52(model) &&
+      ["alibaba", "alibaba-cn"].includes(model.providerID) &&
+      model.api.npm === "@ai-sdk/openai-compatible"
+    ) {
+      return Object.fromEntries(
+        ["none", "minimal", "low", "medium", "high", "xhigh", "max"].map((effort) => [
+          effort,
+          effort === "none"
+            ? {
+                enable_thinking: false,
+                thinking_budget: undefined,
+                reasoningEffort: undefined,
+                reasoning_effort: undefined,
+              }
+            : { enable_thinking: true, reasoningEffort: effort },
+        ]),
+      )
+    }
+    if (glm52(model)) {
+      if (model.api.npm === "@openrouter/ai-sdk-provider") {
+        return {
+          high: { reasoning: { effort: "high" } },
+          xhigh: { reasoning: { effort: "xhigh" } },
+        }
+      }
+      if (model.api.npm === "@ai-sdk/openai-compatible") {
+        return {
+          high: { reasoningEffort: "high" },
+          max: { reasoningEffort: "max" },
+        }
+      }
+      if (model.api.npm === "@ai-sdk/anthropic") {
+        return {
+          high: { effort: "high" },
+          max: { effort: "max" },
+        }
+      }
+    }
     if (
       /(^|\/)deepseek-v4-(pro|flash)$/.test(model.api.id.toLowerCase()) &&
       ["deepseek", "vercel", "openrouter"].includes(model.providerID)
@@ -593,7 +637,7 @@ export namespace ProviderTransform {
     if (
       id.includes("deepseek") ||
       id.includes("minimax") ||
-      id.includes("glm") ||
+      (api.includes("glm") && !glm52(model)) ||
       id.includes("mistral") ||
       id.includes("kimi") ||
       // TODO: Remove this after models.dev data is fixed to use "kimi-k2.5" instead of "k2p5"
@@ -1037,6 +1081,15 @@ export namespace ProviderTransform {
 
     // Enable thinking by default for kimi-k2.5/k2p5 models using anthropic SDK
     const modelId = input.model.api.id.toLowerCase()
+    if (
+      glm52(input.model) &&
+      ["alibaba", "alibaba-cn"].includes(input.model.providerID) &&
+      input.model.api.npm === "@ai-sdk/openai-compatible"
+    ) {
+      result["enable_thinking"] = true
+      result["thinking_budget"] = 32_000
+      if (input.model.providerID === "alibaba-cn") result["clear_thinking"] = true
+    }
     if (
       (input.model.api.npm === "@ai-sdk/anthropic" || input.model.api.npm === "@ai-sdk/google-vertex/anthropic") &&
       (modelId.includes("k2p5") || modelId.includes("kimi-k2.5") || modelId.includes("kimi-k2p5"))

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -79,6 +79,7 @@ export namespace LLM {
     retries?: number
     toolChoice?: "auto" | "required" | "none"
     purpose?: "chat" | "title" | "compaction"
+    override?: Record<string, unknown>
   }
 
   export type StreamOutput = StreamTextResult<ToolSet, unknown>
@@ -184,6 +185,7 @@ export namespace LLM {
       mergeDeep(input.model.options),
       mergeDeep(input.agent.options),
       mergeDeep(variant),
+      mergeDeep(input.override ?? {}),
     )
     if (isOpenaiOauth) {
       options.instructions = system.join("\n")

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -9,6 +9,7 @@ import { SessionRetry } from "./retry"
 import { SessionStatus } from "./status"
 import { Plugin } from "@/plugin"
 import type { Provider } from "@/provider/provider"
+import { ProviderTransform } from "@/provider/transform"
 import { LLM } from "./llm"
 import { Config } from "@/config/config"
 import { SessionCompaction } from "./compaction"
@@ -63,11 +64,28 @@ export namespace SessionProcessor {
         needsCompaction = false
         idle = false
         const shouldBreak = (await Config.get()).experimental?.continue_loop_on_deny !== true
+        let recovered = false
         while (true) {
           try {
             let currentText: MessageV2.TextPart | undefined
             let reasoningMap: Record<string, MessageV2.ReasoningPart> = {}
-            const stream = await LLM.stream(streamInput)
+            let reasoning = false
+            let text = false
+            let tools = false
+            let finish = ""
+            const request = recovered
+              ? {
+                  ...streamInput,
+                  override: {
+                    ...streamInput.override,
+                    enable_thinking: false,
+                    thinking_budget: undefined,
+                    reasoningEffort: undefined,
+                    reasoning_effort: undefined,
+                  },
+                }
+              : streamInput
+            const stream = await LLM.stream(request)
 
             // Runaway guard: the counter (set only for background reviews) owns
             // both the per-step count and the whole-review total. Reset the
@@ -107,6 +125,7 @@ export namespace SessionProcessor {
                   break
 
                 case "reasoning-delta":
+                  if (value.text.trim()) reasoning = true
                   if (value.id in reasoningMap) {
                     const part = reasoningMap[value.id]
                     part.text += value.text
@@ -138,6 +157,7 @@ export namespace SessionProcessor {
                   break
 
                 case "tool-input-start":
+                  tools = true
                   const part = await Session.updatePart({
                     id: toolcalls[value.id]?.id ?? PartID.ascending(),
                     messageID: input.assistantMessage.id,
@@ -161,6 +181,7 @@ export namespace SessionProcessor {
                   break
 
                 case "tool-call": {
+                  tools = true
                   const match = toolcalls[value.toolCallId]
                   if (match) {
                     const part = await Session.updatePart({
@@ -207,6 +228,7 @@ export namespace SessionProcessor {
                   break
                 }
                 case "tool-result": {
+                  tools = true
                   const match = toolcalls[value.toolCallId]
                   if (match && match.state.status === "running") {
                     await Session.updatePart({
@@ -231,6 +253,7 @@ export namespace SessionProcessor {
                 }
 
                 case "tool-error": {
+                  tools = true
                   const match = toolcalls[value.toolCallId]
                   if (match && match.state.status === "running") {
                     await Session.updatePart({
@@ -271,6 +294,7 @@ export namespace SessionProcessor {
                   break
 
                 case "finish-step":
+                  finish = value.finishReason
                   const usage = Session.getUsage({
                     model: input.model,
                     usage: value.usage,
@@ -359,6 +383,7 @@ export namespace SessionProcessor {
                       { text: currentText.text },
                     )
                     currentText.text = textOutput.text
+                    if (currentText.text.trim()) text = true
                     currentText.time = {
                       start: Date.now(),
                       end: Date.now(),
@@ -392,6 +417,32 @@ export namespace SessionProcessor {
                 reviewStopped = true
                 break
               }
+            }
+            const retry =
+              !recovered &&
+              ["alibaba", "alibaba-cn"].includes(input.model.providerID) &&
+              input.model.api.npm === "@ai-sdk/openai-compatible" &&
+              ProviderTransform.glm52(input.model) &&
+              ["stop", "length"].includes(finish) &&
+              reasoning &&
+              !text &&
+              !tools &&
+              !needsCompaction &&
+              !blocked &&
+              !reviewStopped
+            if (retry) {
+              recovered = true
+              log.warn("retrying GLM-5.2 without thinking after reasoning-only response", {
+                sessionID: input.sessionID,
+                finish,
+              })
+              continue
+            }
+            if (recovered && ["stop", "length"].includes(finish) && reasoning && !text && !tools) {
+              log.warn("GLM-5.2 recovery response still has no visible text", {
+                sessionID: input.sessionID,
+                finish,
+              })
             }
           } catch (e: any) {
             log.error("process", {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -111,25 +111,13 @@ test("models.dev local overlay overrides only selected model metadata", () => {
   expect("meta" in data.test.models.model).toBe(false)
 })
 
-test("models.dev local overlay inserts GLM-5.2 models", () => {
+test("models.dev local overlay inserts alibaba-cn deepseek-v4-flash-0731", () => {
   const data = apply(
     {
-      alibaba: {
-        ...provider,
-        id: "alibaba",
-        api: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-        models: {},
-      },
       "alibaba-cn": {
         ...provider,
         id: "alibaba-cn",
         api: "https://dashscope.aliyuncs.com/compatible-mode/v1",
-        models: {},
-      },
-      aihubmix: {
-        ...provider,
-        id: "aihubmix",
-        api: "https://aihubmix.com/v1",
         models: {},
       },
     },
@@ -139,87 +127,6 @@ test("models.dev local overlay inserts GLM-5.2 models", () => {
       strict: true,
     },
   )
-
-  const intl = data.alibaba.models["glm-5.2"]
-  const cn = data["alibaba-cn"].models["glm-5.2"]
-  const hub = data.aihubmix.models["glm-5.2"]
-
-  expect(intl.limit.context).toBe(1_000_000)
-  expect(intl.limit.input).toBe(868_928)
-  expect(intl.limit.output).toBe(131_072)
-  expect(intl.options?.maxOutputTokens).toBe(65_536)
-  expect(intl.provider?.npm).toBe("@ai-sdk/openai-compatible")
-  expect(intl.provider?.api).toBe("https://dashscope-intl.aliyuncs.com/compatible-mode/v1")
-  expect("meta" in intl).toBe(false)
-
-  expect(cn.limit.context).toBe(1_000_000)
-  expect(cn.limit.input).toBe(868_928)
-  expect(cn.limit.output).toBe(131_072)
-  expect(cn.options?.maxOutputTokens).toBe(65_536)
-  expect(cn.provider?.npm).toBe("@ai-sdk/openai-compatible")
-  expect(cn.provider?.api).toBe("https://dashscope.aliyuncs.com/compatible-mode/v1")
-  expect("meta" in cn).toBe(false)
-
-  expect(hub.limit.context).toBe(1_000_000)
-  expect(hub.limit.input).toBe(868_928)
-  expect(hub.limit.output).toBe(131_072)
-  expect(hub.options?.maxOutputTokens).toBe(65_536)
-  expect(hub.provider?.npm).toBe("@ai-sdk/openai-compatible")
-  expect(hub.provider?.api).toBe("https://aihubmix.com/v1")
-  expect("meta" in hub).toBe(false)
-
-  const info = Provider.fromModelsDevProvider(data["alibaba-cn"])
-  expect(info.models["glm-5.2"].api.npm).toBe("@ai-sdk/openai-compatible")
-  expect(info.models["glm-5.2"].api.url).toBe("https://dashscope.aliyuncs.com/compatible-mode/v1")
-  expect(info.models["glm-5.2"].capabilities.interleaved).toEqual({ field: "reasoning_content" })
-
-  const mix = Provider.fromModelsDevProvider(data.aihubmix)
-  expect(mix.models["glm-5.2"].api.npm).toBe("@ai-sdk/openai-compatible")
-  expect(mix.models["glm-5.2"].api.url).toBe("https://aihubmix.com/v1")
-})
-
-test("models.dev local overlay inserts alibaba-cn qwen3.8-max and deepseek-v4-flash-0731", () => {
-  const data = apply(
-    {
-      alibaba: {
-        ...provider,
-        id: "alibaba",
-        api: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-        models: {},
-      },
-      "alibaba-cn": {
-        ...provider,
-        id: "alibaba-cn",
-        api: "https://dashscope.aliyuncs.com/compatible-mode/v1",
-        models: {},
-      },
-      aihubmix: {
-        ...provider,
-        id: "aihubmix",
-        api: "https://aihubmix.com/v1",
-        models: {},
-      },
-    },
-    {
-      additions: {},
-      overrides: {},
-      strict: true,
-    },
-  )
-
-  const qwen = data["alibaba-cn"].models["qwen3.8-max"]
-  expect(qwen.limit.context).toBe(1_000_000)
-  expect(qwen.limit.input).toBe(991_000)
-  expect(qwen.limit.output).toBe(131_072)
-  expect(qwen.attachment).toBe(true)
-  expect(qwen.reasoning).toBe(true)
-  expect(qwen.tool_call).toBe(true)
-  expect(qwen.modalities?.input).toEqual(["text", "image", "video"])
-  expect(qwen.cost?.input).toBe(1.67)
-  expect(qwen.cost?.output).toBe(5.0)
-  expect(qwen.provider?.npm).toBe("@ai-sdk/openai-compatible")
-  expect(qwen.provider?.api).toBe("https://dashscope.aliyuncs.com/compatible-mode/v1")
-  expect("meta" in qwen).toBe(false)
 
   const ds = data["alibaba-cn"].models["deepseek-v4-flash-0731"]
   expect(ds.limit.context).toBe(1_000_000)
@@ -234,8 +141,6 @@ test("models.dev local overlay inserts alibaba-cn qwen3.8-max and deepseek-v4-fl
   expect("meta" in ds).toBe(false)
 
   const info = Provider.fromModelsDevProvider(data["alibaba-cn"])
-  expect(info.models["qwen3.8-max"].capabilities.interleaved).toEqual({ field: "reasoning_content" })
-  expect(info.models["qwen3.8-max"].capabilities.input.image).toBe(true)
   expect(info.models["deepseek-v4-flash-0731"].capabilities.interleaved).toEqual({ field: "reasoning_content" })
   expect(info.models["deepseek-v4-flash-0731"].capabilities.toolcall).toBe(true)
 })

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -19,6 +19,34 @@ async function sample(pid: string, id: string) {
   return model
 }
 
+function glm(pid: string, npm = "@ai-sdk/openai-compatible", id = "glm-5.2"): Provider.Model {
+  return {
+    id: ModelID.make(id),
+    providerID: ProviderID.make(pid),
+    api: {
+      id,
+      url: "https://api.test.com/v1",
+      npm,
+    },
+    name: "GLM-5.2",
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: false,
+      toolcall: true,
+      input: { text: true, audio: false, image: false, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: { field: "reasoning_content" },
+    },
+    cost: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+    limit: { context: 1_000_000, output: 131_072 },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2026-06-25",
+  }
+}
+
 describe("ProviderTransform.options - setCacheKey", () => {
   const sessionID = "test-session-123"
 
@@ -180,6 +208,27 @@ describe("ProviderTransform.options - zai/zhipuai thinking", () => {
       })
     })
   }
+})
+
+describe("ProviderTransform.options - Alibaba GLM-5.2 thinking", () => {
+  test("sets a bounded thinking budget for Alibaba endpoints", () => {
+    const intl = ProviderTransform.options({ model: glm("alibaba"), sessionID: "test" })
+    const cn = ProviderTransform.options({ model: glm("alibaba-cn"), sessionID: "test" })
+
+    expect(intl.enable_thinking).toBe(true)
+    expect(intl.thinking_budget).toBe(32_000)
+    expect(intl.clear_thinking).toBeUndefined()
+    expect(cn.enable_thinking).toBe(true)
+    expect(cn.thinking_budget).toBe(32_000)
+    expect(cn.clear_thinking).toBe(true)
+  })
+
+  test("does not add the budget to other GLM models or providers", () => {
+    expect(
+      ProviderTransform.options({ model: glm("alibaba-cn", undefined, "glm-5.1"), sessionID: "test" }).thinking_budget,
+    ).toBeUndefined()
+    expect(ProviderTransform.options({ model: glm("aihubmix"), sessionID: "test" }).thinking_budget).toBeUndefined()
+  })
 })
 
 describe("ProviderTransform.options - google thinkingConfig gating", () => {
@@ -2516,6 +2565,36 @@ describe("ProviderTransform.variants", () => {
     })
     const result = ProviderTransform.variants(model)
     expect(result).toEqual({})
+  })
+
+  test("Alibaba GLM-5.2 exposes every documented reasoning effort", () => {
+    for (const pid of ["alibaba", "alibaba-cn"]) {
+      const result = ProviderTransform.variants(glm(pid))
+      expect(Object.keys(result)).toEqual(["none", "minimal", "low", "medium", "high", "xhigh", "max"])
+      expect(result.none).toEqual({
+        enable_thinking: false,
+        thinking_budget: undefined,
+        reasoningEffort: undefined,
+        reasoning_effort: undefined,
+      })
+      expect(result.minimal).toEqual({ enable_thinking: true, reasoningEffort: "minimal" })
+      expect(result.max).toEqual({ enable_thinking: true, reasoningEffort: "max" })
+    }
+  })
+
+  test("GLM-5.2 uses provider-specific upstream variants", () => {
+    expect(ProviderTransform.variants(glm("openrouter", "@openrouter/ai-sdk-provider"))).toEqual({
+      high: { reasoning: { effort: "high" } },
+      xhigh: { reasoning: { effort: "xhigh" } },
+    })
+    expect(ProviderTransform.variants(glm("aihubmix"))).toEqual({
+      high: { reasoningEffort: "high" },
+      max: { reasoningEffort: "max" },
+    })
+    expect(ProviderTransform.variants(glm("anthropic", "@ai-sdk/anthropic", "vendor/glm-5p2"))).toEqual({
+      high: { effort: "high" },
+      max: { effort: "max" },
+    })
   })
 
     test("mistral returns empty object", () => {

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -570,7 +570,7 @@ describe("session.llm.stream", () => {
     })
   })
 
-  test("uses model maxOutputTokens option as request cap", async () => {
+  test("sends bounded thinking controls for Alibaba GLM-5.2", async () => {
     const server = state.server
     if (!server) {
       throw new Error("Server not initialized")
@@ -596,6 +596,19 @@ describe("session.llm.stream", () => {
             enabled_providers: [providerID],
             provider: {
               [providerID]: {
+                models: {
+                  [modelID]: {
+                    name: "GLM-5.2",
+                    reasoning: true,
+                    tool_call: true,
+                    interleaved: { field: "reasoning_content" },
+                    limit: { context: 1_000_000, output: 131_072 },
+                    modalities: { input: ["text"], output: ["text"] },
+                    provider: {
+                      npm: "@ai-sdk/openai-compatible",
+                    },
+                  },
+                },
                 options: {
                   apiKey: "test-key",
                   baseURL: `${server.url.origin}/v1`,
@@ -642,8 +655,11 @@ describe("session.llm.stream", () => {
         }
 
         const capture = await request
-        expect(capture.body.max_tokens).toBe(65_536)
+        expect(capture.body.max_tokens).toBe(32_000)
         expect(capture.body.maxOutputTokens).toBeUndefined()
+        expect(capture.body.enable_thinking).toBe(true)
+        expect(capture.body.thinking_budget).toBe(32_000)
+        expect(capture.body.clear_thinking).toBe(true)
       },
     })
   })

--- a/packages/opencode/test/session/processor.test.ts
+++ b/packages/opencode/test/session/processor.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import path from "path"
+import { Instance } from "../../src/project/instance"
+import { Memory } from "../../src/memory"
+import { ProviderID, ModelID } from "../../src/provider/schema"
+import { Session } from "../../src/session"
+import { MessageV2 } from "../../src/session/message-v2"
+import { SessionPrompt } from "../../src/session/prompt"
+import { tmpdir } from "../fixture/fixture"
+import { serve } from "../lib/server"
+
+type Item = {
+  reasoning?: string
+  text?: string
+  finish?: "stop" | "length"
+  tool?: {
+    name: string
+    input: Record<string, unknown>
+  }
+}
+
+type Hit = {
+  body: Record<string, unknown>
+}
+
+const pid = ProviderID.make("alibaba-cn")
+const mid = ModelID.make("glm-5.2")
+const model = { providerID: pid, modelID: mid }
+const servers: Array<ReturnType<typeof Bun.serve>> = []
+
+afterEach(async () => {
+  await Memory.stop()
+  await Promise.all(servers.splice(0).map((server) => server.stop(true)))
+})
+
+function line(input: unknown) {
+  if (input === "done") return "data: [DONE]\n\n"
+  return `data: ${JSON.stringify(input)}\n\n`
+}
+
+function chunk(delta: Record<string, unknown>, finish?: Item["finish"]) {
+  return {
+    id: "chatcmpl-glm-52",
+    object: "chat.completion.chunk",
+    choices: [
+      {
+        delta,
+        ...(finish ? { finish_reason: finish } : {}),
+      },
+    ],
+    ...(finish
+      ? {
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 5,
+            total_tokens: 15,
+            completion_tokens_details: { reasoning_tokens: 4 },
+          },
+        }
+      : {}),
+  }
+}
+
+function stream(item: Item) {
+  const body = [
+    line(chunk({ role: "assistant" })),
+    ...(item.reasoning ? [line(chunk({ reasoning_content: item.reasoning }))] : []),
+    ...(item.text ? [line(chunk({ content: item.text }))] : []),
+    ...(item.tool
+      ? [
+          line(
+            chunk({
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_glm_52",
+                  type: "function",
+                  function: { name: item.tool.name, arguments: JSON.stringify(item.tool.input) },
+                },
+              ],
+            }),
+          ),
+        ]
+      : []),
+    line(chunk({}, item.finish ?? "stop")),
+    line("done"),
+  ].join("")
+  return new Response(body, {
+    headers: { "Content-Type": "text/event-stream" },
+  })
+}
+
+async function setup(items: Item[]) {
+  const hits: Hit[] = []
+  const queue = [...items]
+  const server = await serve({
+    port: 0,
+    async fetch(req) {
+      const body = (await req.json()) as Record<string, unknown>
+      hits.push({ body })
+      const item = queue.shift()
+      if (!item) return new Response(JSON.stringify({ error: "unexpected request" }), { status: 500 })
+      return stream(item)
+    },
+  })
+  servers.push(server)
+  return {
+    hits,
+    tmp: await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [pid],
+            provider: {
+              [pid]: {
+                npm: "@ai-sdk/openai-compatible",
+                models: {
+                  [mid]: {
+                    name: "GLM-5.2",
+                    reasoning: true,
+                    tool_call: true,
+                    temperature: true,
+                    interleaved: { field: "reasoning_content" },
+                    limit: { context: 1_000_000, output: 131_072 },
+                    modalities: { input: ["text"], output: ["text"] },
+                  },
+                },
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    }),
+  }
+}
+
+async function prompt(dir: string) {
+  return Instance.provide({
+    directory: dir,
+    fn: async () => {
+      const session = await Session.create({ title: "GLM recovery" })
+      const result = await SessionPrompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        model,
+        parts: [{ type: "text", text: "Answer briefly." }],
+      })
+      await Instance.dispose()
+      return result
+    },
+  })
+}
+
+function parts(msg: MessageV2.WithParts, type: "text" | "reasoning") {
+  return msg.parts.flatMap((part) => (part.type === type ? [part.text] : []))
+}
+
+describe("session processor GLM-5.2 recovery", () => {
+  test("retries a reasoning-only response once with thinking disabled", async () => {
+    const srv = await setup([{ reasoning: "internal work", finish: "length" }, { text: "final answer" }])
+    await using tmp = srv.tmp
+    const result = await prompt(tmp.path)
+
+    expect(srv.hits).toHaveLength(2)
+    expect(srv.hits[0].body.enable_thinking).toBe(true)
+    expect(srv.hits[0].body.thinking_budget).toBe(32_000)
+    expect(srv.hits[1].body.enable_thinking).toBe(false)
+    expect(srv.hits[1].body.thinking_budget).toBeUndefined()
+    expect(srv.hits[1].body.reasoning_effort).toBeUndefined()
+    expect(parts(result, "reasoning")).toContain("internal work")
+    expect(parts(result, "text")).toContain("final answer")
+  })
+
+  test("does not retry a normal text response", async () => {
+    const srv = await setup([{ reasoning: "short thought", text: "visible answer" }])
+    await using tmp = srv.tmp
+    const result = await prompt(tmp.path)
+
+    expect(srv.hits).toHaveLength(1)
+    expect(parts(result, "text")).toContain("visible answer")
+  })
+
+  test("does not treat a tool step as a reasoning-only failure", async () => {
+    const srv = await setup([
+      { reasoning: "need the file", tool: { name: "read", input: { filePath: "opencode.json" } } },
+      { text: "tool finished" },
+    ])
+    await using tmp = srv.tmp
+    const result = await prompt(tmp.path)
+
+    expect(srv.hits).toHaveLength(2)
+    expect(srv.hits[1].body.enable_thinking).toBe(true)
+    expect(srv.hits[1].body.thinking_budget).toBe(32_000)
+    expect(parts(result, "text")).toContain("tool finished")
+  })
+
+  test("stops after one recovery attempt when visible text is still missing", async () => {
+    const srv = await setup([{ reasoning: "first thought" }, { reasoning: "second thought" }])
+    await using tmp = srv.tmp
+    const result = await prompt(tmp.path)
+
+    expect(srv.hits).toHaveLength(2)
+    expect(parts(result, "reasoning")).toEqual(["first thought", "second thought"])
+    expect(parts(result, "text")).toEqual([])
+  })
+})

--- a/packages/opencode/test/system/llm/providers.example.yaml
+++ b/packages/opencode/test/system/llm/providers.example.yaml
@@ -31,6 +31,13 @@ providers:
           temperature: true
           tool: true
           interleaved: reasoning_content
+      - id: glm-5.2
+        cases: [p0-basic, p1-reasoning]
+        capabilities:
+          reasoning: true
+          temperature: true
+          tool: true
+          interleaved: reasoning_content
 
   - id: deepseek
     name: DeepSeek Official


### PR DESCRIPTION
### Issue for this PR

Closes #1137

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

修复阿里云 DashScope GLM-5.2 在部分请求中只输出思维链、没有最终回答正文的问题。

- 为阿里国际站和中国站的 GLM-5.2 设置默认 32,000 token 思考预算，避免推理耗尽回答额度。
- 补充 `none`、`minimal`、`low`、`medium`、`high`、`xhigh`、`max` 思考强度档位。
- 当响应包含推理但没有正文，并以 `stop` 或 `length` 结束时，关闭思考自动重试一次。
- 恢复逻辑不会在正常正文或工具调用步骤触发，也不会无限重试。
- 移除已由 models.dev 提供的 GLM-5.2、Qwen3.8 Max 和 OpenCode GPT-5.5 本地冗余配置。
- 增加 GLM-5.2 请求参数、恢复行为和系统 smoke 配置测试。

### How did you verify your code works?

运行：

`bun test --timeout 30000 test/provider/provider.test.ts test/provider/transform.test.ts test/session/llm.test.ts test/session/processor.test.ts`

结果：363 项测试通过，0 项失败。

同时执行了 `bun typecheck`。类型检查仍被仓库现有的 `.worktrees/mineru-skill` 插件重复类型冲突阻塞；本次修改没有新增类型错误。

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR