### PR TITLE
fix(models): discover Codex client version dynamically

### DIFF
--- a/packages/opencode/src/plugin/codex-models.ts
+++ b/packages/opencode/src/plugin/codex-models.ts
@@ -1,6 +1,5 @@
 import fs from "fs/promises"
 import path from "path"
-import semver from "semver"
 import z from "zod"
 import { Global } from "../global"
 import { Installation } from "../installation"
@@ -13,8 +12,13 @@ export namespace CodexModels {
   const log = Log.create({ service: "plugin.codex.models" })
   const ttl = 5 * 60 * 1000
   const interval = 60 * 60 * 1000
-  export const VERSION = "0.144.0"
-  export const URL = `https://chatgpt.com/backend-api/codex/models?client_version=${VERSION}`
+  const baseline = "0.144.0"
+  export const REGISTRY = "https://registry.npmjs.org/@openai/codex/latest"
+  export const URL = "https://chatgpt.com/backend-api/codex/models"
+
+  export function url(version: string) {
+    return `${URL}?client_version=${version}`
+  }
 
   const Model = z
     .object({
@@ -24,6 +28,7 @@ export namespace CodexModels {
     })
     .passthrough()
   const Response = z.object({ models: z.array(Model) }).passthrough()
+  const Release = z.object({ version: z.string().regex(/^\d+\.\d+\.\d+$/) }).passthrough()
 
   export const Source = z.enum(["none", "fallback", "cache", "remote"])
   export const Status = z
@@ -45,7 +50,7 @@ export namespace CodexModels {
   const Cache = z
     .object({
       version: z.literal(1),
-      clientVersion: z.literal(VERSION),
+      clientVersion: z.string().regex(/^\d+\.\d+\.\d+$/),
       checkedAt: z.number().nullable(),
       updatedAt: z.number().nullable(),
       etag: z.string().nullable(),
@@ -62,6 +67,7 @@ export namespace CodexModels {
     fetcher: Request
     status: Status
     models?: string[]
+    version?: string
   }
   type Input = {
     identity?: string
@@ -73,6 +79,8 @@ export namespace CodexModels {
     models?: string[]
     fetcher: Request
     timeout?: number
+    version?: string
+    prior?: string
   }
 
   const empty: Status = {
@@ -91,6 +99,8 @@ export namespace CodexModels {
   const listeners = new Set<() => void>()
   let active: string | undefined
   let timer: ReturnType<typeof setInterval> | undefined
+  let release = { version: baseline, checkedAt: 0 }
+  let resolving: Promise<string> | undefined
 
   function message(err: unknown) {
     if (err instanceof Error) return err.message
@@ -101,15 +111,35 @@ export namespace CodexModels {
     return path.join(Global.Path.cache, `codex-models-${key}.json`)
   }
 
-  function compatible(version?: string | null) {
-    if (!version) return true
-    if (!semver.valid(version)) return false
-    return semver.lte(version, VERSION)
-  }
-
   function parse(content: string) {
     const data = Response.parse(JSON.parse(content))
-    return [...new Set(data.models.filter((x) => x.visibility === "list" && compatible(x.minimal_client_version)).map((x) => x.slug))].sort()
+    return [...new Set(data.models.filter((x) => x.visibility === "list").map((x) => x.slug))].sort()
+  }
+
+  function version(input?: { fetcher?: Request; force?: boolean; timeout?: number; fallback?: string }) {
+    if (!input?.force && Date.now() - release.checkedAt < interval) return Promise.resolve(release.version)
+    if (resolving) return resolving
+    resolving = (input?.fetcher ?? fetch)(REGISTRY, {
+      headers: { "User-Agent": Installation.USER_AGENT },
+      signal: AbortSignal.timeout(input?.timeout ?? 10 * 1000),
+    })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(`Failed to discover Codex version: ${response.status}`)
+        return Release.parse(await response.json()).version
+      })
+      .then((value) => {
+        release = { version: value, checkedAt: Date.now() }
+        return value
+      })
+      .catch((err) => {
+        release = { version: input?.fallback ?? release.version, checkedAt: Date.now() }
+        log.warn("failed to discover Codex version", { error: err, fallback: release.version })
+        return release.version
+      })
+      .finally(() => {
+        resolving = undefined
+      })
+    return resolving
   }
 
   async function read(key: string) {
@@ -124,7 +154,7 @@ export namespace CodexModels {
     const tmp = `${file}.${process.pid}.${Date.now()}.tmp`
     await Filesystem.writeJson(tmp, {
       version: 1,
-      clientVersion: VERSION,
+      clientVersion: entry.version ?? baseline,
       checkedAt: entry.status.checkedAt,
       updatedAt: entry.status.updatedAt,
       etag: entry.status.etag,
@@ -140,10 +170,11 @@ export namespace CodexModels {
 
   async function download(input: Download) {
     const checkedAt = Date.now()
+    const current = input.version ?? (await version())
     const headers = new Headers({ "User-Agent": Installation.USER_AGENT })
-    if (input.previous.etag) headers.set("If-None-Match", input.previous.etag)
+    if (input.previous.etag && input.prior === current) headers.set("If-None-Match", input.previous.etag)
     const response = await input
-      .fetcher(URL, {
+      .fetcher(url(current), {
         headers,
         signal: AbortSignal.timeout(input.timeout ?? 10 * 1000),
       })
@@ -168,7 +199,7 @@ export namespace CodexModels {
     if (!response.ok) throw new Error(`Failed to fetch Codex models: ${response.status}`)
 
     const models = parse(await response.text())
-    if (models.length === 0) throw new Error("Codex models returned no compatible visible models")
+    if (models.length === 0) throw new Error("Codex models returned no visible models")
     const hash = Hash.fast(models.join("\n"))
     const changed = hash !== input.previous.hash
     return {
@@ -210,6 +241,7 @@ export namespace CodexModels {
           }
         : { ...empty, enabled: true, source: "fallback" },
       models: saved?.models,
+      version: saved?.clientVersion,
     }
     entries.set(key, entry)
     return entry
@@ -235,13 +267,17 @@ export namespace CodexModels {
     }
 
     try {
+      const current = await version({ fallback: entry.version })
       const result = await download({
         previous: entry.status,
         models: entry.models,
         fetcher: entry.fetcher,
+        version: current,
+        prior: entry.version,
       })
       entry.status = result.status
       entry.models = result.models
+      entry.version = current
       await write(entry).catch((err) => log.warn("failed to write Codex models cache", { error: err }))
       if (!result.changed || active !== entry.key || !result.status.hash || !result.status.updatedAt) {
         return { ...result.status, changed: result.changed }
@@ -288,7 +324,7 @@ export namespace CodexModels {
     const entry = await pending
     entry.fetcher = input.fetcher
     start()
-    void once(entry, false)
+    void version({ fallback: entry.version }).then((current) => once(entry, current !== entry.version))
     return select(entry)
   }
 
@@ -311,7 +347,10 @@ export namespace CodexModels {
 
   export const Test = {
     parse,
-    download,
+    download(input: Download) {
+      return download({ ...input, version: input.version ?? baseline, prior: input.prior ?? baseline })
+    },
+    version,
     once,
     filepath,
     key: Hash.fast,
@@ -340,6 +379,8 @@ export namespace CodexModels {
       entries.clear()
       loads.clear()
       tasks.clear()
+      release = { version: baseline, checkedAt: 0 }
+      resolving = undefined
       if (timer) clearInterval(timer)
       timer = undefined
     },

--- a/packages/opencode/test/plugin/codex-models-auth.test.ts
+++ b/packages/opencode/test/plugin/codex-models-auth.test.ts
@@ -126,11 +126,18 @@ test("uses remote slugs as the sole allowlist and matches model api ids", async 
 })
 
 test("authenticates catalog requests with the current subscription account", async () => {
-  const request = spyOn(globalThis, "fetch").mockResolvedValue(
-    new Response(
-      JSON.stringify({
-        models: [{ slug: "gpt-5.5", visibility: "list", minimal_client_version: "0.144.0" }],
-      }),
+  const request = spyOn(globalThis, "fetch").mockImplementation(
+    Object.assign(
+      async (input: RequestInfo | URL) => {
+        const url = input instanceof Request ? input.url : input.toString()
+        if (url === CodexModels.REGISTRY) return new Response(JSON.stringify({ version: "0.154.0" }))
+        return new Response(
+          JSON.stringify({
+            models: [{ slug: "gpt-5.5", visibility: "list", minimal_client_version: "0.144.0" }],
+          }),
+        )
+      },
+      { preconnect: fetch.preconnect },
     ),
   )
   const hooks = await CodexAuthPlugin({} as unknown as PluginInput)
@@ -162,9 +169,11 @@ test("authenticates catalog requests with the current subscription account", asy
     const call = request.mock.calls.at(-1)
     const url = call?.[0]
     const headers = new Headers(call?.[1]?.headers)
-    expect(url instanceof Request ? url.url : url?.toString()).toBe(CodexModels.URL)
+    expect(url instanceof Request ? url.url : url?.toString()).toBe(CodexModels.url("0.154.0"))
     expect(headers.get("authorization")).toBe("Bearer access")
     expect(headers.get("chatgpt-account-id")).toBe("account")
+    const discovery = request.mock.calls.find((call) => call[0].toString() === CodexModels.REGISTRY)
+    expect(new Headers(discovery?.[1]?.headers).has("authorization")).toBe(false)
   } finally {
     request.mockRestore()
   }

--- a/packages/opencode/test/plugin/codex-models.test.ts
+++ b/packages/opencode/test/plugin/codex-models.test.ts
@@ -30,7 +30,7 @@ function model(slug: string, input?: { visibility?: string; version?: string | n
 
 afterEach(() => CodexModels.Test.reset())
 
-test("accepts only compatible visible slugs and ignores protocol fields", () => {
+test("accepts all visible slugs regardless of client version", () => {
   const result = CodexModels.Test.parse(
     body([
       model("zeta"),
@@ -41,7 +41,25 @@ test("accepts only compatible visible slugs and ignores protocol fields", () => 
       model("alpha"),
     ]),
   )
-  expect(result).toEqual(["alpha", "zeta"])
+  expect(result).toEqual(["alpha", "future", "invalid", "zeta"])
+})
+
+test("discovers the latest published Codex version", async () => {
+  const value = await CodexModels.Test.version({
+    force: true,
+    fetcher: async () => new Response(JSON.stringify({ version: "0.154.0" })),
+  })
+  expect(value).toBe("0.154.0")
+  expect(CodexModels.url(value)).toBe(`${CodexModels.URL}?client_version=0.154.0`)
+})
+
+test("keeps the cached Codex version when discovery fails", async () => {
+  const value = await CodexModels.Test.version({
+    force: true,
+    fallback: "0.153.0",
+    fetcher: async () => new Response("offline", { status: 503 }),
+  })
+  expect(value).toBe("0.153.0")
 })
 
 test("downloads changes and sends ETag for 304", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #1169

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Replaces the hard-coded Codex client version with the latest published `@openai/codex` version, cached for one hour with the last known version as an offline fallback. The account catalog now contributes every `visibility=list` slug without applying a second local `minimal_client_version` filter, so the final OpenAI subscription list remains the intersection of models.dev metadata and the account's remote Codex catalog.

Catalog ETags are reused only when the discovered client version is unchanged, preventing stale 304 responses across version updates. Version discovery is unauthenticated and does not expose OpenAI credentials to npm.

### How did you verify your code works?

- `bun test test/plugin/codex-models.test.ts test/plugin/codex-models-auth.test.ts` (19 passed)
- `bun typecheck` in `packages/opencode`
- Push hook: `bun turbo typecheck` (12 tasks successful)
- Live `models openai --refresh` returned `openai/gpt-6-astra`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR