### PR TITLE
feat(app): 面板宽度约束系统化重构

### DIFF
--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -1,5 +1,5 @@
 import { createStore, produce } from "solid-js/store"
-import { batch, createEffect, createMemo, onCleanup, onMount, type Accessor } from "solid-js"
+import { batch, createEffect, createMemo, createSignal, onCleanup, onMount, type Accessor } from "solid-js"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { useGlobalSync } from "./global-sync"
 import { useGlobalSDK } from "./global-sdk"
@@ -489,8 +489,18 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
 
     setupSkillEvolutionAutoOpen(globalSync, server)
 
+    const [demandPx, setDemandPx] = createSignal(0)
+
     return {
       ready,
+      demand: {
+        px: demandPx,
+        set(px: number) {
+          const next = Math.max(0, Math.floor(px))
+          if (next === demandPx()) return
+          setDemandPx(next)
+        },
+      },
       handoff: {
         tabs: createMemo(() => store.handoff?.tabs),
         setTabs(dir: string, id: string) {

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -54,6 +54,7 @@ import { createAim } from "@/utils/aim"
 import { setNavigate } from "@/utils/notification-click"
 import { Worktree as WorktreeState } from "@/utils/worktree"
 import { setSessionHandoff } from "@/pages/session/handoff"
+import { SIDEBAR_MIN } from "@/pages/session/reading-layout"
 import type { E2EWindow } from "@/testing/terminal"
 import { OpenIntent } from "@/utils/open-intent"
 import { MessageOrder } from "@/utils/message-order"
@@ -2346,7 +2347,13 @@ export default function Layout(props: ParentProps) {
     document.documentElement.style.setProperty("--dialog-left-margin", `${sidebarWidth}px`)
   })
 
-  const side = createMemo(() => Math.max(layout.sidebar.width(), 244))
+  const side = createMemo(() => {
+    const demand = layout.demand.px()
+    const stored = Math.max(layout.sidebar.width(), SIDEBAR_MIN)
+    if (demand <= 0) return stored
+    const viewport = typeof window === "undefined" ? 1280 : window.innerWidth
+    return Math.max(SIDEBAR_MIN, Math.min(stored, viewport - demand))
+  })
   const panel = createMemo(() => Math.max(side() - 64, 0))
 
   const loadedSessionDirs = new Set<string>()
@@ -2967,8 +2974,8 @@ export default function Layout(props: ParentProps) {
                 <ResizeHandle
                   direction="horizontal"
                   size={layout.sidebar.width()}
-                  min={244}
-                  max={typeof window === "undefined" ? 1000 : window.innerWidth * 0.3 + 64}
+                  min={SIDEBAR_MIN}
+                  max={typeof window === "undefined" ? 3000 : window.innerWidth}
                   onResize={(w) => {
                     setState("sizing", true)
                     if (sizet !== undefined) clearTimeout(sizet)

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -2,6 +2,7 @@ import {
   batch,
   createEffect,
   createMemo,
+  createSignal,
   For,
   on,
   onCleanup,
@@ -2342,19 +2343,25 @@ export default function Layout(props: ParentProps) {
     ),
   )
 
-  createEffect(() => {
-    const sidebarWidth = layout.sidebar.opened() ? layout.sidebar.width() : 48
-    document.documentElement.style.setProperty("--dialog-left-margin", `${sidebarWidth}px`)
+  const [viewport, setViewport] = createSignal(typeof window === "undefined" ? 1280 : window.innerWidth)
+  onMount(() => {
+    const sync = () => setViewport(window.innerWidth)
+    window.addEventListener("resize", sync)
+    onCleanup(() => window.removeEventListener("resize", sync))
   })
 
   const side = createMemo(() => {
     const demand = layout.demand.px()
     const stored = Math.max(layout.sidebar.width(), SIDEBAR_MIN)
     if (demand <= 0) return stored
-    const viewport = typeof window === "undefined" ? 1280 : window.innerWidth
-    return Math.max(SIDEBAR_MIN, Math.min(stored, viewport - demand))
+    return Math.max(SIDEBAR_MIN, Math.min(stored, viewport() - demand))
   })
   const panel = createMemo(() => Math.max(side() - 64, 0))
+
+  createEffect(() => {
+    const sidebarWidth = layout.sidebar.opened() ? side() : 48
+    document.documentElement.style.setProperty("--dialog-left-margin", `${sidebarWidth}px`)
+  })
 
   const loadedSessionDirs = new Set<string>()
 
@@ -2973,7 +2980,7 @@ export default function Layout(props: ParentProps) {
               >
                 <ResizeHandle
                   direction="horizontal"
-                  size={layout.sidebar.width()}
+                  size={side()}
                   min={SIDEBAR_MIN}
                   max={typeof window === "undefined" ? 3000 : window.innerWidth}
                   onResize={(w) => {

--- a/packages/app/src/pages/reading-session.tsx
+++ b/packages/app/src/pages/reading-session.tsx
@@ -10,45 +10,17 @@ import { CommentsProvider } from "@/context/comments"
 import { useLayout } from "@/context/layout"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { createSizing } from "@/pages/session/helpers"
+import {
+  FILE_TREE_RATIOS,
+  PDF_RATIO_BOUNDS,
+  CHAT_RATIO_BOUNDS,
+  VARIANT_DEFAULTS,
+  type LayoutVariant,
+  type ReadingLayoutMode,
+} from "@/pages/session/reading-layout"
 import SessionPage from "./session"
 
-type LayoutVariant = "two-pane" | "tree" | "review" | "review-tree"
-type ReadingLayoutMode =
-  | "two-left"
-  | "two-right"
-  | "tree-left"
-  | "tree-right"
-  | "review-left"
-  | "review-right"
-  | "review-tree-left"
-  | "review-tree-right"
-
 const LAYOUT_STORAGE_PREFIX = "aether-reading-layout:"
-const VARIANT_DEFAULTS: Record<LayoutVariant, { pdf: number; chat: number }> = {
-  "two-pane": { pdf: 0.55, chat: 0.45 },
-  tree: { pdf: 0.5, chat: 0.35 },
-  review: { pdf: 0.4, chat: 0.25 },
-  "review-tree": { pdf: 0.4, chat: 0.25 },
-}
-
-const FILE_TREE_RATIOS: Record<LayoutVariant, number> = {
-  "two-pane": 0,
-  tree: 0.15,
-  review: 0,
-  "review-tree": 0.12,
-}
-
-const PDF_RATIO_BOUNDS: Record<LayoutVariant, { min: number; max: number }> = {
-  "two-pane": { min: 0.3, max: 0.75 },
-  tree: { min: 0.3, max: 0.6 },
-  review: { min: 0.3, max: 0.45 },
-  "review-tree": { min: 0.3, max: 0.4 },
-}
-
-const CHAT_RATIO_BOUNDS: Partial<Record<LayoutVariant, { min: number; max: number }>> = {
-  review: { min: 0.25, max: 0.4 },
-  "review-tree": { min: 0.25, max: 0.3 },
-}
 
 const ReadingSession: Component = () => {
   const params = useParams<{ id: string }>()
@@ -286,7 +258,10 @@ const ReadingSession: Component = () => {
     const total = totalWidth()
     const bounds = chatRatioBounds()
     if (total <= 0 || !bounds) return
-    const nextComposite = Math.min(compositeResizeBounds().max / total, Math.max(compositeResizeBounds().min / total, width / total))
+    const nextComposite = Math.min(
+      compositeResizeBounds().max / total,
+      Math.max(compositeResizeBounds().min / total, width / total),
+    )
     switch (mode()) {
       case "review-left":
       case "review-tree-left": {
@@ -309,11 +284,7 @@ const ReadingSession: Component = () => {
   const handleResizeSessionWidth = (width: number) => {
     const total = totalWidth()
     const bounds = chatRatioBounds()
-    if (
-      total <= 0 ||
-      !bounds ||
-      (mode() !== "review-right" && mode() !== "review-tree-right")
-    ) {
+    if (total <= 0 || !bounds || (mode() !== "review-right" && mode() !== "review-tree-right")) {
       return
     }
     const nextChat = Math.min(bounds.max, Math.max(bounds.min, width / total))
@@ -335,11 +306,11 @@ const ReadingSession: Component = () => {
                       minWidth={pdfMinWidth()}
                       maxWidth={Math.max(pdfMinWidth(), pdfMaxWidth())}
                       layoutSwapped={layoutSwapped()}
-                    onSwapLayout={handleSwapLayout}
-                    onResizeWidth={handleResizeWidth}
-                    resizeHandleEnabled={mode() !== "review-right" && mode() !== "review-tree-right"}
-                    sizing={sizing}
-                  />
+                      onSwapLayout={handleSwapLayout}
+                      onResizeWidth={handleResizeWidth}
+                      resizeHandleEnabled={mode() !== "review-right" && mode() !== "review-tree-right"}
+                      sizing={sizing}
+                    />
                   }
                   readingPanePosition={layoutSwapped() ? "after" : "before"}
                   readingPaneWidth={pdfPixelWidth()}

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -67,6 +67,7 @@ import { SessionSidePanel } from "@/pages/session/session-side-panel"
 import { TerminalPanel } from "@/pages/session/terminal-panel"
 import { useQuickReadingController } from "@/pages/session/use-quick-reading-controller"
 import { useQuickReadingLayout } from "@/pages/session/use-quick-reading-layout"
+import { CHAT_MIN, REVIEW_MIN, SESSION_MIN, SIDEBAR_MIN, TREE_MIN } from "@/pages/session/reading-layout"
 import { useSessionCommands } from "@/pages/session/use-session-commands"
 import { useSessionHashScroll } from "@/pages/session/use-session-hash-scroll"
 import { Identifier } from "@/utils/id"
@@ -77,8 +78,8 @@ import { MessageOrder } from "@/utils/message-order"
 
 const emptyUserMessages: UserMessage[] = []
 const emptyFollowups: (FollowupDraft & { id: string })[] = []
-const READING_CHAT_MIN_WIDTH = 360
-const READING_REVIEW_MIN_WIDTH = 320
+const READING_CHAT_MIN_WIDTH = CHAT_MIN
+const READING_REVIEW_MIN_WIDTH = REVIEW_MIN
 
 type ChangeMode = "git" | "branch" | "session" | "turn" | "graph"
 type VcsMode = "git" | "branch"
@@ -456,28 +457,6 @@ function SessionPageContent(props: SessionPageProps = {}) {
   const desktopSidePanelOpen = createMemo(() => desktopReviewOpen() || desktopFileTreeOpen())
   let rowRef: HTMLDivElement | undefined
   const [rowWidth, setRowWidth] = createSignal(0)
-  const readingPaneWidth = createMemo(() => {
-    if (!isDesktop()) return 0
-    if (propReadingModeActive()) return Math.max(0, props.readingPaneWidth ?? 0)
-    if (quickReadingModeActive()) return quickReadingLayout.pdfPixelWidth()
-    return 0
-  })
-  const readingCompositeMinWidth = createMemo(() =>
-    propReadingModeActive()
-      ? Math.max(0, props.readingCompositeMinWidth ?? 0)
-      : quickReadingModeActive()
-        ? Math.max(0, quickReadingLayout.compositeResizeBounds().min)
-        : 0,
-  )
-  const readingCompositeMaxWidth = createMemo(() => {
-    if (!readingModeActive()) return 0
-    const fallback = propReadingModeActive()
-      ? rowWidth() > 0
-        ? rowWidth()
-        : (props.readingCompositeWidth ?? 0)
-      : quickReadingLayout.compositeResizeBounds().max
-    return Math.max(readingCompositeMinWidth(), props.readingCompositeMaxWidth ?? fallback)
-  })
   const readingFileTreeWidth = createMemo(() =>
     propReadingModeActive()
       ? Math.max(0, props.readingFileTreeWidth ?? 0)
@@ -487,13 +466,47 @@ function SessionPageContent(props: SessionPageProps = {}) {
   )
   const sidePanelMinWidth = createMemo(() => {
     let width = 0
-    if (desktopReviewOpen()) width += READING_REVIEW_MIN_WIDTH
-    if (desktopFileTreeOpen()) width += readingFileTreeWidth()
+    if (desktopReviewOpen()) width += REVIEW_MIN
+    if (desktopFileTreeOpen()) width += TREE_MIN
     return width
+  })
+  const readingPaneWidth = createMemo(() => {
+    if (!isDesktop()) return 0
+    const cap = rowWidth() > 0 ? Math.max(0, rowWidth() - sidePanelMinWidth() - CHAT_MIN) : undefined
+    if (propReadingModeActive()) {
+      const w = Math.max(0, props.readingPaneWidth ?? 0)
+      return cap === undefined ? w : Math.min(w, cap)
+    }
+    if (quickReadingModeActive()) {
+      const w = quickReadingLayout.pdfPixelWidth()
+      return cap === undefined ? w : Math.min(w, cap)
+    }
+    return 0
+  })
+  const readingCompositeMinWidth = createMemo(() => {
+    const value = propReadingModeActive()
+      ? Math.max(0, props.readingCompositeMinWidth ?? 0)
+      : quickReadingModeActive()
+        ? Math.max(0, quickReadingLayout.compositeResizeBounds().min)
+        : 0
+    if (rowWidth() <= 0) return value
+    return Math.min(value, Math.max(0, rowWidth() - sidePanelMinWidth()))
+  })
+  const readingCompositeMaxWidth = createMemo(() => {
+    if (!readingModeActive()) return 0
+    const reserved = sidePanelMinWidth()
+    const total = propReadingModeActive() ? rowWidth() : quickReadingLayout.rowWidth()
+    const absolute = total > 0 ? Math.max(0, total - reserved) : Number.POSITIVE_INFINITY
+    const fallback = propReadingModeActive()
+      ? rowWidth() > 0
+        ? Math.max(0, rowWidth() - reserved)
+        : (props.readingCompositeWidth ?? 0)
+      : Math.max(0, quickReadingLayout.compositeResizeBounds().max - reserved)
+    return Math.max(readingCompositeMinWidth(), Math.min(absolute, props.readingCompositeMaxWidth ?? fallback))
   })
   const compositeMinWidth = createMemo(() => {
     if (!readingModeActive()) return 0
-    return readingPaneWidth() + READING_CHAT_MIN_WIDTH
+    return readingPaneWidth() + CHAT_MIN
   })
   const effectiveCompositeWidth = createMemo(() => {
     if (!readingModeActive()) return 0
@@ -515,22 +528,30 @@ function SessionPageContent(props: SessionPageProps = {}) {
   const effectiveSidePanelWidth = createMemo(() => {
     if (!readingModeActive()) return undefined
     if (!desktopSidePanelOpen()) return 0
+    const min = sidePanelMinWidth()
+    const cap = rowWidth() > 0 ? Math.max(min, rowWidth() - effectiveCompositeWidth()) : undefined
     if (propReadingModeActive() && typeof props.readingSidePanelWidth === "number") {
-      return Math.max(0, props.readingSidePanelWidth)
+      const w = Math.max(min, props.readingSidePanelWidth)
+      return cap === undefined ? w : Math.min(w, cap)
     }
-    if (quickReadingModeActive()) return quickReadingLayout.sidePanelWidth()
-    return Math.max(sidePanelMinWidth(), rowWidth() - effectiveCompositeWidth())
+    if (quickReadingModeActive()) {
+      const w = Math.max(min, quickReadingLayout.sidePanelWidth())
+      return cap === undefined ? w : Math.min(w, cap)
+    }
+    return Math.max(min, rowWidth() - effectiveCompositeWidth())
   })
   const sessionPanelWidth = createMemo(() => {
     if (readingModeActive()) {
-      return `${effectiveSessionPanelWidth() ?? READING_CHAT_MIN_WIDTH}px`
+      return `${Math.max(CHAT_MIN, effectiveSessionPanelWidth() ?? CHAT_MIN)}px`
     }
     const pdfWidth = readingPaneWidth()
     if (!desktopSidePanelOpen()) {
       return pdfWidth > 0 ? `calc(100% - ${pdfWidth}px)` : "100%"
     }
     if (desktopReviewOpen()) {
-      return `${Math.max(360, layout.session.width() - pdfWidth)}px`
+      const w = Math.max(SESSION_MIN, layout.session.width() - pdfWidth)
+      const cap = rowWidth() > 0 ? Math.max(SESSION_MIN, rowWidth() - sidePanelMinWidth()) : undefined
+      return `${cap === undefined ? w : Math.min(cap, w)}px`
     }
     return pdfWidth > 0
       ? `calc(100% - ${layout.fileTree.width()}px - ${pdfWidth}px)`
@@ -548,11 +569,40 @@ function SessionPageContent(props: SessionPageProps = {}) {
     return 0
   })
   const readingSessionResizeMax = createMemo(() => {
-    if (propReadingModeActive()) return Math.max(readingSessionResizeMin(), props.readingSessionResizeMax ?? 0)
-    if (quickReadingModeActive())
-      return Math.max(readingSessionResizeMin(), quickReadingLayout.sessionResizeBounds().max)
+    const room = rowWidth() > 0 ? Math.max(0, rowWidth() - sidePanelMinWidth() - readingPaneWidth()) : undefined
+    if (propReadingModeActive()) {
+      const cap = Math.min(props.readingSessionResizeMax ?? 0, room ?? Number.POSITIVE_INFINITY)
+      return Math.max(readingSessionResizeMin(), cap)
+    }
+    if (quickReadingModeActive()) {
+      const cap = Math.min(quickReadingLayout.sessionResizeBounds().max, room ?? Number.POSITIVE_INFINITY)
+      return Math.max(readingSessionResizeMin(), cap)
+    }
     return 0
   })
+  const rowDemand = createMemo(() => {
+    if (!isDesktop()) return 0
+    if (readingModeActive()) {
+      let demand = propReadingModeActive()
+        ? Math.max(CHAT_MIN, props.readingCompositeMinWidth ?? 0)
+        : quickReadingLayout.pdfMinWidth() + CHAT_MIN
+      if (desktopReviewOpen()) demand += REVIEW_MIN
+      if (desktopFileTreeOpen()) demand += TREE_MIN
+      return Math.ceil(demand)
+    }
+    if (!desktopSidePanelOpen()) return 0
+    let demand = SESSION_MIN
+    if (desktopReviewOpen()) demand += REVIEW_MIN
+    if (desktopFileTreeOpen()) demand += TREE_MIN
+    return Math.ceil(demand)
+  })
+  createEffect(() => layout.demand.set(rowDemand()))
+  const pushSidebar = (deficit: number) => {
+    if (deficit <= 0) return
+    const cur = layout.sidebar.width()
+    const next = Math.max(SIDEBAR_MIN, cur - deficit)
+    if (next !== cur) layout.sidebar.resize(next)
+  }
   const readingFileTreeResizable = createMemo(() => {
     if (propReadingModeActive()) return props.readingFileTreeResizable
     if (quickReadingModeActive()) return false
@@ -696,7 +746,13 @@ function SessionPageContent(props: SessionPageProps = {}) {
         authHeader={quickReadingController.authHeader()}
         width={readingPaneWidth()}
         minWidth={quickReadingLayout.pdfMinWidth()}
-        maxWidth={Math.max(quickReadingLayout.pdfMinWidth(), quickReadingLayout.pdfMaxWidth())}
+        maxWidth={Math.max(
+          quickReadingLayout.pdfMinWidth(),
+          Math.min(
+            quickReadingLayout.pdfMaxWidth(),
+            rowWidth() > 0 ? rowWidth() - sidePanelMinWidth() - CHAT_MIN : quickReadingLayout.pdfMaxWidth(),
+          ),
+        )}
         page={quickReadingController.page()}
         location={quickReadingController.location()}
         layoutSwapped={quickReadingController.layoutSwapped()}
@@ -2270,8 +2326,8 @@ function SessionPageContent(props: SessionPageProps = {}) {
 
         <Show when={readingModeActive()}>
           <div
-            class="relative flex min-h-0 shrink-0 overflow-hidden"
-            style={{ width: `${effectiveCompositeWidth()}px` }}
+            class="relative flex min-h-0 overflow-hidden"
+            style={{ width: `${effectiveCompositeWidth()}px`, "min-width": `${compositeMinWidth()}px` }}
           >
             <Show when={effectiveReadingPanePosition() !== "after"}>
               <div class="min-h-0 shrink-0" style={{ order: String(readingPaneOrder()) }}>
@@ -2280,7 +2336,7 @@ function SessionPageContent(props: SessionPageProps = {}) {
             </Show>
             <div
               classList={{
-                "@container relative shrink-0 flex flex-col min-h-0 h-full bg-background-stronger flex-1 md:flex-none": true,
+                "@container relative flex flex-col min-h-0 h-full bg-background-stronger flex-1 md:flex-initial md:min-w-[150px]": true,
                 "transition-[width] duration-[240ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[width] motion-reduce:transition-none":
                   !size.active() && !ui.reviewSnap,
               }}
@@ -2406,9 +2462,16 @@ function SessionPageContent(props: SessionPageProps = {}) {
                     class="after:bg-border-base/90"
                     size={readingSessionResizeSize()}
                     min={readingSessionResizeMin()}
-                    max={readingSessionResizeMax()}
+                    max={Math.max(
+                      readingSessionResizeMin(),
+                      typeof window === "undefined"
+                        ? 3000
+                        : window.innerWidth - SIDEBAR_MIN - sidePanelMinWidth() - readingPaneWidth(),
+                    )}
                     onResize={(width) => {
                       size.touch()
+                      const room = rowWidth() > 0 ? rowWidth() - sidePanelMinWidth() - readingPaneWidth() : undefined
+                      if (room !== undefined && width > room) pushSidebar(width - room)
                       if (propReadingModeActive()) {
                         props.onReadingSessionResize?.(width)
                         return
@@ -2432,9 +2495,14 @@ function SessionPageContent(props: SessionPageProps = {}) {
                   class="after:bg-border-base/90"
                   size={effectiveCompositeWidth()}
                   min={readingCompositeMinWidth()}
-                  max={readingCompositeMaxWidth()}
+                  max={Math.max(
+                    readingCompositeMinWidth(),
+                    typeof window === "undefined" ? 3000 : window.innerWidth - SIDEBAR_MIN - sidePanelMinWidth(),
+                  )}
                   onResize={(width) => {
                     size.touch()
+                    const room = rowWidth() > 0 ? rowWidth() - sidePanelMinWidth() : undefined
+                    if (room !== undefined && width > room) pushSidebar(width - room)
                     if (propReadingModeActive()) {
                       props.onReadingCompositeResize?.(width)
                       return
@@ -2450,7 +2518,7 @@ function SessionPageContent(props: SessionPageProps = {}) {
         <Show when={!readingModeActive()}>
           <div
             classList={{
-              "@container relative shrink-0 flex flex-col min-h-0 h-full bg-background-stronger flex-1 md:flex-none": true,
+              "@container relative flex flex-col min-h-0 h-full bg-background-stronger flex-1 md:flex-initial md:min-w-[150px]": true,
               "transition-[width] duration-[240ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[width] motion-reduce:transition-none":
                 !size.active() && !ui.reviewSnap,
             }}
@@ -2567,10 +2635,15 @@ function SessionPageContent(props: SessionPageProps = {}) {
                 <ResizeHandle
                   direction="horizontal"
                   size={layout.session.width()}
-                  min={450}
-                  max={typeof window === "undefined" ? 1000 : window.innerWidth * 0.45}
+                  min={SESSION_MIN}
+                  max={Math.max(
+                    SESSION_MIN,
+                    typeof window === "undefined" ? 3000 : window.innerWidth - SIDEBAR_MIN - sidePanelMinWidth(),
+                  )}
                   onResize={(width) => {
                     size.touch()
+                    const room = rowWidth() > 0 ? rowWidth() - sidePanelMinWidth() : undefined
+                    if (room !== undefined && width > room) pushSidebar(width - room)
                     layout.session.resize(width)
                   }}
                 />
@@ -2585,6 +2658,15 @@ function SessionPageContent(props: SessionPageProps = {}) {
           reviewOpenOverride={readingModeActive() ? desktopReviewOpen() : undefined}
           fileOpenOverride={readingModeActive() ? desktopFileTreeOpen() : undefined}
           treeWidthOverride={readingModeActive() ? readingFileTreeWidth() : undefined}
+          treeMaxWidth={
+            typeof window === "undefined" ? undefined : window.innerWidth - SIDEBAR_MIN - SESSION_MIN - REVIEW_MIN
+          }
+          onOverflow={(deficit) => {
+            const cur = Math.max(SESSION_MIN, layout.session.width())
+            const give = Math.min(deficit, cur - SESSION_MIN)
+            if (give > 0) layout.session.resize(cur - give)
+            if (deficit - give > 0) pushSidebar(deficit - give)
+          }}
           fileTreeResizable={readingModeActive() ? readingFileTreeResizable() : undefined}
           canReview={canReview}
           diffs={reviewDiffs}

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -78,8 +78,6 @@ import { MessageOrder } from "@/utils/message-order"
 
 const emptyUserMessages: UserMessage[] = []
 const emptyFollowups: (FollowupDraft & { id: string })[] = []
-const READING_CHAT_MIN_WIDTH = CHAT_MIN
-const READING_REVIEW_MIN_WIDTH = REVIEW_MIN
 
 type ChangeMode = "git" | "branch" | "session" | "turn" | "graph"
 type VcsMode = "git" | "branch"
@@ -554,8 +552,8 @@ function SessionPageContent(props: SessionPageProps = {}) {
       return `${cap === undefined ? w : Math.min(cap, w)}px`
     }
     return pdfWidth > 0
-      ? `calc(100% - ${layout.fileTree.width()}px - ${pdfWidth}px)`
-      : `calc(100% - ${layout.fileTree.width()}px)`
+      ? `calc(100% - ${Math.max(TREE_MIN, layout.fileTree.width())}px - ${pdfWidth}px)`
+      : `calc(100% - ${Math.max(TREE_MIN, layout.fileTree.width())}px)`
   })
   const centered = createMemo(() => isDesktop() && !desktopReviewOpen())
   const readingSessionResizeSize = createMemo(() => {
@@ -597,6 +595,7 @@ function SessionPageContent(props: SessionPageProps = {}) {
     return Math.ceil(demand)
   })
   createEffect(() => layout.demand.set(rowDemand()))
+  onCleanup(() => layout.demand.set(0))
   const pushSidebar = (deficit: number) => {
     if (deficit <= 0) return
     const cur = layout.sidebar.width()

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -52,7 +52,9 @@ export function SessionComposerRegion(props: {
   const readingMode = useMaybeReadingMode()
   const quickReadingMode = useMaybeQuickReadingMode()
   const route = useSessionKey()
-  const quotes = createMemo(() => quote?.store.pendingQuestions.filter((item) => item.sessionID === route.params.id) ?? [])
+  const quotes = createMemo(
+    () => quote?.store.pendingQuestions.filter((item) => item.sessionID === route.params.id) ?? [],
+  )
   const quoteCards = createMemo(() => quotes().slice().reverse())
   const pendingQuestion = createMemo(() => {
     const quickPending = quickReadingMode?.store.pendingQuestion
@@ -147,7 +149,7 @@ export function SessionComposerRegion(props: {
       <div
         classList={{
           "w-full px-3 pointer-events-auto": true,
-          "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": props.centered,
+          "md:max-w-[2400px] md:mx-auto 2xl:max-w-[3000px]": props.centered,
         }}
       >
         <Show when={props.state.questionRequest()} keyed>

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -595,7 +595,7 @@ export function MessageTimeline(props: {
     })
   }
 
-  const parent = (node: Node | null) => (node instanceof Element ? node : node?.parentElement ?? undefined)
+  const parent = (node: Node | null) => (node instanceof Element ? node : (node?.parentElement ?? undefined))
 
   const rects = (input: { range: Range; container: HTMLElement }) => {
     const list: Array<{
@@ -1222,7 +1222,7 @@ export function MessageTimeline(props: {
                   "w-full": true,
                   "pb-4": true,
                   "pl-2 pr-3 md:pl-4 md:pr-3": true,
-                  "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": props.centered,
+                  "md:max-w-[2400px] md:mx-auto 2xl:max-w-[3000px]": props.centered,
                 }}
               >
                 <div class="h-12 w-full flex items-center justify-between gap-2">
@@ -1520,7 +1520,7 @@ export function MessageTimeline(props: {
               class="flex flex-col items-start justify-start pb-16 transition-[margin]"
               classList={{
                 "w-full": true,
-                "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": props.centered,
+                "md:max-w-[2400px] md:mx-auto 2xl:max-w-[3000px]": props.centered,
                 "mt-0.5": props.centered,
                 "mt-0": !props.centered,
               }}
@@ -1570,19 +1570,23 @@ export function MessageTimeline(props: {
                           quote.imageDataUrl === b[i].imageDataUrl,
                       ),
                   })
-                  const conversationQuotes = createMemo(() => messageConversationQuotes(sync.data.part[messageID] ?? []), [], {
-                    equals: (a, b) =>
-                      a.length === b.length &&
-                      a.every(
-                        (quote, i) =>
-                          quote.kind === b[i].kind &&
-                          quote.source === b[i].source &&
-                          quote.action === b[i].action &&
-                          quote.sourceMessageID === b[i].sourceMessageID &&
-                          quote.summary === b[i].summary &&
-                          quote.fullText === b[i].fullText,
-                      ),
-                  })
+                  const conversationQuotes = createMemo(
+                    () => messageConversationQuotes(sync.data.part[messageID] ?? []),
+                    [],
+                    {
+                      equals: (a, b) =>
+                        a.length === b.length &&
+                        a.every(
+                          (quote, i) =>
+                            quote.kind === b[i].kind &&
+                            quote.source === b[i].source &&
+                            quote.action === b[i].action &&
+                            quote.sourceMessageID === b[i].sourceMessageID &&
+                            quote.summary === b[i].summary &&
+                            quote.fullText === b[i].fullText,
+                        ),
+                    },
+                  )
                   const commentCount = createMemo(() => comments().length)
                   const readingQuoteCount = createMemo(() => readingQuotes().length)
                   const conversationQuoteCount = createMemo(() => conversationQuotes().length)
@@ -1593,7 +1597,7 @@ export function MessageTimeline(props: {
                       data-assistant-collapsed={isAssistantCollapsed(messageID) ? "true" : undefined}
                       classList={{
                         "min-w-0 w-full max-w-full": true,
-                        "md:max-w-200 2xl:max-w-[1000px]": props.centered,
+                        "md:max-w-[2400px] 2xl:max-w-[3000px]": props.centered,
                       }}
                       style={{
                         "content-visibility": "auto",
@@ -1677,7 +1681,9 @@ export function MessageTimeline(props: {
                                   }}
                                 >
                                   <div class="pt-1 text-11-medium text-text-weak">
-                                    {conversationQuoteCount() === 1 ? "Ask" : `Ask · ${conversationQuoteCount()} quotes`}
+                                    {conversationQuoteCount() === 1
+                                      ? "Ask"
+                                      : `Ask · ${conversationQuoteCount()} quotes`}
                                   </div>
                                   <div class="mt-2 flex max-h-[172px] flex-col gap-2 overflow-y-auto pr-1">
                                     <Index each={conversationQuotes()}>

--- a/packages/app/src/pages/session/reading-layout.ts
+++ b/packages/app/src/pages/session/reading-layout.ts
@@ -10,6 +10,12 @@ export type ReadingLayoutMode =
   | "review-tree-left"
   | "review-tree-right"
 
+export const SIDEBAR_MIN = 81
+export const SESSION_MIN = 150
+export const REVIEW_MIN = 107
+export const TREE_MIN = 67
+export const CHAT_MIN = 120
+
 export const VARIANT_DEFAULTS: Record<LayoutVariant, { pdf: number; chat: number }> = {
   "two-pane": { pdf: 0.55, chat: 0.45 },
   tree: { pdf: 0.5, chat: 0.35 },
@@ -25,15 +31,15 @@ export const FILE_TREE_RATIOS: Record<LayoutVariant, number> = {
 }
 
 export const PDF_RATIO_BOUNDS: Record<LayoutVariant, { min: number; max: number }> = {
-  "two-pane": { min: 0.3, max: 0.75 },
-  tree: { min: 0.3, max: 0.6 },
-  review: { min: 0.3, max: 0.45 },
-  "review-tree": { min: 0.3, max: 0.4 },
+  "two-pane": { min: 0.1, max: 0.9 },
+  tree: { min: 0.1, max: 0.9 },
+  review: { min: 0.1, max: 0.9 },
+  "review-tree": { min: 0.1, max: 0.9 },
 }
 
 export const CHAT_RATIO_BOUNDS: Partial<Record<LayoutVariant, { min: number; max: number }>> = {
-  review: { min: 0.25, max: 0.4 },
-  "review-tree": { min: 0.25, max: 0.3 },
+  review: { min: 0.0833, max: 0.9 },
+  "review-tree": { min: 0.0833, max: 0.9 },
 }
 
 export function getReadingLayoutVariant(reviewOpen: boolean, fileTreeOpen: boolean): LayoutVariant {

--- a/packages/app/src/pages/session/session-side-panel-state.ts
+++ b/packages/app/src/pages/session/session-side-panel-state.ts
@@ -1,3 +1,5 @@
+import { TREE_MIN } from "@/pages/session/reading-layout"
+
 export function panel(input: {
   desktop: boolean
   review_override?: boolean
@@ -14,6 +16,7 @@ export function panel(input: {
   const file = input.desktop && (typeof input.file_override === "boolean" ? input.file_override : input.file_open)
   const open = review || file
   const tree = typeof input.tree_width_override === "number" ? Math.max(0, input.tree_width_override) : input.tree_width
+  const clamped = Math.max(TREE_MIN, tree)
   const width =
     typeof input.width_override === "number"
       ? `${Math.max(0, input.width_override)}px`
@@ -21,7 +24,7 @@ export function panel(input: {
         ? "0px"
         : review
           ? `calc(100% - ${input.session_width}px)`
-          : `${input.tree_width}px`
+          : `${clamped}px`
 
   return {
     review,
@@ -29,7 +32,7 @@ export function panel(input: {
     open,
     review_tab: input.desktop,
     panel_width: width,
-    tree_width: file ? `${tree}px` : "0px",
+    tree_width: file ? `${clamped}px` : "0px",
   }
 }
 

--- a/packages/app/src/pages/session/session-side-panel-state.ts
+++ b/packages/app/src/pages/session/session-side-panel-state.ts
@@ -1,4 +1,4 @@
-import { TREE_MIN } from "@/pages/session/reading-layout"
+import { SESSION_MIN, TREE_MIN } from "@/pages/session/reading-layout"
 
 export function panel(input: {
   desktop: boolean
@@ -23,7 +23,7 @@ export function panel(input: {
       : !open
         ? "0px"
         : review
-          ? `calc(100% - ${input.session_width}px)`
+          ? `calc(100% - ${Math.max(SESSION_MIN, input.session_width)}px)`
           : `${clamped}px`
 
   return {

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -54,6 +54,8 @@ export function SessionSidePanel(props: {
   reviewOpenOverride?: boolean
   fileOpenOverride?: boolean
   treeWidthOverride?: number
+  treeMaxWidth?: number
+  onOverflow?: (deficit: number) => void
   fileTreeResizable?: boolean
   canReview: () => boolean
   diffs: () => FileDiff[]
@@ -344,6 +346,7 @@ export function SessionSidePanel(props: {
   const reviewTab = createMemo(() => state().review_tab)
   const panelWidth = createMemo(() => state().panel_width)
   const treeWidth = createMemo(() => state().tree_width)
+  let treeEl: HTMLDivElement | undefined
 
   const diffFiles = createMemo(() => {
     const d = props.diffs()
@@ -848,7 +851,11 @@ export function SessionSidePanel(props: {
           "transition-[width] duration-[240ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[width] motion-reduce:transition-none":
             !props.size.active() && !props.reviewSnap,
         }}
-        style={{ ...(props.style ?? {}), width: panelWidth() }}
+        style={{
+          ...(props.style ?? {}),
+          width: panelWidth(),
+          "min-width": open() ? `${(reviewOpen() ? 107 : 0) + (fileOpen() ? 67 : 0)}px` : "0px",
+        }}
       >
         <div class="size-full flex border-l border-border-weaker-base">
           <div
@@ -858,6 +865,7 @@ export function SessionSidePanel(props: {
             classList={{
               "pointer-events-none": !reviewOpen(),
             }}
+            style={{ "min-width": reviewOpen() ? "107px" : undefined }}
           >
             <div class="size-full min-w-0 h-full bg-background-base">
               <DragDropProvider
@@ -1024,13 +1032,20 @@ export function SessionSidePanel(props: {
             id="file-tree-panel"
             aria-hidden={!fileOpen()}
             inert={!fileOpen()}
-            class="relative min-w-0 h-full shrink-0 overflow-hidden"
+            ref={(el) => {
+              treeEl = el
+            }}
+            class="relative min-w-0 h-full overflow-hidden"
             classList={{
               "pointer-events-none": !fileOpen(),
               "transition-[width] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[width] motion-reduce:transition-none":
                 !props.size.active(),
             }}
-            style={{ width: treeWidth() }}
+            style={{
+              width: treeWidth(),
+              "min-width": fileOpen() ? "67px" : undefined,
+              "max-width": reviewOpen() ? "calc(100% - 107px)" : undefined,
+            }}
           >
             <div
               class="h-full flex flex-col overflow-hidden group/filetree"
@@ -1252,10 +1267,13 @@ export function SessionSidePanel(props: {
                       ? Math.max(0, props.treeWidthOverride)
                       : layout.fileTree.width()
                   }
-                  min={200}
-                  max={480}
+                  min={67}
+                  max={Math.max(67, props.treeMaxWidth ?? 1440)}
                   onResize={(width) => {
                     props.size.touch()
+                    const aside = treeEl?.parentElement?.clientWidth ?? 0
+                    const room = aside - (reviewOpen() ? 107 : 0)
+                    if (reviewOpen() && aside > 0 && width > room) props.onOverflow?.(width - room)
                     layout.fileTree.resize(width)
                   }}
                 />

--- a/packages/ui/src/components/markdown.css
+++ b/packages/ui/src/components/markdown.css
@@ -267,13 +267,13 @@
 
 /* ── Review mode: enhanced styling for file preview panel ── */
 [data-file-content] > [data-component="markdown"] {
-  max-width: min(860px, 100%);
+  max-width: min(2580px, 100%);
   width: 100%;
   margin-inline: auto;
   padding-inline: 26px;
   color: color-mix(in srgb, var(--text-strong) 94%, var(--text-base));
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif,
-    "Apple Color Emoji", "Segoe UI Emoji";
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
   font-size: 16px;
   line-height: 1.6;
   letter-spacing: 0;


### PR DESCRIPTION
### Issue for this PR

无对应 issue

### Type of change

- [x] New feature
- [x] Refactor / code improvement

### What does this PR do?

面板宽度约束系统化重构，统一为三条规则：每个面板有不可破坏的最小宽度、去除人为最大宽度限制、任何面板可通过拖拽互相压缩（其余面板收缩到各自最小值即停）。

- 统一最小宽度常量（侧栏 81 / 会话 150 / 审查 107 / 文件树 67 / 聊天 120，原值 ÷3），CSS `min-width` 与渲染层钳制双层保护
- 移除人为最大宽度限制：比例上限统一 0.9，居中内容 800/1000px→2400/3000px，markdown 预览 860px→2580px
- 行内面板改用 flexbox 收缩实现互相压缩；拖拽超出当前空间时链式推挤（先压会话栏、再压侧栏，均有下限）
- 新增 `demand` 信号让行内面板的空间需求传导给侧栏布局
- 消除 `reading-session` 与 `reading-layout` 的常量重复；修复原有共变边界（上限随拖动值变化）导致钳制失效、以及持久化极端宽度破坏布局的问题

### How did you verify your code works?

- `bun typecheck`（packages/app）通过
- `bunx vitest run src/pages src/context`（3 文件 7 用例）通过
- Web 端手工验证：会话/审查/文件树/侧栏互相压缩到最小值即停、隐藏文件树无残留边条、md 内容随审查栏同步扩宽、窗口缩放后布局正常
- 确认桌面端（desktop-electron）与 web 共用同一组件树，改动自动生效

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR