### PR TITLE
fix(provider): 修复连接后提供商列表未即时更新

### DIFF
--- a/packages/app/e2e/ci-specs.txt
+++ b/packages/app/e2e/ci-specs.txt
@@ -19,6 +19,7 @@ e2e/prompt/prompt-slash-share.spec.ts
 e2e/prompt/prompt-slash-terminal.spec.ts
 e2e/session/session-child-navigation.spec.ts
 e2e/session/session-undo-redo.spec.ts
+e2e/settings/provider-connect.spec.ts
 e2e/settings/settings-models.spec.ts
 e2e/settings/settings.spec.ts
 e2e/sidebar/sidebar.spec.ts

--- a/packages/app/e2e/settings/provider-connect.spec.ts
+++ b/packages/app/e2e/settings/provider-connect.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "../fixtures"
+import { clickListItem, closeDialog, openSettings } from "../actions"
+
+test("connecting a provider updates the active project immediately", async ({ page, sdk, gotoSession }) => {
+  await sdk.auth.remove({ providerID: "anthropic" }).catch(() => undefined)
+
+  try {
+    await gotoSession()
+
+    const settings = await openSettings(page)
+    await settings.getByRole("tab", { name: "Providers" }).click()
+
+    const connected = page.locator('[data-component="connected-providers-section"]')
+    await expect(connected.getByText("Anthropic", { exact: true })).toHaveCount(0)
+
+    await settings.getByRole("button", { name: "Show more providers" }).click()
+
+    const picker = page.getByRole("dialog").filter({ has: page.getByPlaceholder("Search providers") })
+    await clickListItem(picker, { key: "anthropic" })
+
+    const dialog = page.getByRole("dialog").filter({ has: page.getByLabel("Anthropic API key") })
+    await expect(dialog).toBeVisible()
+    await dialog.getByLabel("Anthropic API key").fill("e2e-anthropic-key")
+    await dialog.getByRole("button", { name: "Continue" }).click()
+    await expect(dialog).toHaveCount(0)
+
+    await expect(connected.getByText("Anthropic", { exact: true })).toHaveCount(1)
+
+    await closeDialog(page, picker)
+    await expect(connected.getByText("Anthropic", { exact: true })).toBeVisible()
+    await closeDialog(page, settings)
+  } finally {
+    await sdk.auth.remove({ providerID: "anthropic" }).catch(() => undefined)
+  }
+})

--- a/packages/app/script/e2e-local.ts
+++ b/packages/app/script/e2e-local.ts
@@ -72,6 +72,8 @@ const serverEnv = {
   OPENCODE_E2E_SESSION_TITLE: "E2E Session",
   OPENCODE_E2E_MESSAGE: "Seeded for UI e2e",
   OPENCODE_E2E_MODEL: process.env.OPENCODE_E2E_MODEL ?? "opencode/gpt-5-nano",
+  OPENCODE_MODELS_PATH: path.join(opencodeDir, "test", "tool", "fixtures", "models-api.json"),
+  ANTHROPIC_API_KEY: "",
   OPENCODE_CLIENT: "app",
   OPENCODE_STRICT_CONFIG_DEPS: "true",
 } satisfies Record<string, string>

--- a/packages/app/src/components/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog-connect-provider.tsx
@@ -322,8 +322,7 @@ export function DialogConnectProvider(props: { provider: string }) {
 
   async function complete() {
     try {
-      await globalSDK.client.global.dispose()
-      await globalSync.bootstrap()
+      await globalSync.provider.refresh()
     } catch (err) {
       console.error("Failed to refresh after provider connect", err)
     }

--- a/packages/app/src/components/settings-providers.tsx
+++ b/packages/app/src/components/settings-providers.tsx
@@ -136,8 +136,7 @@ export const SettingsProviders: Component = () => {
       .remove({ providerID })
       .then(async () => {
         try {
-          await globalSDK.client.global.dispose()
-          await globalSync.bootstrap()
+          await globalSync.provider.refresh()
         } catch (err) {
           console.error("Failed to refresh after provider disconnect", err)
         }

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -31,6 +31,7 @@ import { bootstrapDirectory, bootstrapGlobal } from "./global-sync/bootstrap"
 import { createChildStoreManager } from "./global-sync/child-store"
 import { applyDirectoryEvent, applyGlobalEvent, cleanupDroppedSessionCaches } from "./global-sync/event-reducer"
 import { createRefreshQueue } from "./global-sync/queue"
+import { createProviderRefresh } from "./global-sync/provider-refresh"
 import { clearSessionPrefetchDirectory } from "./global-sync/session-prefetch"
 import {
   estimateRootSessionTotal,
@@ -40,14 +41,7 @@ import {
 import { trimSessions } from "./global-sync/session-trim"
 import type { ProjectMeta } from "./global-sync/types"
 import { SESSION_RECENT_LIMIT } from "./global-sync/types"
-import {
-  isRoot,
-  normalizeAgentList,
-  normalizeDir,
-  normalizeProviderList,
-  sanitizeProject,
-  sanitizeRecent,
-} from "./global-sync/utils"
+import { isRoot, normalizeAgentList, normalizeDir, sanitizeProject, sanitizeRecent } from "./global-sync/utils"
 import { formatServerError } from "@/utils/server-errors"
 
 type GlobalStore = {
@@ -242,8 +236,37 @@ function createGlobalSync() {
     return sdk
   }
 
+  const root = {}
+  const providers = createProviderRefresh({
+    global: () => ({
+      key: "global",
+      identity: root,
+      current: () => (active ? root : undefined),
+      load: () => globalSDK.client.provider.list().then((x) => x.data),
+      apply: (data) => setGlobalStore("provider", reconcile(data)),
+    }),
+    child: (directory) => {
+      directory = normalizeDir(directory)
+      const child = children.getChild(directory)
+      if (!child) return
+      return {
+        key: `directory:${directory}`,
+        identity: child,
+        current: () => children.getChild(directory),
+        load: () =>
+          sdkFor(directory)
+            .provider.list()
+            .then((x) => x.data),
+        apply: (data) => child[1]("provider", reconcile(data)),
+      }
+    },
+    list: () => Object.keys(children.children),
+    error: (key, err) => {
+      console.error(`Failed to refresh providers for ${key}`, err)
+    },
+  })
+
   let recentTask: Promise<void> | undefined
-  let providerTask: Promise<void> | undefined
 
   function refreshRecent() {
     if (recentTask) return recentTask
@@ -266,29 +289,7 @@ function createGlobalSync() {
   }
 
   function refreshProviders() {
-    if (providerTask) return providerTask
-    providerTask = Promise.all([
-      globalSDK.client.provider.list().then((x) => {
-        if (x.data) setGlobalStore("provider", reconcile(x.data))
-      }),
-      ...Object.keys(children.children).map((directory) =>
-        sdkFor(directory)
-          .provider.list()
-          .then((x) => {
-            if (!x.data) return
-            const child = children.getChild(directory)
-            if (child) child[1]("provider", reconcile(x.data))
-          }),
-      ),
-    ])
-      .then(() => {})
-      .catch((err) => {
-        console.error("Failed to refresh providers", err)
-      })
-      .finally(() => {
-        providerTask = undefined
-      })
-    return providerTask
+    return providers.all()
   }
 
   async function loadSessions(directory: string, opts?: { force?: boolean }) {
@@ -387,7 +388,7 @@ function createGlobalSync() {
       retry(() => sdk.app.agents().then((x) => setStore("agent", normalizeAgentList(x.data)))),
       retry(() => sdk.command.list().then((x) => setStore("command", x.data ?? []))),
       retry(() => sdk.config.get().then((x) => setStore("config", x.data!))),
-      retry(() => sdk.provider.list().then((x) => setStore("provider", normalizeProviderList(x.data!)))),
+      retry(() => providers.child(directory)),
       retry(() => sdk.mcp.status().then((x) => setStore("mcp", x.data!))),
       retry(() => sdk.lsp.status().then((x) => setStore("lsp", x.data!))),
     ])
@@ -507,6 +508,7 @@ function createGlobalSync() {
     try {
       await bootstrapGlobal({
         globalSDK: globalSDK.client,
+        provider: providers.global,
         requestFailedTitle: language.t("common.requestFailed"),
         translate: language.t,
         formatMoreCount: (count) => language.t("common.moreCountSuffix", { count }),
@@ -595,11 +597,15 @@ function createGlobalSync() {
   }
 
   const updateConfig = async (config: Config) => {
+    const provider = ["provider", "provider_remove", "enabled_providers", "disabled_providers", "disabled_models"].some(
+      (key) => key in config,
+    )
     setGlobalStore("reload", "pending")
     return globalSDK.client.global.config
       .update({ config })
       .then(bootstrap)
-      .then(() => {
+      .then(async () => {
+        if (provider) await refreshProviders()
         queue.refresh()
         setGlobalStore("reload", undefined)
         queue.refresh()
@@ -623,6 +629,9 @@ function createGlobalSync() {
     peek: children.peek,
     bootstrap,
     updateConfig,
+    provider: {
+      refresh: refreshProviders,
+    },
     project: projectApi,
     todo: {
       set: setSessionTodo,

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -16,7 +16,7 @@ import { retry } from "@opencode-ai/util/retry"
 import { batch } from "solid-js"
 import { reconcile, type SetStoreFunction, type Store } from "solid-js/store"
 import type { State, VcsCache } from "./types"
-import { cmp, normalizeProviderList } from "./utils"
+import { cmp } from "./utils"
 import { formatServerError } from "@/utils/server-errors"
 
 type GlobalStore = {
@@ -76,6 +76,7 @@ function showErrors(input: {
 
 export async function bootstrapGlobal(input: {
   globalSDK: OpencodeClient
+  provider: () => Promise<unknown>
   requestFailedTitle: string
   translate: (key: string, vars?: Record<string, string | number>) => string
   formatMoreCount: (count: number) => string
@@ -94,12 +95,7 @@ export async function bootstrapGlobal(input: {
           input.setGlobalStore("config", x.data!)
         }),
       ),
-    () =>
-      retry(() =>
-        input.globalSDK.provider.list().then((x) => {
-          input.setGlobalStore("provider", normalizeProviderList(x.data!))
-        }),
-      ),
+    () => retry(input.provider),
   ]
 
   const slow = [

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -106,30 +106,40 @@ describe("applyGlobalEvent", () => {
 
   test("handles global.disposed by triggering refresh", () => {
     let refreshCount = 0
+    let providers = 0
     applyGlobalEvent({
       event: { type: "global.disposed" },
       project: [],
       refresh: () => {
         refreshCount += 1
       },
+      providers: () => {
+        providers += 1
+      },
       setGlobalProject() {},
     })
 
     expect(refreshCount).toBe(1)
+    expect(providers).toBe(1)
   })
 
   test("handles server.connected by triggering refresh", () => {
     let refreshCount = 0
+    let providers = 0
     applyGlobalEvent({
       event: { type: "server.connected" },
       project: [],
       refresh: () => {
         refreshCount += 1
       },
+      providers: () => {
+        providers += 1
+      },
       setGlobalProject() {},
     })
 
     expect(refreshCount).toBe(1)
+    expect(providers).toBe(1)
   })
 
   test("upserts a project from session.created when the project is missing", () => {

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -45,10 +45,11 @@ export function applyGlobalEvent(input: {
 
   if (input.event.type === "global.disposed" || input.event.type === "server.connected") {
     input.refresh()
+    input.providers?.()
     return
   }
 
-  if (input.event.type === "provider.models.updated") {
+  if (input.event.type === "provider.updated" || input.event.type === "provider.models.updated") {
     input.providers?.()
     return
   }

--- a/packages/app/src/context/global-sync/provider-models-event.test.ts
+++ b/packages/app/src/context/global-sync/provider-models-event.test.ts
@@ -19,3 +19,22 @@ test("handles provider.models.updated without triggering a full refresh", () => 
   expect(refresh).toBe(0)
   expect(providers).toBe(1)
 })
+
+test("handles provider.updated without triggering a full refresh", () => {
+  let refresh = 0
+  let providers = 0
+  applyGlobalEvent({
+    event: { type: "provider.updated" },
+    project: [],
+    refresh: () => {
+      refresh += 1
+    },
+    providers: () => {
+      providers += 1
+    },
+    setGlobalProject() {},
+  })
+
+  expect(refresh).toBe(0)
+  expect(providers).toBe(1)
+})

--- a/packages/app/src/context/global-sync/provider-refresh.test.ts
+++ b/packages/app/src/context/global-sync/provider-refresh.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test"
+import type { ProviderListResponse } from "@opencode-ai/sdk/v2/client"
+import { createProviderRefresh, type ProviderTarget } from "./provider-refresh"
+
+function defer<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((yes, no) => {
+    resolve = yes
+    reject = no
+  })
+  return { promise, resolve, reject }
+}
+
+function list(id: string, deprecated = false): ProviderListResponse {
+  return {
+    all: [
+      {
+        id,
+        name: id,
+        env: [],
+        models: deprecated
+          ? {
+              old: {
+                id: "old",
+                name: "old",
+                release_date: "2020-01-01",
+                attachment: false,
+                reasoning: false,
+                tool_call: false,
+                limit: { context: 1, output: 1 },
+                status: "deprecated",
+              },
+            }
+          : {},
+      },
+    ],
+    connected: [id],
+    default: {},
+  }
+}
+
+function setup(input: { global: ProviderTarget; children?: Record<string, ProviderTarget>; errors?: string[] }) {
+  const children = input.children ?? {}
+  return createProviderRefresh({
+    global: () => input.global,
+    child: (directory) => children[directory],
+    list: () => Object.keys(children),
+    error: (key) => input.errors?.push(key),
+  })
+}
+
+describe("provider refresh", () => {
+  test("refreshes global and every child while normalizing results", async () => {
+    const applied: Record<string, ProviderListResponse> = {}
+    const target = (key: string): ProviderTarget => {
+      const identity = {}
+      return {
+        key,
+        identity,
+        current: () => identity,
+        load: async () => list(key, true),
+        apply: (data) => {
+          applied[key] = data
+        },
+      }
+    }
+    const refresh = setup({
+      global: target("global"),
+      children: { a: target("a"), b: target("b") },
+    })
+
+    await refresh.all()
+
+    expect(Object.keys(applied).sort()).toEqual(["a", "b", "global"])
+    expect(Object.keys(applied.global!.all[0]!.models)).toEqual([])
+    expect(Object.keys(applied.a!.all[0]!.models)).toEqual([])
+  })
+
+  test("ignores an older response that resolves after a newer refresh", async () => {
+    const old = defer<ProviderListResponse>()
+    const fresh = defer<ProviderListResponse>()
+    const applied: string[] = []
+    const identity = {}
+    const loads = [old.promise, fresh.promise]
+    const target: ProviderTarget = {
+      key: "global",
+      identity,
+      current: () => identity,
+      load: () => loads.shift()!,
+      apply: (data) => applied.push(data.connected[0]!),
+    }
+    const refresh = setup({ global: target })
+
+    const first = refresh.global()
+    const second = refresh.global()
+    fresh.resolve(list("fresh"))
+    await second
+    old.resolve(list("old"))
+    await first
+
+    expect(applied).toEqual(["fresh"])
+  })
+
+  test("ignores a response after its child store is replaced", async () => {
+    const pending = defer<ProviderListResponse>()
+    const old = {}
+    const fresh = {}
+    let current: object = old
+    const applied: string[] = []
+    const child: ProviderTarget = {
+      key: "directory:a",
+      identity: old,
+      current: () => current,
+      load: () => pending.promise,
+      apply: (data) => applied.push(data.connected[0]!),
+    }
+    const refresh = setup({
+      global: { ...child, key: "global" },
+      children: { a: child },
+    })
+
+    const request = refresh.child("a")
+    current = fresh
+    pending.resolve(list("old"))
+    await request
+
+    expect(applied).toEqual([])
+  })
+
+  test("keeps refreshing other targets when one child fails", async () => {
+    const applied: string[] = []
+    const errors: string[] = []
+    const target = (key: string, fail = false): ProviderTarget => {
+      const identity = {}
+      return {
+        key,
+        identity,
+        current: () => identity,
+        load: async () => {
+          if (fail) throw new Error(key)
+          return list(key)
+        },
+        apply: (data) => applied.push(data.connected[0]!),
+      }
+    }
+    const refresh = setup({
+      global: target("global"),
+      children: { broken: target("broken", true), child: target("child") },
+      errors,
+    })
+
+    await refresh.all()
+
+    expect(applied.sort()).toEqual(["child", "global"])
+    expect(errors).toEqual(["broken"])
+  })
+})

--- a/packages/app/src/context/global-sync/provider-refresh.ts
+++ b/packages/app/src/context/global-sync/provider-refresh.ts
@@ -1,0 +1,52 @@
+import type { ProviderListResponse } from "@opencode-ai/sdk/v2/client"
+import { normalizeProviderList } from "./utils"
+
+export type ProviderTarget = {
+  key: string
+  identity: object
+  current: () => object | undefined
+  load: () => Promise<ProviderListResponse | undefined>
+  apply: (data: ProviderListResponse) => void
+}
+
+export function createProviderRefresh(input: {
+  global: () => ProviderTarget
+  child: (directory: string) => ProviderTarget | undefined
+  list: () => string[]
+  error?: (key: string, error: unknown) => void
+}) {
+  const gen = new Map<string, number>()
+
+  const run = async (target: ProviderTarget | undefined) => {
+    if (!target) return false
+    const next = (gen.get(target.key) ?? 0) + 1
+    gen.set(target.key, next)
+    const data = await target.load()
+    if (!data) return false
+    if (gen.get(target.key) !== next) return false
+    if (target.current() !== target.identity) return false
+    target.apply(normalizeProviderList(data))
+    return true
+  }
+
+  const all = async () => {
+    const targets = [
+      input.global(),
+      ...input.list().flatMap((directory) => {
+        const target = input.child(directory)
+        return target ? [target] : []
+      }),
+    ]
+    const results = await Promise.allSettled(targets.map(run))
+    results.forEach((result, index) => {
+      if (result.status === "fulfilled") return
+      input.error?.(targets[index]!.key, result.reason)
+    })
+  }
+
+  return {
+    all,
+    global: () => run(input.global()),
+    child: (directory: string) => run(input.child(directory)),
+  }
+}

--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -4,6 +4,7 @@ import { makeRuntime } from "@/effect/run-service"
 import { zod } from "@/util/effect-zod"
 import { Global } from "../global"
 import { Filesystem } from "../util/filesystem"
+import { ProviderEvent } from "../provider/event"
 
 export const OAUTH_DUMMY_KEY = "opencode-oauth-dummy-key"
 
@@ -72,23 +73,28 @@ export namespace Auth {
       const set = Effect.fn("Auth.set")(function* (key: string, info: Info) {
         const norm = key.replace(/\/+$/, "")
         const data = yield* all()
+        const prev = data[norm] ?? data[key] ?? data[norm + "/"]
         if (norm !== key) delete data[key]
         delete data[norm + "/"]
         yield* Effect.tryPromise({
           try: () => Filesystem.writeJson(file, { ...data, [norm]: info }, 0o600),
           catch: fail("Failed to write auth data"),
         })
+        ProviderEvent.update(!prev || prev.type !== info.type)
       })
 
       const remove = Effect.fn("Auth.remove")(function* (key: string) {
         const norm = key.replace(/\/+$/, "")
         const data = yield* all()
+        const found = key in data || norm in data || norm + "/" in data
         delete data[key]
         delete data[norm]
+        delete data[norm + "/"]
         yield* Effect.tryPromise({
           try: () => Filesystem.writeJson(file, data, 0o600),
           catch: fail("Failed to write auth data"),
         })
+        ProviderEvent.update(found)
       })
 
       return Service.of({ get, all, set, remove })

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -28,6 +28,7 @@ import { ConfigMarkdown } from "./markdown"
 import { constants, existsSync, statSync } from "fs"
 import { Bus } from "@/bus"
 import { GlobalBus } from "@/bus/global"
+import { ProviderEvent } from "../provider/event"
 import { Event } from "../server/event"
 import { Glob } from "../util/glob"
 import { PackageRegistry } from "@/bun/registry"
@@ -1786,6 +1787,14 @@ export namespace Config {
     "skills",
   ])
 
+  const PROVIDER_CONFIG_KEYS = new Set([
+    "provider",
+    "provider_remove",
+    "enabled_providers",
+    "disabled_providers",
+    "disabled_models",
+  ])
+
   export async function updateGlobal(config: Info) {
     const filepath = globalConfigFile()
     const found = existsSync(filepath)
@@ -1835,8 +1844,14 @@ export namespace Config {
 
     global.reset()
 
-    const hasUnsafeKey = Object.keys(config).some((k) => !SAFE_CONFIG_KEYS.has(k))
-    if (hasUnsafeKey) {
+    const keys = Object.keys(config)
+    const provider = keys.some((key) => PROVIDER_CONFIG_KEYS.has(key))
+    const unsafe = keys.some((key) => !SAFE_CONFIG_KEYS.has(key) && !PROVIDER_CONFIG_KEYS.has(key))
+    if (provider) {
+      state.reset()
+      ProviderEvent.update()
+    }
+    if (unsafe) {
       void Instance.disposeAll()
         .catch(() => undefined)
         .finally(() => {
@@ -1848,10 +1863,10 @@ export namespace Config {
             },
           })
         })
-    } else {
-      state.reset()
+      return next
     }
 
+    if (!provider) state.reset()
     return next
   }
 

--- a/packages/opencode/src/provider/event.ts
+++ b/packages/opencode/src/provider/event.ts
@@ -1,0 +1,41 @@
+import z from "zod"
+import { BusEvent } from "../bus/bus-event"
+import { GlobalBus } from "../bus/global"
+import { Log } from "../util/log"
+
+export namespace ProviderEvent {
+  const log = Log.create({ service: "provider.event" })
+  const listeners = new Set<() => void>()
+
+  export const Event = {
+    Updated: BusEvent.define("provider.updated", z.object({})),
+  }
+
+  export function onUpdated(listener: () => void) {
+    listeners.add(listener)
+    return () => listeners.delete(listener)
+  }
+
+  export function update(publish = true) {
+    for (const listener of listeners) {
+      try {
+        listener()
+      } catch (error) {
+        log.error("invalidate failed", { error })
+      }
+    }
+    if (!publish) return
+
+    try {
+      GlobalBus.emit("event", {
+        directory: "global",
+        payload: {
+          type: Event.Updated.type,
+          properties: {},
+        },
+      })
+    } catch (error) {
+      log.error("publish failed", { error })
+    }
+  }
+}

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -52,6 +52,7 @@ import { ProviderTransform } from "./transform"
 import { Installation } from "../installation"
 import { ModelID, ProviderID } from "./schema"
 import { CodexModels } from "../plugin/codex-models"
+import { ProviderEvent } from "./event"
 
 const DEFAULT_CHUNK_TIMEOUT = 600_000
 const DEFAULT_REQUEST_TIMEOUT = 300_000
@@ -1317,6 +1318,7 @@ export namespace Provider {
 
   ModelsDev.onUpdated(() => state.reset())
   CodexModels.onUpdated(() => state.reset())
+  ProviderEvent.onUpdated(() => state.reset())
 
   export function reset() {
     state.reset()

--- a/packages/opencode/test/provider/provider-event.test.ts
+++ b/packages/opencode/test/provider/provider-event.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Auth } from "../../src/auth"
+import { GlobalBus } from "../../src/bus/global"
+import { Config } from "../../src/config/config"
+import { Global } from "../../src/global"
+import { Instance } from "../../src/project/instance"
+import { Provider } from "../../src/provider/provider"
+import { ProviderEvent } from "../../src/provider/event"
+import { ProviderID } from "../../src/provider/schema"
+import { tmpdir } from "../fixture/fixture"
+
+const id = ProviderID.anthropic
+
+function connected(dir: string) {
+  return Instance.provide({ directory: dir, fn: () => Provider.connected() })
+}
+
+function provider(dir: string, value = id) {
+  return Instance.provide({ directory: dir, fn: () => Provider.getProvider(value) })
+}
+
+describe.serial("provider state updates", () => {
+  afterEach(async () => {
+    await Auth.remove(id)
+    await Instance.disposeAll()
+  })
+
+  test("auth changes invalidate every instance and only publish visibility changes", async () => {
+    await Auth.remove(id)
+    await using one = await tmpdir()
+    await using two = await tmpdir()
+    const events: unknown[] = []
+    const listener = (event: { payload: { type: string } }) => {
+      if (event.payload.type === "provider.updated") events.push(event)
+    }
+    GlobalBus.on("event", listener)
+
+    try {
+      expect(await connected(one.path)).not.toContain(id)
+      expect(await connected(two.path)).not.toContain(id)
+
+      await Auth.set(id, { type: "api", key: "old" })
+      expect(events).toHaveLength(1)
+      expect(await connected(one.path)).toContain(id)
+      expect(await connected(two.path)).toContain(id)
+      expect((await provider(one.path))?.key).toBe("old")
+
+      await Auth.set(id, { type: "api", key: "new" })
+      expect(events).toHaveLength(1)
+      expect((await provider(one.path))?.key).toBe("new")
+      expect((await provider(two.path))?.key).toBe("new")
+
+      await Auth.set(id, {
+        type: "oauth",
+        access: "access",
+        refresh: "refresh",
+        expires: Date.now() + 60_000,
+      })
+      expect(events).toHaveLength(2)
+
+      await Auth.set(id, {
+        type: "oauth",
+        access: "refreshed",
+        refresh: "refresh",
+        expires: Date.now() + 120_000,
+      })
+      expect(events).toHaveLength(2)
+
+      await Auth.remove(id)
+      expect(events).toHaveLength(3)
+      expect(await connected(one.path)).not.toContain(id)
+      expect(await connected(two.path)).not.toContain(id)
+
+      await Auth.remove(id)
+      expect(events).toHaveLength(3)
+    } finally {
+      GlobalBus.off("event", listener)
+    }
+  })
+
+  test("global provider config changes invalidate state without disposing instances", async () => {
+    await Auth.remove(id)
+    await Auth.set(id, { type: "api", key: "test" })
+    await using cfg = await tmpdir()
+    await using one = await tmpdir()
+    await using two = await tmpdir()
+    const prev = Global.Path.config
+    const events: unknown[] = []
+    const listener = (event: { payload: { type: string } }) => {
+      if (event.payload.type === "provider.updated") events.push(event)
+    }
+    ;(Global.Path as { config: string }).config = cfg.path
+    Config.global.reset()
+    GlobalBus.on("event", listener)
+
+    try {
+      expect(await connected(one.path)).toContain(id)
+      expect(await connected(two.path)).toContain(id)
+
+      await Config.updateGlobal({ disabled_providers: [id] })
+      expect(await connected(one.path)).not.toContain(id)
+      expect(await connected(two.path)).not.toContain(id)
+
+      await Config.updateGlobal({ disabled_providers: [] })
+      expect(await connected(one.path)).toContain(id)
+      expect(await connected(two.path)).toContain(id)
+
+      await Config.updateGlobal({ enabled_providers: ["openai"] })
+      expect(await connected(one.path)).not.toContain(id)
+
+      await Config.updateGlobal({ enabled_providers: [id] })
+      expect(await connected(one.path)).toContain(id)
+
+      const model = Object.keys((await provider(one.path))!.models)[0]
+      await Config.updateGlobal({ disabled_models: [`${id}/${model}`] })
+      expect((await provider(one.path))!.models[model].disabled).toBe(true)
+      expect((await provider(two.path))!.models[model].disabled).toBe(true)
+
+      await Config.updateGlobal({
+        enabled_providers: [id, "regression"],
+        provider: {
+          regression: {
+            name: "Regression",
+            npm: "@ai-sdk/openai-compatible",
+            api: "https://api.example.com/v1",
+            models: {
+              model: {
+                name: "Model",
+                tool_call: true,
+                limit: { context: 4_000, output: 1_000 },
+              },
+            },
+            options: { apiKey: "test" },
+          },
+        },
+      })
+      const custom = ProviderID.make("regression")
+      expect(await connected(one.path)).toContain(custom)
+      expect(await connected(two.path)).toContain(custom)
+
+      await Config.updateGlobal({ provider_remove: [custom] })
+      expect(await connected(one.path)).not.toContain(custom)
+      expect(await connected(two.path)).not.toContain(custom)
+      expect(Instance.has(one.path)).toBe(true)
+      expect(Instance.has(two.path)).toBe(true)
+      expect(events).toHaveLength(7)
+    } finally {
+      GlobalBus.off("event", listener)
+      ;(Global.Path as { config: string }).config = prev
+      Config.global.reset()
+      Provider.reset()
+    }
+  })
+
+  test("event listener failures do not fail persisted auth changes", async () => {
+    const local = ProviderEvent.onUpdated(() => {
+      throw new Error("local failure")
+    })
+    const remote = () => {
+      throw new Error("bus failure")
+    }
+    GlobalBus.on("event", remote)
+
+    try {
+      await Auth.set(id, { type: "api", key: "persisted" })
+      expect(await Auth.get(id)).toEqual({ type: "api", key: "persisted" })
+    } finally {
+      local()
+      GlobalBus.off("event", remote)
+    }
+  })
+})

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -36,6 +36,13 @@ export type EventProviderModelsUpdated = {
   }
 }
 
+export type EventProviderUpdated = {
+  type: "provider.updated"
+  properties: {
+    [key: string]: unknown
+  }
+}
+
 export type EventDbRecoveryStarted = {
   type: "db.recovery.started"
   properties: {
@@ -1090,6 +1097,7 @@ export type Event =
   | EventInstallationUpdated
   | EventInstallationUpdateAvailable
   | EventProviderModelsUpdated
+  | EventProviderUpdated
   | EventDbRecoveryStarted
   | EventDbRecoveryProgress
   | EventDbRecoveryCompleted


### PR DESCRIPTION
### Issue for this PR

Closes #1143

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

连接或断开提供商后，后端 Provider 缓存和活动项目的 provider store 可能仍保留旧值，导致新提供商需要重启 Aether 或切换项目后才会显示。

本 PR：

- 在认证和 Provider 配置变更后统一失效所有 Instance 的 Provider state，并发布 `provider.updated` 事件。
- 统一刷新 global 与当前存活的项目级 child provider stores。
- 使用 per-target generation 和 child identity 校验，避免模型目录的旧请求覆盖认证变更后的新状态。
- 连接、断开和 Provider 配置更新完成后直接等待 Provider 列表刷新。
- 生成对应的 SDK 事件类型，并补充后端、前端和浏览器端回归测试。

### How did you verify your code works?

- 手动验证：在活动项目中连接新提供商后，无需重启、刷新页面或切换项目即可立即显示。
- `packages/app`
  - `bun test --preload ./happydom.ts ./src` — 441 passed
  - `bun typecheck`
- `packages/opencode`
  - `bun test --timeout 30000 test/provider/provider-event.test.ts test/auth/auth.test.ts test/config/config.test.ts` — 77 passed
  - `bun test --timeout 30000 test/provider/provider.test.ts` — 86 passed
  - `bun typecheck`
- `packages/sdk/js`
  - `bun typecheck`
- Browser E2E
  - `bun test:e2e:local --workers 1 e2e/settings/provider-connect.spec.ts` — 1 passed

### Screenshots / recordings

Not applicable — this is a behavior-only fix with no visual layout changes. The affected flow is covered by an automated browser test.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
