### PR TITLE
feat: 新增 GLM-5.3 / GLM-5.3-Flash 模型并置顶智谱编码套餐

### DIFF
--- a/packages/opencode/src/provider/models-local.ts
+++ b/packages/opencode/src/provider/models-local.ts
@@ -35,7 +35,53 @@ export const additions = {
   "tatu-maas": MaaS.provider,
 } satisfies Record<string, ModelsDev.Provider>
 
+function glm53(api: string, context: number, label: string, billed: boolean): Record<string, Insert> {
+  const date = "2026-08-27"
+  const zero = { input: 0, cache_read: 0, cache_write: 0, output: 0 }
+  // Zhipu list prices USD per 1M tokens; Flash runs a 50% promotion until 2026-09-09.
+  const costs = billed
+    ? [
+        { input: 1.4, cache_read: 0.26, cache_write: 0, output: 4.4 },
+        { input: 0.15, cache_read: 0.03, cache_write: 0, output: 0.5 },
+      ]
+    : [zero, zero]
+  const note = billed
+    ? "Zhipu documents OpenAI-compatible hybrid reasoning at GLM-5.2 list prices; Flash has a 50% promotion until 2026-09-09"
+    : "coding plan bundles models at zero incremental token cost"
+  const entry = (id: string, name: string, family: string, cost: typeof zero): Insert => ({
+    id,
+    name,
+    family,
+    attachment: false,
+    reasoning: true,
+    tool_call: true,
+    structured_output: true,
+    interleaved: { field: "reasoning_content" },
+    temperature: true,
+    release_date: date,
+    last_updated: date,
+    modalities: { input: ["text"], output: ["text"] },
+    open_weights: false,
+    provider: { npm: "@ai-sdk/openai-compatible", api },
+    limit: { context, output: 131_072 },
+    options: {},
+    cost,
+    meta: {
+      reason: `models.dev is missing ${label} ${name} metadata; ${note}`,
+      verified_at: date,
+    },
+  })
+  return {
+    "glm-5.3": entry("glm-5.3", "GLM-5.3", "glm", costs[0]),
+    "glm-5.3-flash": entry("glm-5.3-flash", "GLM-5.3-Flash", "glm-flash", costs[1]),
+  }
+}
+
 export const inserts = {
+  zhipuai: glm53("https://open.bigmodel.cn/api/paas/v4", 204_800, "Zhipu", true),
+  zai: glm53("https://api.z.ai/api/paas/v4", 204_800, "Z.AI", true),
+  "zhipuai-coding-plan": glm53("https://open.bigmodel.cn/api/coding/paas/v4", 200_000, "Zhipu coding-plan", false),
+  "zai-coding-plan": glm53("https://api.z.ai/api/coding/paas/v4", 200_000, "Z.AI coding-plan", false),
   "alibaba-cn": {
     "deepseek-v4-flash-0731": {
       id: "deepseek-v4-flash-0731",

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -565,9 +565,13 @@ export namespace ProviderTransform {
     return major > 4 || (major === 4 && minor >= 7)
   }
 
+  // GLM-5.2 and newer GLM-5.x that need thinking variants and reasoning-only recovery handling.
   export function glm52(model: Provider.Model) {
     const api = `${model.id} ${model.api.id}`.toLowerCase()
-    return ["glm-5.2", "glm-5-2", "glm-5p2"].some((id) => api.includes(id))
+    return (
+      ["glm-5.2", "glm-5-2", "glm-5p2"].some((id) => api.includes(id)) ||
+      ["glm-5.3", "glm-5-3", "glm-5p3"].some((id) => api.includes(id))
+    )
   }
 
   export function variants(model: Provider.Model): Record<string, Record<string, any>> {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -432,14 +432,14 @@ export namespace SessionProcessor {
               !reviewStopped
             if (retry) {
               recovered = true
-              log.warn("retrying GLM-5.2 without thinking after reasoning-only response", {
+              log.warn("retrying GLM-5.2/5.3 without thinking after reasoning-only response", {
                 sessionID: input.sessionID,
                 finish,
               })
               continue
             }
             if (recovered && ["stop", "length"].includes(finish) && reasoning && !text && !tools) {
-              log.warn("GLM-5.2 recovery response still has no visible text", {
+              log.warn("GLM-5.2/5.3 recovery response still has no visible text", {
                 sessionID: input.sessionID,
                 finish,
               })

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -120,6 +120,30 @@ test("models.dev local overlay inserts alibaba-cn deepseek-v4-flash-0731, deepse
         api: "https://dashscope.aliyuncs.com/compatible-mode/v1",
         models: {},
       },
+      zhipuai: {
+        ...provider,
+        id: "zhipuai",
+        api: "https://open.bigmodel.cn/api/paas/v4",
+        models: {},
+      },
+      zai: {
+        ...provider,
+        id: "zai",
+        api: "https://api.z.ai/api/paas/v4",
+        models: {},
+      },
+      "zhipuai-coding-plan": {
+        ...provider,
+        id: "zhipuai-coding-plan",
+        api: "https://open.bigmodel.cn/api/coding/paas/v4",
+        models: {},
+      },
+      "zai-coding-plan": {
+        ...provider,
+        id: "zai-coding-plan",
+        api: "https://api.z.ai/api/coding/paas/v4",
+        models: {},
+      },
     },
     {
       additions: {},
@@ -175,6 +199,75 @@ test("models.dev local overlay inserts alibaba-cn deepseek-v4-flash-0731, deepse
   expect(info.models["kimi-k3"].capabilities.interleaved).toEqual({ field: "reasoning_content" })
   expect(info.models["kimi-k3"].capabilities.toolcall).toBe(true)
   expect(info.models["kimi-k3"].capabilities.input.image).toBe(true)
+})
+
+test("models.dev local overlay inserts zhipuai/zai/coding-plan glm-5.3 and glm-5.3-flash", () => {
+  const base: Record<string, ModelsDev.Provider> = {
+    "alibaba-cn": {
+      ...provider,
+      id: "alibaba-cn",
+      api: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      models: {},
+    },
+    zhipuai: {
+      ...provider,
+      id: "zhipuai",
+      api: "https://open.bigmodel.cn/api/paas/v4",
+      models: {},
+    },
+    zai: {
+      ...provider,
+      id: "zai",
+      api: "https://api.z.ai/api/paas/v4",
+      models: {},
+    },
+    "zhipuai-coding-plan": {
+      ...provider,
+      id: "zhipuai-coding-plan",
+      api: "https://open.bigmodel.cn/api/coding/paas/v4",
+      models: {},
+    },
+    "zai-coding-plan": {
+      ...provider,
+      id: "zai-coding-plan",
+      api: "https://api.z.ai/api/coding/paas/v4",
+      models: {},
+    },
+  }
+  const data = apply(base, { additions: {}, overrides: {}, strict: true })
+
+  for (const pid of ["zhipuai", "zai"] as const) {
+    const m = data[pid].models["glm-5.3"]
+    expect(m.limit.context).toBe(204_800)
+    expect(m.limit.output).toBe(131_072)
+    expect(m.reasoning).toBe(true)
+    expect(m.tool_call).toBe(true)
+    expect(m.structured_output).toBe(true)
+    expect(m.interleaved).toEqual({ field: "reasoning_content" })
+    expect(m.cost?.input).toBe(1.4)
+    expect(m.cost?.cache_read).toBe(0.26)
+    expect(m.cost?.output).toBe(4.4)
+    expect("meta" in m).toBe(false)
+
+    const f = data[pid].models["glm-5.3-flash"]
+    expect(f.limit.context).toBe(204_800)
+    expect(f.family).toBe("glm-flash")
+    expect(f.cost?.input).toBe(0.15)
+    expect(f.cost?.cache_read).toBe(0.03)
+    expect(f.cost?.output).toBe(0.5)
+    expect(f.cost?.cache_write).toBe(0)
+    expect("meta" in f).toBe(false)
+  }
+
+  for (const pid of ["zhipuai-coding-plan", "zai-coding-plan"] as const) {
+    const m = data[pid].models["glm-5.3"]
+    expect(m.limit.context).toBe(200_000)
+    expect(m.cost?.input).toBe(0)
+    expect(m.cost?.output).toBe(0)
+    const f = data[pid].models["glm-5.3-flash"]
+    expect(f.cost?.input).toBe(0)
+    expect(f.cost?.output).toBe(0)
+  }
 })
 
 test("models.dev local overlay rejects duplicate model insertions", () => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2594,6 +2594,17 @@ describe("ProviderTransform.variants", () => {
     })
   })
 
+  test("GLM-5.3 reuses GLM-5.2 variants and detection", () => {
+    for (const id of ["glm-5.3", "glm-5.3-flash", "glm-5-3", "glm-5p3"]) {
+      expect(ProviderTransform.variants(glm("zhipuai", undefined, id))).toEqual({
+        high: { reasoningEffort: "high" },
+        max: { reasoningEffort: "max" },
+      })
+      expect(ProviderTransform.glm52(glm("zai-coding-plan", undefined, id))).toBe(true)
+    }
+    expect(ProviderTransform.glm52(glm("zhipuai", undefined, "glm-5.1"))).toBe(false)
+  })
+
   test("mistral returns empty object", () => {
     const model = createMockModel({
       id: "mistral/mistral-large",

--- a/packages/util/src/provider.ts
+++ b/packages/util/src/provider.ts
@@ -1,6 +1,6 @@
 export const popularProviders = [
   "opencode",
-  "opencode-go",  
+  "opencode-go",
   "anthropic",
   "openai",
   "google",
@@ -11,7 +11,7 @@ export const popularProviders = [
   "tatu-maas",
   "siliconflow-cn",
   "deepseek",
-  "zhipuai"
+  "zhipuai-coding-plan",
 ]
 
 export function rank(id: string) {


### PR DESCRIPTION
### Issue for this PR

Closes #1148

### Type of change

- [x] New feature

### What does this PR do?

1. 在 `models-local.ts` 的本地 models.dev overlay 中，通过一个 `glm53()` 工厂函数把 `glm-5.3` / `glm-5.3-flash` 插入 `zhipuai`、`zai`、`zhipuai-coding-plan`、`zai-coding-plan` 四个 provider。按量付费端使用官方列表价（GLM-5.3 与 5.2 相同 $1.4/$0.26/$4.4；Flash $0.15/$0.03/$0.5，注释记录了 2026-09-09 到期的 5 折促销），编码套餐端为零增量费用；上下文按各 provider 现有惯例（payg 204800 / coding plan 200000），输出 131072。
2. 扩展 `glm52()` 检测以覆盖 `glm-5.3`/`glm-5-3`/`glm-5p3`，使 GLM-5.3 复用 GLM-5.2 已有的 thinking 变体（high/max reasoningEffort）、`enable_thinking` 与 reasoning-only 响应自动重试逻辑，并同步更新 processor 日志文案。
3. `popularProviders` 中把 `zhipuai` 换成 `zhipuai-coding-plan`，使编码套餐在提供商选择器"热门"分组中置顶。

### How did you verify your code works?

- `bun typecheck`（packages/opencode、packages/util）通过
- `bun test test/provider/provider.test.ts test/provider/transform.test.ts test/provider/models.test.ts`：359 pass / 0 fail，含新增的 overlay 插入断言与 GLM-5.3 变体/检测测试
- 通过 `bun -e` 实际调用 `apply()` 验证插入后的模型字段（cost/limit/provider/meta 清理）正确

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR