### PR TITLE
fix(app): 修复 Windows 目录 URL 分隔符误判

### DIFF
--- a/packages/app/src/pages/directory-guard.test.ts
+++ b/packages/app/src/pages/directory-guard.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test"
+import { known } from "./directory-guard"
+
+describe("directory guard", () => {
+  test("matches Windows paths with different separators", () => {
+    expect(known("F:/Desktop/Paper", ["F:\\Desktop\\Paper"])).toBe(true)
+  })
+
+  test("matches equivalent paths with trailing separators", () => {
+    expect(known("F:/Desktop/Paper/", ["F:\\Desktop\\Paper\\"])).toBe(true)
+  })
+
+  test("blocks directories that are not registered", () => {
+    expect(known("F:/Desktop/Other", ["F:\\Desktop\\Paper"])).toBe(false)
+  })
+
+  test("keeps POSIX backslashes distinct from separators", () => {
+    expect(known("/srv/a\\b", ["/srv/a/b"])).toBe(false)
+  })
+
+  test("does not resolve parent segments", () => {
+    expect(known("F:/Desktop/Paper/../Other", ["F:\\Desktop\\Other"])).toBe(false)
+  })
+
+  test("preserves Windows path casing", () => {
+    expect(known("f:/Desktop/Paper", ["F:\\Desktop\\Paper"])).toBe(false)
+  })
+})

--- a/packages/app/src/pages/directory-guard.ts
+++ b/packages/app/src/pages/directory-guard.ts
@@ -1,0 +1,9 @@
+export function known(dir: string, dirs: string[]) {
+  const key = (value: string) => {
+    if (/^[A-Za-z]:[\\/]/.test(value)) {
+      return `win:${value.replace(/\\/g, "/").replace(/\/+$/, "")}`
+    }
+    return `path:${value.replace(/\/+$/, "") || value}`
+  }
+  return new Set(dirs.map(key)).has(key(dir))
+}

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -11,6 +11,7 @@ import { useServer } from "@/context/server"
 import { SyncProvider, useSync } from "@/context/sync"
 import { decode64 } from "@/utils/base64"
 import { OpenIntent } from "@/utils/open-intent"
+import { known } from "./directory-guard"
 
 function DirectoryDataProvider(props: ParentProps<{ directory: string }>) {
   const location = useLocation()
@@ -45,8 +46,6 @@ export default function Layout(props: ParentProps) {
   const server = useServer()
   let invalid = ""
   let blocked = ""
-
-  const norm = (dir: string) => dir.replace(/[\\/]+$/, "") || dir
 
   const resolved = createMemo(() => {
     if (!params.dir) return ""
@@ -89,8 +88,7 @@ export default function Layout(props: ParentProps) {
       if (OpenIntent.consume(input.key, input.dir)) return "pass"
       const client = global.createClient({ throwOnError: true })
       const result = await client.project.directories()
-      const dirs = new Set((result.data ?? []).map(norm))
-      if (dirs.has(norm(input.dir))) return "pass"
+      if (known(input.dir, result.data ?? [])) return "pass"
       return "block"
     },
   )


### PR DESCRIPTION
### Issue for this PR

Closes #1150

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

目录 URL 守卫在比较 Windows 路径时，只移除了路径末尾的分隔符。因此，URL 解码得到的 `F:/Desktop/Paper` 无法匹配后端返回的 `F:\Desktop\Paper`，导致合法会话被误判为无效目录，随后跳转回主界面。

本次修改仅对 Windows 盘符绝对路径统一正反斜杠，然后继续执行原有的精确目录成员校验。

POSIX 路径中的反斜杠、路径大小写、父目录片段以及未知目录拦截逻辑均保持不变，避免放宽现有目录安全边界。

同时增加回归测试，覆盖本次 Windows 分隔符问题及相关安全边界。

### How did you verify your code works?

- `bun test --preload ./happydom.ts ./src/pages/directory-guard.test.ts ./src/pages/layout/helpers.test.ts`：25 项测试通过
- `bun typecheck`：通过
- `bun run build`：通过
- 仓库 pre-push 全量类型检查：12 项任务通过

### Screenshots / recordings

不适用；本次修复的是路由校验逻辑，不涉及视觉界面变更。

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR