### PR TITLE
fix(mobile): resolve file paths containing spaces when sending files

### DIFF
--- a/packages/opencode/src/mobile/base.ts
+++ b/packages/opencode/src/mobile/base.ts
@@ -1047,10 +1047,7 @@ export abstract class MobileManagerBase {
   }
 
   protected extractFilePathsFromText(text: string): string[] {
-    const files = [
-      ...this.extractPathTokens(text, /`([^`]+)`/g),
-      ...this.extractPathTokens(text, /([A-Za-z]:\\[^\s'"(){}<>]+|\/(?:[^\s`'"(){}<>]+\/?)+)/g),
-    ]
+    const files = [...this.extractPathTokens(text, /`([^`]+)`/g), ...this.extractBarePaths(text)]
     return [...new Set(files.filter((p) => this.isFilePath(p)))]
   }
 
@@ -1058,10 +1055,35 @@ export abstract class MobileManagerBase {
     const items: string[] = []
     for (const match of text.matchAll(pattern)) {
       const raw = (match[1] ?? match[0] ?? "").trim()
-      const file = raw.replace(/^[`'\"]+|[`'\",.;:!?]+$/g, "").trim()
+      const file = this.cleanPathToken(raw)
       if (file) items.push(file)
     }
     return items
+  }
+
+  private cleanPathToken(raw: string): string {
+    return raw.replace(/^[`'\"]+|[`'\",.;:!?。，；！？]+$/g, "").trim()
+  }
+
+  private extractBarePaths(text: string): string[] {
+    const pattern = /([A-Za-z]:\\[^\s'"(){}<>]+|\/(?:[^\s`'"(){}<>]+\/?)+)/g
+    const found: string[] = []
+    for (const match of text.matchAll(pattern)) {
+      const token = this.cleanPathToken(match[1] ?? "")
+      if (!token) continue
+      let cur = existsSync(token) ? token : ""
+      const words = text
+        .slice((match.index ?? 0) + match[0].length)
+        .split(/\s+/)
+        .slice(0, 8)
+        .filter(Boolean)
+      for (let i = 0; i < words.length; i++) {
+        const next = this.cleanPathToken([token, ...words.slice(0, i + 1)].join(" "))
+        if (next && existsSync(next)) cur = next
+      }
+      if (cur) found.push(cur)
+    }
+    return found
   }
 
   private isFilePath(p: string): boolean {


### PR DESCRIPTION
### Issue for this PR

Closes #1161

### Type of change

- [x] Bug fix

### What does this PR do?

移动端发文件时，`extractFilePathsFromText()` 的裸路径正则以空白符为路径边界，含空格的路径（如 `E:\work\my docs\report.pdf`）被截断为 `E:\work\my`，`existsSync` 校验失败后被静默过滤，`replyFile` 从不执行。

修复方式：新增 `extractBarePaths()`，对每个裸路径匹配向后取最多 8 个空格分词，测试所有前缀组合并取磁盘上真实存在的最长路径（逐词贪心扩展在多词目录名如 `aether mobile-测试 v3zImi` 上会因中间前缀不存在而失效，故测试全部前缀长度）。同时把路径清洗规则抽出为 `cleanPathToken()`，并补充剥离常见中文尾部标点（`。，；！？`），避免中文回复中标点粘在路径末尾导致校验失败。反引号路径与 `read` 工具输入路径原本就不受空格影响，行为不变。

### How did you verify your code works?

- 在 `packages/opencode` 运行 `bun typecheck` 通过
- 用临时目录实测 `extractFilePathsFromText()`：多级含空格+中文目录名、文件名含空格、句尾中文标点的纯文本路径均可提取完整路径；不存在路径仍被过滤；反引号路径行为不变

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR