### PR TITLE
fix(desktop): 让翻译子任务继承当前模型

### DIFF
--- a/.opencode/agent/translator.md
+++ b/.opencode/agent/translator.md
@@ -1,7 +1,7 @@
 ---
 description: Translate content for a specified locale while preserving technical terms
 mode: subagent
-model: opencode/gpt-5.4
+# Keep model unset so tasks inherit the model selected in the calling conversation.
 ---
 
 You are a professional translator and localization specialist.

--- a/packages/desktop-electron/electron-builder.config.test.ts
+++ b/packages/desktop-electron/electron-builder.config.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test"
+import path from "node:path"
+import config from "./electron-builder.config"
+
+function resource(to: string) {
+  if (!Array.isArray(config.extraResources)) throw new Error("Desktop extraResources must be an array")
+
+  const item = config.extraResources.find((item) => typeof item === "object" && item !== null && item.to === to)
+  if (!item || typeof item === "string") throw new Error(`Desktop resource ${to} not found`)
+  return item
+}
+
+async function pins(dir: string, to: string) {
+  const filter = resource(to).filter
+  if (!Array.isArray(filter)) throw new Error(`Desktop resource ${to} must declare filters`)
+
+  const excluded = new Set(filter.filter((item) => item.startsWith("!")).map((item) => item.slice(1)))
+  const root = `${import.meta.dir}/../../.opencode/${dir}`
+  const files = await Array.fromAsync(new Bun.Glob("**/*.md").scan({ cwd: root, absolute: true }))
+
+  return (
+    await Promise.all(
+      files
+        .filter((file) => !excluded.has(path.relative(root, file).replaceAll("\\", "/")))
+        .map(async (file) => {
+          const match = (await Bun.file(file).text()).match(/^---\r?\n([\s\S]*?)\r?\n---/)
+          return /^\s*(?:model|["']model["'])\s*:/m.test(match?.[1] ?? "") ? file : undefined
+        }),
+    )
+  ).filter((file) => file !== undefined)
+}
+
+test("desktop excludes repository-only agents", () => {
+  expect(resource(".aether/agent").filter).toEqual(["**/*", "!triage.md", "!duplicate-pr.md"])
+})
+
+test("desktop excludes repository-only commands", () => {
+  expect(resource(".aether/command").filter).toEqual(["**/*", "!issues.md", "!commit.md", "!changelog.md"])
+})
+
+test("desktop-facing agents and commands inherit the conversation model", async () => {
+  expect(await pins("agent", ".aether/agent")).toEqual([])
+  expect(await pins("command", ".aether/command")).toEqual([])
+})

--- a/packages/desktop-electron/electron-builder.config.ts
+++ b/packages/desktop-electron/electron-builder.config.ts
@@ -40,10 +40,12 @@ const getBase = (): Configuration => ({
     {
       from: "../../.opencode/agent",
       to: ".aether/agent",
+      filter: ["**/*", "!triage.md", "!duplicate-pr.md"],
     },
     {
       from: "../../.opencode/command",
       to: ".aether/command",
+      filter: ["**/*", "!issues.md", "!commit.md", "!changelog.md"],
     },
     {
       from: "../../.opencode/themes",

--- a/packages/opencode/test/layer-1/single-track-permission.test.ts
+++ b/packages/opencode/test/layer-1/single-track-permission.test.ts
@@ -234,7 +234,7 @@ describe("Layer 1.5 — single-track permission contract", () => {
     })
   })
 
-  test("task dispatch preserves finalPermission (no tools overwrite)", async () => {
+  test("task dispatch preserves finalPermission and inherits the caller model", async () => {
     const srv = await stub([
       { type: "text", text: "ok", usage: { input: 4, output: 2 } },
       { type: "text", text: "done", usage: { input: 4, output: 2 } },
@@ -272,9 +272,13 @@ describe("Layer 1.5 — single-track permission contract", () => {
         )
 
         const child = await Session.get(result.metadata.sessionId)
+        const user = (await Session.messages({ sessionID: child.id })).find((x) => x.info.role === "user")
+        if (user?.info.role !== "user") throw new Error("Child user message not found")
         const hasBashDeny = child.permission?.some(
           (r) => r.permission === "bash" && r.pattern === "*" && r.action === "deny",
         )
+        expect(user.info.model).toEqual(model)
+        expect(result.metadata.model).toEqual(model)
         expect(hasBashDeny).toBe(true)
       },
     })

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { Agent } from "../../src/agent/agent"
+import { ConfigMarkdown } from "../../src/config/markdown"
 import { Instance } from "../../src/project/instance"
 import { TaskTool } from "../../src/tool/task"
 import { tmpdir } from "../fixture/fixture"
@@ -9,6 +10,12 @@ afterEach(async () => {
 })
 
 describe("tool.task", () => {
+  test("bundled translator leaves model unset", async () => {
+    const cfg = await ConfigMarkdown.parse(import.meta.dir + "/../../../../.opencode/agent/translator.md")
+
+    expect(cfg.data.model).toBeUndefined()
+  })
+
   test("description sorts subagents by name and is stable across calls", async () => {
     await using tmp = await tmpdir({
       config: {


### PR DESCRIPTION
### Issue for this PR

Closes #1155

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

移除 bundled translator 固定的 `opencode/gpt-5.4`，使 PDF 选中文字后的翻译子任务继承用户当前选择的对话模型。

同时从 Aether Desktop 安装包中排除仅供仓库维护或 CI 使用的 agents 和 commands，避免这些内部资源覆盖用户模型或出现在普通桌面环境中，并增加模型继承和桌面打包边界的回归测试。

### How did you verify your code works?

- 在 `packages/desktop-electron` 运行 `bun test`：32 项测试通过。
- 在 `packages/desktop-electron` 运行 `bun typecheck`：通过。
- 在 `packages/opencode` 运行 `bun test test/tool/task.test.ts`：2 项测试通过。
- 在 `packages/opencode` 运行 `bun typecheck`：通过。
- TaskTool 模型继承集成断言通过；Windows 环境在测试结束清理临时日志目录时仍会遇到既存的 `EBUSY`，与本次模型逻辑无关。
- `git diff --cached --check`：通过。
- 推送前仓库级 typecheck：12 项任务全部通过。

### Screenshots / recordings

Not applicable. 本次修改不改变界面，只修正模型继承和桌面资源打包行为。

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR