### PR TITLE
feat(provider): 阿里百炼 deepseek-v4 带日期后缀思考档位修复 + 新增 kimi-k3 模型支持

### DIFF
--- a/packages/opencode/src/provider/models-local.ts
+++ b/packages/opencode/src/provider/models-local.ts
@@ -76,6 +76,45 @@ export const inserts = {
         verified_at: "2026-08-05",
       },
     },
+    "kimi-k3": {
+      id: "kimi-k3",
+      name: "Kimi K3",
+      family: "kimi",
+      attachment: true,
+      reasoning: true,
+      tool_call: true,
+      structured_output: true,
+      interleaved: {
+        field: "reasoning_content",
+      },
+      temperature: false,
+      release_date: "2026-07-27",
+      modalities: {
+        input: ["text", "image"],
+        output: ["text"],
+      },
+      provider: {
+        npm: "@ai-sdk/openai-compatible",
+        api: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      },
+      limit: {
+        context: 1_048_576,
+        output: 131_072,
+      },
+      options: {},
+      // Alibaba Bailian list price is CNY 20 / 2 (cache hit) / 100 per 1M tokens;
+      // converted to USD at 1 USD ≈ 7.2 CNY to match models.dev's USD convention.
+      cost: {
+        input: 2.78,
+        cache_read: 0.28,
+        output: 13.89,
+      },
+      meta: {
+        reason:
+          "models.dev is missing Alibaba Bailian kimi-k3 metadata; Kimi K3 always thinks with configurable reasoning_effort (low/high/max), streams reasoning_content by default, supports vision input, 1M context and 131,072 default output budget",
+        verified_at: "2026-08-25",
+      },
+    },
     "deepseek-v4-pro-0813": {
       id: "deepseek-v4-pro-0813",
       name: "DeepSeek V4 Pro 0813",

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -577,8 +577,7 @@ export namespace ProviderTransform {
     const api = `${id} ${model.api.id.toLowerCase()}`
     const opus = opus47(api)
     const isAnthropicAdaptive =
-      opus ||
-      ["opus-4-6", "opus-4.6", "4-6-opus", "4.6-opus", "sonnet-4-6", "sonnet-4.6"].some((v) => api.includes(v))
+      opus || ["opus-4-6", "opus-4.6", "4-6-opus", "4.6-opus", "sonnet-4-6", "sonnet-4.6"].some((v) => api.includes(v))
     const adaptiveEfforts = opus ? ["low", "medium", "high", "xhigh", "max"] : ["low", "medium", "high", "max"]
     if (
       glm52(model) &&
@@ -638,6 +637,14 @@ export namespace ProviderTransform {
       return {
         high: { thinking: { type: "enabled" }, reasoningEffort: "high" },
         max: { thinking: { type: "enabled" }, reasoningEffort: "max" },
+      }
+    }
+    if (id.includes("kimi-k3") && model.providerID === "alibaba-cn" && model.api.npm === "@ai-sdk/openai-compatible") {
+      // Kimi K3 always thinks and accepts top-level reasoning_effort: low / high / max (default max)
+      return {
+        low: { reasoningEffort: "low" },
+        high: { reasoningEffort: "high" },
+        max: { reasoningEffort: "max" },
       }
     }
     if (
@@ -1042,7 +1049,10 @@ export namespace ProviderTransform {
       result["promptCacheKey"] = input.messageCount ? `${input.sessionID}:${input.messageCount}` : input.sessionID
     }
 
-    if (input.model.api.npm === "@openrouter/ai-sdk-provider" || input.model.api.npm === "@llmgateway/ai-sdk-provider") {
+    if (
+      input.model.api.npm === "@openrouter/ai-sdk-provider" ||
+      input.model.api.npm === "@llmgateway/ai-sdk-provider"
+    ) {
       result["usage"] = {
         include: true,
       }
@@ -1109,12 +1119,13 @@ export namespace ProviderTransform {
     // Enable thinking for reasoning models on providers using DashScope-style OpenAI-compatible APIs.
     // These APIs require `enable_thinking: true` in the request body to return reasoning_content.
     // Without it, models never output thinking/reasoning tokens.
-    // Note: kimi-k2-thinking is excluded as it returns reasoning_content by default.
+    // Note: kimi-k2-thinking and kimi-k3 are excluded as they return reasoning_content by default.
     if (
       ["alibaba-cn", "siliconflow-cn"].includes(input.model.providerID) &&
       input.model.capabilities.reasoning &&
       input.model.api.npm === "@ai-sdk/openai-compatible" &&
-      !modelId.includes("kimi-k2-thinking")
+      !modelId.includes("kimi-k2-thinking") &&
+      !modelId.includes("kimi-k3")
     ) {
       result["enable_thinking"] = true
     }
@@ -1128,10 +1139,7 @@ export namespace ProviderTransform {
       if (!input.model.api.id.includes("gpt-5-pro") && !input.model.api.id.includes("gpt-5.4")) {
         result["reasoningEffort"] = "medium"
         result["reasoningSummary"] = "auto"
-        if (
-          input.model.api.npm === "@ai-sdk/openai" ||
-          input.model.api.npm === "@ai-sdk/amazon-bedrock/mantle"
-        ) {
+        if (input.model.api.npm === "@ai-sdk/openai" || input.model.api.npm === "@ai-sdk/amazon-bedrock/mantle") {
           result["include"] = ["reasoning.encrypted_content"]
         }
       }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -620,7 +620,7 @@ export namespace ProviderTransform {
       }
     }
     if (
-      /(^|\/)deepseek-v4-(pro|flash)$/.test(model.api.id.toLowerCase()) &&
+      /(^|\/)deepseek-v4-(pro|flash)(-\d+)?$/.test(model.api.id.toLowerCase()) &&
       ["deepseek", "vercel", "openrouter", "alibaba-cn"].includes(model.providerID)
     ) {
       if (model.providerID === "openrouter") {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -111,7 +111,7 @@ test("models.dev local overlay overrides only selected model metadata", () => {
   expect("meta" in data.test.models.model).toBe(false)
 })
 
-test("models.dev local overlay inserts alibaba-cn deepseek-v4-flash-0731 and deepseek-v4-pro-0813", () => {
+test("models.dev local overlay inserts alibaba-cn deepseek-v4-flash-0731, deepseek-v4-pro-0813 and kimi-k3", () => {
   const data = apply(
     {
       "alibaba-cn": {
@@ -153,11 +153,28 @@ test("models.dev local overlay inserts alibaba-cn deepseek-v4-flash-0731 and dee
   expect(pro.provider?.api).toBe("https://dashscope.aliyuncs.com/compatible-mode/v1")
   expect("meta" in pro).toBe(false)
 
+  const k3 = data["alibaba-cn"].models["kimi-k3"]
+  expect(k3.limit.context).toBe(1_048_576)
+  expect(k3.limit.output).toBe(131_072)
+  expect(k3.attachment).toBe(true)
+  expect(k3.reasoning).toBe(true)
+  expect(k3.tool_call).toBe(true)
+  expect(k3.temperature).toBe(false)
+  expect(k3.modalities?.input).toEqual(["text", "image"])
+  expect(k3.cost?.input).toBe(2.78)
+  expect(k3.cost?.cache_read).toBe(0.28)
+  expect(k3.cost?.output).toBe(13.89)
+  expect(k3.provider?.api).toBe("https://dashscope.aliyuncs.com/compatible-mode/v1")
+  expect("meta" in k3).toBe(false)
+
   const info = Provider.fromModelsDevProvider(data["alibaba-cn"])
   expect(info.models["deepseek-v4-flash-0731"].capabilities.interleaved).toEqual({ field: "reasoning_content" })
   expect(info.models["deepseek-v4-flash-0731"].capabilities.toolcall).toBe(true)
   expect(info.models["deepseek-v4-pro-0813"].capabilities.interleaved).toEqual({ field: "reasoning_content" })
   expect(info.models["deepseek-v4-pro-0813"].capabilities.toolcall).toBe(true)
+  expect(info.models["kimi-k3"].capabilities.interleaved).toEqual({ field: "reasoning_content" })
+  expect(info.models["kimi-k3"].capabilities.toolcall).toBe(true)
+  expect(info.models["kimi-k3"].capabilities.input.image).toBe(true)
 })
 
 test("models.dev local overlay rejects duplicate model insertions", () => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1254,24 +1254,21 @@ describe("ProviderTransform.schema - moonshot $ref siblings", () => {
   } as any
 
   test("removes sibling descriptions from referenced schemas", () => {
-    const result = ProviderTransform.schema(
-      moonshotModel,
-      {
-        type: "object",
-        properties: {
-          value: {
-            $ref: "#/$defs/Value",
-            description: "Moonshot rejects sibling keywords after ref expansion.",
-          },
+    const result = ProviderTransform.schema(moonshotModel, {
+      type: "object",
+      properties: {
+        value: {
+          $ref: "#/$defs/Value",
+          description: "Moonshot rejects sibling keywords after ref expansion.",
         },
-        $defs: {
-          Value: {
-            description: "Referenced schema description stays here.",
-            type: "object",
-          },
+      },
+      $defs: {
+        Value: {
+          description: "Referenced schema description stays here.",
+          type: "object",
         },
-      } as any,
-    ) as any
+      },
+    } as any) as any
 
     expect(result.properties.value).toEqual({
       $ref: "#/$defs/Value",
@@ -2597,11 +2594,11 @@ describe("ProviderTransform.variants", () => {
     })
   })
 
-    test("mistral returns empty object", () => {
-      const model = createMockModel({
-        id: "mistral/mistral-large",
-        providerID: "mistral",
-        api: {
+  test("mistral returns empty object", () => {
+    const model = createMockModel({
+      id: "mistral/mistral-large",
+      providerID: "mistral",
+      api: {
         id: "mistral-large-latest",
         url: "https://api.mistral.com",
         npm: "@ai-sdk/mistral",
@@ -3279,6 +3276,45 @@ describe("ProviderTransform.variants", () => {
       }
     })
 
+    test("alibaba cn kimi-k3 returns reasoning variants and skips enable_thinking", () => {
+      const model = createMockModel({
+        id: "alibaba-cn/kimi-k3",
+        providerID: "alibaba-cn",
+        api: {
+          id: "kimi-k3",
+          url: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+          npm: "@ai-sdk/openai-compatible",
+        },
+      })
+      const want = {
+        low: { reasoningEffort: "low" },
+        high: { reasoningEffort: "high" },
+        max: { reasoningEffort: "max" },
+      }
+      expect(ProviderTransform.variants(model)).toEqual(want)
+
+      const base = ProviderTransform.options({ model, sessionID: "test", providerOptions: {} })
+      expect(base.enable_thinking).toBeUndefined()
+      expect(ProviderTransform.providerOptions(model, { ...base, ...want.max })).toEqual({
+        "alibaba-cn": {
+          reasoningEffort: "max",
+        },
+      })
+    })
+
+    test("kimi-k3 outside alibaba-cn returns no variants", () => {
+      const model = createMockModel({
+        id: "moonshotai/kimi-k3",
+        providerID: "moonshotai",
+        api: {
+          id: "kimi-k3",
+          url: "https://api.moonshot.cn/v1",
+          npm: "@ai-sdk/openai-compatible",
+        },
+      })
+      expect(ProviderTransform.variants(model)).toEqual({})
+    })
+
     test("fixture chutes non-reasoning model has no variants", async () => {
       const model = await sample("chutes", "XiaomiMiMo/MiMo-V2-Flash-TEE")
       expect(model.api.npm).toBe("@ai-sdk/openai-compatible")
@@ -3346,7 +3382,9 @@ describe("ProviderTransform.variants", () => {
     test("cloudflare ai gateway migrated models use gateway package override", async () => {
       const model = await sample("cloudflare-ai-gateway", "anthropic/claude-opus-4-7")
       expect(model.api.npm).toBe("ai-gateway-provider")
-      expect(model.api.url).toBe("https://gateway.ai.cloudflare.com/v1/${CLOUDFLARE_ACCOUNT_ID}/${CLOUDFLARE_GATEWAY_ID}/compat/")
+      expect(model.api.url).toBe(
+        "https://gateway.ai.cloudflare.com/v1/${CLOUDFLARE_ACCOUNT_ID}/${CLOUDFLARE_GATEWAY_ID}/compat/",
+      )
       expect(ProviderTransform.variants(model)).toEqual({
         low: { reasoningEffort: "low" },
         medium: { reasoningEffort: "medium" },

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3260,6 +3260,25 @@ describe("ProviderTransform.variants", () => {
       })
     })
 
+    test("alibaba cn deepseek v4 dated variants return reasoning effort", () => {
+      const want = {
+        high: { reasoningEffort: "high" },
+        max: { reasoningEffort: "max" },
+      }
+      for (const id of ["deepseek-v4-flash-0731", "deepseek-v4-pro-0813"]) {
+        const model = createMockModel({
+          id,
+          providerID: "alibaba-cn",
+          api: {
+            id,
+            url: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            npm: "@ai-sdk/openai-compatible",
+          },
+        })
+        expect(ProviderTransform.variants(model)).toEqual(want)
+      }
+    })
+
     test("fixture chutes non-reasoning model has no variants", async () => {
       const model = await sample("chutes", "XiaomiMiMo/MiMo-V2-Flash-TEE")
       expect(model.api.npm).toBe("@ai-sdk/openai-compatible")


### PR DESCRIPTION
### Issue for this PR

Closes #1141
Closes #1147

### Type of change

- [x] Bug fix
- [x] New feature

### What does this PR do?

本 PR 包含两个针对阿里百炼（`alibaba-cn`）provider 的适配改动：

**1. deepseek-v4 带日期后缀模型的思考强度档位修复（Closes #1141）**

阿里百炼上线的 `deepseek-v4-pro-0813` 与 `deepseek-v4-flash-0731` 模型 ID 带日期后缀，此前 `adc929efe` 添加的思考强度档位判断用正则 `deepseek-v4-(pro|flash)$` 无法匹配。将正则扩展为 `deepseek-v4-(pro|flash)(-\d+)?$`，使这两个新模型获得与无后缀版本一致的 `high`/`max` 思考强度档位（`reasoningEffort`），并补充对应单测。

**2. 新增 kimi-k3 模型支持（Closes #1147）**

- `models-local.ts`：按既有 deepseek-v4 insert 模式补充 `kimi-k3` 完整元数据（1M 上下文、131,072 输出、视觉输入、`reasoning_content` 交错思考、工具调用、结构化输出、固定 temperature、百炼定价折算 USD）
- `transform.ts`：
  - `variants()` 为 `alibaba-cn` + `@ai-sdk/openai-compatible` 的 kimi-k3 提供 `low` / `high` / `max` 三档 `reasoningEffort` 变体（SDK 序列化为顶层 `reasoning_effort`，与 K3 API 一致）
  - 将 kimi-k3 加入 `enable_thinking` 注入排除名单：K3 始终思考且默认返回 `reasoning_content`，与 kimi-k2-thinking 同理

### How did you verify your code works?

- `bun test test/provider/provider.test.ts test/provider/transform.test.ts`（348 个测试全部通过，含 kimi-k3 insert 断言与变体/排除用例）
- `bun typecheck` 通过

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR