### PR TITLE
fix(ui): render line-wrapped, ill-formed and blocked math in markdown preview

### DIFF
--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -395,12 +395,160 @@ export function normalizeMath(text: string) {
     .replace(/\\\[\s*([\s\S]*?)\s*\\\]/g, (_, math) => `\n$$\n${math}\n$$\n`)
 }
 
+const blockStart = /^[ \t]*(?:\n|\||#{1,6}\s|[-*+]\s|\d+[.)]\s|```|~~~)/
+const blockBreak = /^[ \t]*(?:\n|```|~~~)/
+
+const mathy = /[\\^_{}|~=<>*+/:-]/
+const proseWord =
+  /\b(?:and|or|not|but|if|then|than|is|are|was|were|be|been|being|the|an|of|to|in|on|at|by|for|with|from|into|onto|per|via|vs|versus|up|down|out|over|under|between|each|every|some|any|all|both|more|less|most|least|only|just|also|very|too|here|there|when|where|which|who|what|that|this|these|those|its|our|you|they|them|their|will|would|can|could|should|may|might|must|does|did|have|has|had|about|after|before|during|since|until|while|total|cost|costs|price|fee|pay)\b/i
+const cjk = /[\u4e00-\u9fff\u3040-\u30ff]/
+
+export function mathLike(content: string) {
+  return !/\s/.test(content) || mathy.test(content) || (!proseWord.test(content) && !cjk.test(content))
+}
+
+function stars(span: string) {
+  return span
+    .split(/(\\(?:text|textrm|textbf|textit|mathrm|operatorname)\{[^{}]*\})/g)
+    .map((part, i) => (i % 2 ? part : part.replace(/(?<!\\)\*/g, "\\ast ")))
+    .join("")
+}
+
+function pair(text: string) {
+  let out = ""
+  let i = 0
+  while (i < text.length) {
+    const c = text[i]
+    if (c === "\\") {
+      out += text.slice(i, i + 2)
+      i += 2
+      continue
+    }
+    if (c !== "$") {
+      out += c
+      i++
+      continue
+    }
+    const display = text[i + 1] === "$"
+    const width = display ? 2 : 1
+    let j = i + width
+    let close = -1
+    while (j < text.length) {
+      if (text[j] === "\\") {
+        j += 2
+        continue
+      }
+      if (text[j] === "$") {
+        if (display === (text[j + 1] === "$")) {
+          close = j
+          break
+        }
+        j++
+        continue
+      }
+      if (text[j] === "\n" && (display ? blockBreak : blockStart).test(text.slice(j + 1, j + 40))) break
+      j++
+    }
+    if (close === -1) {
+      out += text.slice(i, i + width)
+      i += width
+      continue
+    }
+    const span = text.slice(i, close + width)
+    const flat = span.includes("\n") ? span.replace(/\s*\n[ \t]*>*[ \t]*/g, " ") : span
+    const content = flat.slice(width, flat.length - width)
+    out += mathLike(content) ? stars(flat) : "\\$".repeat(width) + content + "\\$".repeat(width)
+    i = close + width
+  }
+  return out
+}
+
+const tableRow = /^[ \t]*\|/
+const tableDelim = /^[ \t|:= -]*-[ \t|:= -]*$/
+
+export function guardPipes(text: string) {
+  const lines = text.split("\n")
+  let fence = false
+  let table = false
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    if (/^[ \t]*(```|~~~)/.test(line)) {
+      fence = !fence
+      table = false
+      continue
+    }
+    if (fence) continue
+    const row: boolean = tableRow.test(line)
+    const next = lines[i + 1] ?? ""
+    const opens: boolean = row && !table && tableDelim.test(next)
+    if (row && (table || opens)) {
+      lines[i] = line.replace(/\$[^$\n]*\$/g, (span) => span.replace(/(?<!\\)\|/g, "\\|"))
+    }
+    table = row && (table || opens)
+  }
+  return lines.join("\n")
+}
+
+const fenceLine = /^[ \t]*(```|~~~)/
+
+function splitCode(text: string): [string, boolean][] {
+  const lines = text.split("\n")
+  const flags: boolean[] = []
+  let fence = false
+  let indented = false
+  let prevBlank = true
+  for (const line of lines) {
+    if (fence) {
+      flags.push(true)
+      if (fenceLine.test(line)) fence = false
+      continue
+    }
+    const blank = line.trim() === ""
+    const isIndent = /^(?: {4}|\t)/.test(line)
+    if (indented) {
+      if (isIndent || blank) flags.push(true)
+      else {
+        indented = false
+        flags.push(false)
+      }
+    } else if (isIndent && prevBlank && !fenceLine.test(line)) {
+      indented = true
+      flags.push(true)
+    } else {
+      flags.push(false)
+    }
+    if (fenceLine.test(line)) fence = true
+    prevBlank = blank
+  }
+  const groups: [string, boolean][] = []
+  let buf: string[] = [lines[0]]
+  let code = flags[0]
+  lines.slice(1).forEach((line, i) => {
+    if (flags[i + 1] !== code) {
+      groups.push([buf.join("\n"), code])
+      buf = [line]
+      code = flags[i + 1]
+    } else {
+      buf.push(line)
+    }
+  })
+  groups.push([buf.join("\n"), code])
+  return groups
+}
+
+export function joinMath(text: string) {
+  return splitCode(text.replace(/\r\n?/g, "\n"))
+    .map(([part, code]) => (code ? part : pair(guardPipes(part))))
+    .join("\n")
+}
+
 export function renderMathInText(text: string): string {
   let result = normalizeMath(text)
 
   // Display math: $$...$$
-  const displayMathRegex = /\$\$([\s\S]*?)\$\$/g
-  result = result.replace(displayMathRegex, (_, math) => {
+  const displayMathRegex = /\$\$((?:[^$<>\\]|\\[\s\S])+?)\$\$/g
+  result = result.replace(displayMathRegex, (match, math) => {
+    if (!mathLike(math)) return match
     try {
       return katex.renderToString(decodeMath(math), {
         displayMode: true,
@@ -413,8 +561,9 @@ export function renderMathInText(text: string): string {
   })
 
   // Inline math: $...$
-  const inlineMathRegex = /(?<!\$)\$(?!\$)((?:[^$\\]|\\.)+?)\$(?!\$)/g
-  result = result.replace(inlineMathRegex, (_, math) => {
+  const inlineMathRegex = /(?<!\$)\$(?!\$)((?:[^$\\<>\n]|\\.)+?)\$(?!\$)/g
+  result = result.replace(inlineMathRegex, (match, math) => {
+    if (!mathLike(math)) return match
     try {
       return katex.renderToString(decodeMath(math), {
         displayMode: false,
@@ -444,50 +593,60 @@ function renderMathExpressions(html: string): string {
     .join("")
 }
 
+const jsParser = marked.use(
+  {
+    renderer: {
+      link({ href, title, text }) {
+        const titleAttr = title ? ` title="${title}"` : ""
+        return `<a href="${href}"${titleAttr} class="external-link" target="_blank" rel="noopener noreferrer">${text}</a>`
+      },
+    },
+    tokenizer: {
+      del(src: string) {
+        const match = /^~~(?=[^\s~])((?:\\[\s\S]|[^\\])*?(?:\\[\s\S]|[^\s~\\]))~~(?=[^~]|$)/.exec(src)
+        if (!match) return
+        return {
+          type: "del" as const,
+          raw: match[0],
+          text: match[1],
+          tokens: this.lexer.inlineTokens(match[1]),
+        }
+      },
+    },
+  },
+  markedKatex({
+    throwOnError: false,
+    nonStandard: true,
+    macros: katexMacros,
+  }),
+  markedShiki({
+    async highlight(code, lang) {
+      const highlighter = await getSharedHighlighter({
+        themes: ["OpenCode"],
+        langs: [],
+        preferredHighlighter: "shiki-wasm",
+      })
+      if (!(lang in bundledLanguages)) {
+        lang = "text"
+      }
+      if (!highlighter.getLoadedLanguages().includes(lang)) {
+        await highlighter.loadLanguage(lang as BundledLanguage)
+      }
+      return highlighter.codeToHtml(code, {
+        lang: lang || "text",
+        theme: "OpenCode",
+        tabindex: false,
+      })
+    },
+  }),
+)
+
+export async function parseMarkdown(markdown: string): Promise<string> {
+  const html = await jsParser.parse(joinMath(normalizeMath(markdown)))
+  return renderMathExpressions(html)
+}
+
 export const { use: useMarked, provider: MarkedProvider } = createSimpleContext({
   name: "Marked",
-  init: () => {
-    const jsParser = marked.use(
-      {
-        renderer: {
-          link({ href, title, text }) {
-            const titleAttr = title ? ` title="${title}"` : ""
-            return `<a href="${href}"${titleAttr} class="external-link" target="_blank" rel="noopener noreferrer">${text}</a>`
-          },
-        },
-      },
-      markedKatex({
-        throwOnError: false,
-        nonStandard: true,
-        macros: katexMacros,
-      }),
-      markedShiki({
-        async highlight(code, lang) {
-          const highlighter = await getSharedHighlighter({
-            themes: ["OpenCode"],
-            langs: [],
-            preferredHighlighter: "shiki-wasm",
-          })
-          if (!(lang in bundledLanguages)) {
-            lang = "text"
-          }
-          if (!highlighter.getLoadedLanguages().includes(lang)) {
-            await highlighter.loadLanguage(lang as BundledLanguage)
-          }
-          return highlighter.codeToHtml(code, {
-            lang: lang || "text",
-            theme: "OpenCode",
-            tabindex: false,
-          })
-        },
-      }),
-    )
-
-    return {
-      async parse(markdown: string): Promise<string> {
-        const html = await jsParser.parse(normalizeMath(markdown))
-        return renderMathExpressions(html)
-      },
-    }
-  },
+  init: () => ({ parse: parseMarkdown }),
 })

--- a/packages/ui/src/context/marked.vitest.ts
+++ b/packages/ui/src/context/marked.vitest.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest"
-import { decodeMath, normalizeMath, renderMathInText } from "./marked"
+import { parseMarkdown, joinMath, guardPipes, decodeMath, normalizeMath, renderMathInText } from "./marked"
 
 describe("marked math", () => {
   test("decodes html entities inside math", () => {
@@ -9,9 +9,189 @@ describe("marked math", () => {
 
   test("normalizes tex delimiters", () => {
     expect(normalizeMath(String.raw`consider \(SO(2)\)`)).toBe("consider $SO(2)$")
-    expect(normalizeMath(String.raw`\[
+    expect(
+      normalizeMath(String.raw`\[
 a+b
-\]`)).toContain("$$\na+b\n$$")
+\]`),
+    ).toContain("$$\na+b\n$$")
+  })
+
+  test("joins line-wrapped inline math", () => {
+    expect(joinMath("$a+b\n=c$ x")).toBe("$a+b =c$ x")
+    expect(joinMath("$a+b\n=c\n+d$ x")).toBe("$a+b =c +d$ x")
+    expect(joinMath("$a+b$ and $c\n=d$")).toBe("$a+b$ and $c =d$")
+    expect(joinMath("$a\r\n=b$ x")).toBe("$a =b$ x")
+    expect(joinMath("prev $x$ tail\nnext $y\n=z$ end")).toBe("prev $x$ tail\nnext $y =z$ end")
+    expect(joinMath("$$\na+b\n$$")).toBe("$$ a+b $$")
+    expect(joinMath("$$a+b$$")).toBe("$$a+b$$")
+  })
+
+  test("joins display math not alone on its lines", () => {
+    expect(joinMath("text $$a+b\n=c$$ tail")).toBe("text $$a+b =c$$ tail")
+    expect(joinMath("$$\\underbrace{x}_{y}\n+z$$")).toBe("$$\\underbrace{x}_{y} +z$$")
+    expect(joinMath("$$a\n=b\n$$")).toBe("$$a =b $$")
+    expect(joinMath("$$a\n\nb$$")).toBe("$$a\n\nb$$")
+    expect(joinMath("para text\n$$\na+b\n$$\ntail text")).toBe("para text\n$$ a+b $$\ntail text")
+  })
+
+  test("escapes pipes inside math on table rows", () => {
+    expect(guardPipes("| a | $|x|$ |\n|---|---|")).toBe("| a | $\\|x\\|$ |\n|---|---|")
+    expect(guardPipes("| h |\n|---|\n| $|y|$ |")).toBe("| h |\n|---|\n| $\\|y\\|$ |")
+    expect(guardPipes("| h | $|z|$ |\n---|---")).toBe("| h | $\\|z\\|$ |\n---|---")
+    expect(guardPipes("| $a$ |\n| $|x|$ |")).toBe("| $a$ |\n| $|x|$ |")
+    expect(guardPipes("| $|x|$ |\nprose\n| $|y|$ |")).toBe("| $|x|$ |\nprose\n| $|y|$ |")
+    expect(guardPipes("code:\n```\n| $|x|$ |\n```")).toBe("code:\n```\n| $|x|$ |\n```")
+    expect(guardPipes("$|x|$ plain paragraph")).toBe("$|x|$ plain paragraph")
+  })
+
+  test("does not join inline math across block boundaries", () => {
+    expect(joinMath("$a\n\nb$")).toBe("$a\n\nb$")
+    expect(joinMath("$a\r\n\r\nb$")).toBe("$a\n\nb$")
+    expect(joinMath("$a\n```js\nb\n```\nc$")).toBe("$a\n```js\nb\n```\nc$")
+    expect(joinMath("$a\n| b$")).toBe("$a\n| b$")
+    expect(joinMath("$a\n- b$")).toBe("$a\n- b$")
+    expect(joinMath("$a\n# b$")).toBe("$a\n# b$")
+    expect(joinMath("$a\n1. b$")).toBe("$a\n1. b$")
+  })
+
+  test("joins math wrapped across blockquote lines", () => {
+    expect(joinMath("> $a+b\n> =c$ tail")).toBe("> $a+b =c$ tail")
+    expect(joinMath("> $$a+b\n> =c$$ tail")).toBe("> $$a+b =c$$ tail")
+    expect(joinMath("$a\n> =b$")).toBe("$a =b$")
+  })
+
+  test("escapes bare stars inside math but not in text-mode groups", () => {
+    expect(joinMath("*em* $(x)^*=-y$")).toBe("*em* $(x)^\\ast =-y$")
+    expect(joinMath("$$a*b$$")).toBe("$$a\\ast b$$")
+    expect(joinMath("$\\text{a*b}$")).toBe("$\\text{a*b}$")
+    expect(joinMath("$\\mathrm{conv*}$")).toBe("$\\mathrm{conv*}$")
+    expect(joinMath("plain *em* text")).toBe("plain *em* text")
+  })
+
+  test("keeps prose between dollars as text, not math", () => {
+    expect(joinMath("costs $5 and $10 total")).toBe("costs \\$5 and \\$10 total")
+    expect(joinMath("from $5\nup to $10 total")).toBe("from \\$5 up to \\$10 total")
+    expect(joinMath("between $a and b$ here")).toBe("between \\$a and b\\$ here")
+    expect(joinMath("价格 $5 和 $10 左右")).toContain("\\$")
+    expect(joinMath("math $x$ and $a + b$ stay")).toBe("math $x$ and $a + b$ stay")
+    expect(joinMath("$E=mc^2$ stays")).toBe("$E=mc^2$ stays")
+    expect(joinMath("products $E L$ and $M L$ stay")).toBe("products $E L$ and $M L$ stay")
+    expect(joinMath("scaling $(mv, mv, mv)$ stays")).toBe("scaling $(mv, mv, mv)$ stays")
+  })
+
+  test("does not join or escape dollars inside indented code", () => {
+    const src = ["para:", "", "    code $a", "    b$ code", "", "after"].join("\n")
+    expect(joinMath(src)).toBe(src)
+    const wrapped = "$a\n    =b$ x"
+    expect(joinMath(wrapped)).toBe("$a =b$ x")
+  })
+
+  test("renders wrapped inline math without html leakage", async () => {
+    const out = await parseMarkdown(
+      [
+        "text $x\\to\\ell\\infty$ then $W_\\ell^\\dagger T",
+        "W_\\ell$ and $\\mathrm{Poles}^{(n)}\\propto c_n\\times",
+        "(\\gamma\\coth\\gamma-1)/\\epsilon_{\\rm IR}$ end",
+      ].join("\n"),
+    )
+
+    expect(out).not.toContain("<em>")
+    expect(out).not.toContain("&lt;span")
+    expect(out).not.toContain("$")
+    expect((out.match(/class="katex"/g) ?? []).length).toBe(3)
+  })
+
+  test("single tilde is not strikethrough, double tilde is", async () => {
+    const html = await parseMarkdown("Eqs.~(15) and Eqs.~(16), also ~~gone~~ here")
+    expect(html).toContain("<del>gone</del>")
+    expect(html).not.toContain("<del>(15)")
+    expect(html).toContain("~(15)")
+  })
+
+  test("renders wrapped display math with underbraces", async () => {
+    const out = await parseMarkdown(
+      [
+        "$$\\underbrace{\\text{L1 eikonal}}_{\\text{established}}",
+        "+\\underbrace{\\text{C2 completeness}}_{\\text{core}}",
+        "\\Longrightarrow D_{i\\to H}=\\sum_n d_{i\\to n}.$$",
+      ].join("\n"),
+    )
+    expect(out).toContain("katex-display")
+    expect(out).not.toContain("<em>")
+    expect(out).not.toContain("$")
+  })
+
+  test("paper-style fixture renders without corruption", async () => {
+    const out = await parseMarkdown(
+      [
+        "# Note",
+        "",
+        "Refs with tildes: Eq.~(5), Eqs.~(15)–(16), keep ~~strike~~.",
+        "",
+        "Wrapped inline $W_\\ell^\\dagger T",
+        "W_\\ell$ plus $\\mathrm{Poles}^{(n)}\\propto c_n$.",
+        "",
+        "$$\\underbrace{\\text{L1}}_{\\text{est}}",
+        "+\\Longrightarrow D_{i\\to H}.$$ tail",
+        "",
+        "| k | v |",
+        "|---|---|",
+        "| 1 | $|x|\\sim 2$ |",
+        "",
+        "```ts",
+        "const s = '$5 and $6'",
+        "```",
+        "",
+        "Plain $a<b$ math and $\\ell\\cdot k$.",
+      ].join("\r\n"),
+    )
+
+    expect((out.match(/<del>/g) ?? []).length).toBe(1)
+    expect(out).toContain("<del>strike</del>")
+    expect(out).toContain("~(5)")
+    expect(out).toContain("katex-display")
+    expect(out).not.toContain("&lt;span")
+    expect(out).not.toContain("&lt;em")
+    expect(out).toContain("$5 and $6")
+    expect(out.replace(/<pre[\s\S]*?<\/pre>/g, "")).not.toContain("$")
+  })
+
+  test("star superscript inside math does not close surrounding italics", async () => {
+    const out = await parseMarkdown("**Lemma S.** *With (1.1): (i) $(\\phi_{A,L})^*=-\\phi_{C,L}$ (the graded signs).*")
+    expect(out).toContain("<em>With")
+    expect(out).toContain("katex")
+    expect(out).not.toContain("$")
+  })
+
+  test("renders math wrapped across blockquote lines", async () => {
+    const out = await parseMarkdown(
+      [
+        "> **Corollary T2.** $W_F$ is *not* transverse:",
+        "> $k\\big[(p\\!\\cdot\\!k_1)\\,q\\nu",
+        "> =-\\,ig\\,f_{abc}\\big/\\delta$ tail",
+      ].join("\n"),
+    )
+    expect(out).toContain("blockquote")
+    expect(out).toContain("katex")
+    expect(out).not.toContain("$")
+  })
+
+  test("currency amounts are not rendered as math", async () => {
+    const out = await parseMarkdown("It costs $5 and $10 more, or $x$ in math.")
+    expect(out).toContain("$5")
+    expect(out).toContain("$10")
+    expect((out.match(/class="katex"/g) ?? []).length).toBe(1)
+    expect(out).not.toContain("katex-error")
+  })
+
+  test("fallback pass does not swallow html between stray dollars", () => {
+    const out = renderMathInText('$a\nb$ <span class="katex">keep</span>')
+    expect(out).toContain('<span class="katex">keep</span>')
+    expect(out).not.toContain("&lt;span")
+
+    const display = renderMathInText('$$a <span class="katex">x</span> b$$')
+    expect(display).toContain('$$a <span class="katex">x</span> b$$')
+    expect(display).not.toContain("&lt;span")
   })
 
   test("renders matrix formulas without leaking html entities", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #1167

### Type of change

- [x] Bug fix

### What does this PR do?

Physics-style markdown (soft-wrapped `$...$`, `$$` blocks embedded in paragraphs, `Eq.~(5)` tildes, `$|x|$` in table cells) broke in the markdown preview and session panes. Root causes and fixes, all in the shared parser (`packages/ui/src/context/marked.tsx`):

- `marked-katex-extension`'s inline rule cannot match `$...$` containing newlines, and its block rule requires `$$` alone on its line - such formulas fell into regular markdown parsing, where `_{...}` became `<em>` and orphan `$` delimiters paired across the document. Added `joinMath()`: a sequential dollar-pairing pass (mirroring marked's left-to-right pairing) that joins wrapped inline and display math onto a single line before parsing. Guarded by block boundaries (blank lines, fences, headings, lists, tables) so it never merges across blocks; well-formed code and dollar-free text are untouched.
- marked's GFM `del` rule matches single tildes, so `Eq.~(5)` paired into strikethrough. Overrode the `del` tokenizer to require `~~` (standard GFM, GitHub-compatible).
- marked's table splitter treats `|` inside `$|x|$` as a cell separator. Added `guardPipes()`: on actual table rows (anchored to a delimiter row), pipes inside math are escaped as `\|`; marked converts them back to `|` per cell, so KaTeX receives unchanged source.
- The second-pass fallback regex accepted any content between stray `$`s (including HTML), so one orphan pair swallowed neighboring rendered formulas into a literal-text blob. Tightened both fallback regexes (no `<`, `>`, or newlines inside inline; no `<`/`>` in display).
- Added a `mathLike` gate: `$...$` spans that contain whitespace but no math indicator and a prose word (e.g. `costs $5 and $10`) are escaped as text instead of rendered.

Session chat, file preview and context panes all share this parser, so the fixes apply everywhere.

### How did you verify your code works?

- `bun run test:unit` in `packages/ui`: 28 tests pass, including 20 new tests in `marked.vitest.ts` covering each failure mode and its guards (join/no-join boundaries, blockquote lazy continuation, table pipes, star superscripts vs italics, tildes, currency, indented code blocks).
- `bun typecheck` clean.
- Rendered all 16 project markdown files through the real `parseMarkdown` pipeline: formula counts stable vs. pre-change baseline, zero leftover `$`, zero escaped-HTML leakage, zero stray `<del>`.
