### PR TITLE
fix: 限制 Prompt 持久化与项目数据库内存占用

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -48,6 +48,7 @@ import { createPromptAttachments } from "./prompt-input/attachments"
 import { ACCEPTED_FILE_TYPES } from "./prompt-input/files"
 import {
   canNavigateHistoryAtCursor,
+  migratePromptHistory,
   navigatePromptHistory,
   prependHistoryEntry,
   type PromptHistoryComment,
@@ -370,7 +371,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   })
 
   const [history, setHistory] = persisted(
-    Persist.global("prompt-history", ["prompt-history.v1"]),
+    {
+      ...Persist.global("prompt-history", ["prompt-history.v1"]),
+      migrate: migratePromptHistory,
+      sanitize: migratePromptHistory,
+    },
     createStore<{
       entries: PromptHistoryStoredEntry[]
     }>({
@@ -378,7 +383,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     }),
   )
   const [shellHistory, setShellHistory] = persisted(
-    Persist.global("prompt-history-shell", ["prompt-history-shell.v1"]),
+    {
+      ...Persist.global("prompt-history-shell", ["prompt-history-shell.v1"]),
+      migrate: migratePromptHistory,
+      sanitize: migratePromptHistory,
+    },
     createStore<{
       entries: PromptHistoryStoredEntry[]
     }>({

--- a/packages/app/src/components/prompt-input/history.test.ts
+++ b/packages/app/src/components/prompt-input/history.test.ts
@@ -3,16 +3,25 @@ import type { Prompt } from "@/context/prompt"
 import {
   canNavigateHistoryAtCursor,
   clonePromptParts,
+  migratePromptHistory,
   normalizePromptHistoryEntry,
   navigatePromptHistory,
   prependHistoryEntry,
   promptLength,
   type PromptHistoryComment,
+  type PromptHistoryStoredEntry,
 } from "./history"
 
 const DEFAULT_PROMPT: Prompt = [{ type: "text", content: "", start: 0, end: 0 }]
 
 const text = (value: string): Prompt => [{ type: "text", content: value, start: 0, end: value.length }]
+const image = (id: string): Prompt[number] => ({
+  type: "image",
+  id,
+  filename: `${id}.pdf`,
+  mime: "application/pdf",
+  dataUrl: `data:application/pdf;base64,${id}`,
+})
 const comment = (id: string, value = "note"): PromptHistoryComment => ({
   id,
   path: "src/a.ts",
@@ -41,13 +50,47 @@ describe("prompt-input history", () => {
     expect(dedupedComments).toBe(commentsOnly)
   })
 
+  test("prependHistoryEntry persists prompt content without attachments", () => {
+    const entries = prependHistoryEntry([], [...text("summarize this"), image("large")])
+    expect(entries).toHaveLength(1)
+    expect(normalizePromptHistoryEntry(entries[0]!).prompt).toEqual(text("summarize this"))
+    expect(JSON.stringify(entries)).not.toContain("data:application/pdf")
+
+    expect(prependHistoryEntry([], [image("attachment-only")])).toEqual([])
+
+    const deduped = prependHistoryEntry(entries, [...text("summarize this"), image("different")])
+    expect(deduped).toBe(entries)
+  })
+
+  test("migratePromptHistory removes legacy attachments and drops attachment-only entries", () => {
+    const migrated = migratePromptHistory({
+      entries: [
+        { prompt: [...text("keep me"), image("remove")], comments: [comment("c1")] },
+        [image("drop")],
+        { prompt: [image("commented")], comments: [comment("c2")] },
+        { prompt: [...text("canonical"), null] },
+      ],
+    }) as { entries: PromptHistoryStoredEntry[] }
+
+    expect(migrated.entries).toHaveLength(3)
+    expect(normalizePromptHistoryEntry(migrated.entries[0]!).prompt).toEqual(text("keep me"))
+    expect(normalizePromptHistoryEntry(migrated.entries[0]!).comments).toEqual([comment("c1")])
+    expect(normalizePromptHistoryEntry(migrated.entries[1]!).prompt).toEqual(DEFAULT_PROMPT)
+    expect(normalizePromptHistoryEntry(migrated.entries[1]!).comments).toEqual([comment("c2")])
+    expect(normalizePromptHistoryEntry(migrated.entries[2]!).prompt).toEqual(text("canonical"))
+    expect(normalizePromptHistoryEntry(migrated.entries[2]!).comments).toEqual([])
+    expect(JSON.stringify(migrated)).not.toContain("data:application/pdf")
+    expect(migratePromptHistory(null)).toEqual({ entries: [] })
+    expect(migratePromptHistory({ entries: null })).toEqual({ entries: [] })
+  })
+
   test("navigatePromptHistory restores saved prompt when moving down from newest", () => {
     const entries = [text("third"), text("second"), text("first")]
     const up = navigatePromptHistory({
       direction: "up",
       entries,
       historyIndex: -1,
-      currentPrompt: text("draft"),
+      currentPrompt: [...text("draft"), image("draft")],
       currentComments: [comment("draft")],
       savedPrompt: null,
     })
@@ -69,6 +112,7 @@ describe("prompt-input history", () => {
     if (!down.handled) throw new Error("expected handled")
     expect(down.historyIndex).toBe(-1)
     expect(down.entry.prompt[0]?.type === "text" ? down.entry.prompt[0].content : "").toBe("draft")
+    expect(down.entry.prompt[1]).toEqual(image("draft"))
     expect(down.entry.comments).toEqual([comment("draft")])
   })
 

--- a/packages/app/src/components/prompt-input/history.ts
+++ b/packages/app/src/components/prompt-input/history.ts
@@ -1,5 +1,6 @@
 import type { Prompt } from "@/context/prompt"
 import type { SelectedLineRange } from "@/context/file"
+import { sanitizePrompt } from "@/context/prompt-persist"
 
 const DEFAULT_PROMPT: Prompt = [{ type: "text", content: "", start: 0, end: 0 }]
 
@@ -21,6 +22,76 @@ export type PromptHistoryEntry = {
 }
 
 export type PromptHistoryStoredEntry = Prompt | PromptHistoryEntry
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function content(prompt: unknown[]) {
+  return prompt.some((part) => record(part) && typeof part.content === "string" && !!part.content.trim())
+}
+
+function selection(value: unknown): SelectedLineRange | undefined {
+  if (!record(value)) return
+  if (typeof value.start !== "number" || typeof value.end !== "number") return
+  const side = value.side === "additions" || value.side === "deletions" ? value.side : undefined
+  const endSide = value.endSide === "additions" || value.endSide === "deletions" ? value.endSide : undefined
+  return { start: value.start, end: value.end, ...(side ? { side } : {}), ...(endSide ? { endSide } : {}) }
+}
+
+function comments(value: unknown): PromptHistoryComment[] {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((comment): PromptHistoryComment[] => {
+    if (!record(comment)) return []
+    if (typeof comment.id !== "string") return []
+    if (typeof comment.path !== "string") return []
+    if (typeof comment.comment !== "string") return []
+    if (typeof comment.time !== "number") return []
+    const range = selection(comment.selection)
+    if (!range) return []
+    const origin = comment.origin === "review" || comment.origin === "file" ? comment.origin : undefined
+    return [
+      {
+        id: comment.id,
+        path: comment.path,
+        selection: range,
+        comment: comment.comment,
+        time: comment.time,
+        ...(origin ? { origin } : {}),
+        ...(typeof comment.preview === "string" ? { preview: comment.preview } : {}),
+      },
+    ]
+  })
+}
+
+function clean(prompt: Prompt) {
+  return sanitizePrompt(prompt)
+}
+
+export function migratePromptHistory(value: unknown) {
+  if (!record(value)) return { entries: [] }
+  if (!Array.isArray(value.entries)) return { ...value, entries: [] }
+
+  const entries = value.entries.flatMap((entry) => {
+    const legacy = Array.isArray(entry)
+    const prompt = legacy ? entry : record(entry) && Array.isArray(entry.prompt) ? entry.prompt : undefined
+    if (!prompt) return []
+
+    const next = sanitizePrompt(prompt)
+    const notes = !legacy && record(entry) ? comments(entry.comments) : []
+    if (!content(next) && !notes.some((comment) => !!comment.comment.trim())) return []
+
+    return [
+      {
+        prompt: next.length ? next : clonePromptParts(DEFAULT_PROMPT),
+        comments: notes,
+      } satisfies PromptHistoryEntry,
+    ]
+  })
+
+  const unique = entries.filter((entry, index) => index === 0 || !isPromptEqual(entries[index - 1]!, entry))
+  return { ...value, entries: unique.slice(0, MAX_HISTORY) }
+}
 
 export function canNavigateHistoryAtCursor(direction: "up" | "down", text: string, cursor: number, inHistory = false) {
   const position = Math.max(0, Math.min(cursor, text.length))
@@ -61,13 +132,15 @@ export function clonePromptHistoryComments(comments: PromptHistoryComment[]) {
 
 export function normalizePromptHistoryEntry(entry: PromptHistoryStoredEntry): PromptHistoryEntry {
   if (Array.isArray(entry)) {
+    const prompt = clean(entry)
     return {
-      prompt: clonePromptParts(entry),
+      prompt: prompt.length ? prompt : clonePromptParts(DEFAULT_PROMPT),
       comments: [],
     }
   }
+  const prompt = clean(entry.prompt)
   return {
-    prompt: clonePromptParts(entry.prompt),
+    prompt: prompt.length ? prompt : clonePromptParts(DEFAULT_PROMPT),
     comments: clonePromptHistoryComments(entry.comments),
   }
 }
@@ -82,16 +155,16 @@ export function prependHistoryEntry(
   comments: PromptHistoryComment[] = [],
   max = MAX_HISTORY,
 ) {
-  const text = prompt
+  const stored = clean(prompt)
+  const text = stored
     .map((part) => ("content" in part ? part.content : ""))
     .join("")
     .trim()
-  const hasImages = prompt.some((part) => part.type === "image")
   const hasComments = comments.some((comment) => !!comment.comment.trim())
-  if (!text && !hasImages && !hasComments) return entries
+  if (!text && !hasComments) return entries
 
   const entry = {
-    prompt: clonePromptParts(prompt),
+    prompt: stored.length ? stored : clonePromptParts(DEFAULT_PROMPT),
     comments: clonePromptHistoryComments(comments),
   } satisfies PromptHistoryEntry
   const last = entries[0]

--- a/packages/app/src/context/prompt-persist.ts
+++ b/packages/app/src/context/prompt-persist.ts
@@ -1,0 +1,56 @@
+import type { FileSelection } from "./file"
+import type { Prompt } from "./prompt"
+
+const DEFAULT_PROMPT = [{ type: "text", content: "", start: 0, end: 0 }]
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function range(value: unknown): FileSelection | undefined {
+  if (!record(value)) return
+  if (typeof value.startLine !== "number") return
+  if (typeof value.startChar !== "number") return
+  if (typeof value.endLine !== "number") return
+  if (typeof value.endChar !== "number") return
+  return {
+    startLine: value.startLine,
+    startChar: value.startChar,
+    endLine: value.endLine,
+    endChar: value.endChar,
+  }
+}
+
+export function sanitizePrompt(value: unknown): Prompt {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((part): Prompt => {
+    if (!record(part)) return []
+    if (part.type === "image" || "dataUrl" in part) return []
+    if (typeof part.content !== "string") return []
+
+    const start = typeof part.start === "number" ? part.start : 0
+    const end = typeof part.end === "number" ? part.end : part.content.length
+    if (part.type === "text") return [{ type: "text", content: part.content, start, end }]
+    if (part.type === "agent" && typeof part.name === "string") {
+      return [{ type: "agent", content: part.content, start, end, name: part.name }]
+    }
+    if (part.type !== "file" || typeof part.path !== "string") return []
+    return [
+      {
+        type: "file",
+        content: part.content,
+        start,
+        end,
+        path: part.path,
+        selection: range(part.selection),
+      },
+    ]
+  })
+}
+
+export function sanitizePromptState(value: unknown): Record<string, unknown> {
+  if (!record(value)) return { prompt: DEFAULT_PROMPT, context: { items: [] } }
+  const prompt = sanitizePrompt(value.prompt)
+  const context = record(value.context) && Array.isArray(value.context.items) ? value.context : { items: [] }
+  return { ...value, prompt: prompt.length ? prompt : DEFAULT_PROMPT, context }
+}

--- a/packages/app/src/context/prompt.test.ts
+++ b/packages/app/src/context/prompt.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test"
+import { sanitizePrompt, sanitizePromptState } from "./prompt-persist"
+
+describe("prompt persistence", () => {
+  test("keeps draft content without persisting attachments", () => {
+    const source = {
+      prompt: [
+        { type: "text", content: "summarize", start: 0, end: 9 },
+        {
+          type: "image",
+          id: "pdf",
+          filename: "large.pdf",
+          mime: "application/pdf",
+          dataUrl: "data:application/pdf;base64,large",
+        },
+      ],
+      cursor: 9,
+      context: { items: [{ type: "file", path: "paper.md", key: "paper.md" }] },
+    }
+    const value = sanitizePromptState(source)
+
+    expect(value).toEqual({
+      prompt: [{ type: "text", content: "summarize", start: 0, end: 9 }],
+      cursor: 9,
+      context: { items: [{ type: "file", path: "paper.md", key: "paper.md" }] },
+    })
+    expect(JSON.stringify(value)).not.toContain("data:application/pdf")
+    expect(source.prompt).toHaveLength(2)
+  })
+
+  test("drops malformed and attachment-only persisted parts", () => {
+    expect(sanitizePrompt([null, "bad", { type: "unknown" }, { type: "image", dataUrl: "data:large" }])).toEqual([])
+    expect(
+      sanitizePromptState({
+        prompt: [null, { type: "image", dataUrl: "data:large" }],
+        cursor: 0,
+      }),
+    ).toEqual({
+      prompt: [{ type: "text", content: "", start: 0, end: 0 }],
+      cursor: 0,
+      context: { items: [] },
+    })
+
+    expect(sanitizePromptState(null)).toEqual({
+      prompt: [{ type: "text", content: "", start: 0, end: 0 }],
+      context: { items: [] },
+    })
+    expect(sanitizePromptState({ prompt: null, context: null })).toEqual({
+      prompt: [{ type: "text", content: "", start: 0, end: 0 }],
+      context: { items: [] },
+    })
+  })
+})

--- a/packages/app/src/context/prompt.tsx
+++ b/packages/app/src/context/prompt.tsx
@@ -4,6 +4,7 @@ import { useParams } from "@solidjs/router"
 import { batch, createMemo, createRoot, getOwner, onCleanup } from "solid-js"
 import { createStore, type SetStoreFunction } from "solid-js/store"
 import type { FileSelection } from "@/context/file"
+import { sanitizePromptState } from "@/context/prompt-persist"
 import { Persist, persisted } from "@/utils/persist"
 
 interface PartBase {
@@ -165,7 +166,11 @@ function createPromptSession(dir: string, id: string | undefined) {
   const legacy = `${dir}/prompt${id ? "/" + id : ""}.v2`
 
   const [store, setStore, _, ready] = persisted(
-    Persist.scoped(dir, id, "prompt", [legacy]),
+    {
+      ...Persist.scoped(dir, id, "prompt", [legacy]),
+      migrate: sanitizePromptState,
+      sanitize: sanitizePromptState,
+    },
     createStore<{
       prompt: Prompt
       cursor?: number

--- a/packages/app/src/utils/persist.test.ts
+++ b/packages/app/src/utils/persist.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test"
+import { createStore } from "solid-js/store"
 
 type PersistTestingType = typeof import("./persist").PersistTesting
 
@@ -45,6 +46,7 @@ class MemoryStorage implements Storage {
 const storage = new MemoryStorage()
 
 let persistTesting: PersistTestingType
+let persisted: typeof import("./persist").persisted
 
 beforeAll(async () => {
   mock.module("@/context/platform", () => ({
@@ -53,6 +55,7 @@ beforeAll(async () => {
 
   const mod = await import("./persist")
   persistTesting = mod.PersistTesting
+  persisted = mod.persisted
 })
 
 beforeEach(() => {
@@ -103,6 +106,34 @@ describe("persist localStorage resilience", () => {
   test("normalizer rejects malformed JSON payloads", () => {
     const result = persistTesting.normalize({ value: "ok" }, '{"value":"\\x"}')
     expect(result).toBeUndefined()
+  })
+
+  test("sanitizes before serialization without mutating the live store", () => {
+    const [store, setStore] = createStore({
+      prompt: [] as Array<{ type: string; content?: string; dataUrl?: string }>,
+    })
+    const [state, setState] = persisted(
+      {
+        key: "sanitize-before-serialize",
+        sanitize: (value) => {
+          if (!value || typeof value !== "object" || !("prompt" in value) || !Array.isArray(value.prompt)) return value
+          return {
+            ...value,
+            prompt: value.prompt.filter((part) => !(part && typeof part === "object" && "dataUrl" in part)),
+          }
+        },
+      },
+      [store, setStore],
+    )
+
+    setState("prompt", [
+      { type: "image", dataUrl: "data:large" },
+      { type: "text", content: "ok" },
+    ])
+
+    expect(state.prompt).toHaveLength(2)
+    expect(state.prompt[0]).toMatchObject({ type: "image", dataUrl: "data:large" })
+    expect(storage.getItem("sanitize-before-serialize")).toBe('{"prompt":[{"type":"text","content":"ok"}]}')
   })
 
   test("workspace storage sanitizes Windows filename characters", () => {

--- a/packages/app/src/utils/persist.ts
+++ b/packages/app/src/utils/persist.ts
@@ -17,6 +17,7 @@ type PersistTarget = {
   key: string
   legacy?: string[]
   migrate?: (value: unknown) => unknown
+  sanitize?: (value: unknown) => unknown
 }
 
 const LEGACY_STORAGE = "default.dat"
@@ -208,6 +209,10 @@ function normalize(defaults: unknown, raw: string, migrate?: (value: unknown) =>
   return JSON.stringify(merged)
 }
 
+function serialize(value: unknown, sanitize?: (value: unknown) => unknown) {
+  return JSON.stringify(sanitize ? sanitize(value) : value) ?? "null"
+}
+
 function workspaceStorage(dir: string) {
   const head = (dir.slice(0, 12) || "workspace").replace(/[^a-zA-Z0-9._-]/g, "-")
   const sum = checksum(dir) ?? "0"
@@ -305,6 +310,7 @@ export const PersistTesting = {
   localStorageDirect,
   localStorageWithPrefix,
   normalize,
+  serialize,
   workspaceStorage,
 }
 
@@ -453,16 +459,23 @@ export function persisted<T>(
     return api
   })()
 
-  const [state, setState, init] = makePersisted(store, { name: config.key, storage })
+  const [state, setState, init] = makePersisted(store, {
+    name: config.key,
+    storage,
+    serialize: (value) => serialize(value, config.sanitize),
+  })
 
-  const isAsync = init instanceof Promise
+  if (!(init instanceof Promise)) {
+    return [state, setState, init, Object.assign(() => true, { promise: undefined })]
+  }
+
   const [ready] = createResource(
     () => init,
     async (initValue) => {
       if (initValue instanceof Promise) await initValue
       return true
     },
-    { initialValue: !isAsync },
+    { initialValue: false },
   )
 
   return [
@@ -470,7 +483,7 @@ export function persisted<T>(
     setState,
     init,
     Object.assign(() => ready() === true, {
-      promise: init instanceof Promise ? init : undefined,
+      promise: init,
     }),
   ]
 }

--- a/packages/app/src/utils/persist.ts
+++ b/packages/app/src/utils/persist.ts
@@ -25,6 +25,38 @@ const GLOBAL_STORAGE = "opencode.global.dat"
 const LOCAL_PREFIX = "opencode."
 const fallback = new Map<string, boolean>()
 
+type Journal = {
+  version: number
+  pending: Promise<void>
+}
+
+// Desktop hydration can outlive its component, so writes are coordinated by backing store and key.
+const journals = new WeakMap<AsyncStorage, Map<string, Journal>>()
+
+function journal(storage: AsyncStorage, key: string) {
+  const cached = journals.get(storage)
+  if (cached) {
+    const value = cached.get(key)
+    if (value) return value
+    const next = { version: 0, pending: Promise.resolve() }
+    cached.set(key, next)
+    return next
+  }
+
+  const next = { version: 0, pending: Promise.resolve() }
+  journals.set(storage, new Map([[key, next]]))
+  return next
+}
+
+function queue<T>(journal: Journal, task: () => Promise<T>) {
+  const next = journal.pending.then(task, task)
+  journal.pending = next.then(
+    () => undefined,
+    () => undefined,
+  )
+  return next
+}
+
 const CACHE_MAX_ENTRIES = 500
 const CACHE_MAX_BYTES = 8 * 1024 * 1024
 
@@ -334,7 +366,11 @@ export function removePersisted(target: { storage?: string; key: string }, platf
   const isDesktop = platform?.platform === "desktop" && !!platform.storage
 
   if (isDesktop) {
-    return platform.storage?.(target.storage)?.removeItem(target.key)
+    const storage = platform.storage?.(target.storage) as AsyncStorage | undefined
+    if (!storage) return
+    const writes = journal(storage, target.key)
+    writes.version += 1
+    return queue(writes, () => storage.removeItem(target.key))
   }
 
   if (!target.storage) {
@@ -416,17 +452,19 @@ export function persisted<T>(
 
     const current = currentStorage as AsyncStorage
     const legacyStore = legacyStorage as AsyncStorage | undefined
+    const writes = journal(current, config.key)
 
     const api: AsyncStorage = {
       getItem: async (key) => {
+        const version = writes.version
         const raw = await current.getItem(key)
         if (raw !== null) {
           const next = normalize(defaults, raw, config.migrate)
           if (next === undefined) {
-            await current.removeItem(key).catch(() => undefined)
+            if (version === writes.version) await queue(writes, () => current.removeItem(key)).catch(() => undefined)
             return null
           }
-          if (raw !== next) await current.setItem(key, next)
+          if (raw !== next && version === writes.version) await queue(writes, () => current.setItem(key, next))
           return next
         }
 
@@ -441,7 +479,8 @@ export function persisted<T>(
             await legacyStore.removeItem(legacyKey).catch(() => undefined)
             continue
           }
-          await current.setItem(key, next)
+          if (version !== writes.version) return next
+          await queue(writes, () => current.setItem(key, next))
           await legacyStore.removeItem(legacyKey)
           return next
         }
@@ -449,10 +488,12 @@ export function persisted<T>(
         return null
       },
       setItem: async (key, value) => {
-        await current.setItem(key, value)
+        writes.version += 1
+        await queue(writes, () => current.setItem(key, value))
       },
       removeItem: async (key) => {
-        await current.removeItem(key)
+        writes.version += 1
+        await queue(writes, () => current.removeItem(key))
       },
     }
 

--- a/packages/app/src/utils/persist.vitest.ts
+++ b/packages/app/src/utils/persist.vitest.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+import type { AsyncStorage } from "@solid-primitives/storage"
+import type { Platform } from "@/context/platform"
+import { createRoot } from "solid-js"
+import { createStore } from "solid-js/store"
+
+const state = vi.hoisted(() => ({
+  storage: undefined as AsyncStorage | undefined,
+}))
+
+vi.mock("@/context/platform", () => ({
+  usePlatform: () => ({
+    platform: "desktop",
+    storage: () => state.storage!,
+  }),
+}))
+
+import { persisted, removePersisted } from "./persist"
+
+function clean(value: unknown) {
+  if (!value || typeof value !== "object" || !("entries" in value) || !Array.isArray(value.entries)) {
+    return { entries: [] }
+  }
+  return {
+    entries: value.entries.flatMap((entry): { content: string }[] => {
+      if (!entry || typeof entry !== "object" || !("content" in entry)) return []
+      if (typeof entry.content !== "string") return []
+      return [{ content: entry.content }]
+    }),
+  }
+}
+
+function mount(storage: AsyncStorage, key: string) {
+  state.storage = storage
+  return createRoot((dispose) => {
+    const [store, setStore] = createStore({ entries: [] as { content: string }[] })
+    const [value, set, , ready] = persisted({ key, migrate: clean, sanitize: clean }, [store, setStore])
+    return { value, set, ready, dispose }
+  })
+}
+
+function desktop(storage: AsyncStorage): Platform {
+  return {
+    platform: "desktop",
+    storage: () => storage,
+    openLink: () => undefined,
+    restart: async () => undefined,
+    back: () => undefined,
+    forward: () => undefined,
+    notify: async () => undefined,
+  }
+}
+
+beforeEach(() => {
+  state.storage = undefined
+})
+
+describe("persist async storage", () => {
+  test("migration does not overwrite a newer value while reading", async () => {
+    const read = Promise.withResolvers<string | null>()
+    const saved = Promise.withResolvers<void>()
+    const values = new Map<string, string>()
+    const storage: AsyncStorage = {
+      getItem: () => read.promise,
+      setItem: async (key, value) => {
+        values.set(key, value)
+        if (value.includes("new")) saved.resolve()
+      },
+      removeItem: async (key) => {
+        values.delete(key)
+      },
+    }
+    const item = mount(storage, "async-read-race")
+
+    item.set("entries", [{ content: "new" }])
+    read.resolve('{"entries":[{"content":"old","dataUrl":"data:large"}]}')
+    await Promise.all([item.ready.promise, saved.promise])
+
+    expect(item.value.entries).toEqual([{ content: "new" }])
+    expect(JSON.parse(values.get("async-read-race")!)).toEqual({ entries: [{ content: "new" }] })
+    item.dispose()
+  })
+
+  test("migration preserves a newer value when its write is already pending", async () => {
+    const started = Promise.withResolvers<void>()
+    const release = Promise.withResolvers<void>()
+    const saved = Promise.withResolvers<void>()
+    const calls = { value: 0 }
+    const values = new Map<string, string>()
+    const storage: AsyncStorage = {
+      getItem: async () => '{"entries":[{"content":"old","dataUrl":"data:large"}]}',
+      setItem: async (key, value) => {
+        calls.value += 1
+        if (calls.value === 1) {
+          started.resolve()
+          await release.promise
+        }
+        values.set(key, value)
+        if (value.includes("new")) saved.resolve()
+      },
+      removeItem: async (key) => {
+        values.delete(key)
+      },
+    }
+    const item = mount(storage, "async-write-race")
+
+    await started.promise
+    item.set("entries", [{ content: "new" }])
+    release.resolve()
+    await Promise.all([item.ready.promise, saved.promise])
+
+    expect(item.value.entries).toEqual([{ content: "new" }])
+    expect(JSON.parse(values.get("async-write-race")!)).toEqual({ entries: [{ content: "new" }] })
+    item.dispose()
+  })
+
+  test("an unmounted instance does not overwrite a newer instance", async () => {
+    const read = Promise.withResolvers<string | null>()
+    const saved = Promise.withResolvers<void>()
+    const values = new Map<string, string>()
+    const calls = { value: 0 }
+    const storage: AsyncStorage = {
+      getItem: async () => {
+        calls.value += 1
+        if (calls.value === 1) return read.promise
+        return values.get("async-remount-race") ?? null
+      },
+      setItem: async (key, value) => {
+        values.set(key, value)
+        if (value.includes("new")) saved.resolve()
+      },
+      removeItem: async (key) => {
+        values.delete(key)
+      },
+    }
+    const old = mount(storage, "async-remount-race")
+    old.dispose()
+    const item = mount(storage, "async-remount-race")
+
+    item.set("entries", [{ content: "new" }])
+    read.resolve('{"entries":[{"content":"old","dataUrl":"data:large"}]}')
+    await Promise.all([old.ready.promise, item.ready.promise, saved.promise])
+
+    expect(item.value.entries).toEqual([{ content: "new" }])
+    expect(JSON.parse(values.get("async-remount-race")!)).toEqual({ entries: [{ content: "new" }] })
+    item.dispose()
+  })
+
+  test("remove does not let a pending migration restore the value", async () => {
+    const key = "async-remove-race"
+    const raw = '{"entries":[{"content":"old","dataUrl":"data:large"}]}'
+    const read = Promise.withResolvers<string | null>()
+    const values = new Map([[key, raw]])
+    const saved: string[] = []
+    const storage: AsyncStorage = {
+      getItem: () => read.promise,
+      setItem: async (key, value) => {
+        saved.push(value)
+        values.set(key, value)
+      },
+      removeItem: async (key) => {
+        values.delete(key)
+      },
+    }
+    const item = mount(storage, key)
+
+    await removePersisted({ key }, desktop(storage))
+    read.resolve(raw)
+    await item.ready.promise
+
+    expect(values.has(key)).toBe(false)
+    expect(saved).toEqual([])
+    item.dispose()
+  })
+})

--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -524,7 +524,7 @@ export namespace Database {
     db.run("PRAGMA journal_mode = WAL")
     db.run("PRAGMA synchronous = NORMAL")
     db.run("PRAGMA busy_timeout = 5000")
-    db.run("PRAGMA cache_size = -64000")
+    db.run("PRAGMA cache_size = -32768")
     db.run("PRAGMA foreign_keys = ON")
     const isNewProjDb = seedSplitMigration(db)
     if (!isNewProjDb) seedAllMigrations(db)

--- a/packages/opencode/test/storage/db-project-guard.test.ts
+++ b/packages/opencode/test/storage/db-project-guard.test.ts
@@ -26,6 +26,7 @@ describe("Database.attach() guard", () => {
     Database.detach(project.id)
     const reopened = Database.attach(project.id)
     expect(reopened).toBeDefined()
+    expect((reopened.$client.prepare("PRAGMA cache_size").get() as { cache_size: number }).cache_size).toBe(-32768)
   })
 
   test("attach() succeeds for git project registered via fromDirectory", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #1152

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Prompt History 和未发送草稿只持久化文字、轻量引用、评论及上下文信息，不再把图片或 PDF 的 Base64 数据写入存储。
- 运行中的附件仍可正常发送和读取；应用重启后不会恢复尚未发送的附件。
- 加载旧历史时自动清理已持久化的附件和异常数据，并协调同一 Desktop 存储键的迁移与实时写入，避免旧迁移覆盖用户的新输入。
- 将单项目 SQLite 页面缓存上限从约 64 MiB 调整为约 32 MiB，降低多项目连接的内存高水位。

### How did you verify your code works?

- `packages/app`: `bun run test:unit`
  - 446 Bun tests passed
  - 33 Vitest tests passed, 2 skipped
- `packages/app`: `bun typecheck`
- `packages/opencode`: `bun test test/storage/db-project-guard.test.ts`
  - 4 tests passed
- `packages/opencode`: `bun typecheck`
- `git diff --check`
- Confirmed no merge conflicts against `origin/dev`

### Screenshots / recordings

Not applicable. This PR does not change the UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR