### PR TITLE
feat(app): add provider-wide model toggle

### DIFF
--- a/packages/app/e2e/settings/settings-models.spec.ts
+++ b/packages/app/e2e/settings/settings-models.spec.ts
@@ -1,6 +1,19 @@
+import type { Locator } from "@playwright/test"
 import { test, expect } from "../fixtures"
 import { promptSelector } from "../selectors"
 import { closeDialog, openSettings } from "../actions"
+
+async function state(list: Locator, values: boolean[]) {
+  await expect(list).toHaveCount(values.length)
+  await Promise.all(
+    values.map((value, index) =>
+      expect(list.nth(index).locator('[data-slot="switch-input"]')).toHaveAttribute(
+        "aria-checked",
+        String(value),
+      ),
+    ),
+  )
+}
 
 test("hiding a model removes it from the model picker", async ({ page, gotoSession }) => {
   await gotoSession()
@@ -119,4 +132,107 @@ test("showing a hidden model restores it to the model picker", async ({ page, go
 
   await page.keyboard.press("Escape")
   await expect(pickerAgain).toHaveCount(0)
+})
+
+test("provider toggle controls every model without affecting other providers", async ({ page, project }) => {
+  const model = (id: string, name: string) => ({
+    id,
+    name,
+    release_date: "2026-01-01",
+    attachment: false,
+    reasoning: false,
+    tool_call: true,
+    limit: { context: 1, output: 1 },
+  })
+  const providers = {
+    all: [
+      {
+        id: "bulk-alpha-e2e",
+        name: "Bulk Alpha E2E",
+        env: [],
+        models: {
+          "alpha-one-e2e": model("alpha-one-e2e", "Alpha One E2E"),
+          "alpha-two-e2e": model("alpha-two-e2e", "Alpha Two E2E"),
+          "alpha-three-e2e": model("alpha-three-e2e", "Alpha Three E2E"),
+        },
+      },
+      {
+        id: "bulk-beta-e2e",
+        name: "Bulk Beta E2E",
+        env: [],
+        models: {
+          "beta-one-e2e": model("beta-one-e2e", "Beta One E2E"),
+        },
+      },
+    ],
+    default: {
+      "bulk-alpha-e2e": "alpha-one-e2e",
+      "bulk-beta-e2e": "beta-one-e2e",
+    },
+    connected: ["bulk-alpha-e2e", "bulk-beta-e2e"],
+  }
+
+  await page.route(/\/provider(?:\?.*)?$/, (route) => route.fulfill({ json: providers }))
+  await project.open()
+
+  const settings = await openSettings(page)
+  await settings.getByRole("tab", { name: "Models" }).click()
+
+  const group = settings.locator(
+    '[data-component="settings-model-provider"][data-provider="bulk-alpha-e2e"]',
+  )
+  const other = settings.locator(
+    '[data-component="settings-model-provider"][data-provider="bulk-beta-e2e"]',
+  )
+  await expect(group).toBeVisible()
+  await expect(other).toBeVisible()
+
+  const bulk = group.locator('[data-action="toggle-provider-models"]')
+  const input = bulk.getByRole("switch", { name: "Toggle all Bulk Alpha E2E models" })
+  const rows = group.locator('[data-component="switch"]:not([data-action="toggle-provider-models"])')
+  const peer = other.locator('[data-action="toggle-provider-models"]')
+  const guard = peer.getByRole("switch", { name: "Toggle all Bulk Beta E2E models" })
+  const rest = other.locator('[data-component="switch"]:not([data-action="toggle-provider-models"])')
+
+  await expect(input).toHaveAccessibleName("Toggle all Bulk Alpha E2E models")
+  await expect(input).toHaveAttribute("aria-checked", "true")
+  await state(rows, [true, true, true])
+  await expect(guard).toHaveAttribute("aria-checked", "true")
+  await state(rest, [true])
+
+  await input.focus()
+  await expect(input).toBeFocused()
+  await input.press("Space")
+  await expect(input).toHaveAttribute("aria-checked", "false")
+  await state(rows, [false, false, false])
+  await expect(guard).toHaveAttribute("aria-checked", "true")
+  await state(rest, [true])
+
+  await rows.first().locator('[data-slot="switch-control"]').click()
+  await state(rows, [true, false, false])
+  await expect(input).toHaveAttribute("aria-checked", "false")
+
+  await bulk.locator('[data-slot="switch-control"]').click()
+  await expect(input).toHaveAttribute("aria-checked", "true")
+  await state(rows, [true, true, true])
+
+  const search = settings.getByPlaceholder("Search models")
+  await search.fill("Alpha One E2E")
+  await expect(group).toBeVisible()
+  await state(rows, [true])
+
+  await bulk.locator('[data-slot="switch-control"]').click()
+  await expect(input).toHaveAttribute("aria-checked", "false")
+  await state(rows, [false])
+
+  await search.fill("")
+  await state(rows, [false, false, false])
+  await expect(guard).toHaveAttribute("aria-checked", "true")
+  await state(rest, [true])
+
+  await bulk.locator('[data-slot="switch-control"]').click()
+  await expect(input).toHaveAttribute("aria-checked", "true")
+  await state(rows, [true, true, true])
+
+  await closeDialog(page, settings)
 })

--- a/packages/app/src/components/settings-models.tsx
+++ b/packages/app/src/components/settings-models.tsx
@@ -1,6 +1,7 @@
 import { useFilteredList } from "@opencode-ai/ui/hooks"
 import { ProviderIcon } from "@opencode-ai/ui/provider-icon"
 import { Switch } from "@opencode-ai/ui/switch"
+import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { Icon } from "@opencode-ai/ui/icon"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { TextField } from "@opencode-ai/ui/text-field"
@@ -87,6 +88,16 @@ export const SettingsModels: Component = () => {
     },
   })
 
+  const owned = (id: string) => models.list().filter((x) => x.provider.id === id)
+  const enabled = (id: string) =>
+    owned(id).every((x) => models.visible({ providerID: x.provider.id, modelID: x.id }))
+  const toggle = (id: string, checked: boolean) => {
+    models.setManyVisibility(
+      owned(id).map((x) => ({ providerID: x.provider.id, modelID: x.id })),
+      checked,
+    )
+  }
+
   return (
     <div class="flex flex-col h-full overflow-y-auto no-scrollbar px-4 pb-10 sm:px-10 sm:pb-10">
       <div class="sticky top-0 z-10 bg-[linear-gradient(to_bottom,var(--surface-stronger-non-alpha)_calc(100%_-_24px),transparent)]">
@@ -154,10 +165,34 @@ export const SettingsModels: Component = () => {
           >
             <For each={list.grouped.latest}>
               {(group) => (
-                <div class="flex flex-col gap-1">
-                  <div class="flex items-center gap-2 pb-2">
-                    <ProviderIcon id={group.category} class="size-5 shrink-0 icon-strong-base" />
-                    <span class="text-14-medium text-text-strong">{group.items[0].provider.name}</span>
+                <div
+                  class="flex flex-col gap-1"
+                  data-component="settings-model-provider"
+                  data-provider={group.category}
+                >
+                  <div class="flex items-center justify-between gap-3 pb-2">
+                    <div class="flex min-w-0 items-center gap-2">
+                      <ProviderIcon id={group.category} class="size-5 shrink-0 icon-strong-base" />
+                      <span class="truncate text-14-medium text-text-strong">{group.items[0].provider.name}</span>
+                    </div>
+                    <Tooltip
+                      placement="top"
+                      value={language.t("dialog.model.manage.provider.toggle", {
+                        provider: group.items[0].provider.name,
+                      })}
+                    >
+                      <Switch
+                        class="shrink-0"
+                        data-action="toggle-provider-models"
+                        checked={enabled(group.category)}
+                        onChange={(checked) => toggle(group.category, checked)}
+                        hideLabel
+                      >
+                        {language.t("dialog.model.manage.provider.toggle", {
+                          provider: group.items[0].provider.name,
+                        })}
+                      </Switch>
+                    </Tooltip>
                   </div>
                   <SettingsList>
                     <For each={group.items}>


### PR DESCRIPTION
### Issue for this PR

Closes #1145

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a bulk visibility switch to each provider header in Settings → Models.

The switch is enabled only when every model from that provider is visible. Clicking it disables all models when they are all enabled, or enables all models when the provider is partially or fully disabled. The batch always uses the provider's complete unfiltered catalog and updates visibility through a single setManyVisibility call.

The switch reuses the existing localized provider-toggle label for its tooltip and accessible name. The settings E2E coverage verifies keyboard operation, mixed state behavior, provider isolation, and operation while search results are filtered.

### How did you verify your code works?

From packages/app:

- bun typecheck
- bun test src/context/models.test.ts — 3 passed
- bun run build
- bun test:e2e -- settings/settings-models.spec.ts -g "provider toggle" — Chromium, 1 passed
- git diff --check dev...HEAD
- Repository pre-push typecheck — 12 tasks passed

### Screenshots / recordings

Not included. The interaction is covered by the targeted Playwright test.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR